### PR TITLE
fix(school-website): iframe 改用 absolute 撑满，修复 iOS 仅显示顶部一小块

### DIFF
--- a/src-tauri/src/modules/module_bundle.rs
+++ b/src-tauri/src/modules/module_bundle.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::io::{Cursor, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Manager};
+
+#[cfg(desktop)]
+use tauri::{WebviewUrl, WebviewWindowBuilder};
 
 const DEFAULT_BRIDGE_PORT: u16 = 4399;
 const MODULE_CACHE_ROOT: &str = "more_modules";

--- a/src-tauri/src/modules/school_website_embed.rs
+++ b/src-tauri/src/modules/school_website_embed.rs
@@ -1,7 +1,10 @@
 //! 学校官网内嵌子 WebView：全高度展示 + 站外链接外部打开。
 
+use tauri::{AppHandle, Manager};
+
+#[cfg(desktop)]
 use tauri::{
-    AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl,
+    LogicalPosition, LogicalSize, WebviewUrl,
     webview::{NewWindowResponse, WebviewBuilder},
 };
 use url::Url;
@@ -32,6 +35,7 @@ fn open_external(app: &AppHandle, target: &str) {
     let _ = crate::open_external_url_impl(app, target);
 }
 
+#[cfg(desktop)]
 fn close_embed_if_exists(app: &AppHandle) {
     if let Some(webview) = app.get_webview(EMBED_LABEL) {
         let _ = webview.close();

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -223,6 +223,8 @@ onBeforeUnmount(() => {
 }
 
 .website-frame {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   border: none;

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -74,7 +74,7 @@ export const measureSchoolWebsiteEmbedBounds = async (
       width = Math.max(1, Math.round(rect.width || innerLogical.width - left * 2))
       const heightFromWindow = Math.max(1, Math.round(innerLogical.height - top - bottomPadding))
       const minExpected = Math.round(innerLogical.height * 0.45)
-      height = heightFromRect >= minExpected ? heightFromRect : heightFromWindow
+      height = height >= minExpected ? height : heightFromWindow
     } catch {
       // 保留 DOM 测量结果
     }


### PR DESCRIPTION
## 关联 issue

Fixes #32

## 原因

iOS 端 `detectRuntime()` 返回 `capacitor`，学校官网走 `<iframe>` 模式而非桌面端的 `tauri-webview` 原生子 webview。iframe 用 `height:100%` 参考作为 flex item 的父容器 `.frame-shell`，在 iOS WKWebView 中高度塌缩，只露出页面顶部一小块。详见 issue #32。

附带修复 `school_website_embed.ts` 中未定义变量 `heightFromRect`（应为 `height`）的 latent bug，该 ReferenceError 之前被 catch 静默吞掉。

## 修复

- `src/components/SchoolWebsiteView.vue`：`.website-frame` 改用 `position:absolute;inset:0` 撑满已 `position:relative` 的 `.frame-shell`，规避 WKWebView iframe 百分比高度塌缩问题。
- `src/utils/school_website_embed.ts`：`heightFromRect` → `height`，消除 ReferenceError。

## 验证

- 本地 `npm run build` 通过（built in 5.97s），产物 CSS 确认含 `position:absolute;inset:0`，JS 中 `heightFromRect` 已消失。
- `me_quick_links_contract.spec.ts` 6 项全通过。
- 合并后触发 Dev Build 验证 iOS / Android / 桌面端构建全绿。

## 影响范围

- iOS / Android 端 iframe 高度修复，恢复完整可滚动；PC 桌面走原生子 webview，行为无变化。