### PR TITLE
[我的/教务] 学校官网内嵌、消息推送与消息浏览

### DIFF
--- a/android/app/src/main/java/com/hbut/mini/BackgroundFetchHeadlessTask.java
+++ b/android/app/src/main/java/com/hbut/mini/BackgroundFetchHeadlessTask.java
@@ -48,6 +48,9 @@ public class BackgroundFetchHeadlessTask {
     private static final String KEY_ENABLE_EXAM = "hbu_bg_enable_exam";
     private static final String KEY_ENABLE_POWER = "hbu_bg_enable_power";
     private static final String KEY_ENABLE_CLASS = "hbu_bg_enable_class";
+    private static final String KEY_ENABLE_SCHOOL_INBOX = "hbu_bg_enable_school_inbox";
+    private static final String KEY_LOGIN_METHOD = "hbu_bg_login_method";
+    private static final String KEY_CHAOXING_NOTICE_COOKIE = "hbu_bg_chaoxing_notice_cookie";
     private static final String KEY_CLASS_LEAD_MINUTES = "hbu_bg_class_lead_min";
     private static final String KEY_DORM_SELECTION = "hbu_bg_dorm_selection";
     private static final String KEY_WIDGET_LAST_SCHEDULE_HASH = "hbu_bg_widget_schedule_hash";
@@ -108,6 +111,7 @@ public class BackgroundFetchHeadlessTask {
         boolean enableExam = "1".equals(safe(prefs.getString(KEY_ENABLE_EXAM, "1")));
         boolean enablePower = "1".equals(safe(prefs.getString(KEY_ENABLE_POWER, "1")));
         boolean enableClass = "1".equals(safe(prefs.getString(KEY_ENABLE_CLASS, "1")));
+        boolean enableSchoolInbox = "1".equals(safe(prefs.getString(KEY_ENABLE_SCHOOL_INBOX, "1")));
 
         if (enableGrade) {
             checkGrade(context, prefs, apiBase, studentId);
@@ -121,7 +125,106 @@ public class BackgroundFetchHeadlessTask {
         if (enableClass) {
             checkClassReminder(context, prefs, apiBase, studentId);
         }
+        if (enableSchoolInbox) {
+            checkSchoolInbox(context, prefs, studentId);
+        }
         WidgetRefreshScheduler.INSTANCE.ensurePeriodic(context);
+    }
+
+    private String schoolInboxStateKey(String studentId) {
+        return "hbu_bg_school_inbox_state:" + studentId;
+    }
+
+    private void checkSchoolInbox(Context context, SharedPreferences prefs, String studentId) {
+        try {
+            String loginMethod = safe(prefs.getString(KEY_LOGIN_METHOD, "")).toLowerCase(Locale.US);
+            if (!loginMethod.startsWith("chaoxing")) {
+                Log.i(TAG, "school inbox headless skipped: portal mode needs in-app session");
+                return;
+            }
+            String cookie = safe(prefs.getString(KEY_CHAOXING_NOTICE_COOKIE, ""));
+            if (cookie.isEmpty()) {
+                Log.i(TAG, "school inbox headless skipped: missing chaoxing cookie snapshot");
+                return;
+            }
+
+            JSONObject resp = getJsonWithCookie(
+                    "https://notice.chaoxing.com/apis/other/getNoticeList?type=2&crossOrigin=true&pageSize=50",
+                    cookie
+            );
+            if (resp.optInt("result", 0) != 1) {
+                Log.w(TAG, "school inbox headless failed: " + resp.optString("msg", "unknown"));
+                return;
+            }
+
+            JSONArray list = resp.optJSONObject("data") != null
+                    && resp.optJSONObject("data").optJSONObject("notices") != null
+                    ? resp.optJSONObject("data").optJSONObject("notices").optJSONArray("list")
+                    : null;
+            if (list == null) list = new JSONArray();
+
+            String stateKey = schoolInboxStateKey(studentId);
+            JSONArray known = new JSONArray(safe(prefs.getString(stateKey, "[]")));
+            List<String> knownIds = new ArrayList<>();
+            for (int i = 0; i < known.length(); i++) {
+                String id = safe(known.optString(i, ""));
+                if (!id.isEmpty()) knownIds.add(id);
+            }
+            boolean isFirstSync = knownIds.isEmpty();
+
+            List<String> allIds = new ArrayList<>();
+            List<JSONObject> freshItems = new ArrayList<>();
+            for (int i = 0; i < list.length(); i++) {
+                JSONObject item = list.optJSONObject(i);
+                if (item == null) continue;
+                String rawId = safe(item.optString("id", ""));
+                if (rawId.isEmpty()) continue;
+                String normalizedId = "chaoxing:notice:" + rawId;
+                allIds.add(normalizedId);
+                if (!isFirstSync && !knownIds.contains(normalizedId)) {
+                    freshItems.add(item);
+                }
+            }
+
+            for (JSONObject item : freshItems) {
+                String title = safe(item.optString("title", "学校通知"));
+                String body = safe(item.optString("content", "你有新的学习通消息"));
+                if (body.length() > 160) body = body.substring(0, 159) + "…";
+                sendNotification(context, title, body);
+            }
+
+            JSONArray nextKnown = new JSONArray();
+            int limit = Math.min(allIds.size(), 500);
+            for (int i = 0; i < limit; i++) {
+                nextKnown.put(allIds.get(i));
+            }
+            prefs.edit().putString(stateKey, nextKnown.toString()).apply();
+            Log.i(TAG, "school inbox headless checked total=" + allIds.size() + " fresh=" + freshItems.size());
+        } catch (Exception e) {
+            Log.w(TAG, "checkSchoolInbox failed: " + e.getMessage());
+        }
+    }
+
+    private JSONObject getJsonWithCookie(String url, String cookie) throws Exception {
+        HttpURLConnection conn = null;
+        try {
+            URL endpoint = new URL(url);
+            conn = (HttpURLConnection) endpoint.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(15000);
+            conn.setRequestProperty("Accept", "application/json, text/plain, */*");
+            conn.setRequestProperty("Cookie", cookie);
+            conn.setRequestProperty("Referer", "https://i.chaoxing.com/");
+
+            int status = conn.getResponseCode();
+            InputStream stream = status >= 200 && status < 300 ? conn.getInputStream() : conn.getErrorStream();
+            String text = readText(stream);
+            if (text.isEmpty()) return new JSONObject();
+            return new JSONObject(text);
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
     }
 
     private void checkGrade(Context context, SharedPreferences prefs, String apiBase, String studentId) {

--- a/docs/school-inbox-api-notes.md
+++ b/docs/school-inbox-api-notes.md
@@ -1,0 +1,117 @@
+# 学校消息中心 API 调研笔记
+
+> 来源：本地抓包 `captures/network_capture_20260330_101304.csv`、`network_capture_20260323_085734.csv` 与门户/教务页面 JS 静态分析。Cookie 值不入库。
+
+## 分流规则
+
+| 登录方式（`hbu_login_method`） | 数据源 | 会话 |
+|--------------------------------|--------|------|
+| `portal_*` | 教务 `jwxt.hbut.edu.cn` 通知列表 | 现有教务 Cookie（`jw_uf` 等） |
+| `chaoxing_*` | 学习通 `notice.chaoxing.com` 收件箱 API | `ensure_chaoxing_session_for_checkin` |
+
+Rust 以 Cookie 有效性为最终判据；`login_mode` 仅作路由提示。
+
+---
+
+## 门户 / 教务（强智 jwxt）
+
+### 通知公告列表（主列表 API）
+
+- **URL**：`GET {jwxt_base}/admin/system/tzsjx/ajaxList`
+- **Query**（示例）：
+  - `gridtype=jqgrid`
+  - `queryFields=id,dqstatus,collectstatus,title,content,releaseDate,`
+  - `_search=false`
+  - `page.size=500`
+  - `page.pn=1`
+  - `sort=id`
+  - `order=desc`
+- **Headers**：
+  - `X-Requested-With: XMLHttpRequest`
+  - `Referer: {jwxt_base}/admin/`
+- **响应**（JSON）：
+  - `results`: 数组，元素字段：
+    - `id` — 唯一 ID（字符串或数字）
+    - `title` — 标题
+    - `content` — 正文摘要
+    - `releaseDate` — 发布时间
+    - `dqstatus` — 阅读状态（`0` 未读 / `1` 已读，以实网为准）
+- **归一化 ID**：`portal:tzsjx:{id}`
+
+### 红点计数（非列表，仅辅助）
+
+- `GET {jwxt_base}/admin/workcenter/message/getTotalRedCount`
+- 响应 body 为纯数字 JSON（如 `0`）
+
+### 消息中心入口（页面，非 API）
+
+- `/admin/workcenter/homepage/list?center=msg`
+- 未读快捷列表 JS 引用：`/admin/getWdxxList`（抓包中未见到实网列表响应，实现以 `tzsjx/ajaxList` 为准）
+
+---
+
+## 学习通（chaoxing）
+
+### 通知列表
+
+- **URL**：`GET https://notice.chaoxing.com/apis/other/getNoticeList`
+- **Query**：
+  - `type=2`
+  - `crossOrigin=true`
+  - `pageSize=30`（可增大，建议 ≤50）
+  - 可选分页：`lastGetId`（响应 `data.notices.lastGetId`）
+- **Headers**：
+  - `Accept: application/json`
+  - Cookie：需 `UID` / `vc3` / `uf` 等学习通域 Cookie（由 Rust 会话复用）
+- **响应**（JSON）：
+  - `result`: `1` 成功
+  - `data.notices.list[]`：
+    - `id` — 数字唯一 ID
+    - `title` — 标题
+    - `content` — 纯文本摘要
+    - `sendTime` — 发送时间字符串
+    - `isread` — `1` 已读 / `0` 未读
+    - `uuid` — 备用唯一键
+- **归一化 ID**：`chaoxing:notice:{id}`
+
+### 未读计数（辅助）
+
+- `GET https://i.chaoxing.com/base/getNoticeCount`（门户首页亦有 `e.hbut.edu.cn/getMessageCount`）
+
+---
+
+## 归一化结构（应用内）
+
+```json
+{
+  "items": [
+    {
+      "id": "chaoxing:notice:1048653913",
+      "title": "...",
+      "summary": "...",
+      "created_at": "2026-03-18 19:32:42",
+      "is_read": true,
+      "source": "chaoxing"
+    }
+  ],
+  "fetched_at": "2026-06-25T12:00:00+08:00",
+  "source": "chaoxing"
+}
+```
+
+`source` 取值：`portal` | `chaoxing`。
+
+---
+
+## 分页与基线策略
+
+- 首次拉取：写入全部 `id` 到 `hbu_notify_school_inbox_state:{studentId}`，**不推送**。
+- 后续：仅 `id` 不在快照中的条目入队本地通知。
+- 门户列表默认 `page.size=500`；学习通默认 `pageSize=30`，可按 `lastGetId` 追加（首版单次请求即可）。
+
+---
+
+## 风险
+
+- 教务工作台 `center=msg` 的独立列表 API 未在抓包中确认；当前以 `tzsjx/ajaxList` 覆盖门户登录场景。
+- Android Headless 无 Rust Cookie 时仅能依赖前台同步的 Cookie 快照与去重状态（见 `background_fetch.js`）。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.0", features = [] }
+tauri = { version = "2.0", features = ["unstable"] }
 tauri-plugin-fs = "2.0"
 tauri-plugin-shell = "2.0"
 tauri-plugin-notification = "2.0"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -5,6 +5,13 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:webview:allow-create-webview",
+    "core:webview:allow-webview-close",
+    "core:webview:allow-webview-show",
+    "core:webview:allow-webview-hide",
+    "core:webview:allow-set-webview-position",
+    "core:webview:allow-set-webview-size",
+    "core:webview:allow-set-webview-auto-resize",
     "notification:default",
     "notification:allow-request-permission",
     "notification:allow-is-permission-granted",

--- a/src-tauri/src/http_client/mod.rs
+++ b/src-tauri/src/http_client/mod.rs
@@ -171,6 +171,16 @@ impl HbutClient {
         self.prefer_chaoxing_jwxt = enabled;
     }
 
+    /// 供业务模块发起教务域 HTTP 请求（如学校消息抓取）。
+    pub(crate) fn http_client(&self) -> &Client {
+        &self.client
+    }
+
+    /// 当前应使用的教务系统根地址。
+    pub(crate) fn jwxt_base_url(&self) -> &'static str {
+        self.academic_base_url()
+    }
+
     fn build_http_client(jar: Arc<Jar>) -> Client {
         Client::builder()
             .cookie_store(true)

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -588,6 +588,8 @@ async fn run_http_server(state: HttpState) -> Result<(), Box<dyn std::error::Err
         .route("/library/search", post(search_library_books))
         .route("/library/detail", post(fetch_library_book_detail))
         .route("/towergo/*path", any(towergo_proxy))
+        .route("/school-website", any(school_website_proxy_root))
+        .route("/school-website/", any(school_website_proxy_root))
         .route("/school-website/*path", any(school_website_proxy))
         .route("/resource_share/direct_url", get(resource_share_direct_url))
         .route("/resource_share/proxy", get(resource_share_proxy))
@@ -2449,6 +2451,15 @@ fn school_website_sanitize_request_headers(headers: &HeaderMap) -> HeaderMap {
         );
     }
     out
+}
+
+async fn school_website_proxy_root(
+    method: Method,
+    raw_query: RawQuery,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
+    school_website_proxy(method, Path(String::new()), raw_query, headers, body).await
 }
 
 async fn school_website_proxy(

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -588,6 +588,7 @@ async fn run_http_server(state: HttpState) -> Result<(), Box<dyn std::error::Err
         .route("/library/search", post(search_library_books))
         .route("/library/detail", post(fetch_library_book_detail))
         .route("/towergo/*path", any(towergo_proxy))
+        .route("/school-website/*path", any(school_website_proxy))
         .route("/resource_share/direct_url", get(resource_share_direct_url))
         .route("/resource_share/proxy", get(resource_share_proxy))
         .route("/electricity_query_location", post(electricity_query_location))
@@ -2301,6 +2302,7 @@ fn encode_resource_share_path(path: &str) -> String {
 }
 
 const TOWERGO_TARGET_BASE: &str = "https://ebike-oper.chinatowercom.cn";
+const HBUT_WEBSITE_TARGET_BASE: &str = "https://www.hbut.edu.cn";
 const TOWERGO_TARGET_HOST: &str = "ebike-oper.chinatowercom.cn";
 const TOWERGO_APP_ID: &str = "wx278283883c249e3e";
 const TOWERGO_MINIPROGRAM_REFERER: &str = "https://servicewechat.com/wx278283883c249e3e/47/page-frame.html";
@@ -2399,6 +2401,136 @@ fn towergo_copy_response_header(name: &str) -> bool {
             | "last-modified"
             | "set-cookie"
     )
+}
+
+fn school_website_copy_response_header(name: &str) -> bool {
+    matches!(
+        name,
+        "content-type"
+            | "content-length"
+            | "cache-control"
+            | "etag"
+            | "last-modified"
+            | "set-cookie"
+            | "content-encoding"
+            | "accept-ranges"
+            | "content-language"
+    )
+}
+
+fn school_website_sanitize_request_headers(headers: &HeaderMap) -> HeaderMap {
+    let mut out = HeaderMap::new();
+    for key in [
+        "accept",
+        "accept-language",
+        "cache-control",
+        "if-modified-since",
+        "if-none-match",
+        "range",
+        "user-agent",
+        "referer",
+    ] {
+        if let Some(value) = headers.get(key) {
+            out.insert(key, value.clone());
+        }
+    }
+    if !out.contains_key("accept") {
+        out.insert(
+            HeaderName::from_static("accept"),
+            HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
+        );
+    }
+    if !out.contains_key("user-agent") {
+        out.insert(
+            HeaderName::from_static("user-agent"),
+            HeaderValue::from_static(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            ),
+        );
+    }
+    out
+}
+
+async fn school_website_proxy(
+    method: Method,
+    Path(path): Path<String>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
+    if method == Method::OPTIONS {
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::NO_CONTENT;
+        return Ok(response);
+    }
+
+    let clean_path = path.trim_start_matches('/');
+    if clean_path.contains("..") {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "参数错误",
+            "学校官网代理路径非法".to_string(),
+        ));
+    }
+
+    let remote_url = match query {
+        Some(q) if !q.trim().is_empty() => {
+            if clean_path.is_empty() {
+                format!("{}/?{}", HBUT_WEBSITE_TARGET_BASE, q)
+            } else {
+                format!("{}/{}?{}", HBUT_WEBSITE_TARGET_BASE, clean_path, q)
+            }
+        }
+        _ => {
+            if clean_path.is_empty() {
+                format!("{}/", HBUT_WEBSITE_TARGET_BASE)
+            } else {
+                format!("{}/{}", HBUT_WEBSITE_TARGET_BASE, clean_path)
+            }
+        }
+    };
+
+    let request_headers = school_website_sanitize_request_headers(&headers);
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(20))
+        .redirect(reqwest::redirect::Policy::limited(8))
+        .build()
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, "系统错误", format!("创建学校官网代理客户端失败: {}", e)))?;
+
+    let mut request_builder = client.request(method, remote_url).headers(request_headers);
+    if !body.is_empty() {
+        request_builder = request_builder.body(body);
+    }
+
+    let upstream = request_builder
+        .send()
+        .await
+        .map_err(|e| err(StatusCode::BAD_GATEWAY, "代理错误", format!("学校官网代理请求失败: {}", e)))?;
+
+    let status = upstream.status();
+    let upstream_headers = upstream.headers().clone();
+    let mut response = if status.is_success() {
+        let stream = upstream
+            .bytes_stream()
+            .map(|chunk| chunk.map_err(|e| std::io::Error::new(ErrorKind::Other, e.to_string())));
+        let mut resp = Response::new(Body::from_stream(stream));
+        *resp.status_mut() = status;
+        resp
+    } else {
+        let body_bytes = upstream.bytes().await.unwrap_or_default();
+        let mut resp = Response::new(Body::from(body_bytes));
+        *resp.status_mut() = status;
+        resp
+    };
+
+    for (name, value) in upstream_headers.iter() {
+        let lower = name.as_str().to_ascii_lowercase();
+        if school_website_copy_response_header(&lower) {
+            response.headers_mut().insert(name.clone(), value.clone());
+        }
+    }
+    Ok(response)
 }
 
 async fn towergo_proxy(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3071,6 +3071,10 @@ async fn cache_remote_image(
 
 #[tauri::command]
 fn open_external_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
+    open_external_url_impl(&app, &url)
+}
+
+pub(crate) fn open_external_url_impl(app: &tauri::AppHandle, url: &str) -> Result<(), String> {
     let mut target = url.trim().to_string();
     if target.is_empty() {
         return Err("url is empty".to_string());
@@ -6104,6 +6108,9 @@ pub fn run() {
             debug_bridge::complete_debug_state,
             debug_bridge::save_debug_capture_file,
             open_external_url,
+            modules::school_website_embed::school_website_embed_open,
+            modules::school_website_embed::school_website_embed_resize,
+            modules::school_website_embed::school_website_embed_close,
             prepare_module_bundle,
             open_file_with_system,
             open_module_bundle_window,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4717,6 +4717,17 @@ async fn fetch_ranking(
 }
 
 #[tauri::command]
+async fn school_inbox_fetch(
+    state: State<'_, AppState>,
+    login_mode: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let mut client = state.client.lock().await;
+    let mode = login_mode.unwrap_or_default();
+    let response = modules::school_inbox::fetch_school_inbox(&mut client, &mode).await?;
+    Ok(serde_json::to_value(response).map_err(|e| e.to_string())?)
+}
+
+#[tauri::command]
 async fn fetch_student_info(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
     let client = state.client.lock().await;
     let uid = client
@@ -6133,6 +6144,7 @@ pub fn run() {
             fetch_exams,
             fetch_ranking,
             fetch_student_info,
+            school_inbox_fetch,
             fetch_personal_login_access_info,
             fetch_semesters,
             fetch_classroom_buildings,

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -21,3 +21,4 @@ pub mod module_bundle;
 pub mod online_learning;
 pub mod chaoxing_checkin;
 pub mod weather;
+pub mod school_inbox;

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -22,3 +22,4 @@ pub mod online_learning;
 pub mod chaoxing_checkin;
 pub mod weather;
 pub mod school_inbox;
+pub mod school_website_embed;

--- a/src-tauri/src/modules/school_inbox.rs
+++ b/src-tauri/src/modules/school_inbox.rs
@@ -1,0 +1,295 @@
+//! 学校消息中心（教务通知 / 学习通收件箱）抓取与归一化。
+
+use crate::http_client::HbutClient;
+use crate::modules::online_learning;
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const CHAOXING_NOTICE_LIST_URL: &str =
+    "https://notice.chaoxing.com/apis/other/getNoticeList?type=2&crossOrigin=true&pageSize=50";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchoolInboxItem {
+    pub id: String,
+    pub title: String,
+    pub summary: String,
+    pub created_at: String,
+    pub is_read: bool,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchoolInboxResponse {
+    pub items: Vec<SchoolInboxItem>,
+    pub fetched_at: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn looks_like_login_redirect(url: &str) -> bool {
+    let lower = url.to_lowercase();
+    lower.contains("authserver/login")
+        || lower.contains("/login")
+            && (lower.contains("cas") || lower.contains("passport"))
+}
+
+fn trim_summary(text: &str, max_len: usize) -> String {
+    let collapsed = text
+        .replace(['\r', '\n'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if collapsed.chars().count() <= max_len {
+        return collapsed;
+    }
+    let mut out = String::new();
+    for ch in collapsed.chars().take(max_len.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    out
+}
+
+fn json_string(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(s)) => s.trim().to_string(),
+        Some(Value::Number(n)) => n.to_string(),
+        Some(Value::Bool(b)) => b.to_string(),
+        _ => String::new(),
+    }
+}
+
+fn is_chaoxing_login_mode(login_mode: &str) -> bool {
+    let mode = login_mode.trim().to_lowercase();
+    mode.starts_with("chaoxing")
+}
+
+pub fn parse_portal_tzsjx_payload(payload: &Value) -> Vec<SchoolInboxItem> {
+    let rows = payload
+        .get("results")
+        .or_else(|| payload.get("rows"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    rows.into_iter()
+        .filter_map(|row| {
+            let id_raw = json_string(row.get("id"));
+            if id_raw.is_empty() {
+                return None;
+            }
+            let title = json_string(row.get("title"));
+            let content = json_string(row.get("content"));
+            let release_date = json_string(row.get("releaseDate"));
+            let dqstatus = json_string(row.get("dqstatus"));
+            let is_read = dqstatus == "1" || dqstatus.eq_ignore_ascii_case("read");
+            Some(SchoolInboxItem {
+                id: format!("portal:tzsjx:{id_raw}"),
+                title: if title.is_empty() {
+                    "教务通知".to_string()
+                } else {
+                    title
+                },
+                summary: trim_summary(&content, 160),
+                created_at: release_date,
+                is_read,
+                source: "portal".to_string(),
+            })
+        })
+        .collect()
+}
+
+pub fn parse_chaoxing_notice_payload(payload: &Value) -> Vec<SchoolInboxItem> {
+    let list = payload
+        .pointer("/data/notices/list")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    list.into_iter()
+        .filter_map(|row| {
+            let id_raw = json_string(row.get("id"));
+            if id_raw.is_empty() {
+                return None;
+            }
+            let title = json_string(row.get("title"));
+            let content = json_string(row.get("content"));
+            let send_time = json_string(row.get("sendTime"));
+            let isread = json_string(row.get("isread"));
+            let is_read = isread == "1";
+            Some(SchoolInboxItem {
+                id: format!("chaoxing:notice:{id_raw}"),
+                title: if title.is_empty() {
+                    "学习通通知".to_string()
+                } else {
+                    title
+                },
+                summary: trim_summary(&content, 160),
+                created_at: send_time,
+                is_read,
+                source: "chaoxing".to_string(),
+            })
+        })
+        .collect()
+}
+
+async fn fetch_portal_inbox(client: &HbutClient) -> Result<Vec<SchoolInboxItem>, String> {
+    let base = client.jwxt_base_url();
+    let url = format!(
+        "{base}/admin/system/tzsjx/ajaxList?gridtype=jqgrid&queryFields=id%2Cdqstatus%2Ccollectstatus%2Ctitle%2Ccontent%2CreleaseDate%2C&_search=false&page.size=500&page.pn=1&sort=id&order=desc"
+    );
+    let referer = format!("{base}/admin/");
+
+    let response = client
+        .http_client()
+        .get(&url)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Accept", "application/json, text/javascript, */*; q=0.01")
+        .header("Referer", referer.clone())
+        .send()
+        .await
+        .map_err(|e| format!("教务通知请求失败: {e}"))?;
+
+    let status = response.status();
+    let final_url = response.url().to_string();
+    if looks_like_login_redirect(&final_url) {
+        return Err("教务会话已过期，请重新登录".into());
+    }
+
+    if !status.is_success() {
+        return Err(format!("教务通知 HTTP {status}"));
+    }
+
+    let text = response
+        .text()
+        .await
+        .map_err(|e| format!("教务通知响应读取失败: {e}"))?;
+    let payload: Value =
+        serde_json::from_str(&text).map_err(|e| format!("教务通知 JSON 解析失败: {e}"))?;
+    Ok(parse_portal_tzsjx_payload(&payload))
+}
+
+async fn fetch_chaoxing_inbox(client: &mut HbutClient, student_id: &str) -> Result<Vec<SchoolInboxItem>, String> {
+    if !online_learning::ensure_chaoxing_session_for_checkin(client, student_id).await {
+        return Err("学习通会话未就绪，请重新登录".into());
+    }
+
+    let response = client
+        .http_client()
+        .get(CHAOXING_NOTICE_LIST_URL)
+        .header("Accept", "application/json, text/plain, */*")
+        .header("Referer", "https://i.chaoxing.com/")
+        .send()
+        .await
+        .map_err(|e| format!("学习通通知请求失败: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!("学习通通知 HTTP {}", response.status()));
+    }
+
+    let text = response
+        .text()
+        .await
+        .map_err(|e| format!("学习通通知响应读取失败: {e}"))?;
+    let payload: Value = serde_json::from_str(&text)
+        .map_err(|e| format!("学习通通知 JSON 解析失败: {e}"))?;
+
+    let result = json_string(payload.get("result"));
+    if result != "1" {
+        let msg = json_string(payload.get("msg"));
+        return Err(if msg.is_empty() {
+            "学习通通知接口返回失败".into()
+        } else {
+            msg
+        });
+    }
+
+    Ok(parse_chaoxing_notice_payload(&payload))
+}
+
+/// 按登录方式抓取学校消息中心并归一化。
+pub async fn fetch_school_inbox(
+    client: &mut HbutClient,
+    login_mode: &str,
+) -> Result<SchoolInboxResponse, String> {
+    let use_chaoxing = is_chaoxing_login_mode(login_mode);
+    client.set_chaoxing_login_mode(use_chaoxing);
+
+    let fetched_at = Local::now().to_rfc3339();
+    let source = if use_chaoxing { "chaoxing" } else { "portal" };
+
+    let items = if use_chaoxing {
+        let sid = client
+            .user_info
+            .as_ref()
+            .map(|u| u.student_id.clone())
+            .unwrap_or_default();
+        if sid.trim().is_empty() {
+            return Err("缺少学号，无法检查学习通消息".into());
+        }
+        fetch_chaoxing_inbox(client, &sid).await?
+    } else {
+        fetch_portal_inbox(client).await?
+    };
+
+    Ok(SchoolInboxResponse {
+        items,
+        fetched_at,
+        source: source.to_string(),
+        error: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_portal_tzsjx_rows() {
+        let payload = json!({
+            "results": [
+                {
+                    "id": "abc123",
+                    "title": "期末考试安排",
+                    "content": "请同学们注意考试时间",
+                    "releaseDate": "2026-03-01",
+                    "dqstatus": "0"
+                }
+            ]
+        });
+        let items = parse_portal_tzsjx_payload(&payload);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "portal:tzsjx:abc123");
+        assert!(!items[0].is_read);
+        assert_eq!(items[0].source, "portal");
+    }
+
+    #[test]
+    fn parse_chaoxing_notice_rows() {
+        let payload = json!({
+            "result": 1,
+            "data": {
+                "notices": {
+                    "list": [
+                        {
+                            "id": 1048653913,
+                            "title": "作业提醒",
+                            "content": "第一章作业已发布",
+                            "sendTime": "2026-03-18 19:32:42",
+                            "isread": 1
+                        }
+                    ]
+                }
+            }
+        });
+        let items = parse_chaoxing_notice_payload(&payload);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "chaoxing:notice:1048653913");
+        assert!(items[0].is_read);
+    }
+}

--- a/src-tauri/src/modules/school_website_embed.rs
+++ b/src-tauri/src/modules/school_website_embed.rs
@@ -1,0 +1,164 @@
+//! 学校官网内嵌子 WebView：全高度展示 + 站外链接外部打开。
+
+use tauri::{
+    AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl,
+    webview::{NewWindowResponse, WebviewBuilder},
+};
+use url::Url;
+
+const EMBED_LABEL: &str = "school-website-embed";
+const START_URL: &str = "https://www.hbut.edu.cn/";
+
+#[derive(Debug, serde::Deserialize)]
+pub struct EmbedBounds {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+fn is_hbut_official_host(host: &str) -> bool {
+    host == "hbut.edu.cn" || host == "www.hbut.edu.cn" || host.ends_with(".hbut.edu.cn")
+}
+
+fn is_embeddable_url(url: &Url) -> bool {
+    match url.scheme() {
+        "http" | "https" => url.host_str().map(is_hbut_official_host).unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn open_external(app: &AppHandle, target: &str) {
+    let _ = crate::open_external_url_impl(app, target);
+}
+
+fn close_embed_if_exists(app: &AppHandle) {
+    if let Some(webview) = app.get_webview(EMBED_LABEL) {
+        let _ = webview.close();
+    }
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub async fn school_website_embed_open(app: AppHandle, bounds: EmbedBounds) -> Result<(), String> {
+    close_embed_if_exists(&app);
+
+    let window = app
+        .get_window("main")
+        .ok_or_else(|| "找不到主窗口".to_string())?;
+    let start_url: Url = START_URL
+        .parse()
+        .map_err(|e| format!("官网地址无效: {}", e))?;
+
+    let app_for_nav = app.clone();
+    let builder = WebviewBuilder::new(EMBED_LABEL, WebviewUrl::External(start_url))
+        .on_navigation({
+            let app_for_nav = app_for_nav.clone();
+            move |url| {
+                if is_embeddable_url(url) {
+                    true
+                } else {
+                    open_external(&app_for_nav, url.as_str());
+                    false
+                }
+            }
+        })
+        .on_new_window({
+            let app_for_nav = app_for_nav.clone();
+            move |url, _features| {
+                if is_embeddable_url(&url) {
+                    if let Some(webview) = app_for_nav.get_webview(EMBED_LABEL) {
+                        let _ = webview.navigate(url);
+                    }
+                    NewWindowResponse::Deny
+                } else {
+                    open_external(&app_for_nav, url.as_str());
+                    NewWindowResponse::Deny
+                }
+            }
+        });
+
+    window
+        .add_child(
+            builder,
+            LogicalPosition::new(bounds.x, bounds.y),
+            LogicalSize::new(bounds.width.max(1.0), bounds.height.max(1.0)),
+        )
+        .map_err(|e| format!("创建学校官网内嵌失败: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub async fn school_website_embed_resize(app: AppHandle, bounds: EmbedBounds) -> Result<(), String> {
+    let webview = app
+        .get_webview(EMBED_LABEL)
+        .ok_or_else(|| "学校官网内嵌未打开".to_string())?;
+    webview
+        .set_position(LogicalPosition::new(bounds.x, bounds.y))
+        .map_err(|e| e.to_string())?;
+    webview
+        .set_size(LogicalSize::new(
+            bounds.width.max(1.0),
+            bounds.height.max(1.0),
+        ))
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub async fn school_website_embed_close(app: AppHandle) -> Result<(), String> {
+    close_embed_if_exists(&app);
+    Ok(())
+}
+
+#[cfg(not(desktop))]
+#[tauri::command]
+pub async fn school_website_embed_open(_app: AppHandle, _bounds: EmbedBounds) -> Result<(), String> {
+    Err("当前平台不支持学校官网内嵌".to_string())
+}
+
+#[cfg(not(desktop))]
+#[tauri::command]
+pub async fn school_website_embed_resize(_app: AppHandle, _bounds: EmbedBounds) -> Result<(), String> {
+    Err("当前平台不支持学校官网内嵌".to_string())
+}
+
+#[cfg(not(desktop))]
+#[tauri::command]
+pub async fn school_website_embed_close(_app: AppHandle) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_hbut_official_hosts() {
+        assert!(is_hbut_official_host("www.hbut.edu.cn"));
+        assert!(is_hbut_official_host("hbut.edu.cn"));
+        assert!(is_hbut_official_host("news.hbut.edu.cn"));
+        assert!(is_hbut_official_host("e.hbut.edu.cn"));
+    }
+
+    #[test]
+    fn rejects_external_hosts() {
+        assert!(!is_hbut_official_host("baidu.com"));
+        assert!(!is_hbut_official_host("github.com"));
+        assert!(!is_hbut_official_host("chaoxing.com"));
+    }
+
+    #[test]
+    fn classifies_embeddable_urls() {
+        let official: Url = "https://www.hbut.edu.cn/xxgk/index.htm".parse().unwrap();
+        let portal: Url = "https://e.hbut.edu.cn/login".parse().unwrap();
+        let external: Url = "https://www.baidu.com/".parse().unwrap();
+
+        assert!(is_embeddable_url(&official));
+        assert!(is_embeddable_url(&portal));
+        assert!(!is_embeddable_url(&external));
+    }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -82,6 +82,8 @@ const loadConfigEditorView = () => import('./components/ConfigEditor.vue')
 const loadSettingsView = () => import('./components/SettingsView.vue')
 const loadExportCenterView = () => import('./components/ExportCenterView.vue')
 const loadServiceStatsView = () => import('./components/ServiceStatsView.vue')
+const loadSchoolWebsiteView = () => import('./components/SchoolWebsiteView.vue')
+const loadQuickLinksView = () => import('./components/QuickLinksView.vue')
 const loadMoreView = () => import('./components/MoreView.vue')
 const loadMoreModuleHostView = () => import('./components/MoreModuleHostView.vue')
 const loadMoreChaoxingCheckinView = () => import('./components/MoreChaoxingCheckinView.vue')
@@ -115,6 +117,8 @@ const ConfigEditor = createAsyncPage(loadConfigEditorView)
 const SettingsView = createAsyncPage(loadSettingsView)
 const ExportCenterView = createAsyncPage(loadExportCenterView)
 const ServiceStatsView = createAsyncPage(loadServiceStatsView)
+const SchoolWebsiteView = createAsyncPage(loadSchoolWebsiteView)
+const QuickLinksView = createAsyncPage(loadQuickLinksView)
 const MoreView = createAsyncPage(loadMoreView)
 const MoreModuleHostView = createAsyncPage(loadMoreModuleHostView)
 const MoreChaoxingCheckinView = createAsyncPage(loadMoreChaoxingCheckinView)
@@ -174,6 +178,8 @@ const ME_SUB_VIEWS = [
   'settings',
   'export_center',
   'service_stats',
+  'school_website',
+  'quick_links',
   'more',
   'more_module_host',
   'more_chaoxing_checkin'
@@ -190,6 +196,8 @@ const HIERARCHICAL_PARENT_VIEW_MAP = Object.freeze({
   settings: 'me',
   export_center: 'me',
   service_stats: 'me',
+  school_website: 'me',
+  quick_links: 'me',
   more: 'me',
   more_module_host: 'more',
   more_chaoxing_checkin: 'more'
@@ -212,6 +220,8 @@ const VIEW_PREFETCHERS = Object.freeze({
   settings: loadSettingsView,
   export_center: loadExportCenterView,
   service_stats: loadServiceStatsView,
+  school_website: loadSchoolWebsiteView,
+  quick_links: loadQuickLinksView,
   more: loadMoreView,
   more_module_host: loadMoreModuleHostView,
   more_chaoxing_checkin: loadMoreChaoxingCheckinView,
@@ -2936,6 +2946,16 @@ onBeforeUnmount(() => {
 
       <ServiceStatsView
         v-else-if="currentView === 'service_stats'"
+        @back="handleBackToMe"
+      />
+
+      <SchoolWebsiteView
+        v-else-if="currentView === 'school_website'"
+        @back="handleBackToMe"
+      />
+
+      <QuickLinksView
+        v-else-if="currentView === 'quick_links'"
         @back="handleBackToMe"
       />
 

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -63,6 +63,8 @@ const handleOpenConfig = () => emit('openConfig')
 const handleOpenSettings = () => emit('openSettings')
 const handleOpenExport = () => emit('navigate', 'export_center')
 const handleOpenServiceStats = () => emit('navigate', 'service_stats')
+const handleOpenSchoolWebsite = () => emit('navigate', 'school_website')
+const handleOpenQuickLinks = () => emit('navigate', 'quick_links')
 const handleOpenMore = () => emit('navigate', 'more')
 const isConfigAdmin = () => Array.isArray(props.configAdminIds) && props.configAdminIds.includes(props.studentId)
 
@@ -151,6 +153,18 @@ const handleShowLegal = async (tab) => {
           <span class="material-symbols-outlined" style="color: #1E8E3E;">download</span>
         </div>
         <span class="grid-label">导出中心</span>
+      </button>
+      <button class="grid-item" @click="handleOpenSchoolWebsite">
+        <div class="grid-icon-box" style="background: #E8EAF6;">
+          <span class="material-symbols-outlined" style="color: #3949AB;">language</span>
+        </div>
+        <span class="grid-label">学校官网</span>
+      </button>
+      <button class="grid-item" @click="handleOpenQuickLinks">
+        <div class="grid-icon-box" style="background: #E0F7FA;">
+          <span class="material-symbols-outlined" style="color: #00838F;">link</span>
+        </div>
+        <span class="grid-label">快捷链接</span>
       </button>
       <button v-if="isLoggedIn" class="grid-item" @click="handleOpenServiceStats">
         <div class="grid-icon-box" style="background: #E0F2F1;">

--- a/src/components/NotificationView.vue
+++ b/src/components/NotificationView.vue
@@ -43,6 +43,7 @@ const enableExamReminders = ref(true)
 const enableGradeNotices = ref(true)
 const enablePowerNotices = ref(true)
 const enableClassReminders = ref(true)
+const enableSchoolInboxNotices = ref(true)
 const classLeadMinutes = ref(30)
 const checkInterval = ref(30)
 const showBatteryPrompt = ref(false)
@@ -118,6 +119,7 @@ const saveSettings = () => {
   localStorage.setItem('hbu_notify_grade', enableGradeNotices.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_power', enablePowerNotices.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_class', enableClassReminders.value ? 'true' : 'false')
+  localStorage.setItem('hbu_notify_school_inbox', enableSchoolInboxNotices.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_class_lead_min', String(classLeadMinutes.value))
   localStorage.setItem('hbu_notify_interval', String(checkInterval.value))
   syncBackgroundFetchContext({
@@ -128,6 +130,7 @@ const saveSettings = () => {
       enableGradeNotice: enableGradeNotices.value,
       enablePowerNotice: enablePowerNotices.value,
       enableClassReminder: enableClassReminders.value,
+      enableSchoolInbox: enableSchoolInboxNotices.value,
       classLeadMinutes: classLeadMinutes.value,
       intervalMinutes: checkInterval.value
     },
@@ -142,6 +145,7 @@ const updateSettingsFromStorage = () => {
   enableGradeNotices.value = !!settings.enableGradeNotice
   enablePowerNotices.value = !!settings.enablePowerNotice
   enableClassReminders.value = !!settings.enableClassReminder
+  enableSchoolInboxNotices.value = settings.enableSchoolInbox !== false
   classLeadMinutes.value = [5, 10, 15, 20, 30, 45, 60].includes(Number(settings.classLeadMinutes))
     ? Number(settings.classLeadMinutes)
     : 30
@@ -197,6 +201,7 @@ const formatNotifyExamTime = (timeStr) => {
 }
 
 const classSummary = computed(() => snapshot.value?.classReminder || {})
+const schoolInboxSummary = computed(() => snapshot.value?.schoolInbox || {})
 const powerSummary = computed(() => snapshot.value?.electricity || {})
 
 const powerQuantityText = computed(() => {
@@ -279,7 +284,8 @@ const orderedInfoCards = computed(() => {
     class_reminder: { key: 'class_reminder' },
     electricity: { key: 'electricity' },
     grades: { key: 'grades' },
-    exams: { key: 'exams' }
+    exams: { key: 'exams' },
+    school_inbox: { key: 'school_inbox' }
   }
   return notificationCardsOrder.value
     .map((key) => cardMap[key])
@@ -303,7 +309,8 @@ const getNotificationCollisionPalette = (activeKey, targetKey = '') => {
     class_reminder: ['#5b8cff', '#8fd6ff', '#c4b5fd'],
     electricity: ['#22c55e', '#86efac', '#bef264'],
     grades: ['#f59e0b', '#fcd34d', '#fdba74'],
-    exams: ['#ef4444', '#fda4af', '#fbbf24']
+    exams: ['#ef4444', '#fda4af', '#fbbf24'],
+    school_inbox: ['#6366f1', '#a5b4fc', '#c4b5fd']
   }
   return resolveCollisionPalette(paletteMap[activeKey], paletteMap[targetKey], '#8fd6ff')
 }
@@ -923,6 +930,23 @@ watch(
                 <p class="notify-type-desc">课前 {{ classLeadMinutes }} 分钟提醒</p>
               </div>
             </div>
+
+            <!-- School Inbox Alerts -->
+            <div v-if="card.key === 'school_inbox'" class="notify-type-card">
+              <div class="notify-type-top">
+                <div class="notify-type-icon icon-indigo">
+                  <span class="material-symbols-outlined fill">mail</span>
+                </div>
+                <label class="toggle-switch" @click.stop>
+                  <input type="checkbox" v-model="enableSchoolInboxNotices" @change="handleOtherSettingChange">
+                  <span class="toggle-track"></span>
+                </label>
+              </div>
+              <div class="notify-type-body">
+                <h4 class="notify-type-name">学校消息</h4>
+                <p class="notify-type-desc">教务/学习通消息中心新通知</p>
+              </div>
+            </div>
           </SortableSurface>
           <LayoutCollisionFxLayer :particles="notificationCollisionFx" />
         </div>
@@ -1044,6 +1068,29 @@ watch(
                   </span>
                 </li>
               </ul>
+            </div>
+          </div>
+        </div>
+
+        <!-- School Inbox Card -->
+        <div v-if="schoolInboxSummary?.enabled" class="notify-message-card">
+          <div class="notify-msg-left">
+            <div class="notify-msg-icon icon-indigo">
+              <span class="material-symbols-outlined fill">mail</span>
+            </div>
+            <div class="notify-msg-body">
+              <div class="notify-msg-head">
+                <h4 class="notify-msg-title" :class="{ bold: schoolInboxSummary?.triggered > 0 }">
+                  {{ schoolInboxSummary?.triggered > 0 ? '新学校消息' : '学校消息' }}
+                </h4>
+                <span class="notify-msg-time">{{ lastCheckText }}</span>
+              </div>
+              <p class="notify-msg-text">
+                共 {{ schoolInboxSummary?.total || 0 }} 条
+                <template v-if="schoolInboxSummary?.source">（{{ schoolInboxSummary.source === 'chaoxing' ? '学习通' : '教务' }}）</template>
+                · 本次新增 {{ schoolInboxSummary?.triggered || 0 }} 条
+              </p>
+              <p v-if="schoolInboxSummary?.error" class="notify-msg-text warn">{{ schoolInboxSummary.error }}</p>
             </div>
           </div>
         </div>
@@ -1236,6 +1283,11 @@ watch(
 .icon-sky {
   background: rgba(56, 189, 248, 0.1);
   color: #38bdf8;
+}
+
+.icon-indigo {
+  background: rgba(99, 102, 241, 0.1);
+  color: #6366f1;
 }
 
 .notify-type-body h4 {

--- a/src/components/QuickLinksView.vue
+++ b/src/components/QuickLinksView.vue
@@ -1,0 +1,203 @@
+<script setup>
+import { openExternal } from '../utils/external_link'
+import { showToast } from '../utils/toast'
+
+const emit = defineEmits(['back'])
+
+const quickLinks = [
+  {
+    id: 'portal',
+    title: '新融合门户',
+    subtitle: '湖北工业大学统一身份认证与办事入口',
+    url: 'https://e.hbut.edu.cn/',
+    icon: 'account_balance',
+    iconBg: '#E8F0FE',
+    iconColor: '#1A73E8'
+  },
+  {
+    id: 'chaoxing',
+    title: '学习通',
+    subtitle: '超星学习通网页版',
+    url: 'https://i.chaoxing.com/',
+    icon: 'school',
+    iconBg: '#E6F4EA',
+    iconColor: '#1E8E3E'
+  }
+]
+
+const handleOpenLink = async (link) => {
+  const ok = await openExternal(link.url)
+  if (!ok) {
+    showToast(`无法打开「${link.title}」，请稍后重试`, 'error')
+  }
+}
+</script>
+
+<template>
+  <div class="quick-links-view">
+    <header class="subpage-header">
+      <button class="back-button" type="button" @click="emit('back')" aria-label="返回">
+        <span class="material-symbols-outlined">arrow_back</span>
+      </button>
+      <div class="header-copy">
+        <span class="header-kicker">我的</span>
+        <h1>快捷链接</h1>
+      </div>
+      <span class="header-spacer" aria-hidden="true"></span>
+    </header>
+
+    <p class="intro">常用校园系统入口，点击后在系统浏览器中打开。</p>
+
+    <section class="links-list" aria-label="快捷链接列表">
+      <button
+        v-for="link in quickLinks"
+        :key="link.id"
+        class="link-card"
+        type="button"
+        @click="handleOpenLink(link)"
+      >
+        <div class="link-icon-box" :style="{ background: link.iconBg }">
+          <span class="material-symbols-outlined" :style="{ color: link.iconColor }">{{ link.icon }}</span>
+        </div>
+        <div class="link-copy">
+          <strong>{{ link.title }}</strong>
+          <span>{{ link.subtitle }}</span>
+        </div>
+        <span class="material-symbols-outlined link-arrow">open_in_new</span>
+      </button>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.quick-links-view {
+  min-height: calc(var(--app-vh, 1vh) * 100);
+  min-height: 100dvh;
+  padding: 16px 16px 120px;
+  background: var(--ui-bg-gradient, #f9f9ff);
+}
+
+.subpage-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.back-button {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ui-primary, #2563eb) 8%, #ffffff 92%);
+  color: var(--ui-primary, #2563eb);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.header-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.header-kicker {
+  display: block;
+  margin-bottom: 2px;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.header-copy h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #0f172a;
+}
+
+.header-spacer {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+}
+
+.intro {
+  margin: 0 0 16px;
+  color: #64748b;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.links-list {
+  display: grid;
+  gap: 12px;
+}
+
+.link-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.link-card:active {
+  transform: scale(0.98);
+}
+
+.link-icon-box {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.link-icon-box .material-symbols-outlined {
+  font-size: 26px;
+}
+
+.link-copy {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.link-copy strong {
+  color: #0f172a;
+  font-size: 16px;
+}
+
+.link-copy span {
+  color: #64748b;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.link-arrow {
+  color: #94a3b8;
+  font-size: 20px;
+  flex: 0 0 auto;
+}
+
+@media (min-width: 720px) {
+  .quick-links-view {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+}
+</style>

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -1,0 +1,244 @@
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { openExternal } from '../utils/external_link'
+
+const emit = defineEmits(['back'])
+
+const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'
+
+const frameRef = ref(null)
+const loading = ref(true)
+const loadError = ref('')
+const loadHint = ref('')
+
+let loadingGuardTimer = null
+
+const clearLoadingGuardTimer = () => {
+  if (loadingGuardTimer) {
+    clearTimeout(loadingGuardTimer)
+    loadingGuardTimer = null
+  }
+}
+
+const resetFrameState = () => {
+  clearLoadingGuardTimer()
+  loading.value = true
+  loadError.value = ''
+  loadHint.value = ''
+
+  loadingGuardTimer = window.setTimeout(() => {
+    if (!loading.value) return
+    loading.value = false
+    loadHint.value = '页面加载较慢，若长时间空白可尝试在浏览器中打开。'
+  }, 4500)
+}
+
+const handleLoad = () => {
+  clearLoadingGuardTimer()
+  loading.value = false
+  loadError.value = ''
+  loadHint.value = ''
+}
+
+const handleError = () => {
+  clearLoadingGuardTimer()
+  loading.value = false
+  loadError.value = '官网页面无法在应用内嵌入显示，请点击下方按钮在浏览器中打开。'
+  loadHint.value = ''
+}
+
+const handleOpenExternal = async () => {
+  await openExternal(SCHOOL_WEBSITE_URL)
+}
+
+onMounted(() => {
+  resetFrameState()
+})
+
+onBeforeUnmount(() => {
+  clearLoadingGuardTimer()
+})
+</script>
+
+<template>
+  <div class="school-website-view">
+    <header class="subpage-header">
+      <button class="back-button" type="button" @click="emit('back')" aria-label="返回">
+        <span class="material-symbols-outlined">arrow_back</span>
+      </button>
+      <div class="header-copy">
+        <span class="header-kicker">我的</span>
+        <h1>学校官网</h1>
+      </div>
+      <button class="external-button" type="button" @click="handleOpenExternal" aria-label="在浏览器中打开">
+        <span class="material-symbols-outlined">open_in_new</span>
+      </button>
+    </header>
+
+    <div class="frame-shell">
+      <div v-if="loading" class="frame-overlay">
+        <span class="material-symbols-outlined spinning">progress_activity</span>
+        <p>正在加载学校官网…</p>
+      </div>
+
+      <div v-if="loadError" class="frame-message frame-message--error">
+        <p>{{ loadError }}</p>
+        <button class="external-open-btn" type="button" @click="handleOpenExternal">在浏览器中打开</button>
+      </div>
+
+      <div v-else-if="loadHint" class="frame-message frame-message--hint">
+        <p>{{ loadHint }}</p>
+        <button class="external-open-btn" type="button" @click="handleOpenExternal">在浏览器中打开</button>
+      </div>
+
+      <iframe
+        ref="frameRef"
+        class="website-frame"
+        :src="SCHOOL_WEBSITE_URL"
+        title="湖北工业大学官网"
+        allowfullscreen
+        referrerpolicy="no-referrer-when-downgrade"
+        loading="eager"
+        @load="handleLoad"
+        @error="handleError"
+      ></iframe>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.school-website-view {
+  min-height: calc(var(--app-vh, 1vh) * 100);
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--ui-bg-gradient, #f9f9ff);
+  overflow: hidden;
+}
+
+.subpage-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 16px 12px;
+  flex: 0 0 auto;
+}
+
+.back-button,
+.external-button {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ui-primary, #2563eb) 8%, #ffffff 92%);
+  color: var(--ui-primary, #2563eb);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.header-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.header-kicker {
+  display: block;
+  margin-bottom: 2px;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.header-copy h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #0f172a;
+}
+
+.frame-shell {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  margin: 0 12px 12px;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+}
+
+.website-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+  background: #ffffff;
+}
+
+.frame-overlay,
+.frame-message {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+}
+
+.frame-overlay {
+  background: color-mix(in srgb, #ffffff 88%, transparent);
+  color: #475569;
+}
+
+.frame-overlay p,
+.frame-message p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.frame-message--error {
+  background: color-mix(in srgb, #ffffff 94%, #fee2e2 6%);
+  color: #7f1d1d;
+}
+
+.frame-message--hint {
+  top: auto;
+  bottom: 0;
+  height: auto;
+  background: color-mix(in srgb, #ffffff 90%, var(--ui-primary, #2563eb) 10%);
+  color: #334155;
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.external-open-btn {
+  border: none;
+  border-radius: 12px;
+  padding: 10px 18px;
+  background: var(--ui-primary, #2563eb);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.spinning {
+  font-size: 28px;
+  color: var(--ui-primary, #2563eb);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -1,17 +1,27 @@
 <script setup>
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { openExternal } from '../utils/external_link'
+import {
+  SCHOOL_WEBSITE_URL,
+  mountSchoolWebsiteEmbed,
+  resolveSchoolWebsiteEmbedMode,
+  resolveSchoolWebsiteIframeUrl
+} from '../utils/school_website_embed'
 
 const emit = defineEmits(['back'])
 
-const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'
-
-const frameRef = ref(null)
+const frameShellRef = ref(null)
+const embedMode = ref('direct-iframe')
 const loading = ref(true)
 const loadError = ref('')
 const loadHint = ref('')
+const useNativeEmbed = computed(() => embedMode.value === 'tauri-webview')
+const iframeSrc = computed(() =>
+  resolveSchoolWebsiteIframeUrl(embedMode.value === 'proxy-iframe' ? 'proxy-iframe' : 'direct-iframe')
+)
 
 let loadingGuardTimer = null
+let embedCleanup = null
 
 const clearLoadingGuardTimer = () => {
   if (loadingGuardTimer) {
@@ -20,20 +30,21 @@ const clearLoadingGuardTimer = () => {
   }
 }
 
-const resetFrameState = () => {
+const resetIframeState = () => {
   clearLoadingGuardTimer()
   loading.value = true
   loadError.value = ''
   loadHint.value = ''
 
   loadingGuardTimer = window.setTimeout(() => {
-    if (!loading.value) return
+    if (!loading.value || useNativeEmbed.value) return
     loading.value = false
     loadHint.value = '页面加载较慢，若长时间空白可尝试在浏览器中打开。'
   }, 4500)
 }
 
 const handleLoad = () => {
+  if (useNativeEmbed.value) return
   clearLoadingGuardTimer()
   loading.value = false
   loadError.value = ''
@@ -41,6 +52,7 @@ const handleLoad = () => {
 }
 
 const handleError = () => {
+  if (useNativeEmbed.value) return
   clearLoadingGuardTimer()
   loading.value = false
   loadError.value = '官网页面无法在应用内嵌入显示，请点击下方按钮在浏览器中打开。'
@@ -51,12 +63,50 @@ const handleOpenExternal = async () => {
   await openExternal(SCHOOL_WEBSITE_URL)
 }
 
+const cleanupEmbed = async () => {
+  clearLoadingGuardTimer()
+  if (embedCleanup) {
+    const cleanup = embedCleanup
+    embedCleanup = null
+    await cleanup()
+  }
+}
+
+const mountEmbed = async () => {
+  const container = frameShellRef.value
+  if (!container) return
+
+  embedMode.value = await resolveSchoolWebsiteEmbedMode()
+
+  if (embedMode.value === 'tauri-webview') {
+    try {
+      const mounted = await mountSchoolWebsiteEmbed({
+        container,
+        onReady: () => {
+          loading.value = false
+          loadError.value = ''
+          loadHint.value = ''
+        },
+        onError: (message) => {
+          loadError.value = message
+        }
+      })
+      embedCleanup = mounted.cleanup
+      return
+    } catch {
+      embedMode.value = 'proxy-iframe'
+    }
+  }
+
+  resetIframeState()
+}
+
 onMounted(() => {
-  resetFrameState()
+  void mountEmbed()
 })
 
 onBeforeUnmount(() => {
-  clearLoadingGuardTimer()
+  void cleanupEmbed()
 })
 </script>
 
@@ -75,7 +125,7 @@ onBeforeUnmount(() => {
       </button>
     </header>
 
-    <div class="frame-shell">
+    <div ref="frameShellRef" class="frame-shell">
       <div v-if="loading" class="frame-overlay">
         <span class="material-symbols-outlined spinning">progress_activity</span>
         <p>正在加载学校官网…</p>
@@ -92,9 +142,9 @@ onBeforeUnmount(() => {
       </div>
 
       <iframe
-        ref="frameRef"
+        v-if="!useNativeEmbed"
         class="website-frame"
-        :src="SCHOOL_WEBSITE_URL"
+        :src="iframeSrc"
         title="湖北工业大学官网"
         allowfullscreen
         referrerpolicy="no-referrer-when-downgrade"

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { openExternal } from '../utils/external_link'
 import {
   SCHOOL_WEBSITE_URL,
@@ -102,7 +102,7 @@ const mountEmbed = async () => {
 }
 
 onMounted(() => {
-  void mountEmbed()
+  void nextTick().then(() => mountEmbed())
 })
 
 onBeforeUnmount(() => {
@@ -158,8 +158,9 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .school-website-view {
-  min-height: calc(var(--app-vh, 1vh) * 100);
-  min-height: 100dvh;
+  height: calc(var(--app-vh, 1vh) * 100);
+  height: 100dvh;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   background: var(--ui-bg-gradient, #f9f9ff);

--- a/src/config/ui_settings.ts
+++ b/src/config/ui_settings.ts
@@ -25,7 +25,7 @@ export type HomeModuleKey =
   | 'resource_share'
   | 'towergo'
   | 'ai'
-export type NotificationCardKey = 'class_reminder' | 'electricity' | 'grades' | 'exams'
+export type NotificationCardKey = 'class_reminder' | 'electricity' | 'grades' | 'exams' | 'school_inbox'
 
 export interface WorkspaceLayoutHome {
   widgetsOrder: HomeWidgetKey[]
@@ -91,7 +91,8 @@ export const NOTIFICATION_CARD_ORDER_DEFAULT = [
   'class_reminder',
   'electricity',
   'grades',
-  'exams'
+  'exams',
+  'school_inbox'
 ] as const satisfies readonly NotificationCardKey[]
 
 export const buildDefaultWorkspaceLayout = (): WorkspaceLayout => ({

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -1180,6 +1180,58 @@ html.dark .me-view .status-icon-box {
   background: rgba(96, 165, 250, 0.15) !important;
 }
 
+/* ─── 学校官网 / 快捷链接子页 ─── */
+html.dark .school-website-view,
+html.dark .quick-links-view {
+  background-color: #0f172a !important;
+}
+
+html.dark .school-website-view .header-copy h1,
+html.dark .quick-links-view .header-copy h1,
+html.dark .quick-links-view .link-copy strong {
+  color: #e2e8f0 !important;
+}
+
+html.dark .school-website-view .header-kicker,
+html.dark .quick-links-view .header-kicker,
+html.dark .quick-links-view .intro,
+html.dark .quick-links-view .link-copy span {
+  color: #94a3b8 !important;
+}
+
+html.dark .school-website-view .back-button,
+html.dark .school-website-view .external-button,
+html.dark .quick-links-view .back-button {
+  background: rgba(96, 165, 250, 0.15) !important;
+  color: #93c5fd !important;
+}
+
+html.dark .school-website-view .frame-shell,
+html.dark .quick-links-view .link-card {
+  background-color: #1e293b !important;
+  border-color: rgba(148, 163, 184, 0.15) !important;
+}
+
+html.dark .school-website-view .frame-overlay {
+  background: rgba(15, 23, 42, 0.72) !important;
+  color: #cbd5e1 !important;
+}
+
+html.dark .school-website-view .frame-message--error {
+  background: rgba(30, 41, 59, 0.96) !important;
+  color: #fecaca !important;
+}
+
+html.dark .school-website-view .frame-message--hint {
+  background: rgba(30, 41, 59, 0.96) !important;
+  color: #cbd5e1 !important;
+  border-top-color: rgba(148, 163, 184, 0.2) !important;
+}
+
+html.dark .quick-links-view .link-arrow {
+  color: #64748b !important;
+}
+
 /* ─── 课表页面 scoped 样式强制覆盖 ─── */
 html.dark .schedule-view .schedule-grid-wrapper,
 html.dark .schedule-view .schedule-grid-container,

--- a/src/utils/background_fetch.js
+++ b/src/utils/background_fetch.js
@@ -9,10 +9,15 @@ const PREF_KEYS = {
   enableExam: 'hbu_bg_enable_exam',
   enablePower: 'hbu_bg_enable_power',
   enableClass: 'hbu_bg_enable_class',
+  enableSchoolInbox: 'hbu_bg_enable_school_inbox',
+  loginMethod: 'hbu_bg_login_method',
   classLeadMinutes: 'hbu_bg_class_lead_min',
   interval: 'hbu_bg_interval_min',
-  dormSelection: 'hbu_bg_dorm_selection'
+  dormSelection: 'hbu_bg_dorm_selection',
+  chaoxingNoticeCookie: 'hbu_bg_chaoxing_notice_cookie'
 }
+
+const schoolInboxStatePrefKey = (studentId) => `hbu_bg_school_inbox_state:${studentId}`
 
 const DEFAULT_API_BASE = 'https://hbut.6661111.xyz/api'
 const LOCAL_API_BASE_KEY = 'hbu_bg_api_base'
@@ -57,7 +62,9 @@ const toSafeText = (value) => String(value ?? '').trim()
 export const syncBackgroundFetchContext = async ({
   studentId,
   settings,
-  dormSelection
+  dormSelection,
+  schoolInboxState,
+  loginMethod
 } = {}) => {
   if (getRuntime() !== 'capacitor') return
   const Preferences = (await getPreferences())?.plugin
@@ -67,6 +74,22 @@ export const syncBackgroundFetchContext = async ({
   const room = Array.isArray(dormSelection) ? dormSelection : []
   const config = settings || {}
   const apiBase = resolveApiBaseForNative()
+  const inboxIds = Array.isArray(schoolInboxState)
+    ? schoolInboxState
+    : (() => {
+        try {
+          const raw = localStorage.getItem(`hbu_notify_school_inbox_state:${sid}`)
+          if (!raw) return []
+          const parsed = JSON.parse(raw)
+          return Array.isArray(parsed?.ids) ? parsed.ids : []
+        } catch {
+          return []
+        }
+      })()
+  const resolvedLoginMethod = toSafeText(
+    loginMethod || localStorage.getItem('hbu_login_method') || ''
+  )
+  const chaoxingCookie = toSafeText(localStorage.getItem('hbu_chaoxing_notice_cookie') || '')
 
   await Preferences.set({ key: PREF_KEYS.studentId, value: sid })
   await Preferences.set({ key: PREF_KEYS.apiBase, value: apiBase })
@@ -75,6 +98,11 @@ export const syncBackgroundFetchContext = async ({
   await Preferences.set({ key: PREF_KEYS.enableExam, value: config.enableExamReminder ? '1' : '0' })
   await Preferences.set({ key: PREF_KEYS.enablePower, value: config.enablePowerNotice ? '1' : '0' })
   await Preferences.set({ key: PREF_KEYS.enableClass, value: config.enableClassReminder ? '1' : '0' })
+  await Preferences.set({
+    key: PREF_KEYS.enableSchoolInbox,
+    value: config.enableSchoolInbox === false ? '0' : '1'
+  })
+  await Preferences.set({ key: PREF_KEYS.loginMethod, value: resolvedLoginMethod })
   await Preferences.set({
     key: PREF_KEYS.classLeadMinutes,
     value: String(Math.max(5, Number(config.classLeadMinutes || 30)))
@@ -87,6 +115,13 @@ export const syncBackgroundFetchContext = async ({
     key: PREF_KEYS.dormSelection,
     value: JSON.stringify(room)
   })
+  await Preferences.set({
+    key: schoolInboxStatePrefKey(sid),
+    value: JSON.stringify(inboxIds.slice(0, 500))
+  })
+  if (chaoxingCookie) {
+    await Preferences.set({ key: PREF_KEYS.chaoxingNoticeCookie, value: chaoxingCookie })
+  }
   localStorage.setItem(LOCAL_API_BASE_KEY, apiBase)
 }
 
@@ -101,6 +136,9 @@ export const clearBackgroundFetchContext = async () => {
     Preferences.remove({ key: PREF_KEYS.enableExam }),
     Preferences.remove({ key: PREF_KEYS.enablePower }),
     Preferences.remove({ key: PREF_KEYS.enableClass }),
+    Preferences.remove({ key: PREF_KEYS.enableSchoolInbox }),
+    Preferences.remove({ key: PREF_KEYS.loginMethod }),
+    Preferences.remove({ key: PREF_KEYS.chaoxingNoticeCookie }),
     Preferences.remove({ key: PREF_KEYS.classLeadMinutes }),
     Preferences.remove({ key: PREF_KEYS.interval }),
     Preferences.remove({ key: PREF_KEYS.dormSelection })

--- a/src/utils/me_quick_links_contract.spec.ts
+++ b/src/utils/me_quick_links_contract.spec.ts
@@ -49,8 +49,10 @@ describe('me quick links frontend contract', () => {
     expect(existsSync(sourcePath('src/utils/school_website_embed.ts'))).toBe(true)
     expect(embedUtil).toContain("export const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'")
     expect(embedUtil).toContain('mountSchoolWebsiteEmbed')
-    expect(embedUtil).toContain('tauri-webview')
-    expect(embedUtil).toContain('/school-website/')
+    expect(embedUtil).toContain('measureSchoolWebsiteEmbedBounds')
+    expect(embedUtil).toContain('school_website_embed_open')
+    expect(embedUtil).toContain('school_website_embed_resize')
+    expect(embedUtil).toContain('school_website_embed_close')
     expect(source).toContain('mountSchoolWebsiteEmbed')
     expect(source).toContain('<iframe')
     expect(source).toContain('在浏览器中打开')
@@ -68,6 +70,18 @@ describe('me quick links frontend contract', () => {
     expect(source).toContain('学习通')
     expect(source).toContain('openExternal')
     expect(source).toContain('showToast')
+  })
+
+  it('registers school website embed commands in Rust', () => {
+    const source = readSource('src-tauri/src/lib.rs')
+    const moduleSource = readSource('src-tauri/src/modules/school_website_embed.rs')
+
+    expect(source).toContain('modules::school_website_embed::school_website_embed_open')
+    expect(source).toContain('modules::school_website_embed::school_website_embed_resize')
+    expect(source).toContain('modules::school_website_embed::school_website_embed_close')
+    expect(moduleSource).toContain('on_navigation')
+    expect(moduleSource).toContain('on_new_window')
+    expect(moduleSource).toContain('.hbut.edu.cn')
   })
 
   it('adds dark mode overrides for the new Me sub pages', () => {

--- a/src/utils/me_quick_links_contract.spec.ts
+++ b/src/utils/me_quick_links_contract.spec.ts
@@ -43,12 +43,17 @@ describe('me quick links frontend contract', () => {
   it('provides a school website page with iframe embed and external fallback', () => {
     const viewPath = 'src/components/SchoolWebsiteView.vue'
     const source = readSource(viewPath)
+    const embedUtil = readSource('src/utils/school_website_embed.ts')
 
     expect(existsSync(sourcePath(viewPath))).toBe(true)
-    expect(source).toContain("const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'")
+    expect(existsSync(sourcePath('src/utils/school_website_embed.ts'))).toBe(true)
+    expect(embedUtil).toContain("export const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'")
+    expect(embedUtil).toContain('mountSchoolWebsiteEmbed')
+    expect(embedUtil).toContain('tauri-webview')
+    expect(embedUtil).toContain('/school-website/')
+    expect(source).toContain('mountSchoolWebsiteEmbed')
     expect(source).toContain('<iframe')
     expect(source).toContain('在浏览器中打开')
-    expect(source).toContain('4500')
     expect(source).toContain('openExternal')
   })
 

--- a/src/utils/me_quick_links_contract.spec.ts
+++ b/src/utils/me_quick_links_contract.spec.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sourcePath = (path: string) => resolve(process.cwd(), path)
+const readSource = (path: string) => {
+  const resolved = sourcePath(path)
+  return existsSync(resolved) ? readFileSync(resolved, 'utf8') : ''
+}
+
+describe('me quick links frontend contract', () => {
+  it('adds Me page entries that navigate to school_website and quick_links', () => {
+    const source = readSource('src/components/MeView.vue')
+
+    expect(source).toContain("const handleOpenSchoolWebsite = () => emit('navigate', 'school_website')")
+    expect(source).toContain("const handleOpenQuickLinks = () => emit('navigate', 'quick_links')")
+    expect(source).toContain('@click="handleOpenSchoolWebsite"')
+    expect(source).toContain('@click="handleOpenQuickLinks"')
+    expect(source).toContain('学校官网')
+    expect(source).toContain('快捷链接')
+  })
+
+  it('registers school_website and quick_links as Me sub views in App.vue', () => {
+    const source = readSource('src/App.vue')
+
+    expect(source).toContain("const loadSchoolWebsiteView = () => import('./components/SchoolWebsiteView.vue')")
+    expect(source).toContain("const loadQuickLinksView = () => import('./components/QuickLinksView.vue')")
+    expect(source).toContain('const SchoolWebsiteView = createAsyncPage(loadSchoolWebsiteView)')
+    expect(source).toContain('const QuickLinksView = createAsyncPage(loadQuickLinksView)')
+    expect(source).toMatch(/ME_SUB_VIEWS\s*=\s*\[[\s\S]*'school_website'/)
+    expect(source).toMatch(/ME_SUB_VIEWS\s*=\s*\[[\s\S]*'quick_links'/)
+    expect(source).toMatch(/HIERARCHICAL_PARENT_VIEW_MAP[\s\S]*school_website:\s*'me'/)
+    expect(source).toMatch(/HIERARCHICAL_PARENT_VIEW_MAP[\s\S]*quick_links:\s*'me'/)
+    expect(source).toMatch(/VIEW_PREFETCHERS[\s\S]*school_website:\s*loadSchoolWebsiteView/)
+    expect(source).toMatch(/VIEW_PREFETCHERS[\s\S]*quick_links:\s*loadQuickLinksView/)
+    expect(source).toContain("v-else-if=\"currentView === 'school_website'\"")
+    expect(source).toContain("v-else-if=\"currentView === 'quick_links'\"")
+    expect(source).toContain('<SchoolWebsiteView')
+    expect(source).toContain('<QuickLinksView')
+    expect(source).toContain('@back="handleBackToMe"')
+  })
+
+  it('provides a school website page with iframe embed and external fallback', () => {
+    const viewPath = 'src/components/SchoolWebsiteView.vue'
+    const source = readSource(viewPath)
+
+    expect(existsSync(sourcePath(viewPath))).toBe(true)
+    expect(source).toContain("const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'")
+    expect(source).toContain('<iframe')
+    expect(source).toContain('在浏览器中打开')
+    expect(source).toContain('4500')
+    expect(source).toContain('openExternal')
+  })
+
+  it('provides a quick links page that opens campus portals externally', () => {
+    const viewPath = 'src/components/QuickLinksView.vue'
+    const source = readSource(viewPath)
+
+    expect(existsSync(sourcePath(viewPath))).toBe(true)
+    expect(source).toContain('https://e.hbut.edu.cn/')
+    expect(source).toContain('https://i.chaoxing.com/')
+    expect(source).toContain('新融合门户')
+    expect(source).toContain('学习通')
+    expect(source).toContain('openExternal')
+    expect(source).toContain('showToast')
+  })
+
+  it('adds dark mode overrides for the new Me sub pages', () => {
+    const source = readSource('src/styles/dark-mode.css')
+
+    expect(source).toContain('html.dark .school-website-view')
+    expect(source).toContain('html.dark .quick-links-view')
+  })
+})

--- a/src/utils/notification_delivery_contract.spec.ts
+++ b/src/utils/notification_delivery_contract.spec.ts
@@ -200,4 +200,38 @@ describe('notification delivery contract', () => {
     expect(debugHeadlessSource).toContain('new com.hbut.mini.BackgroundFetchHeadlessTask()')
     expect(debugHeadlessSource).toContain('onFetch(Context context, BGTask task)')
   })
+
+  it('wires school inbox checks through notify_center and Tauri command', () => {
+    const notifySource = readText('src/utils/notify_center.js')
+    const libSource = readText('src-tauri/src/lib.rs')
+
+    expect(notifySource).toContain("schoolInbox: 'hbu_notify_school_inbox'")
+    expect(notifySource).toContain('checkSchoolInbox')
+    expect(notifySource).toContain("invokeNative('school_inbox_fetch'")
+    expect(notifySource).toContain('schoolInboxStateKeyFor')
+    expect(libSource).toContain('school_inbox_fetch')
+  })
+
+  it('syncs school inbox background prefs for Android headless', () => {
+    const bgSource = readText('src/utils/background_fetch.js')
+    const headlessSource = readText(
+      'android/app/src/main/java/com/hbut/mini/BackgroundFetchHeadlessTask.java'
+    )
+
+    expect(bgSource).toContain('hbu_bg_enable_school_inbox')
+    expect(bgSource).toContain('hbu_bg_login_method')
+    expect(bgSource).toContain('hbu_bg_school_inbox_state:')
+    expect(headlessSource).toContain('checkSchoolInbox')
+    expect(headlessSource).toContain('notice.chaoxing.com/apis/other/getNoticeList')
+  })
+
+  it('exposes school inbox toggle in notification settings UI', () => {
+    const source = readText('src/components/NotificationView.vue')
+    const uiSettings = readText('src/config/ui_settings.ts')
+
+    expect(source).toContain('enableSchoolInboxNotices')
+    expect(source).toContain("card.key === 'school_inbox'")
+    expect(source).toContain('schoolInboxSummary')
+    expect(uiSettings).toContain("'school_inbox'")
+  })
 })

--- a/src/utils/notify_center.js
+++ b/src/utils/notify_center.js
@@ -9,6 +9,7 @@ import {
 import { useAppSettings } from './app_settings'
 import { isCapacitorRuntime } from '../platform/native'
 import { getRuntime, platformBridge } from '../platform'
+import { invokeNative, isTauriRuntime } from '../platform/native'
 import { pushDebugLog } from './debug_logger'
 import {
   clearBackgroundFetchContext,
@@ -36,7 +37,8 @@ const STORAGE_KEYS = {
   class: 'hbu_notify_class',
   classLeadMinutes: 'hbu_notify_class_lead_min',
   interval: 'hbu_notify_interval',
-  dormSelection: 'last_dorm_selection'
+  dormSelection: 'last_dorm_selection',
+  schoolInbox: 'hbu_notify_school_inbox'
 }
 
 const CLASS_PERIOD_TIME_MAP = {
@@ -153,6 +155,7 @@ const getNotifySettings = () => {
     enableGradeNotice: readBool(STORAGE_KEYS.grade, true),
     enablePowerNotice: readBool(STORAGE_KEYS.power, true),
     enableClassReminder: readBool(STORAGE_KEYS.class, true),
+    enableSchoolInbox: readBool(STORAGE_KEYS.schoolInbox, true),
     classLeadMinutes,
     intervalMinutes: interval
   }
@@ -286,6 +289,36 @@ const gradeSigKeyFor = (studentId) => `hbu_notify_grade_signature:${studentId}`
 const examSigKeyFor = (studentId) => `hbu_notify_exam_tomorrow:${studentId}`
 const powerStateKeyFor = (studentId, roomKey) => `hbu_notify_power_state:${studentId}:${roomKey}`
 const classReminderStateKeyFor = (studentId) => `hbu_notify_class_state:${studentId}`
+const schoolInboxStateKeyFor = (studentId) => `hbu_notify_school_inbox_state:${studentId}`
+
+const resolveLoginMode = () => toSafeText(localStorage.getItem('hbu_login_method'))
+
+const syncSchoolInboxBackgroundPrefs = (studentId, settings, knownIds = []) => {
+  if (getRuntime() !== 'capacitor') return
+  try {
+    localStorage.setItem('hbu_bg_enable_school_inbox', settings?.enableSchoolInbox ? '1' : '0')
+    localStorage.setItem('hbu_bg_login_method', resolveLoginMode())
+    localStorage.setItem(
+      `hbu_bg_school_inbox_state:${studentId}`,
+      JSON.stringify(Array.isArray(knownIds) ? knownIds : [])
+    )
+  } catch {
+    // ignore
+  }
+}
+
+const snapshotChaoxingNoticeCookie = async (loginMode) => {
+  const mode = toSafeText(loginMode).toLowerCase()
+  if (!mode.startsWith('chaoxing') || !isTauriRuntime()) return
+  try {
+    const cookies = await invokeNative('get_cookies')
+    if (cookies) {
+      localStorage.setItem('hbu_chaoxing_notice_cookie', String(cookies))
+    }
+  } catch {
+    // ignore
+  }
+}
 
 const getRequestTimeoutMs = () => {
   try {
@@ -1037,6 +1070,86 @@ const checkClassReminder = async (studentId, settings, queue, scheduleResult) =>
   }
 }
 
+const checkSchoolInbox = async (studentId, settings, queue) => {
+  const sid = toSafeText(studentId)
+  if (!sid) {
+    return { success: false, enabled: false, total: 0, triggered: 0, reason: 'missing-student-id' }
+  }
+  if (!settings.enableSchoolInbox) {
+    return { success: true, enabled: false, total: 0, triggered: 0 }
+  }
+  if (!isTauriRuntime()) {
+    syncSchoolInboxBackgroundPrefs(sid, settings, readJSON(schoolInboxStateKeyFor(sid), {})?.ids || [])
+    return {
+      success: false,
+      enabled: true,
+      total: 0,
+      triggered: 0,
+      error: '学校消息抓取需在 Tauri 桌面端前台运行'
+    }
+  }
+
+  try {
+    const loginMode = resolveLoginMode()
+    const response = await invokeNative('school_inbox_fetch', { loginMode })
+    const items = Array.isArray(response?.items) ? response.items : []
+    const stateKey = schoolInboxStateKeyFor(sid)
+    const state = readJSON(stateKey, null)
+    const knownIds = Array.isArray(state?.ids)
+      ? state.ids.map((item) => toSafeText(item)).filter(Boolean)
+      : []
+    const isFirstSync = !state || state.initialized !== true
+    const knownSet = new Set(knownIds)
+    const allIds = items.map((item) => toSafeText(item?.id)).filter(Boolean)
+    const toNotify = isFirstSync
+      ? []
+      : items.filter((item) => !knownSet.has(toSafeText(item?.id)))
+
+    toNotify.forEach((item) => {
+      queue.push({
+        title: toSafeText(item?.title) || '学校通知',
+        body: toSafeText(item?.summary) || '你有新的学校消息',
+        targetView: 'notifications'
+      })
+    })
+
+    writeJSON(stateKey, {
+      initialized: true,
+      ids: allIds.slice(0, 500),
+      updated_at: nowIso()
+    })
+    await snapshotChaoxingNoticeCookie(loginMode)
+    syncSchoolInboxBackgroundPrefs(sid, settings, allIds)
+
+    pushDebugLog(
+      'Notify',
+      `学校消息检查完成 total=${items.length} trigger=${toNotify.length} first=${isFirstSync ? '1' : '0'}`,
+      'info',
+      { source: toSafeText(response?.source), loginMode }
+    )
+
+    return {
+      success: true,
+      enabled: true,
+      total: items.length,
+      triggered: toNotify.length,
+      source: toSafeText(response?.source),
+      checkedAt: toSafeText(response?.fetchedAt),
+      baseline: isFirstSync
+    }
+  } catch (error) {
+    const message = toSafeText(error?.message || error)
+    pushDebugLog('Notify', `学校消息检查失败: ${message}`, 'warn')
+    return {
+      success: false,
+      enabled: true,
+      total: 0,
+      triggered: 0,
+      error: message || '学校消息检查失败'
+    }
+  }
+}
+
 export const runNotificationCheck = async ({
   studentId,
   launchCheck = false,
@@ -1086,6 +1199,12 @@ export const runNotificationCheck = async ({
         selectedPath: dormSelection,
         error: '后台检查未启用'
       },
+      schoolInbox: {
+        success: false,
+        enabled: !!settings.enableSchoolInbox,
+        total: 0,
+        triggered: 0
+      },
       notifications: { queued: 0, sent: 0, items: [] }
     }
   }
@@ -1103,7 +1222,10 @@ export const runNotificationCheck = async ({
     checkExams(sid, settings, queue),
     checkElectricity(sid, settings, queue, launchCheck)
   ])
-  const classReminder = await checkClassReminder(sid, settings, queue, schedule)
+  const [classReminder, schoolInbox] = await Promise.all([
+    checkClassReminder(sid, settings, queue, schedule),
+    checkSchoolInbox(sid, settings, queue)
+  ])
 
   const sent = await sendQueuedNotifications(queue, allowPermissionPrompt)
   pushDebugLog(
@@ -1129,6 +1251,7 @@ export const runNotificationCheck = async ({
     grades,
     exams,
     classReminder,
+    schoolInbox,
     electricity,
     notifications: {
       queued: queue.length,
@@ -1142,6 +1265,16 @@ export const runNotificationCheck = async ({
 
   // 同步数据到 Android 小组件
   syncWidgetData(snapshot).catch(() => {})
+
+  if (isCapacitorRuntime()) {
+    await syncBackgroundFetchContext({
+      studentId: sid,
+      settings,
+      dormSelection,
+      schoolInboxState: readJSON(schoolInboxStateKeyFor(sid), {})?.ids || [],
+      loginMethod: resolveLoginMode()
+    })
+  }
 
   return snapshot
 }

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -1,0 +1,154 @@
+import { detectRuntime } from '../platform/runtime'
+
+export const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'
+const SCHOOL_WEBSITE_EMBED_LABEL = 'school-website-embed'
+const LOCAL_BRIDGE_BASE = 'http://127.0.0.1:4399'
+
+export const SCHOOL_WEBSITE_PROXY_URL = `${LOCAL_BRIDGE_BASE}/school-website/`
+
+export type SchoolWebsiteEmbedMode = 'tauri-webview' | 'proxy-iframe' | 'direct-iframe'
+
+export const resolveSchoolWebsiteIframeUrl = (mode: Exclude<SchoolWebsiteEmbedMode, 'tauri-webview'>) =>
+  mode === 'proxy-iframe' ? SCHOOL_WEBSITE_PROXY_URL : SCHOOL_WEBSITE_URL
+
+const canUseTauriEmbeddedWebview = () => detectRuntime() === 'tauri'
+
+const probeProxyReachable = async () => {
+  try {
+    const controller = new AbortController()
+    const timer = window.setTimeout(() => controller.abort(), 1500)
+    const response = await fetch(SCHOOL_WEBSITE_PROXY_URL, {
+      method: 'HEAD',
+      signal: controller.signal
+    })
+    window.clearTimeout(timer)
+    return response.ok || response.status === 405 || response.status === 404
+  } catch {
+    return false
+  }
+}
+
+export const resolveSchoolWebsiteEmbedMode = async (): Promise<SchoolWebsiteEmbedMode> => {
+  if (canUseTauriEmbeddedWebview()) return 'tauri-webview'
+  if (await probeProxyReachable()) return 'proxy-iframe'
+  return 'direct-iframe'
+}
+
+type MountOptions = {
+  container: HTMLElement
+  onReady?: () => void
+  onError?: (message: string) => void
+}
+
+type MountedEmbed = {
+  mode: SchoolWebsiteEmbedMode
+  cleanup: () => Promise<void>
+}
+
+const syncWebviewBounds = async (
+  webview: import('@tauri-apps/api/webview').Webview,
+  container: HTMLElement
+) => {
+  const { LogicalPosition, LogicalSize } = await import('@tauri-apps/api/dpi')
+  const rect = container.getBoundingClientRect()
+  const width = Math.max(1, Math.round(rect.width))
+  const height = Math.max(1, Math.round(rect.height))
+  await webview.setPosition(new LogicalPosition(Math.round(rect.left), Math.round(rect.top)))
+  await webview.setSize(new LogicalSize(width, height))
+}
+
+export const mountSchoolWebsiteEmbed = async ({
+  container,
+  onReady,
+  onError
+}: MountOptions): Promise<MountedEmbed> => {
+  const mode = await resolveSchoolWebsiteEmbedMode()
+
+  if (mode !== 'tauri-webview') {
+    onReady?.()
+    return {
+      mode,
+      cleanup: async () => {}
+    }
+  }
+
+  try {
+    const { getCurrentWindow } = await import('@tauri-apps/api/window')
+    const { Webview } = await import('@tauri-apps/api/webview')
+
+    const appWindow = getCurrentWindow()
+    const existing = await Webview.getByLabel(SCHOOL_WEBSITE_EMBED_LABEL)
+    if (existing) {
+      try {
+        await existing.close()
+      } catch {
+        // ignore stale embed cleanup failure
+      }
+    }
+
+    const rect = container.getBoundingClientRect()
+    const webview = new Webview(appWindow, SCHOOL_WEBSITE_EMBED_LABEL, {
+      url: SCHOOL_WEBSITE_URL,
+      x: Math.round(rect.left),
+      y: Math.round(rect.top),
+      width: Math.max(1, Math.round(rect.width)),
+      height: Math.max(1, Math.round(rect.height)),
+      focus: true
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        reject(new Error('创建学校官网内嵌视图超时'))
+      }, 8000)
+
+      webview.once('tauri://created', () => {
+        window.clearTimeout(timer)
+        resolve()
+      })
+      webview.once('tauri://error', (event) => {
+        window.clearTimeout(timer)
+        reject(new Error(String(event?.payload || '创建学校官网内嵌视图失败')))
+      })
+    })
+
+    await webview.setAutoResize(false)
+    await syncWebviewBounds(webview, container)
+
+    const resizeObserver = new ResizeObserver(() => {
+      void syncWebviewBounds(webview, container).catch(() => {})
+    })
+    resizeObserver.observe(container)
+
+    let closed = false
+    const handleWindowResize = () => {
+      if (closed) return
+      void syncWebviewBounds(webview, container).catch(() => {})
+    }
+    window.addEventListener('resize', handleWindowResize)
+
+    onReady?.()
+
+    return {
+      mode,
+      cleanup: async () => {
+        if (closed) return
+        closed = true
+        resizeObserver.disconnect()
+        window.removeEventListener('resize', handleWindowResize)
+        try {
+          await webview.close()
+        } catch {
+          try {
+            await webview.hide()
+          } catch {
+            // ignore cleanup failure
+          }
+        }
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '创建学校官网内嵌视图失败'
+    onError?.(message)
+    throw error
+  }
+}

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -1,12 +1,18 @@
 import { detectRuntime } from '../platform/runtime'
 
 export const SCHOOL_WEBSITE_URL = 'https://www.hbut.edu.cn/'
-const SCHOOL_WEBSITE_EMBED_LABEL = 'school-website-embed'
 const LOCAL_BRIDGE_BASE = 'http://127.0.0.1:4399'
 
 export const SCHOOL_WEBSITE_PROXY_URL = `${LOCAL_BRIDGE_BASE}/school-website/`
 
 export type SchoolWebsiteEmbedMode = 'tauri-webview' | 'proxy-iframe' | 'direct-iframe'
+
+export type EmbedBounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
 
 export const resolveSchoolWebsiteIframeUrl = (mode: Exclude<SchoolWebsiteEmbedMode, 'tauri-webview'>) =>
   mode === 'proxy-iframe' ? SCHOOL_WEBSITE_PROXY_URL : SCHOOL_WEBSITE_URL
@@ -34,6 +40,49 @@ export const resolveSchoolWebsiteEmbedMode = async (): Promise<SchoolWebsiteEmbe
   return 'direct-iframe'
 }
 
+const waitForLayout = async () => {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  })
+}
+
+export const measureSchoolWebsiteEmbedBounds = async (
+  container: HTMLElement
+): Promise<EmbedBounds> => {
+  await waitForLayout()
+
+  const rect = container.getBoundingClientRect()
+  let top = Math.max(0, Math.round(rect.top))
+  let left = Math.max(0, Math.round(rect.left))
+  let width = Math.max(1, Math.round(rect.width))
+  let height = Math.max(1, Math.round(rect.height))
+
+  if (canUseTauriEmbeddedWebview()) {
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window')
+      const window = getCurrentWindow()
+      const scaleFactor = await window.scaleFactor()
+      const innerSize = await window.innerSize()
+      const innerLogical = innerSize.toLogical(scaleFactor)
+      const bottomPadding = 12
+
+      if (top <= 0 && container.parentElement) {
+        const parentRect = container.parentElement.getBoundingClientRect()
+        top = Math.max(0, Math.round(parentRect.top + (rect.top - parentRect.top)))
+      }
+
+      width = Math.max(1, Math.round(rect.width || innerLogical.width - left * 2))
+      const heightFromWindow = Math.max(1, Math.round(innerLogical.height - top - bottomPadding))
+      const minExpected = Math.round(innerLogical.height * 0.45)
+      height = heightFromRect >= minExpected ? heightFromRect : heightFromWindow
+    } catch {
+      // 保留 DOM 测量结果
+    }
+  }
+
+  return { x: left, y: top, width, height }
+}
+
 type MountOptions = {
   container: HTMLElement
   onReady?: () => void
@@ -45,16 +94,15 @@ type MountedEmbed = {
   cleanup: () => Promise<void>
 }
 
-const syncWebviewBounds = async (
-  webview: import('@tauri-apps/api/webview').Webview,
-  container: HTMLElement
-) => {
-  const { LogicalPosition, LogicalSize } = await import('@tauri-apps/api/dpi')
-  const rect = container.getBoundingClientRect()
-  const width = Math.max(1, Math.round(rect.width))
-  const height = Math.max(1, Math.round(rect.height))
-  await webview.setPosition(new LogicalPosition(Math.round(rect.left), Math.round(rect.top)))
-  await webview.setSize(new LogicalSize(width, height))
+const invokeNative = async <T = unknown>(command: string, args?: Record<string, unknown>) => {
+  const core = await import('@tauri-apps/api/core')
+  if (typeof args === 'undefined') return core.invoke<T>(command)
+  return core.invoke<T>(command, args)
+}
+
+const syncNativeEmbedBounds = async (container: HTMLElement) => {
+  const bounds = await measureSchoolWebsiteEmbedBounds(container)
+  await invokeNative('school_website_embed_resize', { bounds })
 }
 
 export const mountSchoolWebsiteEmbed = async ({
@@ -73,58 +121,31 @@ export const mountSchoolWebsiteEmbed = async ({
   }
 
   try {
-    const { getCurrentWindow } = await import('@tauri-apps/api/window')
-    const { Webview } = await import('@tauri-apps/api/webview')
-
-    const appWindow = getCurrentWindow()
-    const existing = await Webview.getByLabel(SCHOOL_WEBSITE_EMBED_LABEL)
-    if (existing) {
-      try {
-        await existing.close()
-      } catch {
-        // ignore stale embed cleanup failure
-      }
-    }
-
-    const rect = container.getBoundingClientRect()
-    const webview = new Webview(appWindow, SCHOOL_WEBSITE_EMBED_LABEL, {
-      url: SCHOOL_WEBSITE_URL,
-      x: Math.round(rect.left),
-      y: Math.round(rect.top),
-      width: Math.max(1, Math.round(rect.width)),
-      height: Math.max(1, Math.round(rect.height)),
-      focus: true
-    })
-
-    await new Promise<void>((resolve, reject) => {
-      const timer = window.setTimeout(() => {
-        reject(new Error('创建学校官网内嵌视图超时'))
-      }, 8000)
-
-      webview.once('tauri://created', () => {
-        window.clearTimeout(timer)
-        resolve()
-      })
-      webview.once('tauri://error', (event) => {
-        window.clearTimeout(timer)
-        reject(new Error(String(event?.payload || '创建学校官网内嵌视图失败')))
-      })
-    })
-
-    await webview.setAutoResize(false)
-    await syncWebviewBounds(webview, container)
+    const bounds = await measureSchoolWebsiteEmbedBounds(container)
+    await invokeNative('school_website_embed_open', { bounds })
 
     const resizeObserver = new ResizeObserver(() => {
-      void syncWebviewBounds(webview, container).catch(() => {})
+      void syncNativeEmbedBounds(container).catch(() => {})
     })
     resizeObserver.observe(container)
+    if (container.parentElement) {
+      resizeObserver.observe(container.parentElement)
+    }
 
     let closed = false
     const handleWindowResize = () => {
       if (closed) return
-      void syncWebviewBounds(webview, container).catch(() => {})
+      void syncNativeEmbedBounds(container).catch(() => {})
     }
     window.addEventListener('resize', handleWindowResize)
+
+    const layoutTimer = window.setInterval(() => {
+      if (closed) return
+      void syncNativeEmbedBounds(container).catch(() => {})
+    }, 300)
+    window.setTimeout(() => {
+      window.clearInterval(layoutTimer)
+    }, 1800)
 
     onReady?.()
 
@@ -133,16 +154,13 @@ export const mountSchoolWebsiteEmbed = async ({
       cleanup: async () => {
         if (closed) return
         closed = true
+        window.clearInterval(layoutTimer)
         resizeObserver.disconnect()
         window.removeEventListener('resize', handleWindowResize)
         try {
-          await webview.close()
+          await invokeNative('school_website_embed_close')
         } catch {
-          try {
-            await webview.hide()
-          } catch {
-            // ignore cleanup failure
-          }
+          // ignore cleanup failure
         }
       }
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,6 +101,10 @@ export default defineConfig({
         target: 'http://127.0.0.1:4399',
         changeOrigin: true
       },
+      '/school-website': {
+        target: 'http://127.0.0.1:4399',
+        changeOrigin: true
+      },
       '/font/deyihei.ttf': {
         target: 'https://raw.gitcode.com',
         changeOrigin: true,


### PR DESCRIPTION
## Summary

- 在「我的」页新增学校官网内嵌视图与快捷链接子页面，通过 Tauri 子 WebView / 代理绕过 X-Frame-Options
- 新增学校消息通知：按登录方式抓取教务 `tzsjx` 或学习通收件箱，首次建基线不刷屏，支持 Tauri 本地推送与 Android Headless
- 首页「教务服务」新增「学校消息」模块：列表/详情浏览、链接外开、标记已读；修复详情滚动错位与暗色模式卡片泛白

## Test plan

- [ ] Tauri 桌面登录后，通知中心「立即检查」能返回学校消息列表（首次不推送历史）
- [ ] 首页「教务服务」→「学校消息」：列表下滑后点进详情，标题应在顶部可见
- [ ] 暗色模式下消息卡片/详情卡无白色泛白
- [ ] 详情内链接可外开；右上角「标为已读」可用
- [ ] `npm test -- --run src/utils/school_inbox_content.spec.ts src/utils/notification_delivery_contract.spec.ts` 通过
- [ ] `cargo test school_inbox` 通过

Closes #23
Closes #24
Closes #26
