### PR TITLE
chore(ci): CodeQL 安全扫描与 DevSecOps 文档

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,12 @@
 - [ ] `cargo test --manifest-path src-tauri/Cargo.toml`
 - [ ] 已在目标平台手动验证（如适用）
 
+## 质量门禁
+
+- [ ] CI 通过（`test-frontend`、`test-rust`）
+- [ ] CodeQL 无新增高危告警（Security → Code scanning）
+- [ ] 若为 Dependabot 依赖 PR：已确认变更范围与破坏性
+
 ## 截图 / 录屏
 
 <!-- 如涉及 UI，请附上 -->

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,84 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+    paths-ignore:
+      - "**.md"
+      - "website/**"
+      - "soft-copyright/**"
+  schedule:
+    - cron: "30 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, rust, actions]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node (Rust autobuild prerequisite)
+        if: matrix.language == 'rust'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Build frontend dist (Rust autobuild prerequisite)
+        if: matrix.language == 'rust'
+        run: |
+          npm ci --prefer-offline --no-audit --no-fund
+          npm run build
+
+      - name: Install Linux dependencies (Rust autobuild prerequisite)
+        if: matrix.language == 'rust'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libpipewire-0.3-dev \
+            libgbm-dev \
+            build-essential
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,18 @@
 - **调试接口**：`debug.enable_bridge_tools` 等能力仅在受控调试环境使用，勿在生产分发包中开启。
 - **签名密钥**：Android 发布密钥仅通过 CI Secrets 注入，勿提交 `.jks` / `keystore-base64.txt`。
 
-## Dependency Updates
+## 质量门禁（DevSecOps）
 
-Dependabot 已启用。合并依赖 PR 前请确认 CI 通过。
+| 工具 | 作用 | 配置位置 |
+| ---- | ---- | -------- |
+| **GitHub Actions (CI)** | push/PR 时自动构建、测试、fmt/clippy | [`.github/workflows/ci.yml`](.github/workflows/ci.yml) |
+| **CodeQL** | 静态安全扫描（JS/TS、Rust、Actions workflow） | [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml) |
+| **Dependabot** | 依赖版本升级 PR + 已知 CVE 安全告警 | [`.github/dependabot.yml`](.github/dependabot.yml) |
+
+### Dependabot 说明
+
+- **Version updates**：按 `dependabot.yml` 每周自动开依赖升级 PR（默认忽略 major，降低破坏性）。
+- **Security alerts**：在 **Security → Dependabot** 查看已知漏洞；与版本升级 PR 不同，需单独关注高危 CVE。
+- **Security updates**（若已启用）：Dependabot 会为部分 CVE 自动开修复 PR。
+
+合并依赖或安全修复 PR 前，请确认 **CI** 与 **CodeQL** 均通过。


### PR DESCRIPTION
## Summary

- 新增 CodeQL workflow：扫描 JavaScript/TypeScript、Rust、GitHub Actions
- 更新 SECURITY.md：说明 CI / CodeQL / Dependabot 分工
- 更新 PR 模板：合并前质量门禁检查项
- 已通过 API 启用 Dependabot alerts 与 security updates

## Test plan

- [ ] CodeQL workflow 三路 job 通过
- [ ] 现有 CI 不受影响
- [ ] Security → Dependabot 可见依赖告警
