### PR TITLE
fix(android): 小组件刷新、深链跳转与 UI 优化 (#111)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,12 +24,24 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Deep link: minihbut://schedule（小组件点击跳转） -->
+            <!-- Deep link: minihbut://*（小组件点击跳转） -->
             <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="minihbut" android:host="schedule" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="minihbut" android:host="electricity" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="minihbut" android:host="exam" />
             </intent-filter>
 
         </activity>

--- a/android/app/src/main/java/com/hbut/mini/MainActivity.java
+++ b/android/app/src/main/java/com/hbut/mini/MainActivity.java
@@ -11,6 +11,8 @@ import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
     private static final String TAG = "MainActivity";
+    private String pendingWidgetEvent = null;
+    private String pendingWidgetPayload = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -18,46 +20,84 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(MiniHbutWidgetPlugin.class);
         super.onCreate(savedInstanceState);
         configureWebViewForEmbeddedModules();
-        // 冷启动时也检查 intent 中的 deep link
         handleDeepLinkIntent(getIntent());
     }
 
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        setIntent(intent);
         handleDeepLinkIntent(intent);
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        flushPendingWidgetEvent();
+    }
+
+    private void flushPendingWidgetEvent() {
+        if (pendingWidgetPayload == null || pendingWidgetEvent == null) return;
+        if (getBridge() == null) return;
+        getBridge().triggerJSEvent(pendingWidgetEvent, "window", pendingWidgetPayload);
+        pendingWidgetEvent = null;
+        pendingWidgetPayload = null;
+    }
+
+    private void dispatchWidgetEvent(String eventName, String payloadJson) {
+        Log.i(TAG, "Widget event " + eventName + ": " + payloadJson);
+        if (getBridge() != null) {
+            getBridge().triggerJSEvent(eventName, "window", payloadJson);
+            return;
+        }
+        pendingWidgetEvent = eventName;
+        pendingWidgetPayload = payloadJson;
+    }
+
     /**
-     * 解析 minihbut://schedule 深链接并派发到 Web 层
-     * 仅当 scheme == "minihbut" 且 host == "schedule" 时处理
+     * 解析 minihbut:// 深链接并派发到 Web 层。
      */
     private void handleDeepLinkIntent(Intent intent) {
         if (intent == null) return;
         Uri data = intent.getData();
         if (data == null) return;
-        if (!"minihbut".equals(data.getScheme()) || !"schedule".equals(data.getHost())) return;
+        if (!"minihbut".equals(data.getScheme())) return;
 
-        String date = data.getQueryParameter("date");
-        String source = data.getQueryParameter("source");
-        String period = data.getQueryParameter("period");
+        String host = data.getHost();
+        if (host == null) return;
 
-        // 构建 JSON payload
-        StringBuilder json = new StringBuilder("{");
-        json.append("\"date\":").append(date != null ? "\"" + escapeJson(date) + "\"" : "null");
-        json.append(",\"source\":").append(source != null ? "\"" + escapeJson(source) + "\"" : "\"widget\"");
-        json.append(",\"period\":").append(period != null ? period : "null");
-        json.append("}");
-
-        String payloadJson = json.toString();
-        Log.i(TAG, "Widget deep link received: " + payloadJson);
-
-        if (getBridge() != null) {
-            getBridge().triggerJSEvent("widgetDeeplink", "window", payloadJson);
+        switch (host) {
+            case "schedule": {
+                String date = data.getQueryParameter("date");
+                String source = data.getQueryParameter("source");
+                String period = data.getQueryParameter("period");
+                StringBuilder json = new StringBuilder("{");
+                json.append("\"date\":").append(date != null ? "\"" + escapeJson(date) + "\"" : "null");
+                json.append(",\"source\":").append(source != null ? "\"" + escapeJson(source) + "\"" : "\"widget\"");
+                json.append(",\"period\":").append(period != null ? period : "null");
+                json.append("}");
+                dispatchWidgetEvent("widgetDeeplink", json.toString());
+                break;
+            }
+            case "electricity": {
+                String source = data.getQueryParameter("source");
+                String payload = "{\"view\":\"electricity\",\"source\":\""
+                    + escapeJson(source != null ? source : "widget") + "\"}";
+                dispatchWidgetEvent("widgetNavigate", payload);
+                break;
+            }
+            case "exam": {
+                String source = data.getQueryParameter("source");
+                String payload = "{\"view\":\"exams\",\"source\":\""
+                    + escapeJson(source != null ? source : "widget") + "\"}";
+                dispatchWidgetEvent("widgetNavigate", payload);
+                break;
+            }
+            default:
+                break;
         }
     }
 
-    /** 简单 JSON 字符串转义（防止注入） */
     private static String escapeJson(String value) {
         if (value == null) return "";
         return value
@@ -74,9 +114,6 @@ public class MainActivity extends BridgeActivity {
             if (webView == null) return;
             WebSettings settings = webView.getSettings();
             if (settings == null) return;
-            // 安卓模块页统一改为 Capacitor 本地文件映射内嵌。
-            // 宿主页仍是 https://localhost，部分 WebView 对本地映射资源会误判为混合内容，
-            // 这里保留兼容配置，但不再把 127.0.0.1 module bridge 视为安卓预期链路。
             settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
             settings.setDomStorageEnabled(true);
             settings.setJavaScriptCanOpenWindowsAutomatically(true);
@@ -85,5 +122,4 @@ public class MainActivity extends BridgeActivity {
             Log.w(TAG, "WebView configure skipped: " + e.getMessage());
         }
     }
-
 }

--- a/android/app/src/main/java/com/hbut/mini/widget/ElectricityWidgetRenderer.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/ElectricityWidgetRenderer.kt
@@ -53,16 +53,16 @@ object ElectricityWidgetRenderer {
             if (statusId != 0) views.setViewVisibility(statusId, View.GONE)
         }
 
-        // 点击启动 App
-        val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
-            ?: Intent().apply {
-                setClassName(packageName, "${packageName}.MainActivity")
-                action = Intent.ACTION_MAIN
-                addCategory(Intent.CATEGORY_LAUNCHER)
-            }
-        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-        val pi = PendingIntent.getActivity(context, appWidgetId + 1000, launchIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        // 点击跳转电费查询页
+        val pi = WidgetDeepLink.pendingIntent(
+            context,
+            appWidgetId + 1000,
+            WidgetDeepLink.electricityUri()
+        )
+        val themeColor = parseColor(store.readThemeColor())
+        if (quantityId != 0 && data != null) {
+            views.setTextColor(quantityId, themeColor)
+        }
         val rootId = context.resources.getIdentifier("widget_elec_root", "id", packageName)
         if (rootId != 0) views.setOnClickPendingIntent(rootId, pi)
 
@@ -72,5 +72,13 @@ object ElectricityWidgetRenderer {
     private fun parseJson(json: String?): JSONObject? {
         if (json.isNullOrBlank()) return null
         return try { JSONObject(json) } catch (_: Exception) { null }
+    }
+
+    private fun parseColor(hex: String): Int {
+        return try {
+            android.graphics.Color.parseColor(hex)
+        } catch (_: Exception) {
+            android.graphics.Color.parseColor("#2563eb")
+        }
     }
 }

--- a/android/app/src/main/java/com/hbut/mini/widget/ExamWidgetRenderer.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/ExamWidgetRenderer.kt
@@ -83,16 +83,16 @@ object ExamWidgetRenderer {
             if (countdownId != 0) views.setViewVisibility(countdownId, View.GONE)
         }
 
-        // 点击启动 App
-        val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
-            ?: Intent().apply {
-                setClassName(packageName, "${packageName}.MainActivity")
-                action = Intent.ACTION_MAIN
-                addCategory(Intent.CATEGORY_LAUNCHER)
-            }
-        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-        val pi = PendingIntent.getActivity(context, appWidgetId + 2000, launchIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        // 点击跳转考试安排页
+        val pi = WidgetDeepLink.pendingIntent(
+            context,
+            appWidgetId + 2000,
+            WidgetDeepLink.examUri()
+        )
+        val themeColor = parseColor(store.readThemeColor())
+        if (countdownId != 0 && data != null) {
+            views.setTextColor(countdownId, themeColor)
+        }
         val rootId = context.resources.getIdentifier("widget_exam_root", "id", packageName)
         if (rootId != 0) views.setOnClickPendingIntent(rootId, pi)
 
@@ -107,5 +107,13 @@ object ExamWidgetRenderer {
     private fun parseJson(json: String?): JSONObject? {
         if (json.isNullOrBlank()) return null
         return try { JSONObject(json) } catch (_: Exception) { null }
+    }
+
+    private fun parseColor(hex: String): Int {
+        return try {
+            android.graphics.Color.parseColor(hex)
+        } catch (_: Exception) {
+            android.graphics.Color.parseColor("#2563eb")
+        }
     }
 }

--- a/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesProvider.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesProvider.kt
@@ -25,6 +25,15 @@ class TodayCoursesProvider : AppWidgetProvider() {
         }
     }
 
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: android.os.Bundle
+    ) {
+        WidgetRenderer.updateWidget(context, appWidgetManager, appWidgetId)
+    }
+
     override fun onEnabled(context: Context) {
         // 第一个小组件实例被添加，注册 WorkManager 周期刷新任务
         WidgetRefreshScheduler.ensurePeriodic(context)

--- a/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesRemoteViewsService.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesRemoteViewsService.kt
@@ -112,7 +112,34 @@ class TodayCoursesRemoteViewsFactory(
             contentDesc
         )
 
+        // 行点击深链：携带节次参数
+        val snapshotDate = readSnapshotDate(store.readSnapshot())
+        if (snapshotDate.isNotEmpty() && row.periodStart >= 1) {
+            val fillInIntent = Intent().apply {
+                data = WidgetDeepLink.scheduleUri(snapshotDate, row.periodStart)
+            }
+            views.setOnClickFillInIntent(
+                context.resources.getIdentifier("widget_item_row_root", "id", packageName),
+                fillInIntent
+            )
+        }
+
+        // 节次 badge 背景
+        val periodBgId = context.resources.getIdentifier("widget_period_badge", "drawable", packageName)
+        if (periodBgId != 0) {
+            views.setInt(periodId, "setBackgroundResource", periodBgId)
+        }
+
         return views
+    }
+
+    private fun readSnapshotDate(json: String?): String {
+        if (json.isNullOrBlank()) return ""
+        return try {
+            JSONObject(json).optString("date", "")
+        } catch (_: Exception) {
+            ""
+        }
     }
 
     override fun getLoadingView(): RemoteViews? = null

--- a/android/app/src/main/java/com/hbut/mini/widget/WidgetDeepLink.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/WidgetDeepLink.kt
@@ -1,0 +1,54 @@
+package com.hbut.mini.widget
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * 小组件点击深链构造与 PendingIntent 封装。
+ */
+object WidgetDeepLink {
+    private const val SCHEME = "minihbut"
+
+    fun scheduleUri(date: String, period: Int? = null): Uri {
+        val builder = Uri.Builder()
+            .scheme(SCHEME)
+            .authority("schedule")
+            .appendQueryParameter("date", date)
+            .appendQueryParameter("source", "widget")
+        if (period != null && period >= 1) {
+            builder.appendQueryParameter("period", period.toString())
+        }
+        return builder.build()
+    }
+
+    fun electricityUri(): Uri = Uri.Builder()
+        .scheme(SCHEME)
+        .authority("electricity")
+        .appendQueryParameter("source", "widget")
+        .build()
+
+    fun examUri(): Uri = Uri.Builder()
+        .scheme(SCHEME)
+        .authority("exam")
+        .appendQueryParameter("source", "widget")
+        .build()
+
+    fun pendingIntent(context: Context, requestCode: Int, uri: Uri): PendingIntent {
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            setClassName(context.packageName, "${context.packageName}.MainActivity")
+            addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK
+                    or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                    or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            )
+        }
+        return PendingIntent.getActivity(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}

--- a/android/app/src/main/java/com/hbut/mini/widget/WidgetLayoutHelper.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/WidgetLayoutHelper.kt
@@ -1,0 +1,78 @@
+package com.hbut.mini.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.os.Bundle
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/**
+ * 小组件布局选择与空态文案（镜像 Web 层 resolveRenderKind 语义）。
+ */
+object WidgetLayoutHelper {
+    private val staleThresholdMs = TimeUnit.HOURS.toMillis(24)
+
+    fun resolveLayoutName(options: Bundle?): String {
+        if (options == null) return "widget_today_courses_4x2"
+        val minW = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 250)
+        val minH = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 110)
+        val wCells = (minW + 30) / 70
+        val hCells = (minH + 30) / 70
+        return when {
+            wCells <= 2 && hCells <= 2 -> "widget_today_courses_2x2"
+            hCells <= 1 && wCells >= 3 -> "widget_today_courses_4x1"
+            else -> "widget_today_courses_4x2"
+        }
+    }
+
+    fun isCompactLayout(layoutName: String): Boolean {
+        return layoutName == "widget_today_courses_2x2" || layoutName == "widget_today_courses_4x1"
+    }
+
+    fun listCapacity(layoutName: String): Int = when (layoutName) {
+        "widget_today_courses_2x2" -> 1
+        "widget_today_courses_4x1" -> 1
+        else -> 3
+    }
+
+    fun emptyStateMessage(context: Context, snapshot: JSONObject?): String {
+        if (snapshot == null) {
+            return context.getString(
+                context.resources.getIdentifier("widget_login_required", "string", context.packageName)
+            )
+        }
+        val studentId = snapshot.optString("student_id", "")
+        if (studentId.isBlank()) {
+            return context.getString(
+                context.resources.getIdentifier("widget_login_required", "string", context.packageName)
+            )
+        }
+        val courses = snapshot.optJSONArray("courses")
+        val count = courses?.length() ?: 0
+        if (count > 0) return ""
+        val weekday = snapshot.optInt("weekday", 0)
+        if (weekday == 6 || weekday == 7) {
+            return context.getString(
+                context.resources.getIdentifier("widget_weekend", "string", context.packageName)
+            )
+        }
+        return context.getString(
+            context.resources.getIdentifier("widget_no_course", "string", context.packageName)
+        )
+    }
+
+    fun isStale(snapshot: JSONObject): Boolean {
+        val generatedAt = snapshot.optString("generated_at", "")
+        if (generatedAt.isBlank()) return false
+        val ts = try {
+            java.time.Instant.parse(generatedAt).toEpochMilli()
+        } catch (_: Exception) {
+            return false
+        }
+        return System.currentTimeMillis() - ts > staleThresholdMs
+    }
+
+    fun staleHint(context: Context): String = context.getString(
+        context.resources.getIdentifier("widget_stale_hint", "string", context.packageName)
+    )
+}

