### PR TITLE
fix(school-website): iframe 改用 absolute 撑满，修复 iOS 仅显示顶部一小块

### DIFF
--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -223,6 +223,8 @@ onBeforeUnmount(() => {
 }
 
 .website-frame {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   border: none;

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -74,7 +74,7 @@ export const measureSchoolWebsiteEmbedBounds = async (
       width = Math.max(1, Math.round(rect.width || innerLogical.width - left * 2))
       const heightFromWindow = Math.max(1, Math.round(innerLogical.height - top - bottomPadding))
       const minExpected = Math.round(innerLogical.height * 0.45)
-      height = heightFromRect >= minExpected ? heightFromRect : heightFromWindow
+      height = height >= minExpected ? height : heightFromWindow
     } catch {
       // 保留 DOM 测量结果
     }


### PR DESCRIPTION
## 关联 issue

Fixes #32

## 修复

iOS 上 `detectRuntime()` 返回 `capacitor`，学校官网走 `<iframe>` 而非桌面端 `tauri-webview` 原生子 webview。iframe 用 `height:100%` 参考作为 flex item 的父容器 `.frame-shell`，在 iOS WKWebView 中高度塌缩，只露出页面顶部一小块。

- `src/components/SchoolWebsiteView.vue`：`.website-frame` 改用 `position:absolute;inset:0` 撑满已 `position:relative` 的 `.frame-shell`，规避 WKWebView iframe 百分比高度塌缩。
- `src/utils/school_website_embed.ts`：修正未定义变量 `heightFromRect` -> `height`，消除被 catch 静默吞掉的 ReferenceError。

详见 issue #32。PR #33 已合并至 dev。

## 验证

- 本地 `npm run build` 通过，产物确认 CSS/JS 修复生效。
- `me_quick_links_contract.spec.ts` 全通过。
- Android / macOS / Windows / Linux 在 dev 上构建均成功。

## 影响范围

iOS / Android 端 iframe 高度修复，恢复完整可滚动；PC 桌面走原生子 webview 行为无变化。

## 备注

dev run 28217983436 的 iOS job 失败与本修复无关：GitHub 在 2026-06-25->26 期间把 macos-latest 默认 Xcode 从 16.4 升级到 26.5，导致 swiftCompatibility56/Concurrency/Packs 库缺失。main 的 Sync Website 不构建 iOS，不受影响。