### PR TITLE
fix(ui): dark mode for quick entry, update dialog, and opensource modal

### DIFF
--- a/src/components/Dashboard.spec.ts
+++ b/src/components/Dashboard.spec.ts
@@ -13,7 +13,7 @@ describe('Dashboard quick entry defaults', () => {
     expect(vue).toContain("schedule: { name: '课表'")
   })
 
-  it('uses unified black quick-entry icon surfaces in dark mode', () => {
+  it('keeps per-module tinted quick-entry icon surfaces in dark mode', () => {
     const vue = source()
     const darkCss = readFileSync(new URL('../styles/dark-mode.css', import.meta.url), 'utf8')
 
@@ -21,7 +21,9 @@ describe('Dashboard quick entry defaults', () => {
     expect(vue).toContain(':data-module="item.id"')
     expect(vue).toContain('class="quick-entry-icon w-10 h-10')
     expect(vue).toContain(':data-module="id"')
-    expect(darkCss).toContain('html.dark .quick-entry-icon')
-    expect(darkCss).toContain('background: #000 !important')
+    expect(vue).toContain('quick-entry-editor-item')
+    expect(darkCss).not.toContain('html.dark .quick-entry-icon {\n  background: #000')
+    expect(darkCss).toContain('html.dark .bg-blue-50')
+    expect(darkCss).toContain('html.dark .quick-entry-editor-item--selected')
   })
 })

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1497,8 +1497,8 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
             <div
               v-for="(meta, id) in quickEntryMeta"
               :key="id"
-              class="flex flex-col items-center p-2 rounded-xl cursor-pointer border-2 transition-all"
-              :class="draftQuickEntries.includes(id) ? 'border-blue-500 bg-blue-50' : 'border-transparent hover:bg-gray-50'"
+              class="quick-entry-editor-item flex flex-col items-center p-2 rounded-xl cursor-pointer border-2 transition-all"
+              :class="draftQuickEntries.includes(id) ? 'quick-entry-editor-item--selected' : 'border-transparent'"
               @click="toggleDraftEntry(id)"
             >
               <div

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -256,7 +256,7 @@ const handleShowLegal = async (tab) => {
     <!-- 开源说明弹窗 -->
     <div v-if="showOpenSourceModal" class="modal-mask" @click="showOpenSourceModal = false">
       <div class="modal-card" @click.stop>
-        <h3>📚 开源说明</h3>
+        <h3><span class="material-symbols-outlined opensource-title-icon">menu_book</span> 开源说明</h3>
         <p class="intro">Mini-HBUT 是一个开源项目，致力于提供更好的校园信息查询体验。</p>
         <div class="section">
           <p class="label">项目地址</p>
@@ -627,6 +627,13 @@ const handleShowLegal = async (tab) => {
   font-size: 18px;
   font-weight: 700;
   color: #1f2937;
+}
+
+.opensource-title-icon {
+  font-size: 20px;
+  vertical-align: -4px;
+  margin-right: 6px;
+  color: var(--ui-primary, #2563eb);
 }
 
 .modal-card .intro {

--- a/src/components/UpdateDialog.vue
+++ b/src/components/UpdateDialog.vue
@@ -151,7 +151,7 @@ onMounted(() => {
   <div class="update-dialog-overlay" @click.self="emit('close')">
     <div class="update-dialog">
       <div class="dialog-header">
-        <span class="icon">🔄</span>
+        <span class="material-symbols-outlined dialog-header-icon">sync</span>
         <h3>版本更新</h3>
       </div>
 
@@ -197,7 +197,7 @@ onMounted(() => {
                 @click="handleDownloadFromSource(source.url)"
               >
                 <div class="source-label">
-                  <span class="source-icon">{{ source.tag === 'github' ? '🐙' : '🔗' }}</span>
+                  <span class="material-symbols-outlined source-icon">{{ source.tag === 'github' ? 'code' : 'link' }}</span>
                   <span>{{ source.label }}</span>
                 </div>
                 <div class="source-speed">
@@ -212,15 +212,15 @@ onMounted(() => {
           </div>
 
           <div class="platform-info">
-            <span>📱 检测到平台: {{ updateInfo.platform }}</span>
-            <span v-if="updateInfo.assetName">📦 {{ updateInfo.assetName }}</span>
+            <span class="platform-line"><span class="material-symbols-outlined platform-icon">smartphone</span> 检测到平台: {{ updateInfo.platform }}</span>
+            <span v-if="updateInfo.assetName" class="platform-line"><span class="material-symbols-outlined platform-icon">inventory_2</span> {{ updateInfo.assetName }}</span>
           </div>
         </template>
 
         <!-- 构建中/无可用下载资产 -->
         <template v-else-if="updateInfo?.pending">
           <div class="up-to-date">
-            <span class="icon">⏳</span>
+            <span class="material-symbols-outlined status-icon">hourglass_top</span>
             <p>新版本正在构建中，请稍后再试</p>
             <span class="version">v{{ updateInfo.latestVersion }}</span>
           </div>
@@ -229,7 +229,7 @@ onMounted(() => {
         <!-- 已是最新 -->
         <template v-else-if="updateInfo && !updateInfo.hasUpdate && !updateInfo.error">
           <div class="up-to-date">
-            <span class="icon">✅</span>
+            <span class="material-symbols-outlined status-icon status-icon--success">check_circle</span>
             <p>已是最新版本</p>
             <span class="version">v{{ currentVersion }}</span>
           </div>
@@ -237,7 +237,7 @@ onMounted(() => {
 
         <!-- 错误 -->
         <div v-else-if="error || updateInfo?.error" class="error">
-          <span class="icon">⚠️</span>
+          <span class="material-symbols-outlined status-icon status-icon--warn">error</span>
           <p>{{ error || updateInfo?.message || '无法获取更新信息，请检查网络连接' }}</p>
           <button class="retry-btn" @click="checkUpdate">重试</button>
         </div>
@@ -291,7 +291,11 @@ onMounted(() => {
   color: white;
 }
 
-.dialog-header .icon { font-size: 28px; }
+.dialog-header .dialog-header-icon {
+  font-size: 28px;
+  line-height: 1;
+  font-variation-settings: 'FILL' 0, 'wght' 500, 'GRAD' 0, 'opsz' 24;
+}
 .dialog-header h3 { margin: 0; font-size: 20px; font-weight: 700; }
 
 .dialog-content {
@@ -361,10 +365,21 @@ onMounted(() => {
 .platform-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   font-size: 12px;
   color: #9ca3af;
   margin-top: 12px;
+}
+
+.platform-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.platform-icon {
+  font-size: 16px;
+  line-height: 1;
 }
 
 /* 下载源选择表 */
@@ -424,7 +439,11 @@ onMounted(() => {
   color: #374151;
 }
 
-.source-icon { font-size: 16px; }
+.source-icon {
+  font-size: 18px;
+  line-height: 1;
+  color: var(--ui-primary, #6366f1);
+}
 
 .source-speed { display: flex; align-items: center; }
 
@@ -469,7 +488,22 @@ onMounted(() => {
   padding: 20px 0;
 }
 
-.up-to-date .icon { font-size: 48px; margin-bottom: 12px; }
+.up-to-date .status-icon,
+.error .status-icon {
+  font-size: 48px;
+  line-height: 1;
+  margin-bottom: 12px;
+  color: #6366f1;
+}
+
+.up-to-date .status-icon--success {
+  color: #10b981;
+}
+
+.error .status-icon--warn {
+  color: #f59e0b;
+}
+
 .up-to-date p { margin: 0; font-size: 18px; font-weight: 600; color: #374151; }
 .up-to-date .version { margin-top: 4px; color: #9ca3af; font-size: 14px; }
 
@@ -481,7 +515,6 @@ onMounted(() => {
   color: #6b7280;
 }
 
-.error .icon { font-size: 48px; margin-bottom: 12px; }
 .error p { margin: 0 0 16px 0; text-align: center; }
 
 .retry-btn {

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -58,9 +58,93 @@ html.dark .bg-gray-100 {
   background-color: #334155 !important;
 }
 
-/* 含 Teleport 到 body 的「编辑快捷入口」弹窗，不能限定 .dashboard-root */
-html.dark .quick-entry-icon {
-  background: #000 !important;
+/* 快捷入口：保留各模块 Tailwind 浅色底在暗色下的分色映射（勿统一压黑） */
+html.dark .quick-entry-editor-panel {
+  background-color: #1e293b !important;
+  color: #e2e8f0 !important;
+}
+
+html.dark .quick-entry-editor-item {
+  border-color: transparent !important;
+}
+
+html.dark .quick-entry-editor-item:hover,
+html.dark .quick-entry-editor-item:active {
+  background-color: rgba(148, 163, 184, 0.12) !important;
+}
+
+html.dark .quick-entry-editor-item--selected {
+  border-color: #3b82f6 !important;
+  background-color: rgba(59, 130, 246, 0.18) !important;
+}
+
+html.dark .quick-entry-editor-item--selected:hover,
+html.dark .quick-entry-editor-item--selected:active {
+  background-color: rgba(59, 130, 246, 0.24) !important;
+}
+
+html.dark .bg-orange-50 {
+  background-color: rgba(249, 115, 22, 0.15) !important;
+}
+
+html.dark .bg-green-50 {
+  background-color: rgba(34, 197, 94, 0.15) !important;
+}
+
+html.dark .bg-red-50 {
+  background-color: rgba(239, 68, 68, 0.15) !important;
+}
+
+html.dark .bg-yellow-50 {
+  background-color: rgba(234, 179, 8, 0.15) !important;
+}
+
+html.dark .bg-teal-50 {
+  background-color: rgba(20, 184, 166, 0.15) !important;
+}
+
+html.dark .bg-indigo-50 {
+  background-color: rgba(99, 102, 241, 0.15) !important;
+}
+
+html.dark .bg-emerald-50 {
+  background-color: rgba(16, 185, 129, 0.15) !important;
+}
+
+html.dark .bg-cyan-50 {
+  background-color: rgba(6, 182, 212, 0.15) !important;
+}
+
+html.dark .bg-pink-50 {
+  background-color: rgba(236, 72, 153, 0.15) !important;
+}
+
+html.dark .bg-violet-50 {
+  background-color: rgba(139, 92, 246, 0.15) !important;
+}
+
+html.dark .bg-amber-50 {
+  background-color: rgba(245, 158, 11, 0.15) !important;
+}
+
+html.dark .bg-sky-50 {
+  background-color: rgba(14, 165, 233, 0.15) !important;
+}
+
+html.dark .bg-lime-50 {
+  background-color: rgba(132, 204, 22, 0.15) !important;
+}
+
+html.dark .quick-entry-icon.bg-gray-50 {
+  background-color: rgba(148, 163, 184, 0.12) !important;
+}
+
+html.dark .bg-blue-50 {
+  background-color: rgba(59, 130, 246, 0.15) !important;
+}
+
+html.dark .bg-blue-100 {
+  background-color: rgba(59, 130, 246, 0.2) !important;
 }
 
 /* ─── 通用文字颜色 ─── */
@@ -1328,14 +1412,6 @@ html.dark .dialog-btn.ghost {
   border-color: rgba(148, 163, 184, 0.2) !important;
 }
 
-html.dark .bg-blue-50 {
-  background-color: rgba(59, 130, 246, 0.15) !important;
-}
-
-html.dark .bg-blue-100 {
-  background-color: rgba(59, 130, 246, 0.2) !important;
-}
-
 /* ═══════════════════════════════════════════════════════════════
    设置页面 SettingsView 暗色模式修复
    ═══════════════════════════════════════════════════════════════ */
@@ -2202,4 +2278,158 @@ html.dark .text-orange-700 {
 
 html.dark .text-orange-600 {
   color: #fb923c !important;
+}
+
+/* ─── 检查更新弹窗 UpdateDialog ─── */
+html.dark .update-dialog {
+  background: #1e293b !important;
+  color: #e2e8f0 !important;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55) !important;
+}
+
+html.dark .update-dialog .dialog-content {
+  color: #e2e8f0 !important;
+}
+
+html.dark .update-dialog .checking p,
+html.dark .update-dialog .version-badge.current,
+html.dark .update-dialog .notes-content,
+html.dark .update-dialog .platform-info,
+html.dark .update-dialog .up-to-date p,
+html.dark .update-dialog .up-to-date .version,
+html.dark .update-dialog .error {
+  color: #94a3b8 !important;
+}
+
+html.dark .update-dialog .release-notes {
+  background: rgba(15, 23, 42, 0.72) !important;
+  border: 1px solid rgba(148, 163, 184, 0.16) !important;
+}
+
+html.dark .update-dialog .release-notes h4,
+html.dark .update-dialog .source-table-header,
+html.dark .update-dialog .source-label {
+  color: #e2e8f0 !important;
+}
+
+html.dark .update-dialog .version-badge.current {
+  background: rgba(148, 163, 184, 0.16) !important;
+}
+
+html.dark .update-dialog .source-table {
+  border-color: rgba(148, 163, 184, 0.2) !important;
+}
+
+html.dark .update-dialog .source-table-header,
+html.dark .update-dialog .source-row {
+  background: rgba(15, 23, 42, 0.55) !important;
+  border-color: rgba(148, 163, 184, 0.14) !important;
+}
+
+html.dark .update-dialog .source-row:hover,
+html.dark .update-dialog .source-row:active {
+  background: rgba(59, 130, 246, 0.12) !important;
+}
+
+html.dark .update-dialog .retest-btn {
+  background: rgba(59, 130, 246, 0.14) !important;
+  border-color: rgba(96, 165, 250, 0.35) !important;
+  color: #93c5fd !important;
+}
+
+html.dark .update-dialog .dialog-actions {
+  background: rgba(15, 23, 42, 0.88) !important;
+  border-top-color: rgba(148, 163, 184, 0.18) !important;
+}
+
+html.dark .update-dialog .btn-secondary {
+  background: #334155 !important;
+  color: #e2e8f0 !important;
+}
+
+html.dark .update-dialog .download-progress {
+  background: rgba(59, 130, 246, 0.12) !important;
+}
+
+html.dark .update-dialog .progress-bar {
+  background: rgba(59, 130, 246, 0.22) !important;
+}
+
+html.dark .update-dialog .spinner {
+  border-color: rgba(148, 163, 184, 0.25) !important;
+  border-top-color: var(--ui-primary, #60a5fa) !important;
+}
+
+html.dark .update-dialog .speed-ok {
+  background: rgba(16, 185, 129, 0.18) !important;
+  color: #6ee7b7 !important;
+}
+
+html.dark .update-dialog .speed-slow {
+  background: rgba(245, 158, 11, 0.18) !important;
+  color: #fcd34d !important;
+}
+
+html.dark .update-dialog .speed-fail {
+  background: rgba(239, 68, 68, 0.18) !important;
+  color: #fca5a5 !important;
+}
+
+html.dark .update-dialog .speed-testing {
+  background: rgba(59, 130, 246, 0.18) !important;
+  color: #93c5fd !important;
+}
+
+html.dark .update-dialog .status-icon {
+  color: #93c5fd !important;
+}
+
+html.dark .update-dialog .status-icon--success {
+  color: #34d399 !important;
+}
+
+html.dark .update-dialog .status-icon--warn {
+  color: #fbbf24 !important;
+}
+
+/* ─── 开源说明 / 赞助弹窗（MeView modal-card 子元素） ─── */
+html.dark .modal-card h3 {
+  color: #e2e8f0 !important;
+}
+
+html.dark .modal-card .intro,
+html.dark .modal-card .label,
+html.dark .modal-card .opensource-list,
+html.dark .modal-card .opensource-list li,
+html.dark .modal-card .thanks p {
+  color: #94a3b8 !important;
+}
+
+html.dark .modal-card .github-link {
+  background: rgba(15, 23, 42, 0.72) !important;
+  border: 1px solid rgba(148, 163, 184, 0.18) !important;
+  color: #93c5fd !important;
+}
+
+html.dark .modal-card .thanks {
+  background: rgba(15, 23, 42, 0.72) !important;
+  border-left-color: #60a5fa !important;
+}
+
+html.dark .modal-card .thanks .highlight {
+  color: #93c5fd !important;
+}
+
+html.dark .modal-card .tag {
+  background: rgba(59, 130, 246, 0.22) !important;
+  color: #dbeafe !important;
+}
+
+html.dark .modal-card .opensource-title-icon {
+  color: #93c5fd !important;
+}
+
+/* 快捷入口课表图标：避免被首页维护横幅的 bg-orange-50 规则覆盖 */
+html.dark .quick-entry-icon.bg-orange-50 {
+  background-color: rgba(249, 115, 22, 0.15) !important;
 }


### PR DESCRIPTION
## Summary

- Fix dark mode for home quick entry editor: selected/hover tiles use dark tinted backgrounds instead of light `bg-blue-50` / `hover:bg-gray-50`; remove unified `#000` icon override and restore per-module tinted icon surfaces (grades / schedule / resource share style).
- Adapt `UpdateDialog` for dark mode and replace emoji status/icons with `material-symbols-outlined` (`sync`, `check_circle`, `error`, `link`, etc.).
- Adapt MeView opensource modal sub-elements (GitHub link, tags, thanks block) for dark mode; replace title emoji with Material Symbol.

## Test plan

- [x] `npm run test:ci` — 318/318 passed
- [ ] Dark mode: Home → edit quick entry → select/deselect modules; icon backgrounds stay tinted
- [ ] Dark mode: Me → Check for updates → all states readable; no emoji icons
- [ ] Dark mode: Me → Open source license → modal text/link/thanks readable
- [ ] Light mode smoke check for the three flows above

Closes #94
Closes #95
Closes #96
Closes #97