--- a/android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt
+++ b/android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt
@@ -1,23 +1,16 @@
 package com.hbut.mini.widget
 
-import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.view.View
 import android.widget.RemoteViews
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
  * Widget 渲染器 — 构建 RemoteViews 并推送到 AppWidgetManager。
- *
- * 职责：
- * - 从 WidgetDataStore 读取快照数据
- * - 更新标题栏（周次 + 脱敏学号）
- * - 设置 PendingIntent（点击跳转）
- * - 绑定 RemoteAdapter 到 ListView（课程列表）
- * - 处理无数据/未登录状态的占位显示
  */
 object WidgetRenderer {
 
@@ -27,45 +20,49 @@ object WidgetRenderer {
 
     fun updateWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
         val packageName = context.packageName
-        val layoutId = context.resources.getIdentifier(
-            "widget_today_courses_4x2", "layout", packageName
-        )
+        val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
+        val layoutName = WidgetLayoutHelper.resolveLayoutName(options)
+        val layoutId = context.resources.getIdentifier(layoutName, "layout", packageName)
         if (layoutId == 0) return
 
         val views = RemoteViews(packageName, layoutId)
         val store = WidgetDataStore(context)
         val snapshotJson = store.readSnapshot()
         val themeColor = parseColor(store.readThemeColor())
-
-        // ── 解析快照数据 ──
         val snapshot = parseSnapshot(snapshotJson)
         val date = snapshot?.optString("date", "") ?: ""
         val weekIndex = snapshot?.optInt("week_index", 0) ?: 0
         val studentId = snapshot?.optString("student_id", "") ?: ""
         val courses = snapshot?.optJSONArray("courses")
         val courseCount = courses?.length() ?: 0
+        val emptyMessage = WidgetLayoutHelper.emptyStateMessage(context, snapshot)
+        val stale = snapshot != null && WidgetLayoutHelper.isStale(snapshot)
 
-        // ── 更新标题（含日期） ──
         val titleId = context.resources.getIdentifier("widget_title", "id", packageName)
         val overflowId = context.resources.getIdentifier("widget_overflow_tag", "id", packageName)
+        val emptyId = context.resources.getIdentifier("widget_empty", "id", packageName)
+        val listId = context.resources.getIdentifier("widget_list", "id", packageName)
 
         if (titleId != 0) {
-            val titleText = if (weekIndex > 0 && date.isNotEmpty()) {
-                val displayDate = formatDateChinese(date)
-                "今日课程 · $displayDate"
-            } else if (snapshot == null || studentId.isEmpty()) {
-                "请先在 Mini-HBUT 登录"
-            } else {
-                "今日课程"
+            val titleText = when {
+                weekIndex > 0 && date.isNotEmpty() -> {
+                    val displayDate = formatDateChinese(date)
+                    "今日课程 · $displayDate"
+                }
+                emptyMessage.isNotEmpty() -> emptyMessage
+                else -> "今日课程"
             }
             views.setTextViewText(titleId, titleText)
         }
 
-        // ── 溢出角标 ──
         if (overflowId != 0) {
-            val capacity = 3
+            val capacity = WidgetLayoutHelper.listCapacity(layoutName)
             if (courseCount > capacity) {
                 views.setTextViewText(overflowId, "+${courseCount - capacity} 节")
+                views.setTextColor(overflowId, themeColor)
+                views.setViewVisibility(overflowId, View.VISIBLE)
+            } else if (stale) {
+                views.setTextViewText(overflowId, WidgetLayoutHelper.staleHint(context))
                 views.setTextColor(overflowId, themeColor)
                 views.setViewVisibility(overflowId, View.VISIBLE)
             } else {
@@ -73,53 +70,105 @@ object WidgetRenderer {
             }
         }
 
-        // ── PendingIntent：点击 widget 启动 App ──
-        // 直接使用 MAIN/LAUNCHER intent（最可靠的方式）
-        val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
-            ?: Intent().apply {
-                setClassName(packageName, "${packageName}.MainActivity")
-                action = Intent.ACTION_MAIN
-                addCategory(Intent.CATEGORY_LAUNCHER)
-            }
-        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-
-        val pendingIntent = PendingIntent.getActivity(
+        val deepLinkDate = if (date.isNotEmpty()) date else java.time.LocalDate.now().toString()
+        val rootPendingIntent = WidgetDeepLink.pendingIntent(
             context,
             appWidgetId,
-            launchIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            WidgetDeepLink.scheduleUri(deepLinkDate)
         )
 
         val rootId = context.resources.getIdentifier("widget_root", "id", packageName)
         if (rootId != 0) {
-            views.setOnClickPendingIntent(rootId, pendingIntent)
+            views.setOnClickPendingIntent(rootId, rootPendingIntent)
         }
 
-        // ── RemoteAdapter：绑定 ListView 到 RemoteViewsService ──
-        val listId = context.resources.getIdentifier("widget_list", "id", packageName)
-        if (listId != 0) {
+        if (WidgetLayoutHelper.isCompactLayout(layoutName)) {
+            bindCompactCourse(context, views, courses, themeColor)
+            if (listId != 0) views.setViewVisibility(listId, View.GONE)
+            if (emptyId != 0) views.setViewVisibility(emptyId, View.GONE)
+        } else {
+            bindListCourse(context, views, appWidgetId, appWidgetManager, listId, emptyId, courseCount, emptyMessage, rootPendingIntent)
+        }
+
+        appWidgetManager.updateAppWidget(appWidgetId, views)
+        if (listId != 0 && courseCount > 0 && !WidgetLayoutHelper.isCompactLayout(layoutName)) {
+            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, listId)
+        }
+    }
+
+    private fun bindCompactCourse(
+        context: Context,
+        views: RemoteViews,
+        courses: JSONArray?,
+        themeColor: Int
+    ) {
+        val packageName = context.packageName
+        val nameId = context.resources.getIdentifier("widget_next_course_name", "id", packageName)
+        val timeId = context.resources.getIdentifier("widget_next_course_time", "id", packageName)
+        val locationId = context.resources.getIdentifier("widget_next_course_location", "id", packageName)
+
+        if (courses == null || courses.length() == 0) {
+            if (nameId != 0) views.setTextViewText(nameId, "")
+            if (timeId != 0) views.setTextViewText(timeId, "")
+            if (locationId != 0) views.setViewVisibility(locationId, View.GONE)
+            return
+        }
+
+        val next = courses.getJSONObject(0)
+        val periodStart = next.optInt("period_start", 0)
+        val periodEnd = next.optInt("period_end", periodStart)
+        val periodText = if (periodStart == periodEnd) "${periodStart}节" else "${periodStart}-${periodEnd}节"
+        val timeStart = next.optString("time_start", "")
+        val timeEnd = next.optString("time_end", "")
+        val name = next.optString("name", "")
+        val location = next.optString("location", "")
+
+        if (nameId != 0) views.setTextViewText(nameId, name)
+        if (timeId != 0) {
+            views.setTextViewText(timeId, "$periodText $timeStart-$timeEnd")
+            views.setTextColor(timeId, themeColor)
+        }
+        if (locationId != 0) {
+            if (location.isNotEmpty()) {
+                views.setTextViewText(locationId, location)
+                views.setViewVisibility(locationId, View.VISIBLE)
+            } else {
+                views.setViewVisibility(locationId, View.GONE)
+            }
+        }
+    }
+
+    private fun bindListCourse(
+        context: Context,
+        views: RemoteViews,
+        appWidgetId: Int,
+        appWidgetManager: AppWidgetManager,
+        listId: Int,
+        emptyId: Int,
+        courseCount: Int,
+        emptyMessage: String,
+        rootPendingIntent: android.app.PendingIntent
+    ) {
+        if (listId == 0) return
+
+        if (courseCount > 0) {
             val serviceIntent = Intent(context, TodayCoursesRemoteViewsService::class.java).apply {
                 putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
                 data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
             }
             views.setRemoteAdapter(listId, serviceIntent)
-
-            // 设置 ListView 项的点击 PendingIntent 模板
-            views.setPendingIntentTemplate(listId, pendingIntent)
+            views.setPendingIntentTemplate(listId, rootPendingIntent)
+            views.setViewVisibility(listId, View.VISIBLE)
+            if (emptyId != 0) views.setViewVisibility(emptyId, View.GONE)
+        } else {
+            views.setViewVisibility(listId, View.GONE)
+            if (emptyId != 0) {
+                views.setTextViewText(emptyId, emptyMessage.ifEmpty { "今日无课" })
+                views.setViewVisibility(emptyId, View.VISIBLE)
+            }
         }
-
-        // ── 处理无课程状态 ──
-        val listVisibility = if (courseCount > 0) View.VISIBLE else View.GONE
-        if (listId != 0) {
-            views.setViewVisibility(listId, listVisibility)
-        }
-
-        appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 
-    /**
-     * 安全解析 snapshot JSON。
-     */
     private fun parseSnapshot(json: String?): JSONObject? {
         if (json.isNullOrBlank()) return null
         return try {
@@ -129,9 +178,6 @@ object WidgetRenderer {
         }
     }
 
-    /**
-     * 将 "2026-05-12" 格式化为 "5月12日"
-     */
     private fun formatDateChinese(date: String): String {
         return try {
             val parts = date.split("-")
@@ -147,14 +193,11 @@ object WidgetRenderer {
         }
     }
 
-    /**
-     * 解析 hex 颜色字符串为 Android Color int
-     */
     private fun parseColor(hex: String): Int {
         return try {
             android.graphics.Color.parseColor(hex)
         } catch (_: Exception) {
-            android.graphics.Color.parseColor("#2563eb") // 默认蓝色
+            android.graphics.Color.parseColor("#2563eb")
         }
     }
 }

--- a/android/app/src/main/res/layout/widget_item_course_row.xml
+++ b/android/app/src/main/res/layout/widget_item_course_row.xml
@@ -13,10 +13,14 @@
         android:id="@+id/widget_item_period"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/widget_period_badge"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
         android:textColor="@color/widget_period_text"
         android:textSize="12sp"
         android:textStyle="bold"
-        android:paddingEnd="8dp"
         android:minWidth="40dp" />
 
     <!-- 课程名 -->

--- a/android/app/src/main/res/layout/widget_today_courses_4x2.xml
+++ b/android/app/src/main/res/layout/widget_today_courses_4x2.xml
@@ -21,6 +21,17 @@
         android:ellipsize="end"
         android:paddingBottom="6dp" />
 
+    <!-- 空态提示（4x2 无课程时显示） -->
+    <TextView
+        android:id="@+id/widget_empty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:textColor="@color/widget_text_secondary"
+        android:textSize="13sp"
+        android:visibility="gone" />
+
     <!-- 课程列表 -->
     <ListView
         android:id="@+id/widget_list"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1055,21 +1055,62 @@ const handleWidgetDeeplinkPayload = (payload) => {
 }
 
 /**
- * 解析 minihbut://schedule?... URL 并派发
+ * 处理 Widget 导航 payload（电费 / 考试等）
  */
-const parseWidgetDeeplinkUrl = (urlStr) => {
+const handleWidgetNavigatePayload = (payload) => {
+  if (!payload) return
+  const view = normalizeViewName(String(payload.view || '').trim())
+  const source = String(payload.source || 'widget').trim()
+  if (!view) return
+  if (source && source !== 'widget') return
+  if (view !== 'electricity' && view !== 'exams') return
+  console.info('[Widget] Navigate received:', { view, source })
+  if (currentView.value !== view) {
+    goToView(view, { push: true })
+  }
+}
+
+/**
+ * 解析 minihbut:// 小组件 URL
+ */
+const parseWidgetOpenUrl = (urlStr) => {
   try {
     const url = new URL(urlStr)
-    if (url.protocol !== 'minihbut:' || url.hostname !== 'schedule') return null
-    return {
-      date: url.searchParams.get('date') || '',
-      source: url.searchParams.get('source') || 'widget',
-      period: url.searchParams.get('period') || ''
+    if (url.protocol !== 'minihbut:') return null
+    const source = url.searchParams.get('source') || 'widget'
+    if (url.hostname === 'schedule') {
+      return {
+        kind: 'schedule',
+        date: url.searchParams.get('date') || '',
+        source,
+        period: url.searchParams.get('period') || ''
+      }
     }
+    if (url.hostname === 'electricity') {
+      return { kind: 'navigate', view: 'electricity', source }
+    }
+    if (url.hostname === 'exam') {
+      return { kind: 'navigate', view: 'exams', source }
+    }
+    return null
   } catch {
     return null
   }
 }
+
+const handleWidgetOpenPayload = (payload) => {
+  if (!payload) return
+  if (payload.kind === 'schedule' || payload.date) {
+    handleWidgetDeeplinkPayload(payload)
+    return
+  }
+  if (payload.kind === 'navigate' || payload.view) {
+    handleWidgetNavigatePayload(payload)
+  }
+}
+
+/** @deprecated 使用 parseWidgetOpenUrl */
+const parseWidgetDeeplinkUrl = (urlStr) => parseWidgetOpenUrl(urlStr)
 
 /**
  * 注册 Widget 深链接监听器（Capacitor appUrlOpen + 原生 bridge 事件）
@@ -1081,10 +1122,23 @@ const installWidgetDeeplinkListeners = () => {
       const detail = typeof e.detail === 'string' ? JSON.parse(e.detail) : e.detail
       handleWidgetDeeplinkPayload(detail)
     } catch {
-      // 尝试从 event 本身解析（triggerJSEvent 会把 JSON 字符串作为 CustomEvent.detail）
       try {
         const raw = (e && typeof e === 'object') ? JSON.parse(String(e.data || '{}')) : {}
         handleWidgetDeeplinkPayload(raw)
+      } catch {
+        // ignore
+      }
+    }
+  })
+
+  window.addEventListener('widgetNavigate', (e) => {
+    try {
+      const detail = typeof e.detail === 'string' ? JSON.parse(e.detail) : e.detail
+      handleWidgetNavigatePayload(detail)
+    } catch {
+      try {
+        const raw = (e && typeof e === 'object') ? JSON.parse(String(e.data || '{}')) : {}
+        handleWidgetNavigatePayload(raw)
       } catch {
         // ignore
       }
@@ -1096,20 +1150,19 @@ const installWidgetDeeplinkListeners = () => {
     import('@capacitor/app').then((mod) => {
       mod.App.addListener('appUrlOpen', (event) => {
         if (!event?.url) return
-        const payload = parseWidgetDeeplinkUrl(event.url)
+        const payload = parseWidgetOpenUrl(event.url)
         if (payload) {
-          // 冷启动路径：等 appBootstrapped 后再执行
+          const dispatch = () => handleWidgetOpenPayload(payload)
           if (!appBootstrapped) {
             const waitForBoot = setInterval(() => {
               if (appBootstrapped) {
                 clearInterval(waitForBoot)
-                handleWidgetDeeplinkPayload(payload)
+                dispatch()
               }
             }, 100)
-            // 最多等 5s
             setTimeout(() => clearInterval(waitForBoot), 5000)
           } else {
-            handleWidgetDeeplinkPayload(payload)
+            dispatch()
           }
         }
       })

--- a/src/platform/capacitor/widget.ts
+++ b/src/platform/capacitor/widget.ts
@@ -168,14 +168,17 @@ export async function writeSnapshot(snapshot: TodayCourseSnapshot): Promise<void
  */
 export async function clearSnapshot(): Promise<void> {
   await getWidgetBridge().clearSnapshot()
+  await requestRefresh()
 }
 
 export async function writeElectricitySnapshot(data: ElectricityWidgetSnapshot): Promise<void> {
   await getWidgetBridge().writeElectricity({ data })
+  await requestRefresh()
 }
 
 export async function writeExamSnapshot(data: ExamWidgetSnapshot): Promise<void> {
   await getWidgetBridge().writeExam({ data })
+  await requestRefresh()
 }
 
 export async function writeWidgetThemeColor(color: string): Promise<void> {
@@ -203,6 +206,7 @@ export async function writeSnapshotWithRetry(snapshot: TodayCourseSnapshot): Pro
   for (let attempt = 0; attempt <= RETRY_DELAYS.length; attempt++) {
     try {
       await writeSnapshot(snapshot)
+      await requestRefresh()
       return
     } catch (err: unknown) {
       lastError = err

--- a/src/utils/android_widget_contract.spec.ts
+++ b/src/utils/android_widget_contract.spec.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readText = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8')
+
+describe('android widget contract', () => {
+  it('requests refresh after widget snapshot writes in web bridge', () => {
+    const bridge = readText('src/utils/widget_bridge.ts')
+    const widget = readText('src/platform/capacitor/widget.ts')
+
+    expect(bridge).toContain('requestWidgetRefresh')
+    expect(bridge).toMatch(/afterScheduleRefresh[\s\S]*requestWidgetRefresh/)
+    expect(bridge).toMatch(/tryWriteSnapshotFromCache[\s\S]*requestWidgetRefresh/)
+    expect(widget).toMatch(/writeSnapshotWithRetry[\s\S]*await requestRefresh\(\)/)
+    expect(widget).toMatch(/writeElectricitySnapshot[\s\S]*await requestRefresh\(\)/)
+    expect(widget).toMatch(/writeExamSnapshot[\s\S]*await requestRefresh\(\)/)
+  })
+
+  it('uses minihbut deep links instead of launcher intents in renderers', () => {
+    const schedule = readText('android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt')
+    const electricity = readText('android/app/src/main/java/com/hbut/mini/widget/ElectricityWidgetRenderer.kt')
+    const exam = readText('android/app/src/main/java/com/hbut/mini/widget/ExamWidgetRenderer.kt')
+    const deepLink = readText('android/app/src/main/java/com/hbut/mini/widget/WidgetDeepLink.kt')
+
+    expect(deepLink).toContain('minihbut')
+    expect(schedule).toContain('WidgetDeepLink.scheduleUri')
+    expect(electricity).toContain('WidgetDeepLink.electricityUri')
+    expect(exam).toContain('WidgetDeepLink.examUri')
+    expect(schedule).not.toContain('CATEGORY_LAUNCHER')
+    expect(electricity).not.toContain('CATEGORY_LAUNCHER')
+    expect(exam).not.toContain('CATEGORY_LAUNCHER')
+  })
+
+  it('registers electricity and exam deep link hosts in manifest', () => {
+    const manifest = readText('android/app/src/main/AndroidManifest.xml')
+    expect(manifest).toContain('android:host="electricity"')
+    expect(manifest).toContain('android:host="exam"')
+  })
+
+  it('handles widget navigation for electricity and exams in App.vue', () => {
+    const app = readText('src/App.vue')
+    expect(app).toContain('handleWidgetNavigatePayload')
+    expect(app).toContain("hostname === 'electricity'")
+    expect(app).toContain("hostname === 'exam'")
+    expect(app).toContain("addEventListener('widgetNavigate'")
+  })
+
+  it('supports responsive today-courses widget layouts', () => {
+    const helper = readText('android/app/src/main/java/com/hbut/mini/widget/WidgetLayoutHelper.kt')
+    const provider = readText('android/app/src/main/java/com/hbut/mini/widget/TodayCoursesProvider.kt')
+    expect(helper).toContain('widget_today_courses_2x2')
+    expect(helper).toContain('widget_today_courses_4x1')
+    expect(provider).toContain('onAppWidgetOptionsChanged')
+  })
+})

--- a/src/utils/widget_bridge.ts
+++ b/src/utils/widget_bridge.ts
@@ -11,7 +11,8 @@ import {
   clearSnapshot,
   writeElectricitySnapshot,
   writeExamSnapshot,
-  writeWidgetThemeColor as writeNativeWidgetThemeColor
+  writeWidgetThemeColor as writeNativeWidgetThemeColor,
+  requestRefresh as requestWidgetRefresh
 } from '@/platform/capacitor/widget'
 import { pushDebugLog } from './debug_logger'
 import { getCacheKey } from './api.js'
@@ -146,6 +147,7 @@ export async function afterScheduleRefresh(
     })
 
     await writeSnapshotWithRetry(snapshot)
+    await requestWidgetRefresh()
   } catch (err: unknown) {
     const code = (err as { code?: string })?.code ?? 'UNKNOWN'
     const message = err instanceof Error ? err.message : String(err)
@@ -183,6 +185,7 @@ export async function tryWriteSnapshotFromCache(sid: string): Promise<void> {
     })
 
     await writeSnapshotWithRetry(snapshot)
+    await requestWidgetRefresh()
   } catch (err: unknown) {
     const code = (err as { code?: string })?.code ?? 'UNKNOWN'
     const message = err instanceof Error ? err.message : String(err)
@@ -258,6 +261,7 @@ export async function writeExamToWidget(data: {
 export async function writeWidgetThemeColor(color: string): Promise<void> {
   try {
     await writeNativeWidgetThemeColor(color)
+    await requestWidgetRefresh()
   } catch (err: unknown) {
     console.warn('[widget] writeWidgetThemeColor failed:', err)
     pushDebugLog('widget', 'widget_write_failed', 'warn', { source: 'writeWidgetThemeColor' })


### PR DESCRIPTION
## Summary

- 修复 Android 桌面小组件（今日课程/电费/考试）写入快照后不及时刷新的问题
- 点击小组件通过 `minihbut://` 深链跳转到课表、电费、考试页面；课程行点击携带 `period`
- 今日课程 widget 支持 2×2 / 4×1 / 4×2 布局切换、空态文案与节次 badge 样式

Closes #111
Closes #112
Closes #113
Closes #114

## Test plan

- [x] `npm run test:ci` — 324/324 通过
- [x] `npx vite build` + `npx cap sync android` + `gradlew assembleDebug` 成功
- [ ] MuMu 模拟器（需先启动并 `adb connect`）安装 APK 后验证刷新、点击跳转与多尺寸布局
