### PR TITLE
fix(tauri): Webview::close 限 desktop，修复 Android/iOS 编译 E0599

### DIFF
--- a/src-tauri/src/modules/module_bundle.rs
+++ b/src-tauri/src/modules/module_bundle.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::io::{Cursor, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Manager};
+
+#[cfg(desktop)]
+use tauri::{WebviewUrl, WebviewWindowBuilder};
 
 const DEFAULT_BRIDGE_PORT: u16 = 4399;
 const MODULE_CACHE_ROOT: &str = "more_modules";

--- a/src-tauri/src/modules/school_website_embed.rs
+++ b/src-tauri/src/modules/school_website_embed.rs
@@ -1,7 +1,10 @@
 //! 学校官网内嵌子 WebView：全高度展示 + 站外链接外部打开。
 
+use tauri::{AppHandle, Manager};
+
+#[cfg(desktop)]
 use tauri::{
-    AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl,
+    LogicalPosition, LogicalSize, WebviewUrl,
     webview::{NewWindowResponse, WebviewBuilder},
 };
 use url::Url;
@@ -32,6 +35,7 @@ fn open_external(app: &AppHandle, target: &str) {
     let _ = crate::open_external_url_impl(app, target);
 }
 
+#[cfg(desktop)]
 fn close_embed_if_exists(app: &AppHandle) {
     if let Some(webview) = app.get_webview(EMBED_LABEL) {
         let _ = webview.close();


### PR DESCRIPTION
## 关联 issue

Fixes #29

## 原因

Tauri 2.x 中 \Webview::close()\ 是 desktop-only 方法。dev 分支合并 \eat(school-inbox)\ 后引入的 \close_embed_if_exists\ 缺少 \#[cfg(desktop)]\ 守卫，移动端目标编译时调用 desktop-only 方法报 E0599。详见 issue #29 与最近失败 run 28185597232。

## 修复

- \src-tauri/src/modules/school_website_embed.rs\: 为 \close_embed_if_exists\ 增加 \#[cfg(desktop)]\；将仅桌面使用的符号拆分加 cfg。
- \src-tauri/src/modules/module_bundle.rs\: 将 \WebviewUrl\/\WebviewWindowBuilder\ 的 import 加 \#[cfg(desktop)]\，消除移动端 unused import 警告。

## 验证

- 本地 \cargo check\ 桌面目标通过。
- 合并后将重新触发 Dev Build，确认 Android/iOS 编译成功。

## 影响范围

- 桌面端行为无变化；移动端命令仍返回不支持错误，仅恢复可编译性。