### PR TITLE
fix(me): 暗色模式功能网格图标深色底并保留彩色

### DIFF
--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -598,7 +598,7 @@ html.dark .me-view [class*="action-card"] {
 
 html.dark .me-view .func-item span,
 html.dark .me-view [class*="func-card"] span,
-html.dark .me-view [class*="grid-item"] span {
+html.dark .me-view [class*="grid-item"] .grid-label {
   color: #cbd5e1 !important;
 }
 
@@ -1117,8 +1117,7 @@ html.dark .grid-item {
   color: #e2e8f0 !important;
 }
 
-html.dark .grid-item .grid-label,
-html.dark .grid-item span {
+html.dark .grid-item .grid-label {
   color: #cbd5e1 !important;
 }
 
@@ -1126,10 +1125,16 @@ html.dark .grid-icon {
   background: #334155 !important;
 }
 
-/* 我的页面 - 图标颜色在暗色模式下提亮 */
-html.dark .grid-item .grid-icon .material-symbols-outlined {
+/* 我的页面 - 功能网格图标容器（覆盖内联浅色 background） */
+html.dark .me-view .grid-icon-box {
+  background: #0f172a !important;
+}
+
+/* 我的页面 - 图标颜色在暗色模式下提亮（保留各入口内联彩色） */
+html.dark .grid-item .grid-icon .material-symbols-outlined,
+html.dark .me-view .grid-icon-box .material-symbols-outlined {
   opacity: 1 !important;
-  filter: brightness(1.3) saturate(1.2) !important;
+  filter: brightness(1.15) saturate(1.1) !important;
 }
 
 /* 我的页面 - 所有卡片区域加边框区分 */


### PR DESCRIPTION
## Summary

- 暗色模式下「我的」页功能网格 `grid-icon-box` 使用深色背景（`#0f172a`），消除泛白浅色块
- 收窄暗色文字颜色规则至 `.grid-label`，避免覆盖图标内联彩色
- 保留各入口图标原有 symbol 颜色，并轻微提亮以适配暗色背景

## Test plan

- [ ] 开启暗色模式，进入「我的」页功能网格
- [ ] 确认图标背景为深色，非浅色/泛白
- [ ] 确认各入口图标仍为蓝/红/绿等彩色，而非全白/全灰
- [ ] 切换回浅色模式，确认外观与修复前一致

Closes #25
