### PR TITLE
fix(ci): 修复 Website Modules Deploy 与 Pages 根目录部署

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -794,12 +794,18 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/releases" ]; then
+            RELEASES_SRC=""
+            if [ -d "$RESTORE_DIR/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/releases"
+            elif [ -d "$RESTORE_DIR/dist/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/dist/releases"
+            fi
+            if [ -n "$RELEASES_SRC" ]; then
               mkdir -p website/public/releases
-              cp -a "$RESTORE_DIR/dist/releases/." website/public/releases/
+              cp -a "$RELEASES_SRC/." website/public/releases/
               echo "Restored existing release directories from website-pages"
             else
-              echo "website-pages has no dist/releases, skip restore"
+              echo "website-pages has no releases, skip restore"
             fi
           else
             echo "website-pages branch unavailable, skip restore"
@@ -812,12 +818,18 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/modules" ]; then
+            MODULES_SRC=""
+            if [ -d "$RESTORE_DIR/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/modules"
+            elif [ -d "$RESTORE_DIR/dist/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/dist/modules"
+            fi
+            if [ -n "$MODULES_SRC" ]; then
               mkdir -p website/public/modules
-              cp -a "$RESTORE_DIR/dist/modules/." website/public/modules/
+              cp -a "$MODULES_SRC/." website/public/modules/
               echo "Restored existing module directories from website-pages"
             else
-              echo "website-pages has no dist/modules, skip restore"
+              echo "website-pages has no modules, skip restore"
             fi
           else
             echo "website-pages branch unavailable, skip modules restore"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -795,12 +795,18 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/releases" ]; then
+            RELEASES_SRC=""
+            if [ -d "$RESTORE_DIR/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/releases"
+            elif [ -d "$RESTORE_DIR/dist/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/dist/releases"
+            fi
+            if [ -n "$RELEASES_SRC" ]; then
               mkdir -p website/public/releases
-              cp -a "$RESTORE_DIR/dist/releases/." website/public/releases/
+              cp -a "$RELEASES_SRC/." website/public/releases/
               echo "Restored existing release directories from website-pages"
             else
-              echo "website-pages has no dist/releases, skip restore"
+              echo "website-pages has no releases, skip restore"
             fi
           else
             echo "website-pages branch unavailable, skip restore"
@@ -813,12 +819,18 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/modules" ]; then
+            MODULES_SRC=""
+            if [ -d "$RESTORE_DIR/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/modules"
+            elif [ -d "$RESTORE_DIR/dist/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/dist/modules"
+            fi
+            if [ -n "$MODULES_SRC" ]; then
               mkdir -p website/public/modules
-              cp -a "$RESTORE_DIR/dist/modules/." website/public/modules/
+              cp -a "$MODULES_SRC/." website/public/modules/
               echo "Restored existing module directories from website-pages"
             else
-              echo "website-pages has no dist/modules, skip restore"
+              echo "website-pages has no modules, skip restore"
             fi
           else
             echo "website-pages branch unavailable, skip modules restore"

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -51,12 +51,18 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/releases" ]; then
+            RELEASES_SRC=""
+            if [ -d "$RESTORE_DIR/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/releases"
+            elif [ -d "$RESTORE_DIR/dist/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/dist/releases"
+            fi
+            if [ -n "$RELEASES_SRC" ]; then
               mkdir -p website/public/releases
-              cp -a "$RESTORE_DIR/dist/releases/." website/public/releases/
+              cp -a "$RELEASES_SRC/." website/public/releases/
               echo "Restored existing release directories from website-pages"
             else
-              echo "website-pages has no dist/releases, skip restore"
+              echo "website-pages has no releases, skip restore"
             fi
           else
             echo "website-pages branch unavailable, skip restore"
@@ -69,12 +75,18 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/modules" ]; then
+            MODULES_SRC=""
+            if [ -d "$RESTORE_DIR/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/modules"
+            elif [ -d "$RESTORE_DIR/dist/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/dist/modules"
+            fi
+            if [ -n "$MODULES_SRC" ]; then
               mkdir -p website/public/modules
-              cp -a "$RESTORE_DIR/dist/modules/." website/public/modules/
+              cp -a "$MODULES_SRC/." website/public/modules/
               echo "Restored existing module directories from website-pages"
             else
-              echo "website-pages has no dist/modules, skip restore"
+              echo "website-pages has no modules, skip restore"
             fi
           else
             echo "website-pages branch unavailable, skip modules restore"

--- a/.github/workflows/website-modules.yml
+++ b/.github/workflows/website-modules.yml
@@ -42,19 +42,31 @@ jobs:
           set -euo pipefail
           RESTORE_DIR="$(mktemp -d)"
           if git clone --depth=1 --branch website-pages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$RESTORE_DIR" >/dev/null 2>&1; then
-            if [ -d "$RESTORE_DIR/dist/releases" ]; then
+            RELEASES_SRC=""
+            if [ -d "$RESTORE_DIR/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/releases"
+            elif [ -d "$RESTORE_DIR/dist/releases" ]; then
+              RELEASES_SRC="$RESTORE_DIR/dist/releases"
+            fi
+            if [ -n "$RELEASES_SRC" ]; then
               mkdir -p website/public/releases
-              cp -a "$RESTORE_DIR/dist/releases/." website/public/releases/
+              cp -a "$RELEASES_SRC/." website/public/releases/
               echo "Restored existing releases from website-pages"
             else
-              echo "website-pages has no dist/releases"
+              echo "website-pages has no releases"
             fi
-            if [ -d "$RESTORE_DIR/dist/modules" ]; then
+            MODULES_SRC=""
+            if [ -d "$RESTORE_DIR/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/modules"
+            elif [ -d "$RESTORE_DIR/dist/modules" ]; then
+              MODULES_SRC="$RESTORE_DIR/dist/modules"
+            fi
+            if [ -n "$MODULES_SRC" ]; then
               mkdir -p website/public/modules
-              cp -a "$RESTORE_DIR/dist/modules/." website/public/modules/
+              cp -a "$MODULES_SRC/." website/public/modules/
               echo "Restored existing modules from website-pages"
             else
-              echo "website-pages has no dist/modules"
+              echo "website-pages has no modules"
             fi
           else
             echo "website-pages branch unavailable, skip restore"

--- a/scripts/ci/deploy_website_pages.sh
+++ b/scripts/ci/deploy_website_pages.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# 将 website/dist 强制推送到 website-pages 分支（供多个 workflow 复用）。
+# 将 website/dist 内容强制推送到 website-pages 分支根目录（供多个 workflow 复用）。
+# GitHub Pages「Deploy from a branch」仅支持 / 或 /docs，因此不能发布到 dist/ 子目录。
 set -euo pipefail
 
 DEPLOY_MESSAGE="${DEPLOY_MESSAGE:?DEPLOY_MESSAGE is required}"
@@ -12,8 +13,7 @@ if [ ! -d website/dist ]; then
 fi
 
 DEPLOY="$(mktemp -d)"
-echo '{"name":"mini-hbut-website","private":true,"scripts":{"build":"echo skip"}}' > "$DEPLOY/package.json"
-cp -r website/dist "$DEPLOY/dist"
+cp -r website/dist/. "$DEPLOY/"
 cd "$DEPLOY"
 git init -q
 git config user.name "github-actions[bot]"

--- a/src/utils/static_resource_cache.js
+++ b/src/utils/static_resource_cache.js
@@ -2,8 +2,8 @@ import { getCachedData, setCachedData } from './api.js'
 import { invokeNative, isTauriRuntime } from '../platform/native'
 
 const STATIC_RESOURCE_BASE = 'https://hbut.6661111.xyz/app-resources'
-const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/superdaobo/mini-hbut/website-pages/dist/app-resources'
-const GITHUB_PROXY_BASE = 'https://ghfast.top/https://raw.githubusercontent.com/superdaobo/mini-hbut/website-pages/dist/app-resources'
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/superdaobo/mini-hbut/website-pages/app-resources'
+const GITHUB_PROXY_BASE = 'https://ghfast.top/https://raw.githubusercontent.com/superdaobo/mini-hbut/website-pages/app-resources'
 const DORMITORY_MANIFEST_URL = `${STATIC_RESOURCE_BASE}/dormitory/manifest.json`
 const DORMITORY_FALLBACK_URL = `${STATIC_RESOURCE_BASE}/dormitory/dormitory_data-20260423.json`
 const DORMITORY_CACHE_KEY = 'static_resource:dormitory_data'

--- a/website/modules-src/jump_out_hbut/project/vite.config.js
+++ b/website/modules-src/jump_out_hbut/project/vite.config.js
@@ -17,11 +17,13 @@ export default defineConfig({
     assetsInlineLimit: 4096,
     rollupOptions: {
       output: {
-        manualChunks: {
-          three: ['three'],
-        }
-      }
-    }
+        manualChunks(id) {
+          if (id.includes('node_modules/three')) {
+            return 'three'
+          }
+        },
+      },
+    },
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

- 修复 `jump_out_hbut` 在 Vite 8 下 `manualChunks is not a function` 导致 Website Modules Deploy 失败
- 重新应用 #145 丢失的 `website-pages` 根目录部署逻辑，修复 GitHub Pages 404
- workflow 恢复 `releases`/`modules` 时同时兼容新根目录布局与旧 `dist/` 布局

## 根因

1. Dependabot 将 `jump_out_hbut` 升到 Vite 8 后，`manualChunks` 对象写法不再被 Rolldown 接受
2. #145 合并提交未包含部署脚本/workflow 变更，导致 Pages 仍发布到 `dist/` 子目录

## Test plan

- [x] `website/modules-src/jump_out_hbut/project` 本地 `npm run build` 通过
- [ ] CI / Website Modules Deploy workflow 通过
- [ ] 部署后 `website-pages` 根目录含 `index.html`
