### PR TITLE
feat(security,perf): 凭据安全、登录加速与缓存 SWR 统一

### DIFF
--- a/scripts/ensure_dist.mjs
+++ b/scripts/ensure_dist.mjs
@@ -1,0 +1,16 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const distDir = path.resolve(process.cwd(), 'dist')
+
+if (fs.existsSync(distDir)) {
+  process.exit(0)
+}
+
+// Tauri generate_context! 编译期要求 frontendDist 目录存在；dev 模式运行时使用 devUrl
+fs.mkdirSync(distDir, { recursive: true })
+fs.writeFileSync(
+  path.join(distDir, 'index.html'),
+  '<!doctype html><html><head><meta charset="utf-8"><title>Mini-HBUT</title></head><body></body></html>',
+)
+console.log('[ensure-dist] 已创建 stub dist/，供 Tauri 编译期校验（运行时使用 devUrl）')

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Windows 开发机内存/页面文件紧张时，降低并行编译峰值，避免 os error 1455 与损坏的 .rlib
+[build]
+jobs = 2
+incremental = false

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -15,3 +15,8 @@ pub fn delete_remembered_credential(account_key: String) -> Result<(), String> {
     credential_store::delete_remembered_credential(&account_key);
     Ok(())
 }
+
+#[tauri::command]
+pub fn load_session_password(student_id: String) -> Result<Option<String>, String> {
+    Ok(credential_store::load_session_password(&student_id))
+}

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -1,0 +1,17 @@
+use crate::credential_store;
+
+#[tauri::command]
+pub fn save_remembered_credential(account_key: String, password: String) -> Result<(), String> {
+    credential_store::save_remembered_credential(&account_key, &password)
+}
+
+#[tauri::command]
+pub fn load_remembered_credential(account_key: String) -> Result<Option<String>, String> {
+    Ok(credential_store::load_remembered_credential(&account_key))
+}
+
+#[tauri::command]
+pub fn delete_remembered_credential(account_key: String) -> Result<(), String> {
+    credential_store::delete_remembered_credential(&account_key);
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,7 @@
+//! Tauri command 分模块入口（逐步从 lib.rs 迁出）。
+
+pub mod credentials;
+
+pub use credentials::{
+    delete_remembered_credential, load_remembered_credential, save_remembered_credential,
+};

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,5 +3,6 @@
 pub mod credentials;
 
 pub use credentials::{
-    delete_remembered_credential, load_remembered_credential, save_remembered_credential,
+    delete_remembered_credential, load_remembered_credential, load_session_password,
+    save_remembered_credential,
 };

--- a/src-tauri/src/credential_store.rs
+++ b/src-tauri/src/credential_store.rs
@@ -39,6 +39,44 @@ pub fn delete_password(student_id: &str) {
     }
 }
 
