### PR TITLE
fix(ci): 补齐 lockfile 中 @emnapi 依赖以修复 npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,8 @@
       },
       "devDependencies": {
         "@capacitor/cli": "^6.1.2",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
         "@tauri-apps/cli": "^2.11.3",
         "@vitejs/plugin-vue": "^5.0.0",
         "@vitest/coverage-v8": "^4.1.9",
@@ -267,13 +269,35 @@
         "@capacitor/core": "^6.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^6.1.2",
+    "@emnapi/core": "^1.11.1",
+    "@emnapi/runtime": "^1.11.1",
     "@tauri-apps/cli": "^2.11.3",
     "@vitejs/plugin-vue": "^5.0.0",
     "@vitest/coverage-v8": "^4.1.9",


### PR DESCRIPTION
修复 CI 在 Linux runner 上 npm ci 报错 Missing @emnapi/core@1.11.1 from lock file。

Made with [Cursor](https://cursor.com)