### PR TITLE
fix(ci): iOS 构建固定 Xcode 16.4，规避 macos-latest 默认升到 26.5

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -499,10 +499,23 @@ jobs:
           retention-days: 14
           compression-level: 0
 
-  build-ios:
+build-ios:
     needs: [source, meta]
     runs-on: macos-latest
     steps:
+      - name: Select Xcode 16.4 for iOS build
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode_16.4.app" ]; then
+            sudo xcode-select -s "/Applications/Xcode_16.4.app"
+            echo "Switched to $(xcodebuild -version)"
+          else
+            echo "Xcode_16.4.app not found; available Xcode versions:"
+            ls -d /Applications/Xcode*.app 2>/dev/null || true
+            echo "WARNING: falling back to default Xcode; iOS link may fail with swiftCompatibility56 missing."
+          fi
+
       - name: Download source artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,19 @@ jobs:
     needs: create-release
     runs-on: macos-latest
     steps:
+      - name: Select Xcode 16.4 for iOS build
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode_16.4.app" ]; then
+            sudo xcode-select -s "/Applications/Xcode_16.4.app"
+            echo "Switched to $(xcodebuild -version)"
+          else
+            echo "Xcode_16.4.app not found; available Xcode versions:"
+            ls -d /Applications/Xcode*.app 2>/dev/null || true
+            echo "WARNING: falling back to default Xcode; iOS link may fail with swiftCompatibility56 missing."
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Prune non-runtime files (iOS)


### PR DESCRIPTION
## 关联 issue

Fixes #35

## 原因

GitHub 在 2026-06-25→26 升级 `macos-latest` 默认 Xcode 16.4 → 26.5。Tauri iOS 工程链接 `swiftCompatibility56`/`Concurrency`/`Packs`，这些库在 Xcode 26.5 / iOS 26.5 SDK 已移除，导致 `ld: symbol(s) not found`。详见 issue #35。`release.yml` 的 build-ios 配置相同，发布构建也会失败。

## 修复

在 `dev-build.yml` 与 `release.yml` 的 `build-ios` job 第一步 `sudo xcode-select -s /Applications/Xcode_16.4.app` 显式切回 Xcode 16.4；若不存在则列出可用版本降级默认，便于诊断。`build-macos` 不动（不依赖 iOS Swift 兼容库）。

## 验证

合并 dev 后触发 Dev Build，确认 `build-ios` 成功。

## 影响范围

仅 iOS CI 环境，代码无变化。