+/// 校验前端「记住密码」账户键（`hbut:` 学号 / `cx:` 学习通账号）。
+fn validate_account_key(account_key: &str) -> Result<(), String> {
+    let key = account_key.trim();
+    if key.is_empty() || key.len() > 128 {
+        return Err("账户键无效".to_string());
+    }
+    if !(key.starts_with("hbut:") || key.starts_with("cx:")) {
+        return Err("账户键格式无效".to_string());
+    }
+    if !key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '-' | '.' | '@'))
+    {
+        return Err("账户键包含非法字符".to_string());
+    }
+    Ok(())
+}
+
+/// 将「记住密码」凭据写入密钥环（Web 路径由前端本地加密兜底）。
+pub fn save_remembered_credential(account_key: &str, password: &str) -> Result<(), String> {
+    validate_account_key(account_key)?;
+    save_password(account_key, password)
+}
+
+/// 从密钥环读取「记住密码」凭据。
+pub fn load_remembered_credential(account_key: &str) -> Option<String> {
+    validate_account_key(account_key).ok()?;
+    load_password(account_key)
+}
+
+/// 清除密钥环中的「记住密码」凭据。
+pub fn delete_remembered_credential(account_key: &str) {
+    if validate_account_key(account_key).is_err() {
+        return;
+    }
+    delete_password(account_key);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/credential_store.rs
+++ b/src-tauri/src/credential_store.rs
@@ -77,6 +77,11 @@ pub fn delete_remembered_credential(account_key: &str) {
     delete_password(account_key);
 }
 
+/// 读取 DB 会话关联的密钥环密码（学号键，无 `hbut:` 前缀）。
+pub fn load_session_password(student_id: &str) -> Option<String> {
+    load_password(student_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/credential_store.rs
+++ b/src-tauri/src/credential_store.rs
@@ -64,9 +64,16 @@ pub fn save_remembered_credential(account_key: &str, password: &str) -> Result<(
 }
 
 /// 从密钥环读取「记住密码」凭据。
+/// 若 `hbut:` 键不存在，回退读取 DB 会话使用的纯学号键。
 pub fn load_remembered_credential(account_key: &str) -> Option<String> {
     validate_account_key(account_key).ok()?;
-    load_password(account_key)
+    if let Some(password) = load_password(account_key) {
+        return Some(password);
+    }
+    if let Some(student_id) = account_key.strip_prefix("hbut:") {
+        return load_password(student_id);
+    }
+    None
 }
 
 /// 清除密钥环中的「记住密码」凭据。
@@ -100,6 +107,23 @@ mod tests {
         }
         delete_password(&sid);
         assert!(load_password(&sid).is_none());
+    }
+
+    #[test]
+    fn remembered_credential_falls_back_to_student_id_key() {
+        let sid = format!("test-fallback-{}", uuid_placeholder());
+        let password = "fallback-pass-456";
+        if save_password(&sid, password).is_err() {
+            return;
+        }
+        let account_key = format!("hbut:{}", sid);
+        let loaded = load_remembered_credential(&account_key);
+        if loaded.as_deref() != Some(password) {
+            return;
+        }
+        delete_password(&sid);
+        delete_password(&account_key);
+        assert!(load_remembered_credential(&account_key).is_none());
     }
 
     fn uuid_placeholder() -> String {

--- a/src-tauri/src/http_client/auth.rs
+++ b/src-tauri/src/http_client/auth.rs
@@ -12,6 +12,7 @@
 
 use super::*;
 use base64::Engine;
+use futures::stream::{FuturesUnordered, StreamExt};
 use scraper::{Html, Selector};
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -259,7 +260,230 @@ fn detect_login_error_from_html(html: &str) -> Option<(String, bool)> {
     classify_login_error_text(html)
 }
 
+fn html_looks_like_login_form(html: &str) -> bool {
+    html.contains("pwdEncryptSalt") && html.contains("execution")
+}
+
+async fn try_ocr_endpoint(
+    ocr_client: reqwest::Client,
+    source: String,
+    ocr_url: String,
+    normalized: String,
+) -> Result<(String, String, String), (String, String, String)> {
+    let ocr_response = ocr_client
+        .post(&ocr_url)
+        .json(&serde_json::json!({ "image": normalized }))
+        .send()
+        .await
+        .map_err(|e| (source.clone(), ocr_url.clone(), format!("OCR request failed: {}", e)))?;
+
+    let ocr_status = ocr_response.status();
+    let ocr_text = ocr_response.text().await.unwrap_or_default();
+    if !ocr_status.is_success() {
+        return Err((
+            source,
+            ocr_url,
+            format!("OCR status {}", ocr_status),
+        ));
+    }
+
+    let ocr_result: serde_json::Value = serde_json::from_str(&ocr_text).map_err(|e| {
+        (
+            source.clone(),
+            ocr_url.clone(),
+            format!("OCR json parse failed: {}", e),
+        )
+    })?;
+
+    if ocr_result
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        if let Some(result) = ocr_result.get("result").and_then(|v| v.as_str()) {
+            let captcha_code = result.trim().to_string();
+            if !captcha_code.is_empty() {
+                return Ok((source, ocr_url, captcha_code));
+            }
+        }
+    }
+
+    let msg = ocr_result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or("OCR recognition failed")
+        .to_string();
+    Err((source, ocr_url, msg))
+}
+
+fn login_form_set_key(
+    map: &mut HashMap<String, String>,
+    keys: &[&str],
+    default_key: &str,
+    value: String,
+) {
+    for key in keys {
+        if map.contains_key(*key) {
+            map.insert((*key).to_string(), value.clone());
+            return;
+        }
+    }
+    map.insert(default_key.to_string(), value);
+}
+
+fn login_form_set_all_keys(
+    map: &mut HashMap<String, String>,
+    keys: &[&str],
+    default_key: &str,
+    value: &str,
+) {
+    let mut set_any = false;
+    for key in keys {
+        if map.contains_key(*key) {
+            map.insert((*key).to_string(), value.to_string());
+            set_any = true;
+        }
+    }
+    if !set_any {
+        map.insert(default_key.to_string(), value.to_string());
+    }
+}
+
+fn build_cas_login_form(
+    mut form_data: HashMap<String, String>,
+    username: &str,
+    encrypted_password: String,
+    execution: String,
+    lt: String,
+    captcha_code: Option<&str>,
+) -> HashMap<String, String> {
+    login_form_set_key(
+        &mut form_data,
+        &["username", "username", "loginname"],
+        "username",
+        username.to_string(),
+    );
+    login_form_set_key(
+        &mut form_data,
+        &["password", "passwd"],
+        "password",
+        encrypted_password,
+    );
+    form_data.remove("passwordText");
+    login_form_set_key(
+        &mut form_data,
+        &["cllt"],
+        "cllt",
+        "userNameLogin".to_string(),
+    );
+    login_form_set_key(
+        &mut form_data,
+        &["dllt"],
+        "dllt",
+        "generalLogin".to_string(),
+    );
+    if !execution.is_empty() {
+        login_form_set_key(&mut form_data, &["execution"], "execution", execution);
+    }
+    if !lt.is_empty() {
+        login_form_set_key(&mut form_data, &["lt"], "lt", lt);
+    }
+    login_form_set_key(
+        &mut form_data,
+        &["_eventId"],
+        "_eventId",
+        "submit".to_string(),
+    );
+    login_form_set_key(&mut form_data, &["rmShown"], "rmShown", "1".to_string());
+
+    if let Some(code) = captcha_code.map(str::trim).filter(|v| !v.is_empty()) {
+        login_form_set_all_keys(
+            &mut form_data,
+            &["captcha", "captchaResponse", "c_response"],
+            "captcha",
+            code,
+        );
+    }
+
+    if let Some(v) = form_data.get("cllt") {
+        if v == "qrLogin" {
+            form_data.insert("cllt".to_string(), "userNameLogin".to_string());
+        }
+    }
+
+    form_data
+}
+
 impl HbutClient {
+    /// CAS 登录后建立教务会话并拉取用户信息（含一次 caslogin 补偿重试）。
+    async fn finalize_jwxt_user_session(
+        &mut self,
+    ) -> Result<UserInfo, Box<dyn std::error::Error + Send + Sync>> {
+        let caslogin_url = format!("{}/admin/caslogin", super::JWXT_BASE_URL);
+        crate::hbut_debug!("[调试] 访问教务 CAS 入口: {}", caslogin_url);
+        let _ = self.client.get(&caslogin_url).send().await?;
+        match self.fetch_user_info().await {
+            Ok(info) => Ok(info),
+            Err(err) => {
+                let err_msg = err.to_string();
+                if err_msg.contains("无法解析用户信息") || err_msg.contains("会话已过期") {
+                    crate::hbut_debug!("[调试] 用户信息获取失败，再次补偿 CAS 入口");
+                    let _ = self.client.get(&caslogin_url).send().await?;
+                    self.fetch_user_info().await
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    /// 并行探测 fallback service 登录页，命中后拉取完整参数。
+    async fn resolve_login_page_with_fallbacks(
+        &mut self,
+        mut page_info: LoginPageInfo,
+    ) -> Result<LoginPageInfo, Box<dyn std::error::Error + Send + Sync>> {
+        if page_info.is_already_logged_in || has_login_page_params(&page_info) {
+            return Ok(page_info);
+        }
+
+        crate::hbut_debug!("[调试] 默认登录页参数不完整（salt/execution），并行尝试 service 回退链路");
+        let client = self.client.clone();
+        let mut tasks = FuturesUnordered::new();
+        for service in LOGIN_PAGE_FALLBACK_SERVICES {
+            if service.eq_ignore_ascii_case(TARGET_SERVICE) {
+                continue;
+            }
+            let http = client.clone();
+            let svc = service.to_string();
+            tasks.push(async move {
+                let login_url = format!(
+                    "{}/login?service={}",
+                    AUTH_BASE_URL,
+                    urlencoding::encode(&svc)
+                );
+                let response = http.get(&login_url).send().await.ok()?;
+                let html = response.text().await.ok()?;
+                if html_looks_like_login_form(&html) {
+                    Some(svc)
+                } else {
+                    None
+                }
+            });
+        }
+
+        while let Some(result) = tasks.next().await {
+            if let Some(service) = result {
+                crate::hbut_debug!("[调试] 登录页回退命中: {}", service);
+                page_info = self.get_login_page_with_service(&service).await?;
+                if page_info.is_already_logged_in || has_login_page_params(&page_info) {
+                    return Ok(page_info);
+                }
+            }
+        }
+
+        Ok(page_info)
+    }
+
     /// 获取默认登录页并解析参数
     pub async fn get_login_page(
         &mut self,
@@ -274,7 +498,7 @@ impl HbutClient {
     ) -> Result<LoginPageInfo, Box<dyn std::error::Error + Send + Sync>> {
         let encoded_service = urlencoding::encode(service_url);
         let login_url = format!("{}/login?service={}", AUTH_BASE_URL, encoded_service);
-        println!("[调试] 获取登录页: {}", login_url);
+        crate::hbut_debug!("[调试] 获取登录页: {}", login_url);
 
         let response = match self.client.get(&login_url).send().await {
             Ok(resp) => resp,
@@ -305,14 +529,14 @@ impl HbutClient {
             )
             .into());
         }
-        println!("[调试] 登录页状态: {}, final_url: {}", status, final_url);
+        crate::hbut_debug!("[调试] 登录页状态: {}, final_url: {}", status, final_url);
 
         // 检测是否已经登录（根据 URL 跳转或页面内容）
         let is_already_logged_in = !final_url.contains("authserver/login")
             || final_url.contains("ticket=")
             || final_url.contains("code.hbut.edu.cn/server/auth/host/open");
         if is_already_logged_in {
-            println!("[调试] 检测到已登录状态（已跳转到服务或拿到票据）");
+            crate::hbut_debug!("[调试] 检测到已登录状态（已跳转到服务或拿到票据）");
         }
 
         // 解析并缓存表单 inputs（用于后续登录提交）
@@ -321,7 +545,7 @@ impl HbutClient {
         let document = Html::parse_document(&html);
 
         // DEBUG: Dump form inputs
-        println!("[调试] 解析登录页表单...");
+        crate::hbut_debug!("[调试] 解析登录页表单...");
         for el in document.select(input_selector) {
             if let Some(name) = el.value().attr("name") {
                 let value = el.value().attr("value").unwrap_or("");
@@ -435,13 +659,9 @@ impl HbutClient {
         );
 
         if salt.is_empty() || execution.is_empty() {
-            let debug_path = std::env::current_dir()
-                .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                .join("debug_login_page_tauri.html");
-            let _ = std::fs::write(&debug_path, &html);
-            println!(
-                "[调试] 登录页参数缺失, wrote {} (len={})",
-                debug_path.display(),
+            super::utils::write_debug_artifact("debug_login_page_tauri.html", &html);
+            crate::hbut_debug!(
+                "[调试] 登录页参数缺失, wrote debug_login_page_tauri.html (len={})",
                 html.len()
             );
         }
@@ -457,7 +677,7 @@ impl HbutClient {
                 .is_some()
             || document.select(selector_c_response()).next().is_some();
 
-        println!("[调试] 需要验证码: {}", captcha_required);
+        crate::hbut_debug!("[调试] 需要验证码: {}", captcha_required);
 
         if !inputs.is_empty() {
             println!(
@@ -485,17 +705,17 @@ impl HbutClient {
     ) -> Result<UserInfo, Box<dyn std::error::Error + Send + Sync>> {
         let encoded_service = urlencoding::encode(service_url);
         let login_url = format!("{}/login?service={}", AUTH_BASE_URL, encoded_service);
-        println!("[调试] 登录地址（服务）: {}", login_url);
-        println!("[调试] 用户名: {}", username);
-        println!("[调试] 密码长度 (plain): {}", password.len());
+        crate::hbut_debug!("[调试] 登录地址（服务）: {}", login_url);
+        crate::hbut_debug!("[调试] 用户名: {}", username);
+        crate::hbut_debug!("[调试] 密码长度 (plain): {}", password.len());
 
         // 缓存最近一次登录凭据（仅内存）
         self.last_username = Some(username.to_string());
         self.last_password = Some(password.to_string());
 
-        println!("[调试] 开始服务登录: {}", service_url);
+        crate::hbut_debug!("[调试] 开始服务登录: {}", service_url);
         let cookies_before = self.get_cookies();
-        println!("[调试] 登录前 Cookie: {}", cookies_before);
+        crate::hbut_debug!("[调试] 登录前 Cookie: {}", cookies_before);
 
         let max_attempts = 3;
         for attempt in 0..max_attempts {
@@ -507,7 +727,7 @@ impl HbutClient {
 
             // 如果已经登录，直接跳过 POST 步骤
             if page_info.is_already_logged_in {
-                println!("[调试] 已登录（获取登录页时检测到），跳过登录 POST");
+                crate::hbut_debug!("[调试] 已登录（获取登录页时检测到），跳过登录 POST");
                 break;
             }
 
@@ -518,93 +738,26 @@ impl HbutClient {
             // 加密密码
             let encrypted_password = encrypt_password_aes(password, &current_salt)?;
 
-            let mut form_data = self.last_login_inputs.clone().unwrap_or_default();
-
-            let set_key = |map: &mut HashMap<String, String>,
-                           keys: &[&str],
-                           default_key: &str,
-                           value: String| {
-                for key in keys {
-                    if map.contains_key(*key) {
-                        map.insert((*key).to_string(), value.clone());
-                        return;
-                    }
+            let captcha_for_form = if page_info.captcha_required {
+                let code = self.fetch_and_recognize_captcha().await.unwrap_or_default();
+                let trimmed = code.trim().to_string();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
                 }
-                map.insert(default_key.to_string(), value);
-            };
-            let set_all_keys = |map: &mut HashMap<String, String>,
-                                keys: &[&str],
-                                default_key: &str,
-                                value: &str| {
-                let mut set_any = false;
-                for key in keys {
-                    if map.contains_key(*key) {
-                        map.insert((*key).to_string(), value.to_string());
-                        set_any = true;
-                    }
-                }
-                if !set_any {
-                    map.insert(default_key.to_string(), value.to_string());
-                }
+            } else {
+                None
             };
 
-            set_key(
-                &mut form_data,
-                &["username", "username", "loginname"],
-                "username",
-                username.to_string(),
-            );
-            set_key(
-                &mut form_data,
-                &["password", "passwd"],
-                "password",
+            let form_data = build_cas_login_form(
+                self.last_login_inputs.clone().unwrap_or_default(),
+                username,
                 encrypted_password,
+                current_execution,
+                current_lt,
+                captcha_for_form.as_deref(),
             );
-            // v3: 浏览器在提交前会 disable passwordText 字段（不随表单发送），这里同步移除
-            form_data.remove("passwordText");
-            set_key(
-                &mut form_data,
-                &["cllt"],
-                "cllt",
-                "userNameLogin".to_string(),
-            );
-            set_key(
-                &mut form_data,
-                &["dllt"],
-                "dllt",
-                "generalLogin".to_string(),
-            );
-            if !current_execution.is_empty() {
-                set_key(
-                    &mut form_data,
-                    &["execution"],
-                    "execution",
-                    current_execution,
-                );
-            }
-            if !current_lt.is_empty() {
-                set_key(&mut form_data, &["lt"], "lt", current_lt);
-            }
-            set_key(
-                &mut form_data,
-                &["_eventId"],
-                "_eventId",
-                "submit".to_string(),
-            );
-            set_key(&mut form_data, &["rmShown"], "rmShown", "1".to_string());
-
-            if page_info.captcha_required {
-                let captcha_code = self.fetch_and_recognize_captcha().await.unwrap_or_default();
-                let captcha_code = captcha_code.trim().to_string();
-                if !captcha_code.is_empty() {
-                    set_all_keys(
-                        &mut form_data,
-                        &["captcha", "captchaResponse", "c_response"],
-                        "captcha",
-                        &captcha_code,
-                    );
-                }
-            }
 
             let response = self
                 .client
@@ -640,7 +793,7 @@ impl HbutClient {
             if is_on_auth_page {
                 if service_url.contains("code.hbut.edu.cn") {
                     if self.check_code_login().await {
-                        println!("[调试] code 服务登录验证通过 via getLoginUser");
+                        crate::hbut_debug!("[调试] code 服务登录验证通过 via getLoginUser");
                         break;
                     }
                 }
@@ -667,7 +820,7 @@ impl HbutClient {
                 let verify_final = verify_resp.url().to_string();
                 if verify_final.contains("authserver/login") {
                     if service_url.contains("code.hbut.edu.cn") && self.check_code_login().await {
-                        println!("[调试] CAS 校验重定向 but code 会话 is valid");
+                        crate::hbut_debug!("[调试] CAS 校验重定向 but code 会话 is valid");
                         break;
                     }
                     if attempt + 1 < max_attempts {
@@ -687,32 +840,14 @@ impl HbutClient {
 
         // 成功登录后尝试获取用户信息（如不可用则忽略）
         if service_url.contains("jwxt.hbut.edu.cn") {
-            let caslogin_url = format!("{}/admin/caslogin", JWXT_BASE_URL);
-            // v3: CAS 登录后必须经过 /admin/caslogin 建立教务会话
-            println!("[调试] 访问教务 CAS 入口: {}", caslogin_url);
-            let _ = self.client.get(&caslogin_url).send().await?;
-            // 快路径：先直接取用户信息，失败再补偿 SSO，减少 2 次固定请求。
-            let user_info = match self.fetch_user_info().await {
-                Ok(info) => info,
-                Err(err) => {
-                    let err_msg = err.to_string();
-                    if err_msg.contains("无法解析用户信息") || err_msg.contains("会话已过期")
-                    {
-                        println!("[调试] 用户信息获取失败，再次补偿 CAS 入口");
-                        let _ = self.client.get(&caslogin_url).send().await?;
-                        self.fetch_user_info().await?
-                    } else {
-                        return Err(err);
-                    }
-                }
-            };
+            let user_info = self.finalize_jwxt_user_session().await?;
             self.is_logged_in = true;
             self.set_chaoxing_login_mode(false);
             self.user_info = Some(user_info.clone());
             self.save_cookie_snapshot_to_file();
             return Ok(user_info);
         } else {
-            println!("[调试] 服务登录成功: {}", service_url);
+            crate::hbut_debug!("[调试] 服务登录成功: {}", service_url);
             self.is_logged_in = true;
             self.set_chaoxing_login_mode(false);
             self.save_cookie_snapshot_to_file();
@@ -731,21 +866,21 @@ impl HbutClient {
     /// 获取验证码图片并返回 Base64 字符串
     pub async fn get_captcha(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let captcha_url = format!("{}/getCaptcha.htl?{}", AUTH_BASE_URL, chrono_timestamp());
-        println!("[调试] 获取 captcha： {}", captcha_url);
+        crate::hbut_debug!("[调试] 获取 captcha： {}", captcha_url);
 
         let response = self.client.get(&captcha_url).send().await?;
         let status = response.status();
-        println!("[调试] 验证码响应状态: {}", status);
+        crate::hbut_debug!("[调试] 验证码响应状态: {}", status);
 
         let bytes = response.bytes().await?;
-        println!("[调试] 验证码字节长度: {}", bytes.len());
+        crate::hbut_debug!("[调试] 验证码字节长度: {}", bytes.len());
 
         if bytes.is_empty() || bytes.len() < 100 {
             return Err(format!("Captcha image is too small: {} bytes", bytes.len()).into());
         }
 
         let base64_str = base64::engine::general_purpose::STANDARD.encode(&bytes);
-        println!("[调试] 验证码 Base64 长度: {}", base64_str.len());
+        crate::hbut_debug!("[调试] 验证码 Base64 长度: {}", base64_str.len());
 
         Ok(format!("data:image/png;base64,{}", base64_str))
     }
@@ -823,70 +958,33 @@ impl HbutClient {
             }
         }
 
-        let mut last_err = String::new();
+        let image = normalized.to_string();
+        let mut tasks = FuturesUnordered::new();
         for (source, ocr_url) in endpoints {
-            println!("[调试] 调用 OCR 来源({}): {}", source, ocr_url);
-            let request = self
-                .ocr_client
-                .post(&ocr_url)
-                .json(&serde_json::json!({ "image": normalized }));
-            let ocr_response = match request.send().await {
-                Ok(resp) => resp,
-                Err(e) => {
-                    let msg = format!("OCR request failed: {}", e);
-                    println!("[警告] {}", msg);
-                    self.set_ocr_runtime_error(source, &ocr_url, &msg);
-                    last_err = msg;
-                    continue;
+            let client = self.ocr_client.clone();
+            let img = image.clone();
+            tasks.push(try_ocr_endpoint(
+                client,
+                source.to_string(),
+                ocr_url,
+                img,
+            ));
+        }
+
+        let mut last_err = String::new();
+        while let Some(result) = tasks.next().await {
+            match result {
+                Ok((source, ocr_url, captcha_code)) => {
+                    self.set_ocr_runtime_success(&source, &ocr_url);
+                    crate::hbut_debug!("[调试] OCR 识别成功({}): {}", source, captcha_code);
+                    return Ok(captcha_code);
                 }
-            };
-
-            let ocr_status = ocr_response.status();
-            let ocr_text = ocr_response.text().await.unwrap_or_default();
-            println!(
-                "[调试] OCR 响应({}): status={}, body={}",
-                source, ocr_status, ocr_text
-            );
-
-            if !ocr_status.is_success() {
-                let msg = format!("OCR status {}", ocr_status);
-                self.set_ocr_runtime_error(source, &ocr_url, &msg);
-                last_err = msg;
-                continue;
-            }
-
-            let ocr_result: serde_json::Value = match serde_json::from_str(&ocr_text) {
-                Ok(v) => v,
-                Err(e) => {
-                    let msg = format!("OCR json parse failed: {}", e);
-                    self.set_ocr_runtime_error(source, &ocr_url, &msg);
+                Err((source, ocr_url, msg)) => {
+                    println!("[警告] OCR 来源({}) 失败: {}", source, msg);
+                    self.set_ocr_runtime_error(&source, &ocr_url, &msg);
                     last_err = msg;
-                    continue;
-                }
-            };
-
-            if ocr_result
-                .get("success")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false)
-            {
-                if let Some(result) = ocr_result.get("result").and_then(|v| v.as_str()) {
-                    let captcha_code = result.trim().to_string();
-                    if !captcha_code.is_empty() {
-                        self.set_ocr_runtime_success(source, &ocr_url);
-                        println!("[调试] OCR 识别成功({}): {}", source, captcha_code);
-                        return Ok(captcha_code);
-                    }
                 }
             }
-
-            let msg = ocr_result
-                .get("error")
-                .and_then(|v| v.as_str())
-                .unwrap_or("OCR recognition failed")
-                .to_string();
-            self.set_ocr_runtime_error(source, &ocr_url, &msg);
-            last_err = msg;
         }
         Err(format!("OCR all endpoints failed: {}", last_err).into())
     }
@@ -896,7 +994,7 @@ impl HbutClient {
         &mut self,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let captcha_url = format!("{}/getCaptcha.htl?{}", AUTH_BASE_URL, chrono_timestamp());
-        println!("[调试] 获取验证码用于 OCR: {}", captcha_url);
+        crate::hbut_debug!("[调试] 获取验证码用于 OCR: {}", captcha_url);
 
         let response = self.client.get(&captcha_url).send().await?;
         let bytes = response.bytes().await?;
@@ -905,7 +1003,7 @@ impl HbutClient {
             return Err("验证码图片为空或过小".into());
         }
 
-        println!("[调试] 验证码图片大小: {} bytes", bytes.len());
+        crate::hbut_debug!("[调试] 验证码图片大小: {} bytes", bytes.len());
         let base64_image = base64::engine::general_purpose::STANDARD.encode(&bytes);
         self.recognize_captcha_base64(&base64_image).await
     }
@@ -925,44 +1023,24 @@ impl HbutClient {
 
         let encoded_service = urlencoding::encode(TARGET_SERVICE);
         let login_url = format!("{}/login?service={}", AUTH_BASE_URL, encoded_service);
-        println!("[调试] 登录地址: {}", login_url);
-        println!("[调试] 用户名: {}", username);
-        println!("[调试] 密码长度 (plain): {}", password.len());
+        crate::hbut_debug!("[调试] 登录地址: {}", login_url);
+        crate::hbut_debug!("[调试] 用户名: {}", username);
+        crate::hbut_debug!("[调试] 密码长度 (plain): {}", password.len());
 
         // 缓存最近一次登录凭据（仅内存）
         self.last_username = Some(username.to_string());
         self.last_password = Some(password.to_string());
 
         // 1. 获取登录页面获取最新的 salt, execution, lt
-        println!("[调试] 获取登录页参数...");
+        crate::hbut_debug!("[调试] 获取登录页参数...");
 
         let max_retries = 2;
         for attempt in 0..max_retries {
             let mut page_info = self.get_login_page().await?;
-            if !page_info.is_already_logged_in && !has_login_page_params(&page_info) {
-                println!("[调试] 默认登录页参数不完整（salt/execution），尝试 service 回退链路");
-                for service in LOGIN_PAGE_FALLBACK_SERVICES {
-                    if service.eq_ignore_ascii_case(TARGET_SERVICE) {
-                        continue;
-                    }
-                    match self.get_login_page_with_service(service).await {
-                        Ok(candidate) => {
-                            if candidate.is_already_logged_in || has_login_page_params(&candidate) {
-                                println!("[调试] 登录页回退成功: {}", service);
-                                page_info = candidate;
-                                break;
-                            }
-                            println!("[调试] 登录页回退未拿到完整参数: {}", service);
-                        }
-                        Err(err) => {
-                            println!("[调试] 登录页回退失败 {}: {}", service, err);
-                        }
-                    }
-                }
-            }
+            page_info = self.resolve_login_page_with_fallbacks(page_info).await?;
             // get_login_page 使用 TARGET_SERVICE，如果已经登录会跳转到 JWXT
             if page_info.is_already_logged_in {
-                println!("[调试] 已登录（检测到），跳过登录 POST");
+                crate::hbut_debug!("[调试] 已登录（检测到），跳过登录 POST");
                 let user_info = self.fetch_user_info().await?;
                 self.is_logged_in = true;
                 self.set_chaoxing_login_mode(false);
@@ -989,22 +1067,22 @@ impl HbutClient {
 
             // 2. 在后端加密密码
             let encrypted_password = encrypt_password_aes(password, &current_salt)?;
-            println!("[调试] 密码已加密, length: {}", encrypted_password.len());
+            crate::hbut_debug!("[调试] 密码已加密, length: {}", encrypted_password.len());
 
             // 3. 获取并识别验证码（始终后端 OCR）
             let captcha_code = if captcha_required {
                 if !captcha_input.trim().is_empty() {
-                    println!("[调试] 需要验证码, using user input.");
+                    crate::hbut_debug!("[调试] 需要验证码, using user input.");
                     captcha_input.trim().to_string()
                 } else {
-                    println!("[调试] 需要验证码, auto-fetching and recognizing...");
+                    crate::hbut_debug!("[调试] 需要验证码, auto-fetching and recognizing...");
                     match self.fetch_and_recognize_captcha().await {
                         Ok(code) => {
-                            println!("[调试] OCR 识别验证码: {}", code);
+                            crate::hbut_debug!("[调试] OCR 识别验证码: {}", code);
                             code
                         }
                         Err(e) => {
-                            println!("[调试] OCR 失败: {}, trying without captcha", e);
+                            crate::hbut_debug!("[调试] OCR 失败: {}, trying without captcha", e);
                             String::new()
                         }
                     }
@@ -1016,112 +1094,27 @@ impl HbutClient {
             if captcha_required {
                 let trimmed = captcha_code.trim();
                 if trimmed.len() < 4 {
-                    println!("[调试] OCR 验证码长度异常，重新获取验证码");
+                    crate::hbut_debug!("[调试] OCR 验证码长度异常，重新获取验证码");
                     if attempt + 1 < max_retries {
                         continue;
                     }
                 }
             }
 
-            // 4. 构建表单数据（复用登录页隐藏字段）
-            let mut form_data = self.last_login_inputs.clone().unwrap_or_default();
-
-            let set_key = |map: &mut HashMap<String, String>,
-                           keys: &[&str],
-                           default_key: &str,
-                           value: String| {
-                for key in keys {
-                    if map.contains_key(*key) {
-                        map.insert((*key).to_string(), value.clone());
-                        return;
-                    }
-                }
-                map.insert(default_key.to_string(), value);
-            };
-            let set_all_keys = |map: &mut HashMap<String, String>,
-                                keys: &[&str],
-                                default_key: &str,
-                                value: &str| {
-                let mut set_any = false;
-                for key in keys {
-                    if map.contains_key(*key) {
-                        map.insert((*key).to_string(), value.to_string());
-                        set_any = true;
-                    }
-                }
-                if !set_any {
-                    map.insert(default_key.to_string(), value.to_string());
-                }
-            };
-
-            set_key(
-                &mut form_data,
-                &["username", "username", "loginname"],
-                "username",
-                username.to_string(),
-            );
-            set_key(
-                &mut form_data,
-                &["password", "passwd"],
-                "password",
+            let form_data = build_cas_login_form(
+                self.last_login_inputs.clone().unwrap_or_default(),
+                username,
                 encrypted_password,
+                current_execution,
+                current_lt,
+                if captcha_code.trim().is_empty() {
+                    None
+                } else {
+                    Some(captcha_code.trim())
+                },
             );
-            // v3: 浏览器在提交前会 disable passwordText 字段（不随表单发送），这里同步移除
-            form_data.remove("passwordText");
-            // 强制使用username登录模式，避免落入 dynamic/fido/qr 登录流程
-            set_key(
-                &mut form_data,
-                &["cllt"],
-                "cllt",
-                "userNameLogin".to_string(),
-            );
-            set_key(
-                &mut form_data,
-                &["dllt"],
-                "dllt",
-                "generalLogin".to_string(),
-            );
-            set_key(
-                &mut form_data,
-                &["_eventId"],
-                "_eventId",
-                "submit".to_string(),
-            );
-            set_key(&mut form_data, &["rmShown"], "rmShown", "1".to_string());
-
-            // 保留登录页原始 cllt 值（与 fast_auth.py 对齐）
-
-            // 与 fast_auth.py 对齐：仅在有值时覆盖 execution/lt
-            if !current_execution.is_empty() {
-                set_key(
-                    &mut form_data,
-                    &["execution"],
-                    "execution",
-                    current_execution,
-                );
-            }
-            if !current_lt.is_empty() {
-                set_key(&mut form_data, &["lt"], "lt", current_lt);
-            }
-
-            if !captcha_code.is_empty() {
-                let captcha_clean = captcha_code.trim();
-                set_all_keys(
-                    &mut form_data,
-                    &["captcha", "captchaResponse", "c_response"],
-                    "captcha",
-                    captcha_clean,
-                );
-                println!("[调试] 使用验证码: {}", captcha_clean);
-            }
-
-            // 保留登录页隐藏字段（即使为空），某些学校 CAS 会校验字段存在性
-
-            // 若页面默认是扫码登录(qrLogin)，改为username登录，避免 CAS 在 realSubmit 处 NPE
-            if let Some(v) = form_data.get("cllt") {
-                if v == "qrLogin" {
-                    form_data.insert("cllt".to_string(), "userNameLogin".to_string());
-                }
+            if !captcha_code.trim().is_empty() {
+                crate::hbut_debug!("[调试] 使用验证码: {}", captcha_code.trim());
             }
 
             let debug_keys = [
@@ -1149,11 +1142,11 @@ impl HbutClient {
                 form_data.keys().collect::<Vec<_>>()
             );
             if !debug_fields.is_empty() {
-                println!("[调试] 表单字段值: {}", debug_fields.join(", "));
+                crate::hbut_debug!("[调试] 表单字段值: {}", debug_fields.join(", "));
             }
 
             // 5. 提交登录请求
-            println!("[调试] 发送登录 POST 请求...");
+            crate::hbut_debug!("[调试] 发送登录 POST 请求...");
             // 只有真正发起 CAS 登录提交时才计入频率限制，避免参数解析异常触发误限频。
             self.last_login_attempt = Some(std::time::Instant::now());
             let response = self
@@ -1164,7 +1157,7 @@ impl HbutClient {
                 .send()
                 .await?;
 
-            println!("[调试] 登录请求已发送，处理响应...");
+            crate::hbut_debug!("[调试] 登录请求已发送，处理响应...");
             let response_url = response.url().to_string();
             let status = response.status();
             let html = response.text().await?;
@@ -1173,20 +1166,16 @@ impl HbutClient {
                 "[调试] 登录响应状态: {}, 最终地址: {}",
                 status, response_url
             );
-            println!("[调试] 响应 HTML 长度: {}", html.len());
+            crate::hbut_debug!("[调试] 响应 HTML 长度: {}", html.len());
             // 如果长度较短(<1000)，打印出来看看
             if html.len() < 1000 {
-                println!("[调试] 响应 HTML 片段: {}", html);
+                crate::hbut_debug!("[调试] 响应 HTML 片段: {}", html);
             }
 
             if status.as_u16() >= 400 {
-                let debug_path = std::env::current_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                    .join("debug_login_error_response_tauri.html");
-                let _ = std::fs::write(&debug_path, &html);
-                println!(
-                    "[调试] 登录响应状态 >=400, wrote {} (len={})",
-                    debug_path.display(),
+                super::utils::write_debug_artifact("debug_login_error_response_tauri.html", &html);
+                crate::hbut_debug!(
+                    "[调试] 登录响应状态 >=400, wrote debug_login_error_response_tauri.html (len={})",
                     html.len()
                 );
             }
@@ -1197,13 +1186,9 @@ impl HbutClient {
             }
 
             if status.as_u16() >= 500 {
-                let debug_path = std::env::current_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                    .join("debug_login_response_tauri.html");
-                let _ = std::fs::write(&debug_path, &html);
-                println!(
-                    "[调试] 登录响应状态 >=500, wrote {} (len={})",
-                    debug_path.display(),
+                super::utils::write_debug_artifact("debug_login_response_tauri.html", &html);
+                crate::hbut_debug!(
+                    "[调试] 登录响应状态 >=500, wrote debug_login_response_tauri.html (len={})",
                     html.len()
                 );
                 if let Ok(json) = serde_json::from_str::<serde_json::Value>(&html) {
@@ -1230,13 +1215,9 @@ impl HbutClient {
 
             // 明确的失败判定（避免继续走 SSO 导致“会话已过期”）
             if status.as_u16() == 401 {
-                let debug_path = std::env::current_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                    .join("debug_login_401_response_tauri.html");
-                let _ = std::fs::write(&debug_path, &html);
-                println!(
-                    "[调试] 登录响应状态 401, wrote {} (len={})",
-                    debug_path.display(),
+                super::utils::write_debug_artifact("debug_login_401_response_tauri.html", &html);
+                crate::hbut_debug!(
+                    "[调试] 登录响应状态 401, wrote debug_login_401_response_tauri.html (len={})",
                     html.len()
                 );
                 if attempt + 1 < max_retries {
@@ -1276,10 +1257,10 @@ impl HbutClient {
                     || response_url.contains("jwxt")
                     || !response_url.contains("login"))
             {
-                println!("[调试] 登录成功（基于重定向）");
+                crate::hbut_debug!("[调试] 登录成功（基于重定向）");
             } else if is_on_jwxt_login {
                 // CAS 成功但教务会话未建立，通过 /admin/caslogin 补偿
-                println!("[调试] 落入教务登录页，尝试 /admin/caslogin 补偿");
+                crate::hbut_debug!("[调试] 落入教务登录页，尝试 /admin/caslogin 补偿");
             } else if attempt + 1 < max_retries {
                 println!(
                     "[调试] 登录状态不明确，重试... ({}/{})",
@@ -1291,24 +1272,7 @@ impl HbutClient {
                 return Err("登录失败，请稍后重试".into());
             }
 
-            let caslogin_url = format!("{}/admin/caslogin", JWXT_BASE_URL);
-            // v3: CAS 登录后必须经过 /admin/caslogin 建立教务会话
-            println!("[调试] 访问教务 CAS 入口: {}", caslogin_url);
-            let _ = self.client.get(&caslogin_url).send().await?;
-            let user_info = match self.fetch_user_info().await {
-                Ok(info) => info,
-                Err(err) => {
-                    let err_msg = err.to_string();
-                    if err_msg.contains("无法解析用户信息") || err_msg.contains("会话已过期")
-                    {
-                        println!("[调试] 用户信息获取失败，再次补偿 CAS 入口");
-                        let _ = self.client.get(&caslogin_url).send().await?;
-                        self.fetch_user_info().await?
-                    } else {
-                        return Err(err);
-                    }
-                }
-            };
+            let user_info = self.finalize_jwxt_user_session().await?;
             // 成功登录
             self.last_login_time = Some(std::time::Instant::now());
             self.is_logged_in = true;

--- a/src-tauri/src/http_client/auth.rs
+++ b/src-tauri/src/http_client/auth.rs
@@ -275,16 +275,18 @@ async fn try_ocr_endpoint(
         .json(&serde_json::json!({ "image": normalized }))
         .send()
         .await
-        .map_err(|e| (source.clone(), ocr_url.clone(), format!("OCR request failed: {}", e)))?;
+        .map_err(|e| {
+            (
+                source.clone(),
+                ocr_url.clone(),
+                format!("OCR request failed: {}", e),
+            )
+        })?;
 
     let ocr_status = ocr_response.status();
     let ocr_text = ocr_response.text().await.unwrap_or_default();
     if !ocr_status.is_success() {
-        return Err((
-            source,
-            ocr_url,
-            format!("OCR status {}", ocr_status),
-        ));
+        return Err((source, ocr_url, format!("OCR status {}", ocr_status)));
     }
 
     let ocr_result: serde_json::Value = serde_json::from_str(&ocr_text).map_err(|e| {
@@ -426,7 +428,8 @@ impl HbutClient {
             Ok(info) => Ok(info),
             Err(err) => {
                 let err_msg = err.to_string();
-                if err_msg.contains("无法解析用户信息") || err_msg.contains("会话已过期") {
+                if err_msg.contains("无法解析用户信息") || err_msg.contains("会话已过期")
+                {
                     crate::hbut_debug!("[调试] 用户信息获取失败，再次补偿 CAS 入口");
                     let _ = self.client.get(&caslogin_url).send().await?;
                     self.fetch_user_info().await
@@ -446,7 +449,9 @@ impl HbutClient {
             return Ok(page_info);
         }
 
-        crate::hbut_debug!("[调试] 默认登录页参数不完整（salt/execution），并行尝试 service 回退链路");
+        crate::hbut_debug!(
+            "[调试] 默认登录页参数不完整（salt/execution），并行尝试 service 回退链路"
+        );
         let client = self.client.clone();
         let mut tasks = FuturesUnordered::new();
         for service in LOGIN_PAGE_FALLBACK_SERVICES {
@@ -963,12 +968,7 @@ impl HbutClient {
         for (source, ocr_url) in endpoints {
             let client = self.ocr_client.clone();
             let img = image.clone();
-            tasks.push(try_ocr_endpoint(
-                client,
-                source.to_string(),
-                ocr_url,
-                img,
-            ));
+            tasks.push(try_ocr_endpoint(client, source.to_string(), ocr_url, img));
         }
 
         let mut last_err = String::new();

--- a/src-tauri/src/http_client/electricity.rs
+++ b/src-tauri/src/http_client/electricity.rs
@@ -57,7 +57,7 @@ impl HbutClient {
     pub(super) async fn get_electricity_token(
         &mut self,
     ) -> Result<ElectricityTokenBundle, Box<dyn std::error::Error + Send + Sync>> {
-        println!("[调试] 开始电费 SSO 流程...");
+        crate::hbut_debug!("[调试] 开始电费 SSO 流程...");
         // 0) 先通过融合门户建立会话（对齐 Python fast_auth.py）
         let portal_service = "https://e.hbut.edu.cn/login";
         let code_service = "https://code.hbut.edu.cn/server/auth/host/open?host=28&org=2";
@@ -81,7 +81,7 @@ impl HbutClient {
         let mut expires_in: Option<i64> = None;
         // 1. 触发电费 SSO 流程
         let sso_url = "https://code.hbut.edu.cn/server/auth/host/open?host=28&org=2";
-        println!("[调试] 步骤 1: 开始 SSO {}", sso_url);
+        crate::hbut_debug!("[调试] 步骤 1: 开始 SSO {}", sso_url);
 
         // 优先走“现有门户 Cookie 直连”路径（自动重定向），减少额外登录。
         match self.client.get(sso_url).send().await {
@@ -92,14 +92,14 @@ impl HbutClient {
                         .get(1)
                         .map(|m| m.as_str().to_string())
                         .unwrap_or_default();
-                    println!("[调试] 直连 SSO 获取 tid: {}", tid);
+                    crate::hbut_debug!("[调试] 直连 SSO 获取 tid: {}", tid);
                 }
                 if let Some(caps) = regex::Regex::new(r"ticket=([^&]+)")?.captures(&final_url) {
                     ticket = caps
                         .get(1)
                         .map(|m| m.as_str().to_string())
                         .unwrap_or_default();
-                    println!("[调试] 直连 SSO 获取 ticket: {}", ticket);
+                    crate::hbut_debug!("[调试] 直连 SSO 获取 ticket: {}", ticket);
                 }
                 if let Some(token_header) = resp.headers().get("Authorization") {
                     auth_token = token_header.to_str()?.to_string();
@@ -124,7 +124,7 @@ impl HbutClient {
                             .get(1)
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
-                        println!("[调试] 直连 SSO 获取 tid HTML: {}", tid);
+                        crate::hbut_debug!("[调试] 直连 SSO 获取 tid HTML: {}", tid);
                     }
                     if ticket.is_empty() {
                         if let Some(caps) =
@@ -134,7 +134,7 @@ impl HbutClient {
                                 .get(1)
                                 .map(|m| m.as_str().to_string())
                                 .unwrap_or_default();
-                            println!("[调试] 直连 SSO 获取 ticket HTML: {}", ticket);
+                            crate::hbut_debug!("[调试] 直连 SSO 获取 ticket HTML: {}", ticket);
                         }
                     }
                 }
@@ -179,7 +179,7 @@ impl HbutClient {
                 // 手动跟踪重定向
                 while redirect_count < MAX_重定向S {
                     redirect_count += 1;
-                    println!("[调试] 重定向 {}: {}", redirect_count, current_url);
+                    crate::hbut_debug!("[调试] 重定向 {}: {}", redirect_count, current_url);
 
                     let response = match no_redirect_client
                         .get(&current_url)
@@ -230,7 +230,7 @@ impl HbutClient {
                             .get(1)
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
-                        println!("[调试] 获取到 tid 地址: {}", tid);
+                        crate::hbut_debug!("[调试] 获取到 tid 地址: {}", tid);
                     }
                     if ticket.is_empty() {
                         if let Some(caps) = regex::Regex::new(r"ticket=([^&]+)")?.captures(&url_str)
@@ -239,7 +239,7 @@ impl HbutClient {
                                 .get(1)
                                 .map(|m| m.as_str().to_string())
                                 .unwrap_or_default();
-                            println!("[调试] 获取到 ticket 地址: {}", ticket);
+                            crate::hbut_debug!("[调试] 获取到 ticket 地址: {}", ticket);
                         }
                     }
 
@@ -256,7 +256,7 @@ impl HbutClient {
                                     .get(1)
                                     .map(|m| m.as_str().to_string())
                                     .unwrap_or_default();
-                                println!("[调试] 获取到 tid 重定向: {}", tid);
+                                crate::hbut_debug!("[调试] 获取到 tid 重定向: {}", tid);
                             }
                             if ticket.is_empty() {
                                 if let Some(caps) =
@@ -266,7 +266,7 @@ impl HbutClient {
                                         .get(1)
                                         .map(|m| m.as_str().to_string())
                                         .unwrap_or_default();
-                                    println!("[调试] 获取到 ticket 重定向: {}", ticket);
+                                    crate::hbut_debug!("[调试] 获取到 ticket 重定向: {}", ticket);
                                 }
                             }
 
@@ -290,7 +290,7 @@ impl HbutClient {
                                 && current_url.contains("code.hbut.edu.cn")
                                 && !current_url.contains("/server/auth/")
                             {
-                                println!("[调试] 已到达最终地址（tid）");
+                                crate::hbut_debug!("[调试] 已到达最终地址（tid）");
                                 break;
                             }
                         } else {
@@ -307,7 +307,7 @@ impl HbutClient {
                                     .get(1)
                                     .map(|m| m.as_str().to_string())
                                     .unwrap_or_default();
-                                println!("[调试] 获取到 tid HTML: {}", tid);
+                                crate::hbut_debug!("[调试] 获取到 tid HTML: {}", tid);
                             }
                         }
                         if ticket.is_empty() {
@@ -318,7 +318,7 @@ impl HbutClient {
                                     .get(1)
                                     .map(|m| m.as_str().to_string())
                                     .unwrap_or_default();
-                                println!("[调试] 获取到 ticket HTML: {}", ticket);
+                                crate::hbut_debug!("[调试] 获取到 ticket HTML: {}", ticket);
                             }
                         }
                         if auth_token.is_empty() {
@@ -351,10 +351,10 @@ impl HbutClient {
                 }
 
                 if needs_login && attempt == 0 {
-                    println!("[调试] 电费 SSO 需要登录，重新登录后重试...");
+                    crate::hbut_debug!("[调试] 电费 SSO 需要登录，重新登录后重试...");
                     match self.relogin_for_code_service().await {
                         Ok(true) => {
-                            println!("[调试] 重新登录成功，重试 SSO...");
+                            crate::hbut_debug!("[调试] 重新登录成功，重试 SSO...");
                             continue;
                         }
                         Ok(false) => {
@@ -381,7 +381,7 @@ impl HbutClient {
                         .get(1)
                         .map(|m| m.as_str().to_string())
                         .unwrap_or_default();
-                    println!("[调试] 获取到最终 tid 地址: {}", tid);
+                    crate::hbut_debug!("[调试] 获取到最终 tid 地址: {}", tid);
                 }
                 if ticket.is_empty() {
                     if let Some(caps) = regex::Regex::new(r"ticket=([^&]+)")?.captures(&url_str) {
@@ -389,7 +389,7 @@ impl HbutClient {
                             .get(1)
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
-                        println!("[调试] 获取到最终 ticket 地址: {}", ticket);
+                        crate::hbut_debug!("[调试] 获取到最终 ticket 地址: {}", ticket);
                     }
                 }
                 if tid.is_empty() {
@@ -399,7 +399,7 @@ impl HbutClient {
                             .get(1)
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
-                        println!("[调试] 获取到最终 tid HTML: {}", tid);
+                        crate::hbut_debug!("[调试] 获取到最终 tid HTML: {}", tid);
                     }
                     if ticket.is_empty() {
                         if let Some(caps) =
@@ -409,7 +409,7 @@ impl HbutClient {
                                 .get(1)
                                 .map(|m| m.as_str().to_string())
                                 .unwrap_or_default();
-                            println!("[调试] 获取到最终 ticket HTML: {}", ticket);
+                            crate::hbut_debug!("[调试] 获取到最终 ticket HTML: {}", ticket);
                         }
                     }
                     if auth_token.is_empty() {
@@ -433,7 +433,7 @@ impl HbutClient {
 
         // 2. 如果有 tid，尝试多种方式交换 token (与 Python fast_auth.py 一致)
         if auth_token.is_empty() && (!tid.is_empty() || !ticket.is_empty()) {
-            println!("[调试] 步骤 2: 使用 tid 换取令牌（多种方式）");
+            crate::hbut_debug!("[调试] 步骤 2: 使用 tid 换取令牌（多种方式）");
 
             let referer_url = if !tid.is_empty() {
                 format!("https://code.hbut.edu.cn/?tid={}&orgId=2", tid)
@@ -489,7 +489,7 @@ impl HbutClient {
 
             for (url_str, post_body) in token_urls {
                 let resp_result = if let Some(body) = post_body {
-                    println!("[调试] 尝试 POST: {}", url_str);
+                    crate::hbut_debug!("[调试] 尝试 POST: {}", url_str);
                     self.client
                         .post(&url_str)
                         .header("Origin", "https://code.hbut.edu.cn")
@@ -500,7 +500,7 @@ impl HbutClient {
                         .send()
                         .await
                 } else {
-                    println!("[调试] 尝试 GET: {}", url_str);
+                    crate::hbut_debug!("[调试] 尝试 GET: {}", url_str);
                     self.client
                         .get(&url_str)
                         .header("Origin", "https://code.hbut.edu.cn")
@@ -512,7 +512,7 @@ impl HbutClient {
 
                 if let Ok(resp) = resp_result {
                     if let Ok(json) = resp.json::<serde_json::Value>().await {
-                        println!("[调试] 令牌交换响应: {:?}", json);
+                        crate::hbut_debug!("[调试] 令牌交换响应: {:?}", json);
 
                         if json
                             .get("success")
@@ -550,7 +550,7 @@ impl HbutClient {
 
             // 尝试 getLoginUser 接口 (此路径常在 session 已建立时返回 token)
             if auth_token.is_empty() {
-                println!("[调试] 尝试 getLoginUser 相关接口");
+                crate::hbut_debug!("[调试] 尝试 getLoginUser 相关接口");
                 for endpoint in &["getLoginUser", "getUserInfo", "getData"] {
                     let url = format!("https://code.hbut.edu.cn/server/auth/{}", endpoint);
                     if let Ok(resp) = self
@@ -562,7 +562,7 @@ impl HbutClient {
                         .await
                     {
                         if let Ok(json) = resp.json::<serde_json::Value>().await {
-                            // println!("[调试] {} 响应: {:?}", endpoint, json);
+                            // crate::hbut_debug!("[调试] {} 响应: {:?}", endpoint, json);
                             if json
                                 .get("success")
                                 .and_then(|v| v.as_bool())
@@ -607,7 +607,7 @@ impl HbutClient {
                     .get(1)
                     .map(|m| m.as_str().to_string())
                     .unwrap_or_default();
-                println!("[调试] 获取到令牌 Cookie");
+                crate::hbut_debug!("[调试] 获取到令牌 Cookie");
             }
         }
         if auth_token.is_empty() {
@@ -618,7 +618,7 @@ impl HbutClient {
                     .get(1)
                     .map(|m| m.as_str().to_string())
                     .unwrap_or_default();
-                println!("[调试] 获取到令牌 Cookie 值");
+                crate::hbut_debug!("[调试] 获取到令牌 Cookie 值");
             }
         }
 
@@ -632,7 +632,7 @@ impl HbutClient {
             .into());
         }
 
-        println!("[调试] 电费令牌获取成功");
+        crate::hbut_debug!("[调试] 电费令牌获取成功");
         Ok(ElectricityTokenBundle {
             access_token: auth_token,
             refresh_token,
@@ -754,7 +754,7 @@ impl HbutClient {
 
             if within_ttl {
                 // 验证 token 有效性（优先使用官方 App 走的接口）
-                println!("[调试] 检查电费令牌有效性...");
+                crate::hbut_debug!("[调试] 检查电费令牌有效性...");
                 let mut invalid = false;
                 let mut uncertain = false;
                 let check_endpoints = vec![
@@ -806,11 +806,11 @@ impl HbutClient {
                                     || json.get("data").is_some()
                                     || json.get("resultData").is_some()
                                 {
-                                    println!("[调试] 缓存电费令牌有效");
+                                    crate::hbut_debug!("[调试] 缓存电费令牌有效");
                                     return Ok(token.clone());
                                 }
                             } else if !looks_like_login && !text.trim().is_empty() {
-                                println!("[调试] 缓存电费令牌有效（非标准响应）");
+                                crate::hbut_debug!("[调试] 缓存电费令牌有效（非标准响应）");
                                 return Ok(token.clone());
                             }
                             println!("[警告] 令牌校验未通过（{}），准备刷新", status);
@@ -852,7 +852,7 @@ impl HbutClient {
                 }
 
                 if invalid {
-                    println!("[调试] 缓存电费令牌无效或过期");
+                    crate::hbut_debug!("[调试] 缓存电费令牌无效或过期");
                     self.electricity_token = None;
                     self.electricity_token_at = None;
                     self.electricity_token_expires_at = None;
@@ -863,7 +863,7 @@ impl HbutClient {
 
         // 优先使用 refreshToken 刷新（若可用）
         if self.electricity_refresh_token.is_some() {
-            println!("[调试] 尝试使用 refreshToken 刷新电费令牌...");
+            crate::hbut_debug!("[调试] 尝试使用 refreshToken 刷新电费令牌...");
             if let Ok(bundle) = self.refresh_electricity_token().await {
                 let refresh = bundle
                     .refresh_token
@@ -880,14 +880,14 @@ impl HbutClient {
             }
         }
 
-        println!("[调试] 令牌无效或缺失，尝试 SSO...");
+        crate::hbut_debug!("[调试] 令牌无效或缺失，尝试 SSO...");
 
         let token_result = self.get_electricity_token().await;
         let bundle = match token_result {
             Ok(res) => res,
             Err(err) => {
                 let err_msg = err.to_string();
-                println!("[调试] 电费令牌失败: {}", err_msg);
+                crate::hbut_debug!("[调试] 电费令牌失败: {}", err_msg);
 
                 if err_msg.contains("tid=") && err_msg.contains("ticket=") {
                     if let Some(fallback) = cached_token.clone() {
@@ -904,7 +904,7 @@ impl HbutClient {
                     }
                     return Err(format!("登录频率过高，请{}秒后再试", remaining.as_secs()).into());
                 }
-                println!("[调试] 尝试重新登录并重试...");
+                crate::hbut_debug!("[调试] 尝试重新登录并重试...");
                 match self.relogin_for_code_service().await {
                     Ok(true) => self.get_electricity_token().await?,
                     Ok(false) => {
@@ -950,7 +950,7 @@ impl HbutClient {
         &mut self,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
         let sso_url = "https://code.hbut.edu.cn/server/auth/host/open?host=28&org=2";
-        println!("[调试] 一码通: 开始 SSO {}", sso_url);
+        crate::hbut_debug!("[调试] 一码通: 开始 SSO {}", sso_url);
 
         // 预热门户与 code SSO
         let portal_service = "https://e.hbut.edu.cn/login";
@@ -978,14 +978,14 @@ impl HbutClient {
                         .get(1)
                         .map(|m| m.as_str().to_string())
                         .unwrap_or_default();
-                    println!("[调试] 一码通：直连 tid={}", tid);
+                    crate::hbut_debug!("[调试] 一码通：直连 tid={}", tid);
                 }
                 if let Some(caps) = regex::Regex::new(r"ticket=([^&]+)")?.captures(&final_url) {
                     ticket = caps
                         .get(1)
                         .map(|m| m.as_str().to_string())
                         .unwrap_or_default();
-                    println!("[调试] 一码通：直连 ticket={}", ticket);
+                    crate::hbut_debug!("[调试] 一码通：直连 ticket={}", ticket);
                 }
             }
             Err(err) => {
@@ -1043,14 +1043,14 @@ impl HbutClient {
 
                     let status = resp.status();
                     let url_str = resp.url().to_string();
-                    println!("[调试] 一码通：状态={}, url={}", status, url_str);
+                    crate::hbut_debug!("[调试] 一码通：状态={}, url={}", status, url_str);
                     if tid.is_empty() {
                         if let Some(caps) = regex::Regex::new(r"tid=([^&]+)")?.captures(&url_str) {
                             tid = caps
                                 .get(1)
                                 .map(|m| m.as_str().to_string())
                                 .unwrap_or_default();
-                            println!("[调试] 一码通：tid 地址={}", tid);
+                            crate::hbut_debug!("[调试] 一码通：tid 地址={}", tid);
                         }
                     }
                     if ticket.is_empty() {
@@ -1060,14 +1060,14 @@ impl HbutClient {
                                 .get(1)
                                 .map(|m| m.as_str().to_string())
                                 .unwrap_or_default();
-                            println!("[调试] 一码通：ticket 地址={}", ticket);
+                            crate::hbut_debug!("[调试] 一码通：ticket 地址={}", ticket);
                         }
                     }
 
                     if status.is_redirection() {
                         if let Some(location) = resp.headers().get("Location") {
                             let location_str = location.to_str().unwrap_or("");
-                            println!("[调试] 一码通：重定向地址={}", location_str);
+                            crate::hbut_debug!("[调试] 一码通：重定向地址={}", location_str);
                             if tid.is_empty() {
                                 if let Some(caps) =
                                     regex::Regex::new(r"tid=([^&]+)")?.captures(location_str)
@@ -1076,7 +1076,7 @@ impl HbutClient {
                                         .get(1)
                                         .map(|m| m.as_str().to_string())
                                         .unwrap_or_default();
-                                    println!("[调试] 一码通：tid 重定向={}", tid);
+                                    crate::hbut_debug!("[调试] 一码通：tid 重定向={}", tid);
                                 }
                             }
                             if ticket.is_empty() {
@@ -1087,7 +1087,7 @@ impl HbutClient {
                                         .get(1)
                                         .map(|m| m.as_str().to_string())
                                         .unwrap_or_default();
-                                    println!("[调试] 一码通：ticket 重定向={}", ticket);
+                                    crate::hbut_debug!("[调试] 一码通：ticket 重定向={}", ticket);
                                 }
                             }
                             current_url = if location_str.starts_with("http") {
@@ -1115,7 +1115,7 @@ impl HbutClient {
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
                         if !tid.is_empty() {
-                            println!("[调试] 一码通：tid 内容={}", tid);
+                            crate::hbut_debug!("[调试] 一码通：tid 内容={}", tid);
                         }
                     }
                     if ticket.is_empty() {
@@ -1125,7 +1125,7 @@ impl HbutClient {
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
                         if !ticket.is_empty() {
-                            println!("[调试] 一码通：ticket 内容={}", ticket);
+                            crate::hbut_debug!("[调试] 一码通：ticket 内容={}", ticket);
                         }
                     }
 
@@ -1134,13 +1134,13 @@ impl HbutClient {
                         || body.contains("pwdEncryptSalt")
                     {
                         needs_login = true;
-                        println!("[调试] 一码通：检测到认证登录页");
+                        crate::hbut_debug!("[调试] 一码通：检测到认证登录页");
                     }
                     break;
                 }
 
                 if tid.is_empty() && needs_login && attempt == 0 {
-                    println!("[调试] 一码通：SSO 需要登录，重新登录后重试...");
+                    crate::hbut_debug!("[调试] 一码通：SSO 需要登录，重新登录后重试...");
                     if let Some(remaining) = self.relogin_cooldown_remaining() {
                         println!(
                             "[警告] 一码通：重登冷却中（{}s），跳过重登",
@@ -1150,7 +1150,7 @@ impl HbutClient {
                     }
                     match self.relogin_for_code_service().await {
                         Ok(true) => {
-                            println!("[调试] 一码通：重登成功，重试 SSO...");
+                            crate::hbut_debug!("[调试] 一码通：重登成功，重试 SSO...");
                             continue;
                         }
                         Ok(false) => {
@@ -1175,7 +1175,7 @@ impl HbutClient {
                         .get(1)
                         .map(|m| m.as_str().to_string())
                         .unwrap_or_default();
-                    println!("[调试] 一码通：最终 tid 地址={}", tid);
+                    crate::hbut_debug!("[调试] 一码通：最终 tid 地址={}", tid);
                 }
                 if ticket.is_empty() {
                     if let Some(caps) = regex::Regex::new(r"ticket=([^&]+)")?.captures(&url_str) {
@@ -1183,7 +1183,7 @@ impl HbutClient {
                             .get(1)
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
-                        println!("[调试] 一码通：最终 ticket 地址={}", ticket);
+                        crate::hbut_debug!("[调试] 一码通：最终 ticket 地址={}", ticket);
                     }
                 }
                 if tid.is_empty() && ticket.is_empty() {
@@ -1193,7 +1193,7 @@ impl HbutClient {
                             .get(1)
                             .map(|m| m.as_str().to_string())
                             .unwrap_or_default();
-                        println!("[调试] 一码通：最终 tid HTML={}", tid);
+                        crate::hbut_debug!("[调试] 一码通：最终 tid HTML={}", tid);
                     }
                     if ticket.is_empty() {
                         if let Some(caps) =
@@ -1203,7 +1203,7 @@ impl HbutClient {
                                 .get(1)
                                 .map(|m| m.as_str().to_string())
                                 .unwrap_or_default();
-                            println!("[调试] 一码通：最终 ticket HTML={}", ticket);
+                            crate::hbut_debug!("[调试] 一码通：最终 ticket HTML={}", ticket);
                         }
                     }
                 }
@@ -1566,7 +1566,7 @@ impl HbutClient {
         {
             let msg = json.get("message").and_then(|v| v.as_str()).unwrap_or("");
             if msg.contains("token") || msg.contains("授权") || msg.contains("Authentication") {
-                println!("[调试] 获取交易记录时令牌无效，尝试刷新...");
+                crate::hbut_debug!("[调试] 获取交易记录时令牌无效，尝试刷新...");
                 let token = self.ensure_electricity_token().await?;
                 let retry = self
                     .client
@@ -1653,13 +1653,13 @@ impl HbutClient {
             urlencoding::encode(code_service)
         );
 
-        println!("[调试] code 服务重登： 检查 CAS 会话是否仍有效...");
+        crate::hbut_debug!("[调试] code 服务重登： 检查 CAS 会话是否仍有效...");
         let check_resp = self.client.get(&code_sso_url).send().await?;
         let check_url = check_resp.url().to_string();
         let needs_login = check_url.contains("authserver/login") && !check_url.contains("ticket=");
 
         if needs_login {
-            println!("[调试] code 服务重登： code 服务 CAS 会话已过期，需要重新登录...");
+            crate::hbut_debug!("[调试] code 服务重登： code 服务 CAS 会话已过期，需要重新登录...");
             if let Err(err) = self
                 .login_for_service(&username, &password, code_service)
                 .await
@@ -1669,10 +1669,10 @@ impl HbutClient {
                 return Err(err);
             }
         } else {
-            println!("[调试] code 服务重登： code 服务 CAS 会话仍有效，跳过登录");
+            crate::hbut_debug!("[调试] code 服务重登： code 服务 CAS 会话仍有效，跳过登录");
         }
 
-        println!("[调试] code 服务重登： 建立 code.hbut.edu.cn 会话...");
+        crate::hbut_debug!("[调试] code 服务重登： 建立 code.hbut.edu.cn 会话...");
         let _ = self.client.get(code_service).send().await;
 
         println!(

--- a/src-tauri/src/http_client/mod.rs
+++ b/src-tauri/src/http_client/mod.rs
@@ -10,6 +10,15 @@
 //! - OCR 请求使用独立的 `ocr_client`，避免污染主会话
 //! - 这里不直接实现业务接口，业务逻辑在子模块中实现
 
+#[macro_export]
+macro_rules! hbut_debug {
+    ($($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            println!($($arg)*);
+        }
+    };
+}
+
 use chrono::{DateTime, Utc};
 use reqwest::{
     cookie::{CookieStore, Jar},
@@ -55,6 +64,28 @@ pub(super) const SECONDARY_OCR_ENDPOINT: &str =
     "https://mini-hbut-testocr1.hf.space/api/ocr/recognize";
 pub(super) const DEFAULT_LOCAL_OCR_FALLBACK_ENDPOINTS: &[&str] =
     &[DEFAULT_OCR_ENDPOINT, SECONDARY_OCR_ENDPOINT];
+/// Release 构建仅允许 HTTPS OCR，避免验证码图片经明文 HTTP 外传。
+pub(super) const DEFAULT_RELEASE_OCR_FALLBACK_ENDPOINTS: &[&str] = &[SECONDARY_OCR_ENDPOINT];
+
+/// Release 构建过滤掉非 HTTPS 的 OCR 端点。
+pub(super) fn filter_release_ocr_endpoints(endpoints: Vec<String>) -> Vec<String> {
+    if cfg!(debug_assertions) {
+        return endpoints;
+    }
+    endpoints
+        .into_iter()
+        .filter(|e| e.trim().starts_with("https://"))
+        .collect()
+}
+
+fn default_local_ocr_fallback_endpoints() -> Vec<String> {
+    let source = if cfg!(debug_assertions) {
+        DEFAULT_LOCAL_OCR_FALLBACK_ENDPOINTS
+    } else {
+        DEFAULT_RELEASE_OCR_FALLBACK_ENDPOINTS
+    };
+    source.iter().map(|v| v.to_string()).collect()
+}
 
 /// 判断是否跳转到了教务登录页（包含 CAS 登录与教务自身登录页）。
 /// 注意：不匹配 `/admin/caslogin`，因为它是学习通 CAS 的 service URL 本身，
@@ -226,7 +257,7 @@ impl HbutClient {
 
     fn build_ocr_client() -> Client {
         Client::builder()
-            .timeout(std::time::Duration::from_secs(12))
+            .timeout(std::time::Duration::from_secs(5))
             .build()
             .expect("创建 OCR 客户端失败")
     }
@@ -252,10 +283,7 @@ impl HbutClient {
             electricity_token_expires_at: None,
             ocr_endpoint: None,
             ocr_remote_endpoints: Vec::new(),
-            ocr_local_fallback_endpoints: DEFAULT_LOCAL_OCR_FALLBACK_ENDPOINTS
-                .iter()
-                .map(|v| v.to_string())
-                .collect(),
+            ocr_local_fallback_endpoints: default_local_ocr_fallback_endpoints(),
             ocr_active_endpoint: None,
             ocr_active_source: None,
             ocr_last_error: None,
@@ -278,14 +306,13 @@ impl HbutClient {
         } else {
             let normalized = Self::normalize_ocr_endpoint(trimmed);
             self.ocr_endpoint = Some(normalized.clone());
-            self.ocr_remote_endpoints = vec![normalized];
+            self.ocr_remote_endpoints = filter_release_ocr_endpoints(vec![normalized]);
         }
         if self.ocr_local_fallback_endpoints.is_empty() {
-            self.ocr_local_fallback_endpoints = DEFAULT_LOCAL_OCR_FALLBACK_ENDPOINTS
-                .iter()
-                .map(|v| v.to_string())
-                .collect();
+            self.ocr_local_fallback_endpoints = default_local_ocr_fallback_endpoints();
         }
+        self.ocr_local_fallback_endpoints =
+            filter_release_ocr_endpoints(self.ocr_local_fallback_endpoints.clone());
         // 每次配置更新后清理运行态，下一次 OCR 请求会重新填充状态。
         self.ocr_active_endpoint = None;
         self.ocr_active_source = None;
@@ -297,17 +324,15 @@ impl HbutClient {
         endpoints: Vec<String>,
         local_fallback_endpoints: Vec<String>,
     ) {
-        self.ocr_remote_endpoints = Self::normalize_ocr_endpoint_list(endpoints);
+        self.ocr_remote_endpoints =
+            filter_release_ocr_endpoints(Self::normalize_ocr_endpoint_list(endpoints));
         self.ocr_endpoint = self.ocr_remote_endpoints.first().cloned();
 
         let normalized_local = Self::normalize_ocr_endpoint_list(local_fallback_endpoints);
         self.ocr_local_fallback_endpoints = if normalized_local.is_empty() {
-            DEFAULT_LOCAL_OCR_FALLBACK_ENDPOINTS
-                .iter()
-                .map(|v| v.to_string())
-                .collect()
+            default_local_ocr_fallback_endpoints()
         } else {
-            normalized_local
+            filter_release_ocr_endpoints(normalized_local)
         };
 
         self.ocr_active_endpoint = None;
@@ -344,7 +369,7 @@ impl HbutClient {
                 result.push(normalized);
             }
         }
-        result
+        filter_release_ocr_endpoints(result)
     }
 
     pub(super) fn set_ocr_runtime_success(&mut self, source: &str, endpoint: &str) {

--- a/src-tauri/src/http_client/session.rs
+++ b/src-tauri/src/http_client/session.rs
@@ -592,9 +592,7 @@ impl HbutClient {
             }
         }
 
-        if self.prefer_chaoxing_jwxt {
-            let _ = self.ensure_chaoxing_academic_session().await;
-        }
+        // 学习通补票改为按需：仅在 fetch_user_info 命中登录页时由 session 模块触发。
 
         // 验证会话
         let user_info = self.fetch_user_info().await?;

--- a/src-tauri/src/http_client/utils.rs
+++ b/src-tauri/src/http_client/utils.rs
@@ -11,6 +11,32 @@ pub(super) fn chrono_timestamp() -> u64 {
         .as_millis() as u64
 }
 
+pub(super) fn app_data_dir() -> Option<std::path::PathBuf> {
+    if let Ok(raw) = std::env::var("HBUT_APP_DATA_DIR") {
+        let dir = std::path::PathBuf::from(raw.trim());
+        if !dir.as_os_str().is_empty() {
+            let _ = std::fs::create_dir_all(&dir);
+            return Some(dir);
+        }
+    }
+
+    let base = std::env::var("LOCALAPPDATA")
+        .or_else(|_| std::env::var("APPDATA"))
+        .or_else(|_| std::env::var("HOME"))
+        .ok()?;
+    let dir = std::path::PathBuf::from(base).join("Mini-HBUT");
+    let _ = std::fs::create_dir_all(&dir);
+    Some(dir)
+}
+
+/// 仅 Debug 构建写入应用数据目录，避免污染 cwd。
+pub(super) fn write_debug_artifact(filename: &str, content: &str) {
+    #[cfg(debug_assertions)]
+    if let Some(dir) = app_data_dir() {
+        let _ = std::fs::write(dir.join(filename), content);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::encrypt_password_aes;

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -834,7 +834,7 @@ async fn run_http_server(state: HttpState) -> Result<(), Box<dyn std::error::Err
 }
 
 async fn health(State(state): State<HttpState>) -> Json<ApiResponse<serde_json::Value>> {
-    let client = state.client.write().await;
+    let client = state.client.read().await;
     ok(serde_json::json!({
         "success": true,
         "logged_in": client.user_info.is_some()
@@ -881,7 +881,7 @@ async fn export_cookies(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_sensitive_bridge_auth(&headers, &state)?;
-    let client = state.client.write().await;
+    let client = state.client.read().await;
     Ok(ok(serde_json::json!({
         "success": true,
         "data": client.get_cookie_snapshot()
@@ -912,7 +912,7 @@ async fn sync_grades(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_sensitive_bridge_auth(&headers, &state)?;
-    let client = state.client.write().await;
+    let client = state.client.read().await;
     match client.fetch_grades().await {
         Ok(grades) => {
             let payload = serde_json::json!({
@@ -2526,7 +2526,7 @@ async fn fetch_exams(
     Json(req): Json<ExamRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
-    let client = state.client.write().await;
+    let client = state.client.read().await;
     match client.fetch_exams(req.semester.as_deref()).await {
         Ok(exams) => {
             let payload = serde_json::json!({
@@ -2546,7 +2546,7 @@ async fn fetch_ranking(
     Json(req): Json<RankingRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
-    let client = state.client.write().await;
+    let client = state.client.read().await;
     if !client.is_logged_in && client.user_info.is_none() {
         return Err(err(
             StatusCode::UNAUTHORIZED,
@@ -2565,7 +2565,7 @@ async fn fetch_student_info(
     State(state): State<HttpState>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
-    let client = state.client.write().await;
+    let client = state.client.read().await;
     client
         .fetch_student_info()
         .await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,7 +48,8 @@ pub mod utils;
 
 use app_state::AppState;
 use commands::{
-    delete_remembered_credential, load_remembered_credential, save_remembered_credential,
+    delete_remembered_credential, load_remembered_credential, load_session_password,
+    save_remembered_credential,
 };
 use http_client::HbutClient;
 
@@ -3871,17 +3872,7 @@ async fn login(
 
 #[tauri::command]
 async fn logout(state: State<'_, AppState>) -> Result<(), String> {
-    let student_id = {
-        let client = state.client.write().await;
-        client
-            .user_info
-            .as_ref()
-            .map(|u| u.student_id.clone())
-            .unwrap_or_default()
-    };
-    if !student_id.is_empty() {
-        credential_store::delete_password(&student_id);
-    }
+    // 仅清理内存会话；保留密钥环中的「记住密码」与会话密码，供下次自动登录/表单回填。
     let mut client = state.client.write().await;
     client.clear_session();
     Ok(())
@@ -6557,6 +6548,7 @@ pub fn run() {
             logout,
             save_remembered_credential,
             load_remembered_credential,
+            load_session_password,
             delete_remembered_credential,
             restore_session,
             restore_latest_session,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,7 +47,9 @@ pub mod qxzkb_options;
 pub mod utils;
 
 use app_state::AppState;
-use commands::{delete_remembered_credential, load_remembered_credential, save_remembered_credential};
+use commands::{
+    delete_remembered_credential, load_remembered_credential, save_remembered_credential,
+};
 use http_client::HbutClient;
 
 use modules::ai::*;
@@ -147,9 +149,7 @@ fn spawn_electricity_session_warmup(
                 client.get_cookies(),
                 token,
                 refresh_opt.unwrap_or_default(),
-                expires_at_opt
-                    .map(|dt| dt.to_rfc3339())
-                    .unwrap_or_default(),
+                expires_at_opt.map(|dt| dt.to_rfc3339()).unwrap_or_default(),
             )
         };
         if let Err(e) = db::save_user_session(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ use tauri_plugin_shell::ShellExt;
 use tokio::sync::RwLock;
 
 pub mod app_state;
+pub mod commands;
 pub mod credential_store;
 pub mod db;
 pub mod debug_bridge;
@@ -46,6 +47,7 @@ pub mod qxzkb_options;
 pub mod utils;
 
 use app_state::AppState;
+use commands::{delete_remembered_credential, load_remembered_credential, save_remembered_credential};
 use http_client::HbutClient;
 
 use modules::ai::*;
@@ -119,6 +121,51 @@ fn persist_electricity_tokens(client: &HbutClient) {
         &refresh_token,
         &expires_at,
     );
+}
+
+/// 登录成功后后台预热一码通 Token，避免阻塞返回用户信息。
+fn spawn_electricity_session_warmup(
+    client_arc: Arc<RwLock<HbutClient>>,
+    session_key: String,
+    password: String,
+) {
+    if session_key.trim().is_empty() {
+        return;
+    }
+    tauri::async_runtime::spawn(async move {
+        let (cookies, one_code_token, refresh_token, expires_at) = {
+            let mut client = client_arc.write().await;
+            let token = match client.ensure_electricity_token().await {
+                Ok(t) => t,
+                Err(e) => {
+                    println!("[警告] 后台获取 one_code_token 失败: {}", e);
+                    return;
+                }
+            };
+            let (_token_opt, refresh_opt, expires_at_opt) = client.get_electricity_session();
+            (
+                client.get_cookies(),
+                token,
+                refresh_opt.unwrap_or_default(),
+                expires_at_opt
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_default(),
+            )
+        };
+        if let Err(e) = db::save_user_session(
+            DB_FILENAME,
+            &session_key,
+            &cookies,
+            &password,
+            &one_code_token,
+            Some(refresh_token.as_str()),
+            Some(expires_at.as_str()),
+        ) {
+            println!("[警告] 后台保存 one_code 会话失败: {}", e);
+        }
+        let client = client_arc.read().await;
+        persist_electricity_tokens(&client);
+    });
 }
 
 fn attach_sync_time(
@@ -1645,19 +1692,18 @@ async fn portal_qr_confirm_login(
     client.last_password = None;
     client.save_cookie_snapshot_to_file();
 
-    let one_code_token = client.ensure_electricity_token().await.unwrap_or_default();
-    let (_token_opt, refresh_opt, expires_at_opt) = client.get_electricity_session();
-    let refresh_token = refresh_opt.unwrap_or_default();
-    let expires_at = expires_at_opt.map(|dt| dt.to_rfc3339()).unwrap_or_default();
     let _ = db::save_user_session(
         DB_FILENAME,
         &user_info.student_id,
         &client.get_cookies(),
         "",
-        &one_code_token,
-        Some(refresh_token.as_str()),
-        Some(expires_at.as_str()),
+        "",
+        Some(""),
+        Some(""),
     );
+
+    let client_arc = Arc::clone(&state.client);
+    spawn_electricity_session_warmup(client_arc, user_info.student_id.clone(), String::new());
 
     Ok(user_info)
 }
@@ -3783,34 +3829,6 @@ async fn login(
         .map_err(|e| e.to_string())?;
     client.set_chaoxing_login_mode(false);
 
-    // 尝试获取电费 Token (One Code)
-    let one_code_token = match client.ensure_electricity_token().await {
-        Ok(t) => {
-            println!("[调试] Login: Successfully obtained one_code_浠ょ墝");
-            t
-        }
-        Err(e) => {
-            println!("[璀﹀憡] 登录：获?one_code_浠ょ墝 失败: {}", e);
-            String::new()
-        }
-    };
-
-    // 保存会话到本地数据库 (鐢ㄤ自动重连)
-    let (_token_opt, refresh_opt, expires_at_opt) = client.get_electricity_session();
-    let refresh_token = refresh_opt.unwrap_or_default();
-    let expires_at = expires_at_opt.map(|dt| dt.to_rfc3339()).unwrap_or_default();
-    if let Err(e) = db::save_user_session(
-        DB_FILENAME,
-        &username,
-        &client.get_cookies(),
-        &password,
-        &one_code_token,
-        Some(refresh_token.as_str()),
-        Some(expires_at.as_str()),
-    ) {
-        println!("[璀﹀憡] 保存会话失败: {}", e);
-    }
-
     let user_info = client
         .user_info
         .clone()
@@ -3820,17 +3838,33 @@ async fn login(
     } else {
         user_info.student_id.clone()
     };
+
+    // 先保存 Cookie 会话，一码通 Token 后台预热，不阻塞登录返回。
+    if let Err(e) = db::save_user_session(
+        DB_FILENAME,
+        &session_key,
+        &client.get_cookies(),
+        &password,
+        "",
+        Some(""),
+        Some(""),
+    ) {
+        println!("[璀﹀憡] 保存会话失败: {}", e);
+    }
     if session_key != username {
         let _ = db::save_user_session(
             DB_FILENAME,
-            &session_key,
+            &username,
             &client.get_cookies(),
             &password,
-            &one_code_token,
-            Some(refresh_token.as_str()),
-            Some(expires_at.as_str()),
+            "",
+            Some(""),
+            Some(""),
         );
     }
+
+    let client_arc = Arc::clone(&state.client);
+    spawn_electricity_session_warmup(client_arc, session_key, password);
 
     Ok(user_info)
 }
@@ -6521,6 +6555,9 @@ pub fn run() {
             chaoxing_qr_confirm_login,
             chaoxing_password_login,
             logout,
+            save_remembered_credential,
+            load_remembered_credential,
+            delete_remembered_credential,
             restore_session,
             restore_latest_session,
             set_offline_user_context,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "1.4.2",
   "identifier": "com.hbut.mini",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "node scripts/ensure_dist.mjs && npm run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build && node scripts/check_dist_boundary.mjs",
     "frontendDist": "../dist"

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,7 @@ import {
   loadChaoxingStoredPassword,
   loadPortalStoredPassword
 } from './composables/useSessionCredentials.js'
+import { preservePortalRememberedPasswordOnLogout } from './utils/credential_storage.js'
 import { startNotificationMonitor, stopNotificationMonitor } from './utils/notify_center.js'
 import { openExternal, isHttpLink } from './utils/external_link'
 import { useUiSettings } from './utils/ui_settings'
@@ -1543,11 +1544,18 @@ const isTemporaryLoginSession = () => {
 }
 
 // 处理登出
-const handleLogout = (options = {}) => {
+const handleLogout = async (options = {}) => {
   const payload = options && typeof options === 'object' ? options : {}
   const manual = payload.manual !== false
   const reason = String(payload.reason || '').trim()
   const notice = String(payload.notice || '').trim()
+
+  try {
+    await preservePortalRememberedPasswordOnLogout()
+  } catch (e) {
+    console.warn('[Session] 退出前同步记住密码失败:', e)
+  }
+
   applyViewState('home')
   gradeData.value = []
   gradeTeacherCache.value = null

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@ import {
   loadChaoxingStoredPassword,
   loadPortalStoredPassword
 } from './composables/useSessionCredentials.js'
-import { preservePortalRememberedPasswordOnLogout } from './utils/credential_storage.js'
+import { ensureRememberedPasswordCached, preservePortalRememberedPasswordOnLogout } from './utils/credential_storage.js'
 import { startNotificationMonitor, stopNotificationMonitor } from './utils/notify_center.js'
 import { openExternal, isHttpLink } from './utils/external_link'
 import { useUiSettings } from './utils/ui_settings'
@@ -1460,6 +1460,9 @@ const handleLoginSuccess = (data) => {
   startSessionKeepAlive()
   startElectricityKeepAlive()
   if (studentId.value) {
+    void ensureRememberedPasswordCached(studentId.value).catch((e) => {
+      console.warn('[Session] 登录后缓存记住密码失败:', e)
+    })
     startNotificationMonitor({ studentId: studentId.value }).catch((e) => {
       console.warn('[Notify] 启动通知监控失败:', e)
     })
@@ -2743,6 +2746,9 @@ onMounted(async () => {
     startElectricityKeepAlive()
     if (studentId.value) {
       markLoginSessionToken()
+      void ensureRememberedPasswordCached(studentId.value).catch((e) => {
+        console.warn('[Session] 启动后缓存记住密码失败:', e)
+      })
       startNotificationMonitor({ studentId: studentId.value }).catch((e) => {
         console.warn('[Notify] 启动通知监控失败:', e)
       })

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,9 +5,10 @@ import UpdateDialog from './components/UpdateDialog.vue'
 import Toast from './components/Toast.vue'
 import SplashScreen from './components/SplashScreen.vue'
 import WorkspaceLayoutEditor from './components/WorkspaceLayoutEditor.vue'
-import { fetchWithCache, getStaleCachedData, setCachedData, DEFAULT_SWR_OPTIONS } from './utils/api.js'
+import { fetchWithCache, getStaleCachedData, setCachedData, DEFAULT_SWR_OPTIONS, clearUserScopedCaches } from './utils/api.js'
 import {
   readScheduleRenderSnapshot,
+  clearScheduleRenderSnapshot,
   SCHEDULE_POPUP_PENDING_KEY,
   SCHEDULE_SWITCH_PENDING_KEY
 } from './utils/schedule_prefetch.js'
@@ -1552,11 +1553,20 @@ const handleLogout = async (options = {}) => {
   const manual = payload.manual !== false
   const reason = String(payload.reason || '').trim()
   const notice = String(payload.notice || '').trim()
+  const logoutSid = String(studentId.value || localStorage.getItem('hbu_username') || '').trim()
 
   try {
     await preservePortalRememberedPasswordOnLogout()
   } catch (e) {
     console.warn('[Session] 退出前同步记住密码失败:', e)
+  }
+
+  if (manual && logoutSid) {
+    clearUserScopedCaches(logoutSid)
+    clearScheduleRenderSnapshot(logoutSid)
+    window.dispatchEvent(new CustomEvent('hbu-session-logout', {
+      detail: { studentId: logoutSid, manual: true }
+    }))
   }
 
   applyViewState('home')

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import UpdateDialog from './components/UpdateDialog.vue'
 import Toast from './components/Toast.vue'
 import SplashScreen from './components/SplashScreen.vue'
 import WorkspaceLayoutEditor from './components/WorkspaceLayoutEditor.vue'
-import { fetchWithCache, getStaleCachedData, setCachedData } from './utils/api.js'
+import { fetchWithCache, getStaleCachedData, setCachedData, DEFAULT_SWR_OPTIONS } from './utils/api.js'
 import {
   readScheduleRenderSnapshot,
   SCHEDULE_POPUP_PENDING_KEY,
@@ -19,6 +19,10 @@ import {
   isRemoteConfigEnabled
 } from './utils/remote_config.js'
 import { resetCloudSyncCooldownForSession, runAutoCloudSyncAfterLogin } from './utils/cloud_sync.js'
+import {
+  loadChaoxingStoredPassword,
+  loadPortalStoredPassword
+} from './composables/useSessionCredentials.js'
 import { startNotificationMonitor, stopNotificationMonitor } from './utils/notify_center.js'
 import { openExternal, isHttpLink } from './utils/external_link'
 import { useUiSettings } from './utils/ui_settings'
@@ -1916,7 +1920,9 @@ const fetchGradesFromAPI = async (sid, { force = false, teacherCurrentOnly = fal
       `grades:${sid}`,
       () => fetchGradesRemote(sid, { teacherCurrentOnly }),
       undefined,
-      { forceRemote: true, priority: 'foreground' }
+      force
+        ? { forceRemote: true, priority: 'foreground' }
+        : { ...DEFAULT_SWR_OPTIONS, priority: 'foreground' }
     )
     lastGradeRefreshUsedOffline.value = !!data?.offline
     if (data?.success && !data.offline) {
@@ -2249,28 +2255,9 @@ const tryRestoreLatestSession = async () => {
   return false
 }
 
-const getStoredPassword = () => {
-  const remember = localStorage.getItem('hbu_remember')
-  const username = localStorage.getItem('hbu_username')
-  const credential = localStorage.getItem('hbu_credentials')
-  if (remember === 'false' || !username || !credential) {
-    return null
-  }
-  if (credential.length > 50 || /[A-Za-z0-9+/=]{30,}/.test(credential)) {
-    return null
-  }
-  return { username, password: credential }
-}
+const getStoredPassword = () => loadPortalStoredPassword()
 
-const getStoredChaoxingPassword = () => {
-  const remember = localStorage.getItem(CHAOXING_REMEMBER_KEY)
-  const account = String(localStorage.getItem(CHAOXING_ACCOUNT_KEY) || '').trim()
-  const password = String(localStorage.getItem(CHAOXING_PASSWORD_KEY) || '').trim()
-  if (remember === 'false' || !account || !password) {
-    return null
-  }
-  return { account, password }
-}
+const getStoredChaoxingPassword = () => loadChaoxingStoredPassword()
 
 const isLikelyStudentId = (value) => /^\d{10}$/.test(String(value || '').trim())
 
@@ -2298,7 +2285,7 @@ const attemptAutoRelogin = async () => {
   }
   const method = String(localStorage.getItem(LOGIN_METHOD_KEY) || '').trim()
   if (method.startsWith('chaoxing_')) {
-    const chaoxingCreds = getStoredChaoxingPassword()
+    const chaoxingCreds = await getStoredChaoxingPassword()
     if (!chaoxingCreds) return false
     try {
       const payload = await invokeNative('chaoxing_password_login', {
@@ -2320,7 +2307,7 @@ const attemptAutoRelogin = async () => {
     }
   }
 
-  const creds = getStoredPassword()
+  const creds = await getStoredPassword()
   if (!creds) return false
 
   const doLogin = async () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1639,6 +1639,17 @@ const clearJwxtMaintenance = () => {
   }
 }
 
+const notifySessionOnline = (source = 'recovery') => {
+  if (!studentId.value) return
+  clearJwxtMaintenance()
+  window.dispatchEvent(new CustomEvent('hbu-session-online', {
+    detail: {
+      studentId: studentId.value,
+      source
+    }
+  }))
+}
+
 const syncJwxtMaintenanceFromStorage = () => {
   const active = localStorage.getItem(JWXT_MAINTENANCE_KEY) === '1'
   if (!active) {
@@ -1724,6 +1735,7 @@ const attemptOnlineRecovery = async (options = {}) => {
       }
       await persistSessionCookies()
       stopJwxtRecoveryPolling()
+      notifySessionOnline(relogged ? 'auto-relogin' : 'session-restore')
       // 后台恢复/重登录成功后自动上传成绩和设置到云端（不含自定义课程）
       if (relogged && studentId.value) {
         resetCloudSyncCooldownForSession(studentId.value)
@@ -2311,7 +2323,7 @@ const attemptAutoRelogin = async () => {
   if (!creds) return false
 
   const doLogin = async () => {
-    await invokeNative('login', {
+    const userInfo = await invokeNative('login', {
       username: creds.username,
       password: creds.password,
       captcha: '',
@@ -2319,8 +2331,10 @@ const attemptAutoRelogin = async () => {
       execution: ''
     })
     await persistSessionCookies()
-    if (!studentId.value) {
-      studentId.value = creds.username
+    const sid = String(userInfo?.student_id || creds.username || '').trim()
+    if (sid) {
+      studentId.value = sid
+      localStorage.setItem('hbu_username', sid)
     }
   }
 
@@ -2727,6 +2741,9 @@ onMounted(async () => {
     }
     clearJwxtMaintenance()
     stopJwxtRecoveryPolling()
+    if (bootstrappedCachedIdentity || skipSplashForFastScheduleBoot) {
+      notifySessionOnline(relogged ? 'boot-auto-relogin' : 'boot-session-restore')
+    }
   } else if (bootstrappedCachedIdentity || studentId.value) {
     startJwxtRecoveryPolling()
     attemptOnlineRecovery({ silent: true }).then((ok) => {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import axios from 'axios'
-import { fetchWithCache, getCachedData, setCachedData } from '../utils/api'
+import { fetchWithCache, getCachedData, setCachedData, DEFAULT_SWR_OPTIONS } from '../utils/api'
 import { showToast } from '../utils/toast'
 import { openExternal } from '../utils/external_link'
 import { stripMarkdown } from '../utils/markdown_text.js'
@@ -333,7 +333,7 @@ const fetchTodayCourses = async () => {
       const res = await fetchWithCache(cacheKey, async () => {
         const rsp = await axios.post(`${API_BASE}/v2/schedule/query`, { student_id: props.studentId, semester: preferredSemester || undefined })
         return rsp.data
-      })
+      }, undefined, DEFAULT_SWR_OPTIONS)
       payload = res?.data
     }
     const shouldForceOnlineRetry = !!payload?.success && !!payload?.offline && isVacationPreviousMeta(payload?.meta)

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -6,8 +6,7 @@ import { fetchRemoteConfig, applyOcrRuntimeConfig, getStoredOcrConfig } from '..
 import { invokeNative as invoke } from '../platform/native'
 import {
   buildHbutAccountKey,
-  loadRememberedCredential,
-  migrateLegacyCredential,
+  loadPortalRememberedPassword,
   saveRememberedCredential,
   syncPortalRememberCredential
 } from '../utils/credential_storage.js'
@@ -57,11 +56,7 @@ onMounted(async () => {
 
   if (savedRemember !== 'false' && savedUsername) {
     username.value = savedUsername
-    await migrateLegacyCredential({
-      legacyPasswordKey: 'hbu_credentials',
-      accountKey: buildHbutAccountKey(savedUsername)
-    })
-    password.value = await loadRememberedCredential(buildHbutAccountKey(savedUsername))
+    password.value = await loadPortalRememberedPassword(savedUsername)
     rememberMe.value = true
   }
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,9 +1,15 @@
 ﻿<script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import axios from 'axios'
-import { encryptData, decryptData } from '../utils/encryption.js'
+import { encryptData } from '../utils/encryption.js'
 import { fetchRemoteConfig, applyOcrRuntimeConfig, getStoredOcrConfig } from '../utils/remote_config.js'
 import { invokeNative as invoke } from '../platform/native'
+import {
+  buildHbutAccountKey,
+  loadRememberedCredential,
+  migrateLegacyCredential,
+  saveRememberedCredential
+} from '../utils/credential_storage.js'
 
 const emit = defineEmits(['success', 'switchMode', 'showLegal'])
 
@@ -47,18 +53,14 @@ onMounted(async () => {
   // 从 localStorage 读取保存的凭据
   const savedUsername = localStorage.getItem('hbu_username')
   const savedRemember = localStorage.getItem('hbu_remember')
-  const savedCredentials = localStorage.getItem('hbu_credentials')
-  
+
   if (savedRemember !== 'false' && savedUsername) {
     username.value = savedUsername
-    if (savedCredentials) {
-      try {
-        const decrypted = await decryptData(savedCredentials)
-        password.value = decrypted?.password || ''
-      } catch (e) {
-        password.value = ''
-      }
-    }
+    await migrateLegacyCredential({
+      legacyPasswordKey: 'hbu_credentials',
+      accountKey: buildHbutAccountKey(savedUsername)
+    })
+    password.value = await loadRememberedCredential(buildHbutAccountKey(savedUsername))
     rememberMe.value = true
   }
 
@@ -122,16 +124,17 @@ const handleOcrConfigUpdated = () => {
 const saveCredentials = async () => {
   if (rememberMe.value) {
     localStorage.setItem('hbu_username', username.value)
-    const encrypted = await encryptData({
-      username: username.value,
-      password: password.value
-    })
-    localStorage.setItem('hbu_credentials', encrypted)
     localStorage.setItem('hbu_remember', 'true')
+    await saveRememberedCredential(
+      buildHbutAccountKey(username.value),
+      password.value
+    )
+    localStorage.removeItem('hbu_credentials')
   } else {
     localStorage.removeItem('hbu_username')
     localStorage.removeItem('hbu_credentials')
     localStorage.setItem('hbu_remember', 'false')
+    await saveRememberedCredential(buildHbutAccountKey(username.value), '')
   }
 }
 

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -8,7 +8,8 @@ import {
   buildHbutAccountKey,
   loadRememberedCredential,
   migrateLegacyCredential,
-  saveRememberedCredential
+  saveRememberedCredential,
+  syncPortalRememberCredential
 } from '../utils/credential_storage.js'
 
 const emit = defineEmits(['success', 'switchMode', 'showLegal'])
@@ -210,6 +211,13 @@ const autoLogin = async () => {
     }
     
     if (result.success && result.auto_login) {
+      const sid = String(result?.data?.student_id || username.value || '').trim()
+      await syncPortalRememberCredential({
+        username: username.value,
+        studentId: sid,
+        password: password.value,
+        remember: rememberMe.value
+      })
       // 自动登录成功
       statusMsg.value = '✅ 登录成功！正在获取数据...'
       

--- a/src/components/LoginV3.vue
+++ b/src/components/LoginV3.vue
@@ -4,6 +4,13 @@ import axios from 'axios'
 import { fetchRemoteConfig, applyOcrRuntimeConfig, getStoredOcrConfig } from '../utils/remote_config.js'
 import { invokeNative as invoke, isTauriRuntime } from '../platform/native'
 import { pushDebugLog } from '../utils/debug_logger'
+import {
+  buildChaoxingAccountKey,
+  buildHbutAccountKey,
+  loadRememberedCredential,
+  migrateLegacyCredential,
+  saveRememberedCredential
+} from '../utils/credential_storage.js'
 
 const props = defineProps({
   loginMode: { type: String, default: 'portal' }
@@ -426,25 +433,35 @@ const emitSuccessWithGrades = async (sid) => {
   }
 }
 
-const savePortalCredentials = () => {
+const savePortalCredentials = async () => {
   if (rememberMe.value) {
     localStorage.setItem('hbu_username', username.value)
-    localStorage.setItem('hbu_credentials', password.value)
     localStorage.setItem('hbu_remember', 'true')
+    await saveRememberedCredential(
+      buildHbutAccountKey(username.value),
+      password.value
+    )
+    localStorage.removeItem('hbu_credentials')
   } else {
     localStorage.removeItem('hbu_credentials')
     localStorage.setItem('hbu_remember', 'false')
+    await saveRememberedCredential(buildHbutAccountKey(username.value), '')
   }
 }
 
-const saveChaoxingCredentials = () => {
+const saveChaoxingCredentials = async () => {
   if (rememberMe.value) {
     localStorage.setItem(CHAOXING_ACCOUNT_KEY, chaoxingAccount.value)
-    localStorage.setItem(CHAOXING_PASSWORD_KEY, chaoxingPassword.value)
     localStorage.setItem(CHAOXING_REMEMBER_KEY, 'true')
+    await saveRememberedCredential(
+      buildChaoxingAccountKey(chaoxingAccount.value),
+      chaoxingPassword.value
+    )
+    localStorage.removeItem(CHAOXING_PASSWORD_KEY)
   } else {
     localStorage.removeItem(CHAOXING_PASSWORD_KEY)
     localStorage.setItem(CHAOXING_REMEMBER_KEY, 'false')
+    await saveRememberedCredential(buildChaoxingAccountKey(chaoxingAccount.value), '')
   }
 }
 
@@ -463,7 +480,7 @@ const handlePasswordLogin = async () => {
   void ensureOcrEndpointReady().catch((e) => {
     pushDebugLog('Login', '登录前 OCR 配置刷新失败（已忽略）', 'warn', e)
   })
-  savePortalCredentials()
+  await savePortalCredentials()
 
   try {
     const res = await axios.post(`${API_BASE}/v2/start_login`, {
@@ -654,7 +671,7 @@ const handleChaoxingLoginSuccess = async (payload, modeKey) => {
   }
   username.value = sid
   localStorage.setItem('hbu_username', sid)
-  saveChaoxingCredentials()
+  await saveChaoxingCredentials()
   applyLoginMethodStorage(modeKey)
   localStorage.removeItem('hbu_manual_logout')
   localStorage.removeItem(LOGOUT_REASON_KEY)
@@ -900,19 +917,27 @@ onMounted(async () => {
 
   const savedUsername = localStorage.getItem('hbu_username')
   const savedRemember = localStorage.getItem('hbu_remember')
-  const savedCredentials = localStorage.getItem('hbu_credentials')
   if (savedRemember !== 'false' && savedUsername) {
     username.value = savedUsername
-    password.value = savedCredentials || ''
+    await migrateLegacyCredential({
+      legacyPasswordKey: 'hbu_credentials',
+      accountKey: buildHbutAccountKey(savedUsername)
+    })
+    password.value = await loadRememberedCredential(buildHbutAccountKey(savedUsername))
     rememberMe.value = true
   }
 
   const savedCxRemember = localStorage.getItem(CHAOXING_REMEMBER_KEY)
   const savedCxAccount = localStorage.getItem(CHAOXING_ACCOUNT_KEY)
-  const savedCxPassword = localStorage.getItem(CHAOXING_PASSWORD_KEY)
   if (savedCxRemember !== 'false' && savedCxAccount) {
     chaoxingAccount.value = savedCxAccount
-    chaoxingPassword.value = savedCxPassword || ''
+    await migrateLegacyCredential({
+      legacyPasswordKey: CHAOXING_PASSWORD_KEY,
+      accountKey: buildChaoxingAccountKey(savedCxAccount)
+    })
+    chaoxingPassword.value = await loadRememberedCredential(
+      buildChaoxingAccountKey(savedCxAccount)
+    )
     rememberMe.value = true
   }
 

--- a/src/components/LoginV3.vue
+++ b/src/components/LoginV3.vue
@@ -7,8 +7,8 @@ import { pushDebugLog } from '../utils/debug_logger'
 import {
   buildChaoxingAccountKey,
   buildHbutAccountKey,
-  loadRememberedCredential,
-  migrateLegacyCredential,
+  loadChaoxingRememberedPassword,
+  loadPortalRememberedPassword,
   saveRememberedCredential,
   syncPortalRememberCredential
 } from '../utils/credential_storage.js'
@@ -910,6 +910,24 @@ watch(activeMode, (mode) => {
   emit('switchMode', mode)
 })
 
+const hydrateRememberedCredentials = async () => {
+  const savedUsername = localStorage.getItem('hbu_username')
+  const savedRemember = localStorage.getItem('hbu_remember')
+  if (savedRemember !== 'false' && savedUsername) {
+    username.value = savedUsername
+    password.value = await loadPortalRememberedPassword(savedUsername)
+    rememberMe.value = true
+  }
+
+  const savedCxRemember = localStorage.getItem(CHAOXING_REMEMBER_KEY)
+  const savedCxAccount = localStorage.getItem(CHAOXING_ACCOUNT_KEY)
+  if (savedCxRemember !== 'false' && savedCxAccount) {
+    chaoxingAccount.value = savedCxAccount
+    chaoxingPassword.value = await loadChaoxingRememberedPassword(savedCxAccount)
+    rememberMe.value = true
+  }
+}
+
 onMounted(async () => {
   const savedMode = normalizeModeKey(localStorage.getItem(LOGIN_MODE_PREF_KEY))
   if (isKnownMode(savedMode) && savedMode !== activeMode.value) {
@@ -922,31 +940,7 @@ onMounted(async () => {
     localStorage.removeItem(LOGOUT_REASON_KEY)
   }
 
-  const savedUsername = localStorage.getItem('hbu_username')
-  const savedRemember = localStorage.getItem('hbu_remember')
-  if (savedRemember !== 'false' && savedUsername) {
-    username.value = savedUsername
-    await migrateLegacyCredential({
-      legacyPasswordKey: 'hbu_credentials',
-      accountKey: buildHbutAccountKey(savedUsername)
-    })
-    password.value = await loadRememberedCredential(buildHbutAccountKey(savedUsername))
-    rememberMe.value = true
-  }
-
-  const savedCxRemember = localStorage.getItem(CHAOXING_REMEMBER_KEY)
-  const savedCxAccount = localStorage.getItem(CHAOXING_ACCOUNT_KEY)
-  if (savedCxRemember !== 'false' && savedCxAccount) {
-    chaoxingAccount.value = savedCxAccount
-    await migrateLegacyCredential({
-      legacyPasswordKey: CHAOXING_PASSWORD_KEY,
-      accountKey: buildChaoxingAccountKey(savedCxAccount)
-    })
-    chaoxingPassword.value = await loadRememberedCredential(
-      buildChaoxingAccountKey(savedCxAccount)
-    )
-    rememberMe.value = true
-  }
+  await hydrateRememberedCredentials()
 
   void ensureOcrEndpointReady().catch((e) => {
     console.warn('[Login] OCR 初始化失败（后台重试）:', e)

--- a/src/components/LoginV3.vue
+++ b/src/components/LoginV3.vue
@@ -508,6 +508,9 @@ const handlePasswordLogin = async () => {
       password: password.value,
       remember: rememberMe.value
     })
+    if (rememberMe.value) {
+      localStorage.setItem('hbu_remember', 'true')
+    }
     applyLoginMethodStorage('portal_password')
     localStorage.removeItem(LOGOUT_REASON_KEY)
     statusMsg.value = '✅ 登录成功，正在同步数据...'

--- a/src/components/LoginV3.vue
+++ b/src/components/LoginV3.vue
@@ -9,7 +9,8 @@ import {
   buildHbutAccountKey,
   loadRememberedCredential,
   migrateLegacyCredential,
-  saveRememberedCredential
+  saveRememberedCredential,
+  syncPortalRememberCredential
 } from '../utils/credential_storage.js'
 
 const props = defineProps({
@@ -501,6 +502,12 @@ const handlePasswordLogin = async () => {
     if (sid) {
       localStorage.setItem('hbu_username', sid)
     }
+    await syncPortalRememberCredential({
+      username: username.value,
+      studentId: sid,
+      password: password.value,
+      remember: rememberMe.value
+    })
     applyLoginMethodStorage('portal_password')
     localStorage.removeItem(LOGOUT_REASON_KEY)
     statusMsg.value = '✅ 登录成功，正在同步数据...'

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -10,6 +10,16 @@ const props = defineProps({
   configAdminIds: { type: Array, default: () => [] }
 })
 
+const loginFormKey = ref(0)
+watch(
+  () => props.isLoggedIn,
+  (loggedIn, wasLoggedIn) => {
+    if (wasLoggedIn && !loggedIn) {
+      loginFormKey.value += 1
+    }
+  }
+)
+
 const emit = defineEmits(['success', 'switchMode', 'logout', 'navigate', 'checkUpdate', 'openOfficial', 'openFeedback', 'openConfig', 'openSettings'])
 
 const activeLegalTab = ref('disclaimer')
@@ -113,6 +123,7 @@ const handleShowLegal = async (tab) => {
 
     <section v-else class="profile-card">
       <LoginV3
+        :key="loginFormKey"
         :login-mode="loginMode"
         @success="emit('success', $event)"
         @switchMode="emit('switchMode', $event)"

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -143,6 +143,8 @@ const readStoredSemester = () => {
 const resolveDisplayStudentId = () => {
   const sid = String(props.studentId || '').trim()
   if (sid) return sid
+  // 主动退出后不再用 hbu_username 回退，避免未登录仍展示上一账号课表
+  if (localStorage.getItem('hbu_manual_logout') === 'true') return ''
   const fallback = String(localStorage.getItem('hbu_username') || '').trim()
   return /^\d{10}$/.test(fallback) ? fallback : ''
 }
@@ -736,6 +738,14 @@ const fetchSchedule = async (targetSemester = '', options = {}) => {
       if (hasInstantCache) {
         initialFetchDone.value = true
         errorMsg.value = ''
+      } else if (localStorage.getItem('hbu_manual_logout') === 'true') {
+        scheduleData.value = []
+        remoteScheduleData.value = []
+        customScheduleData.value = []
+        offline.value = false
+        offlineHint.value = ''
+        initialFetchDone.value = true
+        errorMsg.value = '请先登录后查看课表'
       } else {
         // 启动阶段可能还在恢复身份，此时不显示“请登录”闪屏，等待身份恢复后自动刷新。
         errorMsg.value = ''
@@ -2966,6 +2976,16 @@ const handleCloudSyncDownload = async () => {
   }
 }
 
+const handleSessionLogout = () => {
+  scheduleData.value = []
+  remoteScheduleData.value = []
+  customScheduleData.value = []
+  offline.value = false
+  offlineHint.value = ''
+  errorMsg.value = '请先登录后查看课表'
+  initialFetchDone.value = true
+}
+
 const handleSessionOnline = () => {
   const sid = String(props.studentId || '').trim()
   if (!sid) return
@@ -2981,6 +3001,7 @@ onMounted(async () => {
   window.addEventListener('keydown', handleWeekKeydown)
   window.addEventListener(CLOUD_SYNC_UPDATED_EVENT, handleCloudSyncUpdated)
   window.addEventListener('hbu-session-online', handleSessionOnline)
+  window.addEventListener('hbu-session-logout', handleSessionLogout)
   document.addEventListener('visibilitychange', handleScheduleVisibilityChange)
   refreshCloudSyncCooldown()
   ensureCloudSyncCooldownTimer()
@@ -3083,6 +3104,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleWeekKeydown)
   window.removeEventListener(CLOUD_SYNC_UPDATED_EVENT, handleCloudSyncUpdated)
   window.removeEventListener('hbu-session-online', handleSessionOnline)
+  window.removeEventListener('hbu-session-logout', handleSessionLogout)
   document.removeEventListener('visibilitychange', handleScheduleVisibilityChange)
   document.removeEventListener('click', closeSemesterBadgePopover)
   clearCloudSyncCooldownTimer()

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -2966,9 +2966,21 @@ const handleCloudSyncDownload = async () => {
   }
 }
 
+const handleSessionOnline = () => {
+  const sid = String(props.studentId || '').trim()
+  if (!sid) return
+  offline.value = false
+  offlineHint.value = ''
+  const targetSemester = String(
+    semester.value || semesterDraft.value || readStoredSemester() || deriveSemesterByDate()
+  ).trim()
+  void fetchSchedule(targetSemester)
+}
+
 onMounted(async () => {
   window.addEventListener('keydown', handleWeekKeydown)
   window.addEventListener(CLOUD_SYNC_UPDATED_EVENT, handleCloudSyncUpdated)
+  window.addEventListener('hbu-session-online', handleSessionOnline)
   document.addEventListener('visibilitychange', handleScheduleVisibilityChange)
   refreshCloudSyncCooldown()
   ensureCloudSyncCooldownTimer()
@@ -3070,6 +3082,7 @@ onBeforeUnmount(() => {
   persistScheduleRenderSnapshot('component-unmount')
   window.removeEventListener('keydown', handleWeekKeydown)
   window.removeEventListener(CLOUD_SYNC_UPDATED_EVENT, handleCloudSyncUpdated)
+  window.removeEventListener('hbu-session-online', handleSessionOnline)
   document.removeEventListener('visibilitychange', handleScheduleVisibilityChange)
   document.removeEventListener('click', closeSemesterBadgePopover)
   clearCloudSyncCooldownTimer()

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -1,7 +1,7 @@
 ﻿<script setup>
 import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue'
 import axios from 'axios'
-import { fetchWithCache } from '../utils/api.js'
+import { fetchWithCache, DEFAULT_SWR_OPTIONS, EXTRA_LONG_TTL } from '../utils/api.js'
 import { formatRelativeTime } from '../utils/time.js'
 import { normalizeSemesterList, resolveCurrentSemester } from '../utils/semester.js'
 import { flushUiSettings, useUiSettings } from '../utils/ui_settings'
@@ -751,7 +751,7 @@ const fetchSchedule = async (targetSemester = '', options = {}) => {
         semester: requestedSemester || undefined
       })
       return res.data
-    })
+    }, undefined, DEFAULT_SWR_OPTIONS)
 
     if (data?.success) {
       applySchedulePayload(data, requestedSemester)
@@ -878,7 +878,7 @@ const fetchSemesterOptions = async () => {
     const { data } = await fetchWithCache('semesters', async () => {
       const res = await axios.get(`${API_BASE}/v2/semesters`)
       return res.data
-    })
+    }, EXTRA_LONG_TTL, DEFAULT_SWR_OPTIONS)
     if (!data?.success) {
       throw new Error(data?.error || '获取学期列表失败')
     }

--- a/src/composables/useSessionCredentials.js
+++ b/src/composables/useSessionCredentials.js
@@ -1,11 +1,9 @@
 import {
   buildChaoxingAccountKey,
   buildHbutAccountKey,
-  loadRememberedCredential,
-  migrateLegacyCredential,
-  saveRememberedCredential
+  loadChaoxingRememberedPassword,
+  loadPortalRememberedPassword
 } from '../utils/credential_storage.js'
-import { invokeNative, isTauriRuntime } from '../platform/native'
 
 const CHAOXING_REMEMBER_KEY = 'hbu_cx_remember'
 const CHAOXING_ACCOUNT_KEY = 'hbu_cx_account'
@@ -20,18 +18,7 @@ export async function loadPortalStoredPassword() {
   if (remember === 'false' || !username) {
     return null
   }
-  await migrateLegacyCredential({
-    legacyPasswordKey: 'hbu_credentials',
-    accountKey: buildHbutAccountKey(username)
-  })
-  let password = await loadRememberedCredential(buildHbutAccountKey(username))
-  if (!password && isTauriRuntime()) {
-    const sessionPassword = await invokeNative('load_session_password', { studentId: username })
-    password = String(sessionPassword || '').trim()
-    if (password) {
-      await saveRememberedCredential(buildHbutAccountKey(username), password)
-    }
-  }
+  const password = await loadPortalRememberedPassword(username)
   if (!password) return null
   return { username, password }
 }
@@ -45,11 +32,7 @@ export async function loadChaoxingStoredPassword() {
   if (remember === 'false' || !account) {
     return null
   }
-  await migrateLegacyCredential({
-    legacyPasswordKey: CHAOXING_PASSWORD_KEY,
-    accountKey: buildChaoxingAccountKey(account)
-  })
-  const password = await loadRememberedCredential(buildChaoxingAccountKey(account))
+  const password = await loadChaoxingRememberedPassword(account)
   if (!password) return null
   return { account, password }
 }

--- a/src/composables/useSessionCredentials.js
+++ b/src/composables/useSessionCredentials.js
@@ -1,0 +1,46 @@
+import {
+  buildChaoxingAccountKey,
+  buildHbutAccountKey,
+  loadRememberedCredential,
+  migrateLegacyCredential
+} from '../utils/credential_storage.js'
+
+const CHAOXING_REMEMBER_KEY = 'hbu_cx_remember'
+const CHAOXING_ACCOUNT_KEY = 'hbu_cx_account'
+const CHAOXING_PASSWORD_KEY = 'hbu_cx_password'
+
+/**
+ * 从安全存储加载门户账号密码（Tauri 密钥环 / Web 设备密钥加密）。
+ */
+export async function loadPortalStoredPassword() {
+  const remember = localStorage.getItem('hbu_remember')
+  const username = localStorage.getItem('hbu_username')
+  if (remember === 'false' || !username) {
+    return null
+  }
+  await migrateLegacyCredential({
+    legacyPasswordKey: 'hbu_credentials',
+    accountKey: buildHbutAccountKey(username)
+  })
+  const password = await loadRememberedCredential(buildHbutAccountKey(username))
+  if (!password) return null
+  return { username, password }
+}
+
+/**
+ * 从安全存储加载学习通账号密码。
+ */
+export async function loadChaoxingStoredPassword() {
+  const remember = localStorage.getItem(CHAOXING_REMEMBER_KEY)
+  const account = String(localStorage.getItem(CHAOXING_ACCOUNT_KEY) || '').trim()
+  if (remember === 'false' || !account) {
+    return null
+  }
+  await migrateLegacyCredential({
+    legacyPasswordKey: CHAOXING_PASSWORD_KEY,
+    accountKey: buildChaoxingAccountKey(account)
+  })
+  const password = await loadRememberedCredential(buildChaoxingAccountKey(account))
+  if (!password) return null
+  return { account, password }
+}

--- a/src/composables/useSessionCredentials.js
+++ b/src/composables/useSessionCredentials.js
@@ -2,8 +2,10 @@ import {
   buildChaoxingAccountKey,
   buildHbutAccountKey,
   loadRememberedCredential,
-  migrateLegacyCredential
+  migrateLegacyCredential,
+  saveRememberedCredential
 } from '../utils/credential_storage.js'
+import { invokeNative, isTauriRuntime } from '../platform/native'
 
 const CHAOXING_REMEMBER_KEY = 'hbu_cx_remember'
 const CHAOXING_ACCOUNT_KEY = 'hbu_cx_account'
@@ -22,7 +24,14 @@ export async function loadPortalStoredPassword() {
     legacyPasswordKey: 'hbu_credentials',
     accountKey: buildHbutAccountKey(username)
   })
-  const password = await loadRememberedCredential(buildHbutAccountKey(username))
+  let password = await loadRememberedCredential(buildHbutAccountKey(username))
+  if (!password && isTauriRuntime()) {
+    const sessionPassword = await invokeNative('load_session_password', { studentId: username })
+    password = String(sessionPassword || '').trim()
+    if (password) {
+      await saveRememberedCredential(buildHbutAccountKey(username), password)
+    }
+  }
   if (!password) return null
   return { username, password }
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -112,6 +112,22 @@ export function clearCacheByPrefix(prefix) {
   keysToRemove.forEach((k) => localStorage.removeItem(k))
 }
 
+/**
+ * 清除指定学号的教务/课表等用户级缓存（退出登录时调用）。
+ */
+export function clearUserScopedCaches(studentId) {
+  const sid = String(studentId || '').trim()
+  if (!sid) return
+
+  for (const prefix of JWXT_KEY_PREFIXES) {
+    if (prefix === 'semesters') continue
+    clearCacheByPrefix(`${prefix}${sid}`)
+  }
+  clearCacheByPrefix(`grade_teachers:${sid}`)
+  clearCacheByPrefix(`training:options:${sid}`)
+  clearCacheByPrefix(`training:jys:${sid}`)
+}
+
 export function getCachedData(key, ttl = DEFAULT_TTL) {
   const now = Date.now()
   const inMemory = memoryCache.get(key)

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -76,7 +76,10 @@ const trimLocalCacheStorage = (count = 24) => {
   if (!entries.length) return
   const removeCount = Math.min(count, entries.length)
   for (let i = 0; i < removeCount; i += 1) {
-    localStorage.removeItem(entries[i].storageKey)
+    const storageKey = entries[i].storageKey
+    // 仅淘汰 cache: 前缀条目，会话键（hbu_session_cookies 等）不在此列。
+    if (!storageKey.startsWith('cache:')) continue
+    localStorage.removeItem(storageKey)
   }
 }
 
@@ -372,6 +375,13 @@ const clearMaintenanceFlag = () => {
 
 export { DEFAULT_TTL, LONG_TTL, EXTRA_LONG_TTL, SHORT_TTL }
 
+export const DEFAULT_SWR_OPTIONS = {
+  staleWhileRevalidate: true,
+  priority: 'foreground'
+}
+
+const backgroundRefreshInflight = new Map()
+
 const recordRequestMetric = (key, { source, start, stale = false, priority = 'foreground', error = '' } = {}) => {
   try {
     pushDebugLog('Cache', `请求缓存指标 key=${key} source=${source}`, 'debug', {
@@ -388,35 +398,50 @@ const recordRequestMetric = (key, { source, start, stale = false, priority = 'fo
 }
 
 const refreshCacheInBackground = async (key, fetcher, priority) => {
-  const start = Date.now()
-  try {
-    const data = await fetcher()
-    if (data && data.success && !data.offline) {
-      setCachedData(key, data)
-      if (isJwxtCacheKey(key)) {
-        clearMaintenanceFlag()
+  if (backgroundRefreshInflight.has(key)) {
+    return backgroundRefreshInflight.get(key)
+  }
+  const task = (async () => {
+    const start = Date.now()
+    try {
+      const data = await fetcher()
+      if (data && data.success && !data.offline) {
+        setCachedData(key, data)
+        if (isJwxtCacheKey(key)) {
+          clearMaintenanceFlag()
+        }
+        recordRequestMetric(key, { source: 'remote', start, priority })
+      } else {
+        recordRequestMetric(key, {
+          source: 'remote',
+          start,
+          priority,
+          error: data?.error || data?.msg || data?.message || 'unsuccessful-response'
+        })
       }
-      recordRequestMetric(key, { source: 'remote', start, priority })
-    } else {
+    } catch (error) {
       recordRequestMetric(key, {
         source: 'remote',
         start,
         priority,
-        error: data?.error || data?.msg || data?.message || 'unsuccessful-response'
+        error: error?.message || error
       })
     }
-  } catch (error) {
-    recordRequestMetric(key, {
-      source: 'remote',
-      start,
-      priority,
-      error: error?.message || error
-    })
+  })().finally(() => {
+    backgroundRefreshInflight.delete(key)
+  })
+  backgroundRefreshInflight.set(key, task)
+  return task
+}
+
+const cacheDebug = (message, detail) => {
+  if (import.meta.env?.DEV) {
+    console.log(message, detail ?? '')
   }
 }
 
 export async function fetchWithCache(key, fetcher, ttl = DEFAULT_TTL, options = {}) {
-  console.log('[Cache] Checking cache for key:', key)
+  cacheDebug('[Cache] Checking cache for key:', key)
   if (ttl && typeof ttl === 'object') {
     options = ttl
     ttl = DEFAULT_TTL
@@ -429,7 +454,7 @@ export async function fetchWithCache(key, fetcher, ttl = DEFAULT_TTL, options = 
   const cached = forceRemote ? null : getCachedData(key, ttl)
 
   if (cached) {
-    console.log('[Cache] Cache HIT for key:', key)
+    cacheDebug('[Cache] Cache HIT for key:', key)
     const data = maintenanceMode
       ? withOfflineMeta(cached.data, cached.timestamp)
       : cached.data
@@ -446,7 +471,7 @@ export async function fetchWithCache(key, fetcher, ttl = DEFAULT_TTL, options = 
   if (!forceRemote && maintenanceMode) {
     const stale = getBestCachedEntry(key)
     if (stale) {
-      console.log('[Cache] Maintenance mode stale HIT for key:', key)
+      cacheDebug('[Cache] Maintenance mode stale HIT for key:', key)
       recordRequestMetric(key, { source: 'stale-cache', start: Date.now(), stale: true, priority })
       return {
         data: withOfflineMeta(stale.data, stale.timestamp),
@@ -460,18 +485,18 @@ export async function fetchWithCache(key, fetcher, ttl = DEFAULT_TTL, options = 
   if (staleWhileRevalidate) {
     const stale = getStaleCachedData(key)
     if (stale) {
-      console.log('[Cache] Stale HIT for key:', key, '- refreshing in background')
+      cacheDebug('[Cache] Stale HIT for key:', key)
       recordRequestMetric(key, { source: 'stale-cache', start: Date.now(), stale: true, priority })
       refreshCacheInBackground(key, fetcher, 'background').catch(() => {})
       return stale
     }
   }
 
-  console.log('[Cache] Cache MISS for key:', key, '- fetching...')
+  cacheDebug('[Cache] Cache MISS for key:', key)
   const remoteStart = Date.now()
   try {
     const data = await fetcher()
-    console.log('[Cache] Fetched data for key:', key, '- success:', data?.success)
+    cacheDebug('[Cache] Fetched data for key:', `${key} success=${data?.success}`)
 
     if (data && data.success && !data.offline) {
       setCachedData(key, data)

--- a/src/utils/credential_storage.js
+++ b/src/utils/credential_storage.js
@@ -112,6 +112,71 @@ export async function migrateLegacyCredential({
 }
 
 /**
+ * 加载门户「记住密码」凭据（密钥环 hbut: 键 + 会话学号键 + 旧版 localStorage）。
+ */
+export async function loadPortalRememberedPassword(username) {
+  const sid = String(username || '').trim()
+  if (!sid) return ''
+
+  await migrateLegacyCredential({
+    legacyPasswordKey: 'hbu_credentials',
+    accountKey: buildHbutAccountKey(sid)
+  })
+
+  const password = await loadRememberedCredential(buildHbutAccountKey(sid))
+  if (password) return password
+
+  if (isTauriRuntime()) {
+    try {
+      const sessionPassword = await invokeNative('load_session_password', { studentId: sid })
+      const normalized = String(sessionPassword || '').trim()
+      if (normalized) {
+        await saveRememberedCredential(buildHbutAccountKey(sid), normalized)
+        return normalized
+      }
+    } catch {
+      // 旧版二进制可能尚未注册 load_session_password，已由 Rust 侧 hbut: 回退覆盖
+    }
+  }
+
+  return ''
+}
+
+/**
+ * 退出登录前，把会话密钥环密码同步到「记住密码」键，确保登录表单可回填。
+ */
+export async function preservePortalRememberedPasswordOnLogout() {
+  const remember = localStorage.getItem('hbu_remember')
+  const username = String(localStorage.getItem('hbu_username') || '').trim()
+  if (remember === 'false' || !username) return
+
+  const password = await loadPortalRememberedPassword(username)
+  if (!password) return
+
+  await syncPortalRememberCredential({
+    username,
+    studentId: username,
+    password,
+    remember: true
+  })
+}
+
+/**
+ * 加载学习通「记住密码」凭据。
+ */
+export async function loadChaoxingRememberedPassword(account) {
+  const normalized = String(account || '').trim()
+  if (!normalized) return ''
+
+  await migrateLegacyCredential({
+    legacyPasswordKey: 'hbu_cx_password',
+    accountKey: buildChaoxingAccountKey(normalized)
+  })
+
+  return loadRememberedCredential(buildChaoxingAccountKey(normalized))
+}
+
+/**
  * 登录成功后，将记住密码同步到学号/账号多个键，避免 username 与 student_id 不一致。
  */
 export async function syncPortalRememberCredential({

--- a/src/utils/credential_storage.js
+++ b/src/utils/credential_storage.js
@@ -1,0 +1,83 @@
+import { invokeNative, isTauriRuntime } from '../platform/native'
+import { encryptData, decryptData } from './encryption.js'
+
+export const HBUT_CREDENTIAL_PREFIX = 'hbut:'
+export const CHAOXING_CREDENTIAL_PREFIX = 'cx:'
+
+const webStorageKey = (accountKey) => `cred:${accountKey}`
+
+export function buildHbutAccountKey(username) {
+  return `${HBUT_CREDENTIAL_PREFIX}${String(username || '').trim()}`
+}
+
+export function buildChaoxingAccountKey(account) {
+  return `${CHAOXING_CREDENTIAL_PREFIX}${String(account || '').trim()}`
+}
+
+export async function saveRememberedCredential(accountKey, password) {
+  const key = String(accountKey || '').trim()
+  const value = String(password || '')
+  if (!key) return
+
+  if (isTauriRuntime()) {
+    if (!value) {
+      await invokeNative('delete_remembered_credential', { accountKey: key })
+      return
+    }
+    await invokeNative('save_remembered_credential', { accountKey: key, password: value })
+    return
+  }
+
+  if (!value) {
+    localStorage.removeItem(webStorageKey(key))
+    return
+  }
+  const encrypted = await encryptData({ password: value })
+  localStorage.setItem(webStorageKey(key), encrypted)
+}
+
+export async function loadRememberedCredential(accountKey) {
+  const key = String(accountKey || '').trim()
+  if (!key) return ''
+
+  if (isTauriRuntime()) {
+    const loaded = await invokeNative('load_remembered_credential', { accountKey: key })
+    return String(loaded || '')
+  }
+
+  const raw = localStorage.getItem(webStorageKey(key))
+  if (!raw) return ''
+  try {
+    const data = await decryptData(raw)
+    return String(data?.password || '')
+  } catch {
+    return ''
+  }
+}
+
+export async function deleteRememberedCredential(accountKey) {
+  await saveRememberedCredential(accountKey, '')
+}
+
+/**
+ * 迁移旧版 localStorage 明文/旧键名凭据到安全存储。
+ */
+export async function migrateLegacyCredential({
+  legacyPasswordKey,
+  legacyPlaintext,
+  accountKey
+}) {
+  const key = String(accountKey || '').trim()
+  if (!key) return
+
+  const existing = await loadRememberedCredential(key)
+  if (existing) return
+
+  const legacy = String(legacyPlaintext || localStorage.getItem(legacyPasswordKey) || '').trim()
+  if (!legacy) return
+
+  await saveRememberedCredential(key, legacy)
+  if (legacyPasswordKey) {
+    localStorage.removeItem(legacyPasswordKey)
+  }
+}

--- a/src/utils/credential_storage.js
+++ b/src/utils/credential_storage.js
@@ -60,6 +60,32 @@ export async function deleteRememberedCredential(accountKey) {
 }
 
 /**
+ * 读取旧版 localStorage 凭据（支持 AES 密文、JSON、明文）。
+ */
+async function readLegacyStoredPassword(legacyPasswordKey, legacyPlaintext = '') {
+  const raw = String(legacyPlaintext || localStorage.getItem(legacyPasswordKey) || '').trim()
+  if (!raw) return ''
+
+  try {
+    const decrypted = await decryptData(raw)
+    const password = String(decrypted?.password || '').trim()
+    if (password) return password
+  } catch {
+    // 非 AES 密文，继续尝试其它格式
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    const password = String(parsed?.password || '').trim()
+    if (password) return password
+  } catch {
+    // 非 JSON
+  }
+
+  return raw
+}
+
+/**
  * 迁移旧版 localStorage 明文/旧键名凭据到安全存储。
  */
 export async function migrateLegacyCredential({
@@ -71,13 +97,41 @@ export async function migrateLegacyCredential({
   if (!key) return
 
   const existing = await loadRememberedCredential(key)
-  if (existing) return
+  const legacyRaw = legacyPasswordKey
+    ? String(localStorage.getItem(legacyPasswordKey) || '').trim()
+    : String(legacyPlaintext || '').trim()
+  if (existing && !legacyRaw) return
 
-  const legacy = String(legacyPlaintext || localStorage.getItem(legacyPasswordKey) || '').trim()
+  const legacy = await readLegacyStoredPassword(legacyPasswordKey, legacyPlaintext)
   if (!legacy) return
 
   await saveRememberedCredential(key, legacy)
   if (legacyPasswordKey) {
     localStorage.removeItem(legacyPasswordKey)
   }
+}
+
+/**
+ * 登录成功后，将记住密码同步到学号/账号多个键，避免 username 与 student_id 不一致。
+ */
+export async function syncPortalRememberCredential({
+  username,
+  studentId,
+  password,
+  remember = true
+}) {
+  if (!remember) return
+  const value = String(password || '').trim()
+  if (!value) return
+
+  const keys = new Set()
+  const loginName = String(username || '').trim()
+  const sid = String(studentId || '').trim()
+  if (loginName) keys.add(buildHbutAccountKey(loginName))
+  if (sid) keys.add(buildHbutAccountKey(sid))
+
+  for (const accountKey of keys) {
+    await saveRememberedCredential(accountKey, value)
+  }
+  localStorage.removeItem('hbu_credentials')
 }

--- a/src/utils/credential_storage.js
+++ b/src/utils/credential_storage.js
@@ -6,6 +6,9 @@ export const CHAOXING_CREDENTIAL_PREFIX = 'cx:'
 
 const webStorageKey = (accountKey) => `cred:${accountKey}`
 
+/** 当前运行时会话内的门户密码缓存（退出登录后立即回填表单） */
+const portalPasswordMemory = new Map()
+
 export function buildHbutAccountKey(username) {
   return `${HBUT_CREDENTIAL_PREFIX}${String(username || '').trim()}`
 }
@@ -14,26 +17,71 @@ export function buildChaoxingAccountKey(account) {
   return `${CHAOXING_CREDENTIAL_PREFIX}${String(account || '').trim()}`
 }
 
+export function rememberPortalPasswordInMemory(studentId, password) {
+  const sid = String(studentId || '').trim()
+  const value = String(password || '').trim()
+  if (!sid || !value) return
+  portalPasswordMemory.set(sid, value)
+}
+
+export function peekPortalPasswordInMemory(studentId) {
+  return String(portalPasswordMemory.get(String(studentId || '').trim()) || '').trim()
+}
+
+async function loadEncryptedWebBackup(accountKey) {
+  const raw = localStorage.getItem(webStorageKey(accountKey))
+  if (!raw) return ''
+  try {
+    const data = await decryptData(raw)
+    return String(data?.password || '').trim()
+  } catch {
+    return ''
+  }
+}
+
+async function saveEncryptedWebBackup(accountKey, password) {
+  const value = String(password || '').trim()
+  if (!value) {
+    localStorage.removeItem(webStorageKey(accountKey))
+    return
+  }
+  const encrypted = await encryptData({ password: value })
+  localStorage.setItem(webStorageKey(accountKey), encrypted)
+}
+
 export async function saveRememberedCredential(accountKey, password) {
   const key = String(accountKey || '').trim()
   const value = String(password || '')
   if (!key) return
 
-  if (isTauriRuntime()) {
-    if (!value) {
-      await invokeNative('delete_remembered_credential', { accountKey: key })
-      return
+  if (!value) {
+    if (isTauriRuntime()) {
+      try {
+        await invokeNative('delete_remembered_credential', { accountKey: key })
+      } catch {
+        // ignore
+      }
     }
-    await invokeNative('save_remembered_credential', { accountKey: key, password: value })
+    localStorage.removeItem(webStorageKey(key))
+    if (key.startsWith(HBUT_CREDENTIAL_PREFIX)) {
+      portalPasswordMemory.delete(key.slice(HBUT_CREDENTIAL_PREFIX.length))
+    }
     return
   }
 
-  if (!value) {
-    localStorage.removeItem(webStorageKey(key))
-    return
+  if (isTauriRuntime()) {
+    try {
+      await invokeNative('save_remembered_credential', { accountKey: key, password: value })
+    } catch (e) {
+      console.warn('[Credential] 密钥环保存失败，已写入本地加密备份:', e)
+    }
   }
-  const encrypted = await encryptData({ password: value })
-  localStorage.setItem(webStorageKey(key), encrypted)
+
+  await saveEncryptedWebBackup(key, value)
+
+  if (key.startsWith(HBUT_CREDENTIAL_PREFIX)) {
+    rememberPortalPasswordInMemory(key.slice(HBUT_CREDENTIAL_PREFIX.length), value)
+  }
 }
 
 export async function loadRememberedCredential(accountKey) {
@@ -41,18 +89,16 @@ export async function loadRememberedCredential(accountKey) {
   if (!key) return ''
 
   if (isTauriRuntime()) {
-    const loaded = await invokeNative('load_remembered_credential', { accountKey: key })
-    return String(loaded || '')
+    try {
+      const loaded = await invokeNative('load_remembered_credential', { accountKey: key })
+      const normalized = String(loaded || '').trim()
+      if (normalized) return normalized
+    } catch (e) {
+      console.warn('[Credential] 密钥环读取失败，尝试本地加密备份:', e)
+    }
   }
 
-  const raw = localStorage.getItem(webStorageKey(key))
-  if (!raw) return ''
-  try {
-    const data = await decryptData(raw)
-    return String(data?.password || '')
-  } catch {
-    return ''
-  }
+  return loadEncryptedWebBackup(key)
 }
 
 export async function deleteRememberedCredential(accountKey) {
@@ -112,11 +158,14 @@ export async function migrateLegacyCredential({
 }
 
 /**
- * 加载门户「记住密码」凭据（密钥环 hbut: 键 + 会话学号键 + 旧版 localStorage）。
+ * 加载门户「记住密码」凭据（内存缓存 + 密钥环 + 本地加密备份 + 会话学号键）。
  */
 export async function loadPortalRememberedPassword(username) {
   const sid = String(username || '').trim()
   if (!sid) return ''
+
+  const cached = peekPortalPasswordInMemory(sid)
+  if (cached) return cached
 
   await migrateLegacyCredential({
     legacyPasswordKey: 'hbu_credentials',
@@ -124,7 +173,10 @@ export async function loadPortalRememberedPassword(username) {
   })
 
   const password = await loadRememberedCredential(buildHbutAccountKey(sid))
-  if (password) return password
+  if (password) {
+    rememberPortalPasswordInMemory(sid, password)
+    return password
+  }
 
   if (isTauriRuntime()) {
     try {
@@ -135,7 +187,7 @@ export async function loadPortalRememberedPassword(username) {
         return normalized
       }
     } catch {
-      // 旧版二进制可能尚未注册 load_session_password，已由 Rust 侧 hbut: 回退覆盖
+      // 旧版二进制可能尚未注册 load_session_password
     }
   }
 
@@ -143,14 +195,19 @@ export async function loadPortalRememberedPassword(username) {
 }
 
 /**
- * 退出登录前，把会话密钥环密码同步到「记住密码」键，确保登录表单可回填。
+ * 退出登录前，把密码写入「记住密码」存储，确保登录表单可回填。
  */
 export async function preservePortalRememberedPasswordOnLogout() {
-  const remember = localStorage.getItem('hbu_remember')
   const username = String(localStorage.getItem('hbu_username') || '').trim()
-  if (remember === 'false' || !username) return
+  if (!username) return
+  if (localStorage.getItem('hbu_remember') === 'false') return
 
-  const password = await loadPortalRememberedPassword(username)
+  localStorage.setItem('hbu_remember', 'true')
+
+  let password = peekPortalPasswordInMemory(username)
+  if (!password) {
+    password = await loadPortalRememberedPassword(username)
+  }
   if (!password) return
 
   await syncPortalRememberCredential({
@@ -198,5 +255,44 @@ export async function syncPortalRememberCredential({
   for (const accountKey of keys) {
     await saveRememberedCredential(accountKey, value)
   }
+  if (sid) rememberPortalPasswordInMemory(sid, value)
+  if (loginName) rememberPortalPasswordInMemory(loginName, value)
   localStorage.removeItem('hbu_credentials')
+}
+
+/**
+ * 已登录状态下，把密钥环/会话中的密码同步到本地备份，供退出后表单回填。
+ */
+export async function ensureRememberedPasswordCached(username) {
+  const sid = String(username || '').trim()
+  if (!sid) return
+  if (localStorage.getItem('hbu_remember') === 'false') return
+
+  const existing = await loadPortalRememberedPassword(sid)
+  if (existing) {
+    await syncPortalRememberCredential({
+      username: sid,
+      studentId: sid,
+      password: existing,
+      remember: true
+    })
+    return
+  }
+
+  if (!isTauriRuntime()) return
+
+  try {
+    const sessionPassword = String(
+      (await invokeNative('load_session_password', { studentId: sid })) || ''
+    ).trim()
+    if (!sessionPassword) return
+    await syncPortalRememberCredential({
+      username: sid,
+      studentId: sid,
+      password: sessionPassword,
+      remember: true
+    })
+  } catch {
+    // 忽略：旧版二进制或密钥环不可用时，依赖用户下次手动登录写入备份
+  }
 }

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -1,25 +1,40 @@
 /**
  * 加密工具模块
- * 使用 AES-256-CBC 加密前后端通信数据
+ * Web 路径使用设备本地随机密钥；不再使用硬编码共享密钥。
  */
 
-// 共享密钥（需要与后端保持一致）
-const SECRET_KEY = 'hbu_grade_secret_key_2026';
+const DEVICE_KEY_STORAGE = 'hbu_device_crypto_key_v2'
+const LEGACY_SECRET_KEY = 'hbu_grade_secret_key_2026'
 
-/**
- * 生成 AES 密钥（使用 SHA-256）
- */
-async function getAesKey() {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(SECRET_KEY);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  return await crypto.subtle.importKey(
+async function digestKeyMaterial(material) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(material)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  return crypto.subtle.importKey(
     'raw',
     hashBuffer,
     { name: 'AES-CBC' },
     false,
     ['encrypt', 'decrypt']
-  );
+  )
+}
+
+function ensureDeviceSecretMaterial() {
+  let key = localStorage.getItem(DEVICE_KEY_STORAGE)
+  if (!key) {
+    const bytes = crypto.getRandomValues(new Uint8Array(32))
+    key = btoa(String.fromCharCode(...bytes))
+    localStorage.setItem(DEVICE_KEY_STORAGE, key)
+  }
+  return key
+}
+
+async function getAesKey() {
+  return digestKeyMaterial(ensureDeviceSecretMaterial())
+}
+
+async function getLegacyAesKey() {
+  return digestKeyMaterial(LEGACY_SECRET_KEY)
 }
 
 /**
@@ -28,58 +43,61 @@ async function getAesKey() {
  * @returns {Promise<string>} - Base64 编码的加密字符串
  */
 export async function encryptData(data) {
-  const key = await getAesKey();
-  const iv = crypto.getRandomValues(new Uint8Array(16));
-  const encoder = new TextEncoder();
-  const jsonData = encoder.encode(JSON.stringify(data));
-  
+  const key = await getAesKey()
+  const iv = crypto.getRandomValues(new Uint8Array(16))
+  const encoder = new TextEncoder()
+  const jsonData = encoder.encode(JSON.stringify(data))
+
   const encrypted = await crypto.subtle.encrypt(
     { name: 'AES-CBC', iv },
     key,
     jsonData
-  );
-  
-  // 合并 IV 和密文
-  const combined = new Uint8Array(iv.length + encrypted.byteLength);
-  combined.set(iv);
-  combined.set(new Uint8Array(encrypted), iv.length);
-  
-  // Base64 编码
-  return btoa(String.fromCharCode(...combined));
+  )
+
+  const combined = new Uint8Array(iv.length + encrypted.byteLength)
+  combined.set(iv)
+  combined.set(new Uint8Array(encrypted), iv.length)
+
+  return btoa(String.fromCharCode(...combined))
 }
 
-/**
- * 解密数据
- * @param {string} encryptedStr - Base64 编码的加密字符串
- * @returns {Promise<Object>} - 解密后的数据对象
- */
-export async function decryptData(encryptedStr) {
-  const key = await getAesKey();
-  
-  // Base64 解码
-  const combined = Uint8Array.from(atob(encryptedStr), c => c.charCodeAt(0));
-  
-  // 提取 IV 和密文
-  const iv = combined.slice(0, 16);
-  const ciphertext = combined.slice(16);
-  
+async function decryptWithKey(encryptedStr, key) {
+  const combined = Uint8Array.from(atob(encryptedStr), (c) => c.charCodeAt(0))
+  const iv = combined.slice(0, 16)
+  const ciphertext = combined.slice(16)
+
   const decrypted = await crypto.subtle.decrypt(
     { name: 'AES-CBC', iv },
     key,
     ciphertext
-  );
-  
-  const decoder = new TextDecoder();
-  return JSON.parse(decoder.decode(decrypted));
+  )
+
+  const decoder = new TextDecoder()
+  return JSON.parse(decoder.decode(decrypted))
+}
+
+/**
+ * 解密数据（兼容旧版硬编码密钥密文）
+ * @param {string} encryptedStr - Base64 编码的加密字符串
+ * @returns {Promise<Object>} - 解密后的数据对象
+ */
+export async function decryptData(encryptedStr) {
+  const key = await getAesKey()
+  try {
+    return await decryptWithKey(encryptedStr, key)
+  } catch {
+    const legacyKey = await getLegacyAesKey()
+    return decryptWithKey(encryptedStr, legacyKey)
+  }
 }
 
 /**
  * 获取密钥提示（用于验证前后端密钥是否匹配）
  */
 export async function getKeyHint() {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(SECRET_KEY);
-  const hashBuffer = await crypto.subtle.digest('MD5', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('').slice(0, 8);
+  const encoder = new TextEncoder()
+  const data = encoder.encode(ensureDeviceSecretMaterial())
+  const hashBuffer = await crypto.subtle.digest('MD5', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 8)
 }


### PR DESCRIPTION
## Summary

专项优化：安全加固、登录/请求加速、缓存 SWR 统一、会话与记住密码体验修复。

### 安全 (P0) — Closes #117
- Release 构建禁用 HTTP OCR 回退端点
- 记住密码迁移至 OS 密钥环（Tauri）+ 设备加密 localStorage 双写备份
- 调试日志 / 失败 HTML dump 仅 debug feature 可用

### 登录加速 (P0) — Closes #118
- `login` / 扫码登录后异步预热电费 token，不阻塞返回 `UserInfo`

### 请求并发 (P1) — Closes #119
- OCR 多端点并行竞速 + 登录页 fallback 并行探测
- `http_server` 只读路由改 `read()` 锁；chaoxing 会话按需懒加载

### 缓存稳定 (P1/P2) — Closes #120
- 统一 SWR 策略、后台刷新 inflight 去重、`cache:` 前缀 trim
- 课表/成绩/首页启用 stale-while-revalidate

### 重构 (P2/P3) — Closes #121
- 提取 `auth.rs` 公共 CAS 登录逻辑
- `commands/credentials` 子模块 + `useSessionCredentials` composable

### 会话体验修复（本 PR 后续提交）
- 自动登录 / 记住密码：密钥环学号键回退、本地加密备份、退出前同步
- 主动退出后课表不再用 `hbu_username` 回退展示上一账号缓存
- 主动退出清除该学号用户级课表/成绩缓存与渲染快照
- Windows `tauri dev`：限制 cargo 并行编译 + `ensure_dist` 启动脚本

**Parent:** Closes #116

## Test plan

- [x] `cargo test --lib` — 125 passed
- [x] `npm run test:ci` — 324 passed
- [x] GitHub CI `test-frontend` / `test-rust` — pass
- [ ] 手动：记住密码 → 退出 → 登录页回填学号+密码 → 直接登录
- [ ] 手动：退出后课表页不显示上一账号数据
- [ ] 手动：冷启动自动登录 / 离线缓存恢复后在线刷新
