### PR TITLE
feat(testflight): add demo account fixtures

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import UpdateDialog from './components/UpdateDialog.vue'
 import Toast from './components/Toast.vue'
 import SplashScreen from './components/SplashScreen.vue'
 import WorkspaceLayoutEditor from './components/WorkspaceLayoutEditor.vue'
-import { fetchWithCache, getStaleCachedData, setCachedData, DEFAULT_SWR_OPTIONS, clearUserScopedCaches } from './utils/api.js'
+import { fetchWithCache, getStaleCachedData, setCachedData, DEFAULT_SWR_OPTIONS, clearUserScopedCaches, clearCacheByPrefix } from './utils/api.js'
 import {
   readScheduleRenderSnapshot,
   clearScheduleRenderSnapshot,
@@ -20,6 +20,15 @@ import {
   isRemoteConfigEnabled
 } from './utils/remote_config.js'
 import { resetCloudSyncCooldownForSession, runAutoCloudSyncAfterLogin } from './utils/cloud_sync.js'
+import {
+  TEST_ACCOUNT,
+  clearTestAccountSession,
+  isTestAccountSession
+} from './utils/test_account.js'
+import {
+  getTestAccountGrades,
+  seedTestAccountCaches
+} from './utils/test_account_fixtures.js'
 import {
   loadChaoxingStoredPassword,
   loadPortalStoredPassword
@@ -1027,7 +1036,7 @@ const scheduleWidgetCrossDayTimer = () => {
   const delay = msUntilNextDayCrossover()
   widgetCrossDayTimer = setTimeout(() => {
     widgetCrossDayTimer = null
-    if (studentId.value) {
+    if (studentId.value && !isTestAccountSession()) {
       tryWriteSnapshotFromCache(studentId.value).catch(() => {})
       // 递归注册下一天
       scheduleWidgetCrossDayTimer()
@@ -1427,6 +1436,24 @@ const markLoginSessionToken = () => {
   }
 }
 
+const restoreTestAccountSession = () => {
+  if (!isTestAccountSession()) return false
+  const sid = TEST_ACCOUNT.studentId
+  studentId.value = sid
+  gradeData.value = getTestAccountGrades()
+  gradeTeacherCache.value = null
+  gradeTeacherCacheSid.value = sid
+  localStorage.setItem('hbu_username', sid)
+  localStorage.setItem(LOGIN_METHOD_KEY, 'test_account')
+  localStorage.setItem(LOGIN_TEMP_FLAG_KEY, '0')
+  localStorage.removeItem('hbu_manual_logout')
+  localStorage.removeItem(LOGOUT_REASON_KEY)
+  seedTestAccountCaches(setCachedData, sid)
+  clearJwxtMaintenance()
+  stopJwxtRecoveryPolling()
+  return true
+}
+
 // 处理登录成功
 const handleLoginSuccess = (data) => {
   gradeData.value = data
@@ -1440,12 +1467,16 @@ const handleLoginSuccess = (data) => {
   // 预取培养方案默认数据并落地缓存
   if (studentId.value) {
     markLoginSessionToken()
+    if (isTestAccountSession()) {
+      seedTestAccountCaches(setCachedData, studentId.value)
+      gradeData.value = getTestAccountGrades()
+    }
 
     fetchWithCache(`training:options:${studentId.value}`, async () => {
       const res = await axios.post(`${API_BASE}/v2/training_plan/options`, {
         student_id: studentId.value
       })
-      if (res.data?.success) {
+      if (res.data?.success && !isTestAccountSession()) {
         localStorage.setItem('hbu_training_options', JSON.stringify({
           options: res.data.options || {},
           defaults: res.data.defaults || {}
@@ -1457,23 +1488,25 @@ const handleLoginSuccess = (data) => {
 
   localStorage.removeItem('hbu_manual_logout')
   localStorage.removeItem(LOGOUT_REASON_KEY)
-  persistSessionCookies()
-  startSessionKeepAlive()
-  startElectricityKeepAlive()
-  if (studentId.value) {
-    void ensureRememberedPasswordCached(studentId.value).catch((e) => {
-      console.warn('[Session] 登录后缓存记住密码失败:', e)
-    })
-    startNotificationMonitor({ studentId: studentId.value }).catch((e) => {
-      console.warn('[Notify] 启动通知监控失败:', e)
-    })
-    resetCloudSyncCooldownForSession(studentId.value)
-    runAutoCloudSyncAfterLogin({
-      studentId: studentId.value,
-      latestGrades: Array.isArray(data) ? data : []
-    }).catch((e) => {
-      console.warn('[CloudSync] 登录后自动同步失败:', e)
-    })
+  if (!isTestAccountSession()) {
+    persistSessionCookies()
+    startSessionKeepAlive()
+    startElectricityKeepAlive()
+    if (studentId.value) {
+      void ensureRememberedPasswordCached(studentId.value).catch((e) => {
+        console.warn('[Session] 登录后缓存记住密码失败:', e)
+      })
+      startNotificationMonitor({ studentId: studentId.value }).catch((e) => {
+        console.warn('[Notify] 启动通知监控失败:', e)
+      })
+      resetCloudSyncCooldownForSession(studentId.value)
+      runAutoCloudSyncAfterLogin({
+        studentId: studentId.value,
+        latestGrades: Array.isArray(data) ? data : []
+      }).catch((e) => {
+        console.warn('[CloudSync] 登录后自动同步失败:', e)
+      })
+    }
   }
   clearJwxtMaintenance()
   stopJwxtRecoveryPolling()
@@ -1547,6 +1580,21 @@ const isTemporaryLoginSession = () => {
   return marked || method.endsWith('_temp')
 }
 
+const clearTestAccountRuntimeCaches = () => {
+  clearCacheByPrefix(`grades:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`schedule:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`classroom:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`studentinfo:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`student_info:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`exams:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`ranking:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`calendar:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`academic:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`training:options:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`training:jys:${TEST_ACCOUNT.studentId}`)
+  clearCacheByPrefix(`electricity:${TEST_ACCOUNT.studentId}`)
+}
+
 // 处理登出
 const handleLogout = async (options = {}) => {
   const payload = options && typeof options === 'object' ? options : {}
@@ -1554,11 +1602,14 @@ const handleLogout = async (options = {}) => {
   const reason = String(payload.reason || '').trim()
   const notice = String(payload.notice || '').trim()
   const logoutSid = String(studentId.value || localStorage.getItem('hbu_username') || '').trim()
+  const wasTestAccountSession = isTestAccountSession()
 
-  try {
-    await preservePortalRememberedPasswordOnLogout()
-  } catch (e) {
-    console.warn('[Session] 退出前同步记住密码失败:', e)
+  if (!wasTestAccountSession) {
+    try {
+      await preservePortalRememberedPasswordOnLogout()
+    } catch (e) {
+      console.warn('[Session] 退出前同步记住密码失败:', e)
+    }
   }
 
   if (manual && logoutSid) {
@@ -1600,14 +1651,21 @@ const handleLogout = async (options = {}) => {
   } else {
     localStorage.removeItem('hbu_manual_logout')
   }
-  invokeNative('logout').catch(() => {})
+  if (wasTestAccountSession) {
+    clearTestAccountRuntimeCaches()
+    clearTestAccountSession()
+  } else {
+    invokeNative('logout').catch(() => {})
+  }
   if (notice) {
     window.setTimeout(() => {
       window.alert(notice)
     }, 80)
   }
-  // Widget 快照清空（异步，不阻塞登出流程）
-  clearWidgetForLogout().catch(() => {})
+  // Widget 快照属于真实账号设备状态，演示账号退出时不触发 native/plugin 清理。
+  if (!wasTestAccountSession) {
+    clearWidgetForLogout().catch(() => {})
+  }
   // 清除跨天定时器
   if (widgetCrossDayTimer) {
     clearTimeout(widgetCrossDayTimer)
@@ -1709,6 +1767,9 @@ const restoreCachedIdentityFromLocal = async () => {
     localStorage.removeItem('hbu_username')
     return false
   }
+  if (isTestAccountSession() && cachedSid === TEST_ACCOUNT.studentId) {
+    return restoreTestAccountSession()
+  }
 
   studentId.value = cachedSid
   // 异步通知 Rust 侧，不阻塞首屏
@@ -1732,6 +1793,7 @@ const stopJwxtRecoveryPolling = () => {
 }
 
 const attemptOnlineRecovery = async (options = {}) => {
+  if (isTestAccountSession()) return restoreTestAccountSession()
   if (!hasTauri || isManualLogout()) return false
   if (jwxtRecoveryInFlight) return false
   jwxtRecoveryInFlight = true
@@ -1777,6 +1839,7 @@ const attemptOnlineRecovery = async (options = {}) => {
 }
 
 const startJwxtRecoveryPolling = () => {
+  if (isTestAccountSession()) return
   if (isManualLogout() || !studentId.value) return
   stopJwxtRecoveryPolling()
   jwxtRecoveryTimer = setInterval(() => {
@@ -2199,6 +2262,7 @@ const importCookiesViaBridge = async (snapshot) => {
 }
 
 const persistSessionCookies = async () => {
+  if (isTestAccountSession()) return
   if (!hasTauri) return
   try {
     const cookies = await invokeNative('get_cookies')
@@ -2212,6 +2276,7 @@ const persistSessionCookies = async () => {
 }
 
 const tryRestoreSession = async () => {
+  if (isTestAccountSession()) return restoreTestAccountSession()
   const cookies = localStorage.getItem(SESSION_COOKIE_KEY)
   if (!cookies && !hasTauri) {
     try {
@@ -2270,6 +2335,7 @@ const tryRestoreSession = async () => {
 }
 
 const tryRestoreLatestSession = async () => {
+  if (isTestAccountSession()) return restoreTestAccountSession()
   if (!hasTauri) return false
   if (isManualLogout()) {
     return false
@@ -2312,6 +2378,7 @@ const resolveAutoLoginStudentId = async (payload) => {
 }
 
 const attemptAutoRelogin = async () => {
+  if (isTestAccountSession()) return restoreTestAccountSession()
   if (!hasTauri) return false
   if (isManualLogout()) {
     return false
@@ -2386,6 +2453,7 @@ const attemptAutoRelogin = async () => {
 }
 
 const refreshSessionSilently = async () => {
+  if (isTestAccountSession()) return
   const cookies = localStorage.getItem(SESSION_COOKIE_KEY)
   if (!cookies) return
   if (!hasTauri) return
@@ -2679,6 +2747,11 @@ onMounted(async () => {
     console.time('[Boot] session-restore')
     let restored = false
     let relogged = false
+    if (isTestAccountSession()) {
+      restored = restoreTestAccountSession()
+      console.timeEnd('[Boot] session-restore')
+      return { restored, relogged }
+    }
     restored = await tryRestoreSession()
     if (!restored) {
       restored = await tryRestoreLatestSession()
@@ -2751,7 +2824,7 @@ onMounted(async () => {
   }
 
   // ── 阶段 5：后台启动长期任务 ──
-  if (onlineReady) {
+  if (onlineReady && !isTestAccountSession()) {
     startSessionKeepAlive()
     startElectricityKeepAlive()
     if (studentId.value) {
@@ -2768,7 +2841,7 @@ onMounted(async () => {
     if (bootstrappedCachedIdentity || skipSplashForFastScheduleBoot) {
       notifySessionOnline(relogged ? 'boot-auto-relogin' : 'boot-session-restore')
     }
-  } else if (bootstrappedCachedIdentity || studentId.value) {
+  } else if (!isTestAccountSession() && (bootstrappedCachedIdentity || studentId.value)) {
     startJwxtRecoveryPolling()
     attemptOnlineRecovery({ silent: true }).then((ok) => {
       if (!ok) {
@@ -2794,7 +2867,7 @@ onMounted(async () => {
   }
 
   // Widget 快照（异步不阻塞）
-  if (studentId.value) {
+  if (studentId.value && !isTestAccountSession()) {
     tryWriteSnapshotFromCache(studentId.value).catch(() => {})
     scheduleWidgetCrossDayTimer()
   }

--- a/src/components/AiChatView.vue
+++ b/src/components/AiChatView.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { fetchEventSource } from '@microsoft/fetch-event-source'
 import { initMarkdownRuntime, renderMarkdown } from '../utils/markdown.js'
 import { invokeNative, isTauriRuntime } from '../platform/native'
+import { isTestAccountSession } from '../utils/test_account.js'
 
 const props = defineProps({
   studentId: String,
@@ -41,6 +42,15 @@ const AI_MIME_BY_EXT = {
   pdf: 'application/pdf',
   txt: 'text/plain',
   md: 'text/markdown'
+}
+
+const buildTestAccountAiReply = (question = '') => {
+  const prompt = String(question || '').trim()
+  return [
+    '演示账号不会调用外部 AI 服务。',
+    prompt ? `你刚才的问题是：${prompt}` : '你可以继续输入问题查看本地演示回复。',
+    'TestFlight 审核环境下，此模块只展示界面与历史记录交互。'
+  ].join('\n\n')
 }
 
 const defaultModelOptions = [
@@ -474,6 +484,13 @@ const parsePostResponse = async (res) => {
 }
 
 const postJson = async (path, body, options = {}) => {
+  if (isTestAccountSession()) {
+    return {
+      success: false,
+      demo_disabled: true,
+      error: '演示账号不会调用外部 AI 服务'
+    }
+  }
   const retries = Number.isFinite(options?.retries) ? Math.max(0, Number(options.retries)) : 2
   const skipProbe = options?.skipProbe === true
   let lastError = null
@@ -859,6 +876,14 @@ const renderMessage = (msg) => {
 const initAiSession = async () => {
   initStatus.value = 'loading'
   initError.value = ''
+  if (isTestAccountSession()) {
+    token.value = 'test-account-token'
+    bladeAuth.value = 'test-account-blade-auth'
+    dynamicModelOptions.value = defaultModelOptions
+    initStatus.value = 'success'
+    initError.value = ''
+    return
+  }
   try {
     const resp = await postJson(AI_BRIDGE_PATHS.init, {})
     applyInitPayload(resp)
@@ -892,6 +917,7 @@ const ensureInitReady = async () => {
 }
 
 const createRemoteSession = async () => {
+  if (isTestAccountSession()) return ''
   await ensureInitReady()
   const resp = await postJson(AI_BRIDGE_PATHS.sessionNew, {
     token: token.value,
@@ -944,6 +970,7 @@ const loadSessionMessagesFromRemote = async (session, force = false) => {
 }
 
 const syncRemoteHistory = async () => {
+  if (isTestAccountSession()) return
   await ensureInitReady()
   const resp = await postJson(AI_BRIDGE_PATHS.sessionHistory, {
     token: token.value,
@@ -1551,6 +1578,10 @@ const sendMessage = async () => {
   syncMessagesToActiveSession()
 
   try {
+    if (isTestAccountSession()) {
+      await appendTextWithTyping(assistantMsg, buildTestAccountAiReply(userText))
+      return
+    }
     await ensureInitReady()
     ensureModelSelection()
     const active = await ensureActiveSession()
@@ -1682,6 +1713,11 @@ const triggerUpload = () => fileInput.value?.click()
 const handleFileChange = async (event) => {
   const file = event?.target?.files?.[0]
   if (!file) return
+  if (isTestAccountSession()) {
+    attachment.value = { name: file.name, url: 'demo://ai-upload-disabled' }
+    event.target.value = ''
+    return
+  }
   if (initStatus.value !== 'success') {
     await initAiSession()
   }

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -20,6 +20,7 @@ import {
 } from '../utils/layout_collision_fx.js'
 import { buildHomeSearchSections, buildWeeklyCourseSearchEntries } from '../utils/home_search.js'
 import { getForecastTemperatureBounds, getTemperatureColor, getTemperatureRangeStyle, getWeatherIconTone } from '../utils/weather_visuals'
+import { isTestAccountSession } from '../utils/test_account.js'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -367,7 +368,9 @@ const fetchTodayCourses = async () => {
     if (payload?.meta) {
       const nextWeek = Number(payload.meta.current_week || 0)
       const persistedWeek = nextWeek > 0 ? nextWeek : getCurrentWeek()
-      localStorage.setItem('hbu_schedule_meta', JSON.stringify({ semester: payload.meta.semester || preferredSemester || '', start_date: payload.meta.start_date || '', current_week: persistedWeek }))
+      if (!isTestAccountSession()) {
+        localStorage.setItem('hbu_schedule_meta', JSON.stringify({ semester: payload.meta.semester || preferredSemester || '', start_date: payload.meta.start_date || '', current_week: persistedWeek }))
+      }
     }
     const week = getCurrentWeek(payload?.meta?.current_week)
     const remoteCourses = Array.isArray(payload?.data) ? payload.data : []

--- a/src/components/LoginV3.vue
+++ b/src/components/LoginV3.vue
@@ -4,6 +4,17 @@ import axios from 'axios'
 import { fetchRemoteConfig, applyOcrRuntimeConfig, getStoredOcrConfig } from '../utils/remote_config.js'
 import { invokeNative as invoke, isTauriRuntime } from '../platform/native'
 import { pushDebugLog } from '../utils/debug_logger'
+import { setCachedData } from '../utils/api.js'
+import {
+  TEST_ACCOUNT,
+  TEST_ACCOUNT_LOGIN_METHOD,
+  isTestAccountCredentials,
+  markTestAccountSession
+} from '../utils/test_account.js'
+import {
+  getTestAccountGrades,
+  seedTestAccountCaches
+} from '../utils/test_account_fixtures.js'
 import {
   buildChaoxingAccountKey,
   buildHbutAccountKey,
@@ -466,6 +477,26 @@ const saveChaoxingCredentials = async () => {
   }
 }
 
+const handleTestAccountLogin = async () => {
+  loading.value = true
+  statusMsg.value = '正在进入 TestFlight 演示账号...'
+  try {
+    markTestAccountSession()
+    username.value = TEST_ACCOUNT.studentId
+    localStorage.setItem('hbu_username', TEST_ACCOUNT.studentId)
+    localStorage.setItem('hbu_remember', 'false')
+    localStorage.setItem('hbu_login_entry_mode', 'portal')
+    applyLoginMethodStorage(TEST_ACCOUNT_LOGIN_METHOD)
+    localStorage.removeItem('hbu_manual_logout')
+    localStorage.removeItem(LOGOUT_REASON_KEY)
+    seedTestAccountCaches(setCachedData, TEST_ACCOUNT.studentId)
+    statusMsg.value = '登录成功，已加载演示数据'
+    emit('success', getTestAccountGrades())
+  } finally {
+    loading.value = false
+  }
+}
+
 const handlePasswordLogin = async () => {
   if (!username.value || !password.value) {
     statusMsg.value = '请输入完整的账号和密码'
@@ -473,6 +504,11 @@ const handlePasswordLogin = async () => {
   }
   if (!agreePolicy.value) {
     statusMsg.value = '请先阅读并同意免责声明与隐私政策'
+    return
+  }
+
+  if (isTestAccountCredentials(username.value, password.value)) {
+    await handleTestAccountLogin()
     return
   }
 

--- a/src/components/ResourceShareView.vue
+++ b/src/components/ResourceShareView.vue
@@ -5,6 +5,7 @@ import { openExternal } from '../utils/external_link'
 import { invokeNative, isTauriRuntime } from '../platform/native'
 import { detectRuntime } from '../platform/runtime'
 import { importModuleFromCdn, loadScriptFromCdn, loadStyleFromCdn } from '../utils/cdn_loader'
+import { isTestAccountSession } from '../utils/test_account.js'
 import { TPageHeader } from './templates'
 
 const emit = defineEmits(['back'])
@@ -242,6 +243,51 @@ const getTypeClass = (item) => {
   return 'other'
 }
 
+const buildTestAccountResourceShareItems = (path = '/') => {
+  const targetPath = normalizePath(path)
+  if (targetPath === '/') {
+    return [
+      {
+        name: 'TestFlight演示资料',
+        path: '/TestFlight演示资料',
+        isDir: true,
+        size: 0,
+        modified: '2026-07-06T08:00:00+08:00',
+        contentType: ''
+      },
+      {
+        name: '演示说明.txt',
+        path: '/演示说明.txt',
+        isDir: false,
+        size: 128,
+        modified: '2026-07-06T08:00:00+08:00',
+        contentType: 'text/plain'
+      }
+    ]
+  }
+  if (targetPath === '/TestFlight演示资料') {
+    return [
+      {
+        name: '课程资料预览.txt',
+        path: '/TestFlight演示资料/课程资料预览.txt',
+        isDir: false,
+        size: 96,
+        modified: '2026-07-06T08:00:00+08:00',
+        contentType: 'text/plain'
+      }
+    ]
+  }
+  return []
+}
+
+const getTestAccountResourceText = (path = '/') =>
+  `Mini-HBUT TestFlight demo resource\n\nPath: ${normalizePath(path)}\nThis is a local demo payload.`
+
+const getTestAccountResourceDirectUrl = (path = '/') => ({
+  url: `data:text/plain;charset=utf-8,${encodeURIComponent(getTestAccountResourceText(path))}`,
+  needAuth: false
+})
+
 const fetchWithTimeout = async (url, init = {}, timeoutMs = 25000) => {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
@@ -382,6 +428,13 @@ const listDirectory = async (path, force = false) => {
   loadingList.value = true
   try {
     const now = Date.now()
+    if (isTestAccountSession()) {
+      const demoItems = buildTestAccountResourceShareItems(targetPath)
+      currentPath.value = targetPath
+      items.value = demoItems
+      totalCount.value = demoItems.length
+      return
+    }
     const cached = dirCache.value[targetPath]
     if (!force && cached && now - Number(cached.time || 0) <= DIR_CACHE_TTL_MS && Array.isArray(cached.items)) {
       currentPath.value = targetPath
@@ -478,6 +531,7 @@ const withCacheBustUrl = (url) => {
 }
 
 const buildPreviewUrlCandidates = (path, signed) => {
+  if (isTestAccountSession()) return [String(signed?.url || '').trim()].filter(Boolean)
   const normalized = normalizePath(path)
   const candidates = []
   const signedUrl = String(signed?.url || '').trim()
@@ -564,6 +618,7 @@ const fetchDirectUrlFromBridge = async (params) => {
 
 const getSignedDirectUrl = async (path) => {
   const normalized = normalizePath(path)
+  if (isTestAccountSession()) return getTestAccountResourceDirectUrl(normalized)
   const cacheKey = `${endpoint.value}|${normalized}`
   const cached = directUrlCache.get(cacheKey)
   if (cached?.url && Number(cached.expireAt || 0) > Date.now() + 5000) {
@@ -603,6 +658,12 @@ const getSignedDirectUrl = async (path) => {
 }
 
 const fetchNativeResourcePayload = async (path, maxBytes = undefined) => {
+  if (isTestAccountSession()) {
+    return {
+      base64: btoa(getTestAccountResourceText(path)),
+      contentType: 'text/plain'
+    }
+  }
   if (!runtimeIsTauri) return null
   return invokeNative('resource_share_fetch_file_payload_native', {
     req: {
@@ -640,6 +701,9 @@ const resolvePreviewPlayableUrl = (path, signed) => {
 }
 
 const fetchTextWithAuth = async (path) => {
+  if (isTestAccountSession()) {
+    return getTestAccountResourceText(path)
+  }
   const response = await fetchWithTimeout(
     getDavUrl(path),
     {
@@ -1162,6 +1226,10 @@ const openBreadcrumb = async (path) => {
 
 const openDownload = async () => {
   if (!previewPath.value) return
+  if (isTestAccountSession()) {
+    previewHint.value = '演示账号不下载真实资料'
+    return
+  }
   try {
     const signed = await getSignedDirectUrl(previewPath.value)
     const baseCandidates = buildPreviewUrlCandidates(previewPath.value, signed)

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -29,6 +29,7 @@ import { hasBootMetric, markBootMetric } from '../utils/boot_metrics.js'
 import { showToast } from '../utils/toast'
 import { invokeNative, isTauriRuntime } from '../platform/native'
 import { afterScheduleRefresh } from '../utils/widget_bridge'
+import { isTestAccountSession } from '../utils/test_account.js'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -665,13 +666,15 @@ const applyMeta = (meta, requestedSemester = '') => {
   currentWeek.value = safeWeek
   selectedWeek.value = safeWeek
 
-  localStorage.setItem('hbu_schedule_meta', JSON.stringify({
-    semester: resolvedSemester,
-    start_date: startDateStr.value,
-    current_week: currentWeek.value,
-    total_weeks: totalWeeks.value,
-    vacation_notice: vacationNotice.value
-  }))
+  if (!isTestAccountSession()) {
+    localStorage.setItem('hbu_schedule_meta', JSON.stringify({
+      semester: resolvedSemester,
+      start_date: startDateStr.value,
+      current_week: currentWeek.value,
+      total_weeks: totalWeeks.value,
+      vacation_notice: vacationNotice.value
+    }))
+  }
 }
 
 const applySchedulePayload = (payload, requestedSemester = '') => {

--- a/src/components/TrainingPlanView.vue
+++ b/src/components/TrainingPlanView.vue
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { fetchWithCache, LONG_TTL } from '../utils/api.js'
 import { formatRelativeTime } from '../utils/time.js'
 import { TPageHeader, TEmptyState } from './templates'
+import { isTestAccountSession } from '../utils/test_account.js'
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 
@@ -119,10 +120,12 @@ const fetchOptions = async () => {
       defaults.value = data.defaults || defaults.value
       filters.value.grade = defaults.value.grade || ''
       filters.value.kkxq = defaults.value.kkxq || ''
-      localStorage.setItem('hbu_training_options', JSON.stringify({
-        options: options.value,
-        defaults: defaults.value
-      }))
+      if (!isTestAccountSession()) {
+        localStorage.setItem('hbu_training_options', JSON.stringify({
+          options: options.value,
+          defaults: defaults.value
+        }))
+      }
       await fetchJys()
     } else if (data?.need_login) {
       emit('logout')

--- a/src/platform/native.ts
+++ b/src/platform/native.ts
@@ -1,5 +1,7 @@
 import { detectRuntime } from './runtime'
 import { pushDebugLog } from '../utils/debug_logger'
+import { isTestAccountSession } from '../utils/test_account.js'
+import { resolveTestAccountNativeResponse } from '../utils/test_account_fixtures.js'
 
 type InvokeArgs = Record<string, unknown> | undefined
 
@@ -32,6 +34,18 @@ export const invokeNative = async <T = unknown>(
   command: string,
   args?: InvokeArgs
 ): Promise<T> => {
+  if (isTestAccountSession()) {
+    const testAccountResponse = resolveTestAccountNativeResponse(command, args)
+    if (testAccountResponse !== null && testAccountResponse !== undefined) {
+      pushDebugLog('Native', `测试账号 invoke 命中演示数据：${command}`, 'debug', args)
+      return testAccountResponse as T
+    }
+    return {
+      success: false,
+      demo_disabled: true,
+      error: '未知测试账号 invoke 已拦截'
+    } as T
+  }
   if (!isTauriRuntime()) {
     pushDebugLog('Native', `invoke 调用被拒绝：${command}`, 'warn')
     throw new Error(`当前运行时不支持 invoke: ${command}`)

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,4 +1,6 @@
 import { pushDebugLog } from './debug_logger'
+import { isTestAccountSession } from './test_account.js'
+import { resolveTestAccountCachePayload } from './test_account_fixtures.js'
 
 const DEFAULT_TTL = 5 * 60 * 1000
 const LONG_TTL = 3 * 24 * 60 * 60 * 1000
@@ -49,6 +51,13 @@ const shouldPersistToLocalStorage = (key, payloadText) => {
   }
   if (!payloadText) return true
   return payloadText.length <= MAX_LOCAL_CACHE_VALUE_BYTES
+}
+
+const shouldPersistTestAccountPayload = (key) => {
+  const text = String(key || '').trim()
+  if (text === 'semesters') return false
+  if (text.startsWith('classroom:')) return false
+  return true
 }
 
 const collectCacheEntries = () => {
@@ -466,6 +475,21 @@ export async function fetchWithCache(key, fetcher, ttl = DEFAULT_TTL, options = 
   const priority = requestOptions.priority || 'foreground'
   const staleWhileRevalidate = !!requestOptions.staleWhileRevalidate
   const forceRemote = !!requestOptions.forceRemote
+  const testAccountPayload = isTestAccountSession()
+    ? resolveTestAccountCachePayload(key)
+    : null
+  if (testAccountPayload) {
+    if (shouldPersistTestAccountPayload(key)) {
+      setCachedData(key, testAccountPayload)
+    }
+    recordRequestMetric(key, { source: 'test-account-cache', start: Date.now(), priority })
+    return {
+      data: testAccountPayload,
+      fromCache: true,
+      timestamp: Date.now(),
+      demo: true
+    }
+  }
   const maintenanceMode = localStorage.getItem(JWXT_MAINTENANCE_KEY) === '1'
   const cached = forceRemote ? null : getCachedData(key, ttl)
 

--- a/src/utils/axios_adapter.js
+++ b/src/utils/axios_adapter.js
@@ -1,4 +1,6 @@
 import { invokeNative as invoke, isTauriRuntime } from '../platform/native';
+import { isTestAccountSession } from './test_account.js';
+import { resolveTestAccountHttpResponse } from './test_account_fixtures.js';
 
 const hasTauri = isTauriRuntime();
 const LOCAL_BRIDGE = 'http://127.0.0.1:4399';
@@ -92,6 +94,15 @@ const adapter = {
         console.log('[Axios Adapter] GET request received:', url);
         console.log('[Axios Adapter] Full URL:', url);
         try {
+            if (isTestAccountSession()) {
+                const testAccountResponse = resolveTestAccountHttpResponse('get', url, config);
+                if (testAccountResponse) return mockResponse(testAccountResponse);
+                return mockResponse({
+                    success: false,
+                    demo_disabled: true,
+                    error: '未知测试账号 HTTP 请求已拦截'
+                });
+            }
             if (url.includes('/v3/login_params')) {
                 const data = await invoke('get_login_page');
                 // 适配前端期望的格?
@@ -160,6 +171,17 @@ const adapter = {
         console.log('[Axios Adapter] POST request received:', url);
         console.log('[Axios Adapter] POST data:', JSON.stringify(data));
         try {
+            const testAccountResponse = resolveTestAccountHttpResponse('post', url, data);
+            if (testAccountResponse && (isTestAccountSession() || url.includes('/v2/start_login'))) {
+                return mockResponse(testAccountResponse);
+            }
+            if (isTestAccountSession()) {
+                return mockResponse({
+                    success: false,
+                    demo_disabled: true,
+                    error: '未知测试账号 HTTP 请求已拦截'
+                });
+            }
             // 登录
 
             if (url.includes('/v2/start_login')) {

--- a/src/utils/forum_api.js
+++ b/src/utils/forum_api.js
@@ -1,3 +1,6 @@
+import { isTestAccountSession } from './test_account.js'
+import { resolveTestAccountForumResponse } from './test_account_fixtures.js'
+
 const DEFAULT_FORUM_ENDPOINT = 'https://mini-hbut-testocr1.hf.space/api/forum'
 const TOKEN_CACHE_KEY_PREFIX = 'hbu_forum_token:'
 const PROFILE_CACHE_KEY_PREFIX = 'hbu_forum_profile:'
@@ -149,6 +152,20 @@ export const createForumApiClient = ({
   let memoryToken = ''
 
   const request = async (path, { method = 'GET', body, auth = false, headers = {}, etag = '', includeMeta = false } = {}) => {
+    if (isTestAccountSession()) {
+      const payload = resolveTestAccountForumResponse(path, {
+        method,
+        body,
+        auth,
+        headers,
+        etag,
+        studentId: sid
+      })
+      return includeMeta
+        ? { value: payload, etag: 'test-account-forum', notModified: false }
+        : payload
+    }
+
     const createHeaders = async (forceTokenRefresh = false) => {
       const reqHeaders = { Accept: 'application/json', ...headers }
       if (body !== undefined && !(body instanceof FormData)) {

--- a/src/utils/remote_config.js
+++ b/src/utils/remote_config.js
@@ -2,6 +2,7 @@ import { invokeNative as invoke } from '../platform/native'
 import { detectRuntime } from '../platform/runtime'
 import { DEFAULT_CLOUD_SYNC_ENDPOINT, useAppSettings } from './app_settings'
 import { DEFAULT_MODULE_CENTER as DEFAULT_GAME_MODULE_CENTER } from './module_center'
+import { isTestAccountSession } from './test_account.js'
 
 const CONFIG_URLS = [
   'https://raw.gitcode.com/superdaobo/mini-hbut-config/raw/main/remote_config.json',
@@ -710,6 +711,9 @@ export const applyOcrRuntimeConfig = async (configLike) => {
 
 export async function fetchRemoteConfig(options = {}) {
   const forceRefresh = options?.force === true
+  if (isTestAccountSession()) {
+    return normalizeRemoteConfig(DEFAULT_CONFIG)
+  }
   if (!isRemoteConfigEnabled()) {
     return buildLocalOnlyConfig()
   }

--- a/src/utils/test_account.js
+++ b/src/utils/test_account.js
@@ -1,0 +1,61 @@
+export const TEST_ACCOUNT_SESSION_KEY = 'hbu_test_account_session'
+export const TEST_ACCOUNT_LOGIN_METHOD = 'test_account'
+
+export const TEST_ACCOUNT = Object.freeze({
+  username: 'reviewer',
+  password: 'Test2026',
+  studentId: '2026000001',
+  displayName: 'TestFlight 测试账号'
+})
+
+const safeStorage = () => {
+  try {
+    return globalThis.localStorage || null
+  } catch {
+    return null
+  }
+}
+
+const normalizeText = (value) => String(value ?? '').trim()
+
+export const isTestAccountCredentials = (username, password) =>
+  normalizeText(username).toLowerCase() === TEST_ACCOUNT.username &&
+  normalizeText(password) === TEST_ACCOUNT.password
+
+export const isTestAccountStudentId = (studentId) =>
+  normalizeText(studentId) === TEST_ACCOUNT.studentId
+
+export const markTestAccountSession = () => {
+  const storage = safeStorage()
+  if (!storage) return
+  storage.setItem(TEST_ACCOUNT_SESSION_KEY, '1')
+  storage.setItem('hbu_login_method', TEST_ACCOUNT_LOGIN_METHOD)
+  storage.setItem('hbu_username', TEST_ACCOUNT.studentId)
+  storage.setItem('hbu_remember', 'false')
+  storage.setItem('hbu_login_entry_mode', 'portal')
+  storage.removeItem('hbu_manual_logout')
+  storage.removeItem('hbu_logout_reason')
+  storage.removeItem('hbu_login_temporary')
+}
+
+export const clearTestAccountSession = () => {
+  const storage = safeStorage()
+  if (!storage) return
+  storage.removeItem(TEST_ACCOUNT_SESSION_KEY)
+  if (storage.getItem('hbu_login_method') === TEST_ACCOUNT_LOGIN_METHOD) {
+    storage.removeItem('hbu_login_method')
+  }
+  if (isTestAccountStudentId(storage.getItem('hbu_username'))) {
+    storage.removeItem('hbu_username')
+  }
+}
+
+export const isTestAccountSession = () => {
+  const storage = safeStorage()
+  if (!storage) return false
+  return (
+    storage.getItem(TEST_ACCOUNT_SESSION_KEY) === '1' ||
+    storage.getItem('hbu_login_method') === TEST_ACCOUNT_LOGIN_METHOD ||
+    isTestAccountStudentId(storage.getItem('hbu_username'))
+  )
+}

--- a/src/utils/test_account.spec.ts
+++ b/src/utils/test_account.spec.ts
@@ -1,0 +1,169 @@
+import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+const repoPath = (relativePath: string) => resolve(process.cwd(), relativePath)
+const importModule = async <T = Record<string, unknown>>(relativePath: string): Promise<T> => {
+  const fullPath = repoPath(relativePath)
+  expect(existsSync(fullPath)).toBe(true)
+  return await import(pathToFileURL(fullPath).href) as T
+}
+
+describe('TestFlight 演示账号工具', () => {
+  it('只接受 reviewer / Test2026 作为测试账号凭据', async () => {
+    const mod = await importModule<{
+      TEST_ACCOUNT: { username: string; password: string; studentId: string }
+      isTestAccountCredentials: (username: string, password: string) => boolean
+      isTestAccountStudentId: (studentId: string) => boolean
+    }>('src/utils/test_account.js')
+
+    expect(mod.TEST_ACCOUNT).toMatchObject({
+      username: 'reviewer',
+      password: 'Test2026',
+      studentId: '2026000001'
+    })
+    expect(mod.isTestAccountCredentials(' reviewer ', 'Test2026')).toBe(true)
+    expect(mod.isTestAccountCredentials('reviewer', 'wrong')).toBe(false)
+    expect(mod.isTestAccountCredentials('2510231106', 'Test2026')).toBe(false)
+    expect(mod.isTestAccountStudentId('2026000001')).toBe(true)
+    expect(mod.isTestAccountStudentId('2510231106')).toBe(false)
+  })
+
+  it('登录后可一次性种入核心校园模块缓存', async () => {
+    const account = await importModule<{
+      TEST_ACCOUNT: { studentId: string }
+    }>('src/utils/test_account.js')
+    const fixtures = await importModule<{
+      seedTestAccountCaches: (setCachedData: (key: string, data: unknown) => void, studentId?: string) => string[]
+    }>('src/utils/test_account_fixtures.js')
+
+    const written = new Map<string, unknown>()
+    const keys = fixtures.seedTestAccountCaches((key, data) => written.set(key, data), account.TEST_ACCOUNT.studentId)
+
+    expect(keys).toEqual(expect.arrayContaining([
+      `grades:${account.TEST_ACCOUNT.studentId}`,
+      `schedule:${account.TEST_ACCOUNT.studentId}`,
+      `studentinfo:${account.TEST_ACCOUNT.studentId}`,
+      `exams:${account.TEST_ACCOUNT.studentId}:current`,
+      `ranking:${account.TEST_ACCOUNT.studentId}:current`,
+      `calendar:${account.TEST_ACCOUNT.studentId}:current`,
+      `academic:${account.TEST_ACCOUNT.studentId}:1`,
+      `training:options:${account.TEST_ACCOUNT.studentId}`,
+      `electricity:${account.TEST_ACCOUNT.studentId}:light`
+    ]))
+    expect(keys).not.toContain('semesters')
+    expect(keys).not.toContain('classroom:buildings')
+    expect(written.has('semesters')).toBe(false)
+    expect(written.has('classroom:buildings')).toBe(false)
+    expect(written.get(`grades:${account.TEST_ACCOUNT.studentId}`)).toMatchObject({ success: true })
+    expect(written.get(`schedule:${account.TEST_ACCOUNT.studentId}`)).toMatchObject({ success: true })
+  })
+
+  it('为缓存、HTTP 和原生命令提供演示响应，敏感动作返回禁用态', async () => {
+    const fixtures = await importModule<{
+      resolveTestAccountCachePayload: (key: string) => unknown
+      resolveTestAccountHttpResponse: (method: string, url: string, data?: Record<string, unknown>) => unknown
+      resolveTestAccountNativeResponse: (command: string, args?: Record<string, unknown>) => unknown
+      resolveTestAccountForumResponse: (path: string, options?: Record<string, unknown>) => unknown
+    }>('src/utils/test_account_fixtures.js')
+
+    expect(fixtures.resolveTestAccountCachePayload('grades:2026000001')).toMatchObject({ success: true })
+    expect(fixtures.resolveTestAccountHttpResponse('post', '/api/v2/start_login', {
+      username: 'reviewer',
+      password: 'Test2026'
+    })).toMatchObject({ success: true, data: { student_id: '2026000001' } })
+    expect(fixtures.resolveTestAccountHttpResponse('post', '/api/v2/course_selection/select', {})).toMatchObject({
+      success: false,
+      demo_disabled: true
+    })
+    expect(fixtures.resolveTestAccountNativeResponse('fetch_student_info')).toMatchObject({
+      success: true,
+      student_id: '2026000001'
+    })
+    expect(fixtures.resolveTestAccountNativeResponse('resource_share_direct_url_native')).toMatchObject({
+      success: false,
+      demo_disabled: true
+    })
+    expect(fixtures.resolveTestAccountForumResponse('/threads')).toMatchObject({
+      items: expect.arrayContaining([
+        expect.objectContaining({ title: 'TestFlight 演示帖' })
+      ])
+    })
+    expect(fixtures.resolveTestAccountForumResponse('/unknown')).toMatchObject({
+      success: false,
+      demo_disabled: true
+    })
+  })
+
+  it('测试账号全局缓存只读 fixture，不覆盖真实全局缓存', async () => {
+    vi.resetModules()
+    const store = new Map<string, string>([
+      ['cache:semesters', '{"data":{"real":true},"timestamp":1}'],
+      ['hbu_training_options', '{"real":true}'],
+      ['hbu_schedule_meta', '{"real":true}']
+    ])
+    vi.stubGlobal('localStorage', {
+      get length() { return store.size },
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, String(value)),
+      removeItem: (key: string) => store.delete(key)
+    })
+
+    const account = await importModule<{
+      markTestAccountSession: () => void
+      clearTestAccountSession: () => void
+    }>('src/utils/test_account.js')
+    account.markTestAccountSession()
+    const api = await importModule<{
+      fetchWithCache: (key: string, fetcher: () => Promise<unknown>, ttl?: number) => Promise<{ data: unknown; demo?: boolean }>
+    }>('src/utils/api.js')
+
+    const result = await api.fetchWithCache('semesters', async () => {
+      throw new Error('测试账号不应请求真实学期接口')
+    })
+
+    expect(result).toMatchObject({ demo: true })
+    expect(store.get('cache:semesters')).toBe('{"data":{"real":true},"timestamp":1}')
+    expect(store.get('hbu_training_options')).toBe('{"real":true}')
+    expect(store.get('hbu_schedule_meta')).toBe('{"real":true}')
+    account.clearTestAccountSession()
+    expect(store.get('cache:semesters')).toBe('{"data":{"real":true},"timestamp":1}')
+    expect(store.get('hbu_training_options')).toBe('{"real":true}')
+    expect(store.get('hbu_schedule_meta')).toBe('{"real":true}')
+    vi.unstubAllGlobals()
+  })
+
+  it('测试账号会话标记可被写入和清理，且不删除真实全局缓存', async () => {
+    const mod = await importModule<{
+      markTestAccountSession: () => void
+      clearTestAccountSession: () => void
+      isTestAccountSession: () => boolean
+    }>('src/utils/test_account.js')
+
+    const store = new Map<string, string>([
+      ['hbu_training_options', '{"real":true}'],
+      ['hbu_schedule_meta', '{"real":true}'],
+      ['hbut_resource_dir_cache_v4', '{"real":true}'],
+      ['cache:semesters', '{"real":true}'],
+      ['cache:classroom:buildings', '{"real":true}']
+    ])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, String(value)),
+      removeItem: (key: string) => store.delete(key)
+    })
+
+    mod.markTestAccountSession()
+    expect(mod.isTestAccountSession()).toBe(true)
+    mod.clearTestAccountSession()
+    expect(mod.isTestAccountSession()).toBe(false)
+    expect(store.get('hbu_training_options')).toBe('{"real":true}')
+    expect(store.get('hbu_schedule_meta')).toBe('{"real":true}')
+    expect(store.get('hbut_resource_dir_cache_v4')).toBe('{"real":true}')
+    expect(store.get('cache:semesters')).toBe('{"real":true}')
+    expect(store.get('cache:classroom:buildings')).toBe('{"real":true}')
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/utils/test_account_fixtures.js
+++ b/src/utils/test_account_fixtures.js
@@ -1,0 +1,1107 @@
+import { TEST_ACCOUNT, isTestAccountCredentials } from './test_account.js'
+
+const TEST_STUDENT_ID = TEST_ACCOUNT.studentId
+const TEST_SEMESTER = '2025-2026-1'
+const TEST_SYNC_TIME = '2026-07-06T08:00:00+08:00'
+const DEMO_DISABLED_MESSAGE = '演示账号不执行真实操作'
+
+const clone = (value) => {
+  if (value == null) return value
+  return JSON.parse(JSON.stringify(value))
+}
+
+const success = (payload = {}) => ({
+  success: true,
+  sync_time: TEST_SYNC_TIME,
+  ...payload
+})
+
+const demoDisabled = (message = DEMO_DISABLED_MESSAGE) => ({
+  success: false,
+  demo_disabled: true,
+  error: message,
+  message
+})
+
+const resourceShareDisabled = () => ({
+  ...demoDisabled(),
+  url: 'data:text/plain;charset=utf-8,Mini-HBUT%20TestFlight%20demo%20resource',
+  needAuth: false
+})
+
+const semestersPayload = success({
+  semesters: ['2025-2026-1', '2024-2025-2', '2024-2025-1'],
+  current: TEST_SEMESTER
+})
+
+const studentInfo = {
+  student_id: TEST_STUDENT_ID,
+  name: TEST_ACCOUNT.displayName,
+  gender: '男',
+  grade: '2026',
+  college: '计算机学院',
+  major: '软件工程',
+  class_name: '软工2601',
+  ethnicity: '汉族',
+  birth_date: '2006-09-01',
+  phone: '138****2026',
+  email: 'reviewer@example.com',
+  id_number: '4201************26'
+}
+
+const studentInfoPayload = success({
+  data: studentInfo,
+  student_id: TEST_STUDENT_ID,
+  name: TEST_ACCOUNT.displayName
+})
+
+const grades = [
+  {
+    xnxq: TEST_SEMESTER,
+    term: TEST_SEMESTER,
+    kcbh: 'HBUT-DEMO-001',
+    kcmc: '高等数学 A',
+    course_name: '高等数学 A',
+    xf: '4.0',
+    course_credit: '4.0',
+    hdxf: '4.0',
+    earned_credit: '4.0',
+    zhcj: '92',
+    final_score: '92',
+    xfjd: '4.20',
+    kcxz: '必修',
+    skjs: '演示教师'
+  },
+  {
+    xnxq: TEST_SEMESTER,
+    term: TEST_SEMESTER,
+    kcbh: 'HBUT-DEMO-002',
+    kcmc: '程序设计基础',
+    course_name: '程序设计基础',
+    xf: '3.0',
+    course_credit: '3.0',
+    hdxf: '3.0',
+    earned_credit: '3.0',
+    zhcj: '88',
+    final_score: '88',
+    xfjd: '3.80',
+    kcxz: '必修',
+    skjs: '演示教师'
+  },
+  {
+    xnxq: '2024-2025-2',
+    term: '2024-2025-2',
+    kcbh: 'HBUT-DEMO-003',
+    kcmc: '大学英语',
+    course_name: '大学英语',
+    xf: '2.0',
+    course_credit: '2.0',
+    hdxf: '2.0',
+    earned_credit: '2.0',
+    zhcj: '优秀',
+    final_score: '优秀',
+    xfjd: '4.50',
+    kcxz: '公共基础',
+    skjs: '演示教师'
+  }
+]
+
+const gradesPayload = success({ data: grades })
+
+const scheduleCourses = [
+  {
+    id: 'demo-schedule-1',
+    name: '高等数学 A',
+    teacher: '演示教师',
+    room: '一教 301',
+    room_code: '一教 301',
+    building: '第一教学楼',
+    class_name: '软工2601',
+    weekday: 1,
+    period: 1,
+    start_period: 1,
+    end_period: 2,
+    djs: 2,
+    weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    week_text: '1-16周'
+  },
+  {
+    id: 'demo-schedule-2',
+    name: '程序设计基础',
+    teacher: '演示教师',
+    room: '实训楼 502',
+    room_code: '实训楼 502',
+    building: '实训楼',
+    class_name: '软工2601',
+    weekday: 3,
+    period: 5,
+    start_period: 5,
+    end_period: 6,
+    djs: 2,
+    weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    week_text: '1-16周'
+  },
+  {
+    id: 'demo-schedule-3',
+    name: '大学英语',
+    teacher: '演示教师',
+    room: '三教 204',
+    room_code: '三教 204',
+    building: '第三教学楼',
+    class_name: '软工2601',
+    weekday: 5,
+    period: 3,
+    start_period: 3,
+    end_period: 4,
+    djs: 2,
+    weeks: [1, 3, 5, 7, 9, 11, 13, 15],
+    week_text: '单周'
+  }
+]
+
+const schedulePayload = success({
+  data: scheduleCourses,
+  meta: {
+    semester: TEST_SEMESTER,
+    start_date: '2026-03-02',
+    current_week: 8,
+    total_weeks: 20,
+    vacation_notice: ''
+  }
+})
+
+const examsPayload = success({
+  data: [
+    {
+      course_name: '高等数学 A',
+      exam_date: '2026-07-15',
+      exam_time: '09:00-11:00',
+      location: '一教 201',
+      seat_no: '18'
+    },
+    {
+      course_name: '程序设计基础',
+      exam_date: '2026-07-18',
+      exam_time: '14:00-16:00',
+      location: '实训楼 401',
+      seat_no: '06'
+    }
+  ]
+})
+
+const rankingPayload = success({
+  data: {
+    student_id: TEST_STUDENT_ID,
+    name: TEST_ACCOUNT.displayName,
+    major: '软件工程',
+    gpa: '3.86',
+    avg_score: '90.2',
+    gpa_class_rank: 3,
+    gpa_class_total: 42,
+    gpa_major_rank: 12,
+    gpa_major_total: 180,
+    gpa_college_rank: 36,
+    gpa_college_total: 640,
+    avg_class_rank: 4,
+    avg_class_total: 42,
+    avg_major_rank: 15,
+    avg_major_total: 180,
+    avg_college_rank: 41,
+    avg_college_total: 640
+  }
+})
+
+const calendarPayload = success({
+  data: [
+    {
+      ny: '2026-03',
+      zc: 1,
+      monday: '2',
+      tuesday: '3',
+      wednesday: '4',
+      thursday: '5',
+      friday: '6',
+      saturday: '7',
+      sunday: '8',
+      bz: '开学周'
+    },
+    {
+      ny: '2026-03',
+      zc: 2,
+      monday: '9',
+      tuesday: '10',
+      wednesday: '11',
+      thursday: '12',
+      friday: '13',
+      saturday: '14',
+      sunday: '15',
+      bz: ''
+    }
+  ],
+  meta: {
+    semester: TEST_SEMESTER,
+    current_week: 8
+  }
+})
+
+const academicPayload = success({
+  data: {
+    summary: {
+      gpa: '3.86',
+      pjcj: '90.2',
+      hdzxf: '9.0',
+      yxkms: '3',
+      bjgms: '0',
+      gpazypm: '12/180',
+      xwjdpm: '12/180'
+    },
+    tree: [
+      {
+        nodeId: 'demo-required',
+        nodeName: '公共基础与专业基础',
+        yqzdxf: '9',
+        yqzgxf: '12',
+        kcList: grades.map((item) => ({
+          kcbh: item.kcbh,
+          kcmc: item.kcmc,
+          xf: item.xf,
+          hdxf: item.hdxf,
+          xfjd: item.xfjd,
+          zhcj: item.zhcj,
+          xnxq: item.xnxq,
+          kcxz: item.kcxz,
+          skjs: item.skjs,
+          wczt: '已修通过'
+        }))
+      }
+    ]
+  }
+})
+
+const trainingOptionsPayload = success({
+  options: {
+    grade: [{ value: '2026', label: '2026级' }],
+    kkxq: [{ value: TEST_SEMESTER, label: TEST_SEMESTER }],
+    kkyx: [{ value: 'demo-college', label: '计算机学院' }],
+    kkjys: [{ value: 'demo-jys', label: '软件工程系' }],
+    kcxz: [{ value: '必修', label: '必修' }, { value: '公共基础', label: '公共基础' }],
+    kcgs: [{ value: '理论', label: '理论' }, { value: '实验', label: '实验' }]
+  },
+  defaults: {
+    grade: '2026',
+    kkxq: TEST_SEMESTER,
+    kkyx: 'demo-college',
+    kkjys: 'demo-jys'
+  }
+})
+
+const trainingCoursesPayload = success({
+  data: grades.map((item, index) => ({
+    id: `demo-training-${index + 1}`,
+    kcbh: item.kcbh,
+    kcmc: item.kcmc,
+    xf: item.xf,
+    kcxz: item.kcxz,
+    kcgs: index === 1 ? '实验' : '理论',
+    kkyxmc: '计算机学院',
+    kkjysmc: '软件工程系',
+    kkxq: item.xnxq
+  })),
+  page: 1,
+  total: grades.length,
+  totalPages: 1
+})
+
+const electricityPayload = success({
+  balance: '42.60',
+  quantity: '128.50',
+  status: '正常'
+})
+
+const classroomBuildingsPayload = success({
+  data: ['第一教学楼', '第三教学楼', '实训楼']
+})
+
+const classroomPayload = success({
+  data: [
+    { building: '第一教学楼', room: '101', room_name: '一教 101', capacity: 80, seats: 80 },
+    { building: '第一教学楼', room: '203', room_name: '一教 203', capacity: 60, seats: 60 },
+    { building: '第三教学楼', room: '204', room_name: '三教 204', capacity: 72, seats: 72 }
+  ],
+  meta: {
+    date_str: '2026-07-06',
+    week: 8,
+    weekday: 1,
+    weekday_name: '周一',
+    semester: TEST_SEMESTER,
+    periods: [1, 2, 3, 4]
+  }
+})
+
+const loginAccessPayload = success({
+  data: {
+    current_login: {
+      client_ip: '127.0.0.1',
+      ip_location: 'TestFlight 演示环境',
+      login_time: TEST_SYNC_TIME,
+      browser: 'Mini HBUT Demo'
+    },
+    current_logins: [
+      {
+        client_ip: '127.0.0.1',
+        ip_location: 'TestFlight 演示环境',
+        login_time: TEST_SYNC_TIME,
+        browser: 'Mini HBUT Demo'
+      }
+    ],
+    app_access_records: [
+      {
+        app_name: 'mini-hbut',
+        access_time: TEST_SYNC_TIME,
+        auth_result: '成功',
+        browser: 'Mini HBUT Demo'
+      }
+    ],
+    auth_info: {
+      phone_verified: true,
+      phone: '138****2026',
+      email_verified: true,
+      email: 'reviewer@example.com',
+      password_hint: '演示账号'
+    },
+    app_access_pagination: {
+      page: 1,
+      page_size: 10,
+      total: 1,
+      total_pages: 1
+    }
+  }
+})
+
+const libraryDictPayload = success({
+  data: {
+    resourceType: [{ code: 'BK', name: '图书' }],
+    publisher: [{ code: 'demo-publisher', name: '高等教育出版社' }],
+    author: [{ code: 'demo-author', name: '演示作者' }],
+    discode1: [{ code: 'TP', name: '计算机技术' }],
+    langCode: [{ code: 'chi', name: '中文' }],
+    countryCode: [{ code: 'CN', name: '中国' }],
+    locationId: [{ code: 'demo-lib', name: '南湖校区图书馆' }]
+  }
+})
+
+const libraryBook = {
+  recordId: 'demo-book-1',
+  title: '软件工程导论',
+  author: '演示作者',
+  publisher: '高等教育出版社',
+  publishYear: '2024',
+  isbn: '9787040000000',
+  callNo: ['TP311.5/DEMO'],
+  locationName: '南湖校区图书馆',
+  processTypeName: '可借'
+}
+
+const librarySearchPayload = success({
+  data: {
+    searchResult: [libraryBook],
+    numFound: 1,
+    facetResult: {
+      resourceType: { BK: 1 },
+      publisher: { demo_publisher: 1 },
+      author: { demo_author: 1 },
+      discode1: { TP: 1 },
+      langCode: { chi: 1 },
+      countryCode: { CN: 1 },
+      locationId: { demo_lib: 1 }
+    }
+  }
+})
+
+const libraryDetailPayload = success({
+  data: {
+    detail: {
+      ...libraryBook,
+      adstract: '这是演示账号预置的图书详情，用于 TestFlight 审核浏览。'
+    },
+    holding: {
+      orderFlag: '0'
+    },
+    holding_items: [
+      {
+        locationName: '南湖校区图书馆',
+        callNo: 'TP311.5/DEMO',
+        statusName: '在架'
+      }
+    ]
+  }
+})
+
+const courseSelectionOverviewPayload = success({
+  data: {
+    tabs: [
+      {
+        xkgzid: 'demo-batch',
+        xkgzMc: '演示选课批次',
+        kklx: '01'
+      }
+    ],
+    pcencs: {
+      'demo-batch': 'demo-pcenc'
+    },
+    has_valid_pcencs: true,
+    message: '演示账号仅展示选课流程，不允许提交真实选课。'
+  }
+})
+
+const courseSelectionListPayload = success({
+  data: {
+    condition: {},
+    available_ratio: '100',
+    occupied_slots: [],
+    count: 1,
+    courses: [
+      {
+        id: 'demo-course-selection-1',
+        jxbid: 'demo-course-selection-1',
+        kcmc: '创新创业基础',
+        kcbh: 'DEMO-XK-001',
+        teacher: '演示教师',
+        xf: '2.0',
+        kcxz: '通识选修',
+        schedule: '周二第7-8节',
+        capacity: 80,
+        selected: 12
+      }
+    ],
+    message: ''
+  }
+})
+
+const campusCodeConfigPayload = success({
+  resultData: {
+    disableOnline: false,
+    enableOffline: true,
+    refreshSecond: 60
+  }
+})
+
+const campusCodePayload = success({
+  resultData: {
+    qrcode: `MINI-HBUT-DEMO-${TEST_STUDENT_ID}`,
+    balance: '88.80',
+    idSerial: TEST_STUDENT_ID,
+    userName: TEST_ACCOUNT.displayName
+  }
+})
+
+const qxzkbOptionsPayload = success({
+  data: {
+    xnxq: [{ value: TEST_SEMESTER, label: TEST_SEMESTER }],
+    yx: [{ value: 'demo-college', label: '计算机学院' }],
+    nj: [{ value: '2026', label: '2026级' }]
+  }
+})
+
+const onlineLearningPayload = success({
+  data: {
+    connected: true,
+    status: 'ready',
+    message: '演示账号学习平台数据',
+    courses: [
+      {
+        id: 'demo-online-1',
+        course_id: 'demo-online-course',
+        clazz_id: 'demo-online-class',
+        title: '软件工程导论',
+        teacher: '演示教师',
+        progress_text: '已完成 65%',
+        progress_rate: 65,
+        pending_count: 2
+      }
+    ]
+  }
+})
+
+const onlineOutlinePayload = success({
+  data: {
+    sections: [
+      {
+        id: 'demo-section-1',
+        title: '第一章 软件工程概述',
+        tasks: [
+          {
+            id: 'demo-task-1',
+            title: '课程导学',
+            type: 'video',
+            status: '已完成',
+            progress: '100%'
+          },
+          {
+            id: 'demo-task-2',
+            title: '章节测验',
+            type: 'quiz',
+            status: '未完成',
+            progress: '0%'
+          }
+        ]
+      }
+    ]
+  }
+})
+
+const schoolInboxPayload = {
+  items: [
+    {
+      id: 'demo-inbox-1',
+      title: 'TestFlight 演示通知',
+      summary: '这是演示账号的预置消息。',
+      body: '<p>这是演示账号的预置消息内容，用于审核人员浏览学校消息模块。</p>',
+      createdAt: TEST_SYNC_TIME,
+      isRead: false,
+      source: 'portal'
+    }
+  ],
+  fetchedAt: TEST_SYNC_TIME,
+  source: 'portal'
+}
+
+const forumCategories = [
+  { id: 1, slug: 'campus', name: '校园广场', description: 'TestFlight 演示校园交流' },
+  { id: 2, slug: 'study', name: '学习互助', description: '演示账号预置学习讨论' }
+]
+
+const forumThreads = [
+  {
+    id: 101,
+    category_id: 1,
+    title: 'TestFlight 演示帖',
+    content_md: '这是演示账号预置的社区帖子，不会连接真实论坛服务。',
+    author_student_id: TEST_STUDENT_ID,
+    created_at: TEST_SYNC_TIME,
+    updated_at: TEST_SYNC_TIME,
+    reply_count: 1,
+    up_count: 3,
+    down_count: 0,
+    attachment_ids: []
+  },
+  {
+    id: 102,
+    category_id: 2,
+    title: '课程资料互助演示',
+    content_md: '这里展示学习互助模块的本地演示内容。',
+    author_student_id: '2026000002',
+    created_at: TEST_SYNC_TIME,
+    updated_at: TEST_SYNC_TIME,
+    reply_count: 0,
+    up_count: 1,
+    down_count: 0,
+    attachment_ids: ['demo-forum-attachment']
+  }
+]
+
+const forumReplies = [
+  {
+    id: 201,
+    thread_id: 101,
+    content_md: '这是一条本地演示回复。',
+    author_student_id: '2026000002',
+    created_at: TEST_SYNC_TIME,
+    up_count: 2,
+    down_count: 0,
+    attachment_ids: []
+  }
+]
+
+const forumPolls = [
+  {
+    id: 301,
+    title: 'TestFlight 审核体验投票',
+    description: '本地演示投票，不会写入远端。',
+    status: 'active',
+    created_at: TEST_SYNC_TIME,
+    my_vote_option_id: null,
+    options: [
+      { id: 1, label: '界面清晰', score: 10, votes: 8 },
+      { id: 2, label: '功能完整', score: 9, votes: 6 },
+      { id: 3, label: '需要改进', score: 3, votes: 1 }
+    ]
+  }
+]
+
+const forumProfile = {
+  student_id: TEST_STUDENT_ID,
+  nickname: TEST_ACCOUNT.displayName,
+  avatar_url: '',
+  bio: 'TestFlight 本地演示社区资料',
+  is_admin: false
+}
+
+const forumStats = {
+  thread_count: 1,
+  reply_count: 1,
+  bookmark_count: 1,
+  checkin_count: 3
+}
+
+const forumBadges = [
+  { badge_key: 'reviewer', display_name: '审核体验官' }
+]
+
+const forumDemoDisabled = (message = '未知测试账号 forum 请求已拦截') => ({
+  success: false,
+  demo_disabled: true,
+  error: message,
+  message
+})
+
+const resourceShareXml = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype><d:getcontentlength>0</d:getcontentlength></d:prop></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/TestFlight演示资料/</d:href>
+    <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype><d:getcontentlength>0</d:getcontentlength></d:prop></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/TestFlight演示资料/使用说明.txt</d:href>
+    <d:propstat><d:prop><d:resourcetype/><d:getcontentlength>128</d:getcontentlength><d:getcontenttype>text/plain</d:getcontenttype></d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`
+
+const cachePayloads = new Map([
+  ['semesters', semestersPayload],
+  [`grades:${TEST_STUDENT_ID}`, gradesPayload],
+  [`schedule:${TEST_STUDENT_ID}`, schedulePayload],
+  [`schedule:${TEST_STUDENT_ID}:${TEST_SEMESTER}`, schedulePayload],
+  [`studentinfo:${TEST_STUDENT_ID}`, studentInfoPayload],
+  [`student_info:${TEST_STUDENT_ID}`, studentInfoPayload],
+  [`exams:${TEST_STUDENT_ID}:current`, examsPayload],
+  [`exams:${TEST_STUDENT_ID}:${TEST_SEMESTER}`, examsPayload],
+  [`ranking:${TEST_STUDENT_ID}`, rankingPayload],
+  [`ranking:${TEST_STUDENT_ID}:all`, rankingPayload],
+  [`ranking:${TEST_STUDENT_ID}:current`, rankingPayload],
+  [`ranking:${TEST_STUDENT_ID}:${TEST_SEMESTER}`, rankingPayload],
+  [`calendar:${TEST_STUDENT_ID}:current`, calendarPayload],
+  [`calendar:${TEST_STUDENT_ID}:${TEST_SEMESTER}`, calendarPayload],
+  [`academic:${TEST_STUDENT_ID}:1`, academicPayload],
+  [`academic:${TEST_STUDENT_ID}:0`, academicPayload],
+  [`academic:${TEST_STUDENT_ID}:2`, academicPayload],
+  [`academic:${TEST_STUDENT_ID}:4`, academicPayload],
+  [`training:options:${TEST_STUDENT_ID}`, trainingOptionsPayload],
+  [`training:jys:${TEST_STUDENT_ID}:demo-college`, success({ data: trainingOptionsPayload.options.kkjys })],
+  [`electricity:${TEST_STUDENT_ID}:light`, electricityPayload],
+  ['classroom:buildings', classroomBuildingsPayload]
+])
+
+export const getTestAccountGrades = () => clone(grades)
+
+export const seedTestAccountCaches = (setCachedData, studentId = TEST_STUDENT_ID) => {
+  if (typeof setCachedData !== 'function') return []
+  const sid = String(studentId || TEST_STUDENT_ID).trim() || TEST_STUDENT_ID
+  const entries = [
+    [`grades:${sid}`, gradesPayload],
+    [`schedule:${sid}`, schedulePayload],
+    [`schedule:${sid}:${TEST_SEMESTER}`, schedulePayload],
+    [`studentinfo:${sid}`, studentInfoPayload],
+    [`student_info:${sid}`, studentInfoPayload],
+    [`exams:${sid}:current`, examsPayload],
+    [`exams:${sid}:${TEST_SEMESTER}`, examsPayload],
+    [`ranking:${sid}:current`, rankingPayload],
+    [`ranking:${sid}:all`, rankingPayload],
+    [`calendar:${sid}:current`, calendarPayload],
+    [`calendar:${sid}:${TEST_SEMESTER}`, calendarPayload],
+    [`academic:${sid}:1`, academicPayload],
+    [`training:options:${sid}`, trainingOptionsPayload],
+    [`training:jys:${sid}:demo-college`, success({ data: trainingOptionsPayload.options.kkjys })],
+    [`training:${sid}:1:${JSON.stringify(trainingOptionsPayload.defaults)}`, trainingCoursesPayload],
+    [`electricity:${sid}:light`, electricityPayload]
+  ]
+
+  entries.forEach(([key, payload]) => setCachedData(key, clone(payload)))
+  return entries.map(([key]) => key)
+}
+
+export const resolveTestAccountCachePayload = (key) => {
+  const text = String(key || '').trim()
+  if (!text) return null
+  if (cachePayloads.has(text)) return clone(cachePayloads.get(text))
+  if (text.startsWith(`grades:${TEST_STUDENT_ID}`)) return clone(gradesPayload)
+  if (text.startsWith(`schedule:${TEST_STUDENT_ID}`)) return clone(schedulePayload)
+  if (text.startsWith(`studentinfo:${TEST_STUDENT_ID}`) || text.startsWith(`student_info:${TEST_STUDENT_ID}`)) return clone(studentInfoPayload)
+  if (text.startsWith(`exams:${TEST_STUDENT_ID}`)) return clone(examsPayload)
+  if (text.startsWith(`ranking:${TEST_STUDENT_ID}`)) return clone(rankingPayload)
+  if (text.startsWith(`calendar:${TEST_STUDENT_ID}`)) return clone(calendarPayload)
+  if (text.startsWith(`academic:${TEST_STUDENT_ID}`)) return clone(academicPayload)
+  if (text.startsWith(`training:options:${TEST_STUDENT_ID}`)) return clone(trainingOptionsPayload)
+  if (text.startsWith(`training:jys:${TEST_STUDENT_ID}`)) return success({ data: clone(trainingOptionsPayload.options.kkjys) })
+  if (text.startsWith(`training:${TEST_STUDENT_ID}:`)) return clone(trainingCoursesPayload)
+  if (text.startsWith(`electricity:${TEST_STUDENT_ID}:`)) return clone(electricityPayload)
+  if (text.startsWith('classroom:')) return text === 'classroom:buildings' ? clone(classroomBuildingsPayload) : clone(classroomPayload)
+  return null
+}
+
+export const resolveTestAccountHttpResponse = (method, url, data = {}) => {
+  const httpMethod = String(method || '').toLowerCase()
+  const path = String(url || '')
+
+  if (httpMethod === 'post' && path.includes('/v2/start_login')) {
+    if (!isTestAccountCredentials(data?.username, data?.password)) return null
+    return success({
+      data: {
+        student_id: TEST_STUDENT_ID,
+        name: TEST_ACCOUNT.displayName,
+        login_method: 'test_account'
+      }
+    })
+  }
+
+  if (httpMethod === 'get' && path.includes('/v2/semesters')) return clone(semestersPayload)
+  if (httpMethod === 'get' && path.includes('/v2/qxzkb/options')) return clone(qxzkbOptionsPayload)
+  if (httpMethod === 'get' && path.includes('/v2/classroom/buildings')) return clone(classroomBuildingsPayload)
+
+  if (httpMethod !== 'post') return null
+  if (path.includes('/v2/quick_fetch')) return clone(gradesPayload)
+  if (path.includes('/v2/grade_teacher')) return success({ by_kcbh: {}, semesters: {} })
+  if (path.includes('/v2/schedule/custom/list')) return success({ data: [] })
+  if (path.includes('/v2/schedule/custom/add') || path.includes('/v2/schedule/custom/update') || path.includes('/v2/schedule/custom/delete')) return demoDisabled()
+  if (path.includes('/v2/schedule/export_calendar')) return success({ url: 'mini-hbut-demo-calendar://readonly' })
+  if (path.includes('/v2/schedule/query')) return clone(schedulePayload)
+  if (path.includes('/v2/student_login_access')) return clone(loginAccessPayload)
+  if (path.includes('/v2/student_info')) return clone(studentInfoPayload)
+  if (path.includes('/v2/exams')) return clone(examsPayload)
+  if (path.includes('/v2/ranking')) return clone(rankingPayload)
+  if (path.includes('/v2/calendar')) return clone(calendarPayload)
+  if (path.includes('/v2/academic_progress')) return clone(academicPayload)
+  if (path.includes('/v2/classroom/query')) return clone(classroomPayload)
+  if (path.includes('/v2/training_plan/options')) return clone(trainingOptionsPayload)
+  if (path.includes('/v2/training_plan/jys')) return success({ data: clone(trainingOptionsPayload.options.kkjys) })
+  if (path.includes('/v2/training_plan')) return clone(trainingCoursesPayload)
+  if (path.includes('/v2/electricity/balance')) return clone(electricityPayload)
+  if (path.includes('/v2/campus_code/config')) return clone(campusCodeConfigPayload)
+  if (path.includes('/v2/campus_code/qrcode')) return clone(campusCodePayload)
+  if (path.includes('/v2/campus_code/order_status')) return success({ resultData: { status: '5' } })
+  if (path.includes('/v2/library/dict')) return clone(libraryDictPayload)
+  if (path.includes('/v2/library/search')) return clone(librarySearchPayload)
+  if (path.includes('/v2/library/detail')) return clone(libraryDetailPayload)
+  if (path.includes('/v2/qxzkb/jcinfo')) return success({ data: [] })
+  if (path.includes('/v2/qxzkb/zyxx')) return success({ data: [] })
+  if (path.includes('/v2/qxzkb/kkjys')) return success({ data: [] })
+  if (path.includes('/v2/qxzkb/query')) return success({ data: [] })
+  if (path.includes('/v2/course_selection/overview')) return clone(courseSelectionOverviewPayload)
+  if (path.includes('/v2/course_selection/list')) return clone(courseSelectionListPayload)
+  if (path.includes('/v2/course_selection/end_time')) return success({ data: { remaining_seconds: 3600, countdown_text: '01:00:00', is_preview: false } })
+  if (path.includes('/v2/course_selection/selected_courses')) return success({ data: { courses: [] } })
+  if (path.includes('/v2/course_selection/child_classes')) return success({ data: { classes: [] } })
+  if (path.includes('/v2/course_selection/select') || path.includes('/v2/course_selection/withdraw')) return demoDisabled()
+  if (path.includes('/v2/course_selection/detail_intro')) return success({ data: { intro: '演示课程说明。' } })
+  if (path.includes('/v2/course_selection/detail_teacher')) return success({ data: { teachers: [{ name: '演示教师', title: '讲师' }] } })
+  if (path.includes('/v2/online_learning/sync_now') || path.includes('/v2/online_learning/clear_cache')) return demoDisabled()
+  if (path.includes('/v2/online_learning/overview')) return clone(onlineLearningPayload)
+  if (path.includes('/v2/online_learning/sync_runs')) return success({ data: { runs: [] } })
+  if (path.includes('/v2/chaoxing/session_status')) return success({ data: { connected: true, status: 'ready', message: '演示会话已连接' } })
+  if (path.includes('/v2/chaoxing/courses') || path.includes('/v2/yuketang/courses')) return clone(onlineLearningPayload)
+  if (path.includes('/v2/chaoxing/course_outline') || path.includes('/v2/yuketang/course_outline')) return clone(onlineOutlinePayload)
+  if (path.includes('/v2/chaoxing/course_progress') || path.includes('/v2/yuketang/course_progress')) return success({ data: { percent: 65, progress_text: '已完成 65%' } })
+  if (path.includes('/v2/chaoxing/knowledge_cards') || path.includes('/v2/chaoxing/video_status') || path.includes('/v2/yuketang/course_chapters') || path.includes('/v2/yuketang/leaf_info')) return clone(onlineOutlinePayload)
+  if (path.includes('/v2/chaoxing/report_progress') || path.includes('/v2/yuketang/heartbeat') || path.includes('/v2/chaoxing/launch_url') || path.includes('/v2/yuketang/qr_login')) return demoDisabled()
+
+  return null
+}
+
+export const resolveTestAccountNativeResponse = (command, args = {}) => {
+  const name = String(command || '').trim()
+  if (!name) return null
+
+  if (name === 'fetch_student_info') return clone(studentInfoPayload)
+  if (name === 'sync_grades') return clone(gradesPayload)
+  if (name === 'sync_schedule') return clone(schedulePayload)
+  if (name === 'fetch_semesters') return clone(semestersPayload)
+  if (name === 'fetch_exams') return clone(examsPayload)
+  if (name === 'fetch_ranking') return clone(rankingPayload)
+  if (name === 'fetch_calendar_data') return clone(calendarPayload)
+  if (name === 'fetch_academic_progress') return clone(academicPayload)
+  if (name === 'fetch_training_plan_options') return clone(trainingOptionsPayload)
+  if (name === 'fetch_training_plan_jys') return success({ data: clone(trainingOptionsPayload.options.kkjys) })
+  if (name === 'fetch_training_plan_courses') return clone(trainingCoursesPayload)
+  if (name === 'fetch_classroom_buildings') return clone(classroomBuildingsPayload)
+  if (name === 'fetch_classrooms') return clone(classroomPayload)
+  if (name === 'fetch_personal_login_access_info') return clone(loginAccessPayload)
+  if (name === 'get_grade_teacher_cache' || name === 'sync_grade_teachers_current_semester') return success({ by_kcbh: {}, semesters: {} })
+  if (name === 'list_custom_schedule_courses' || name === 'list_all_custom_schedule_courses') return success({ data: [] })
+  if (name === 'add_custom_schedule_course' || name === 'update_custom_schedule_course' || name === 'delete_custom_schedule_course') return demoDisabled()
+  if (name === 'export_schedule_calendar') return success({ url: 'mini-hbut-demo-calendar://readonly' })
+  if (name === 'electricity_query_account') {
+    return {
+      success: true,
+      resultData: {
+        utilityStatusName: '正常',
+        sync_time: TEST_SYNC_TIME,
+        templateList: [
+          { code: 'balance', value: '42.60' },
+          { code: 'quantity', value: '128.50' }
+        ]
+      }
+    }
+  }
+  if (name.startsWith('campus_code_')) {
+    if (name.includes('config')) return clone(campusCodeConfigPayload)
+    if (name.includes('qrcode')) return clone(campusCodePayload)
+    return success({ resultData: { status: '5' } })
+  }
+  if (name.startsWith('fetch_library') || name.startsWith('search_library')) {
+    if (name.includes('dict')) return clone(libraryDictPayload)
+    return clone(librarySearchPayload)
+  }
+  if (name === 'fetch_library_book_detail') return clone(libraryDetailPayload)
+  if (name.startsWith('fetch_qxzkb')) return success({ data: [] })
+  if (name.includes('course_selection')) {
+    if (name.includes('select_') || name.includes('withdraw')) return demoDisabled()
+    return success({ data: {} })
+  }
+  if (name.startsWith('online_learning') || name.startsWith('chaoxing_') || name.startsWith('yuketang_')) {
+    if (name.includes('sync') || name.includes('clear') || name.includes('report') || name.includes('heartbeat') || name.includes('qr_login')) return demoDisabled()
+    return clone(onlineLearningPayload)
+  }
+  if (name === 'fetch_transaction_history') return success({ data: [] })
+  if (name === 'school_inbox_fetch') return clone(schoolInboxPayload)
+  if (name === 'school_inbox_detail_fetch') {
+    const fallback = args?.fallback && typeof args.fallback === 'object' ? args.fallback : schoolInboxPayload.items[0]
+    return { ...clone(fallback), body: fallback.body || schoolInboxPayload.items[0].body }
+  }
+  if (name === 'school_inbox_mark_read') return { success: true }
+  if (name === 'resource_share_list_dir_native') return { success: true, xml: resourceShareXml }
+  if (name === 'resource_share_direct_url_native') return resourceShareDisabled()
+  if (name === 'resource_share_fetch_file_payload_native') return demoDisabled()
+  if (name === 'get_cookies') return ''
+  if (name === 'restore_session' || name === 'restore_latest_session' || name === 'login') return { student_id: TEST_STUDENT_ID, name: TEST_ACCOUNT.displayName }
+  if (name === 'logout' || name === 'refresh_session' || name === 'set_offline_user_context') return { success: true }
+  if (name === 'refresh_electricity_token') return { success: true }
+  if (name === 'get_ocr_runtime_status') return { success: true, status: 'disabled', demo: true }
+  if (name === 'hbut_ai_init' || name === 'hbut_ai_chat' || name === 'hbut_ai_upload') return demoDisabled('演示账号不调用 AI 服务')
+
+  return null
+}
+
+const parseForumPath = (path) => {
+  try {
+    return new URL(String(path || '/'), 'https://mini-hbut.local')
+  } catch {
+    return new URL('/', 'https://mini-hbut.local')
+  }
+}
+
+const isFormDataPayload = (value) =>
+  typeof FormData !== 'undefined' && value instanceof FormData
+
+const normalizeForumBody = (body) =>
+  body && typeof body === 'object' && !isFormDataPayload(body) ? body : {}
+
+const findForumThread = (threadId) => {
+  const id = Number(threadId || 0)
+  return forumThreads.find((thread) => Number(thread.id) === id) || forumThreads[0]
+}
+
+export const resolveTestAccountForumResponse = (path, options = {}) => {
+  const method = String(options?.method || 'GET').toUpperCase()
+  const url = parseForumPath(path)
+  const pathname = url.pathname.replace(/\/+$/, '') || '/'
+  const body = normalizeForumBody(options?.body)
+
+  if (pathname === '/auth/token') {
+    return {
+      token: 'test-account-forum-token',
+      expires_at: 4102444800
+    }
+  }
+
+  if (method === 'GET' && pathname === '/categories') {
+    return { items: clone(forumCategories) }
+  }
+  if (method === 'POST' && pathname === '/categories') {
+    return {
+      id: Number(body.id || 99),
+      slug: String(body.slug || 'demo').trim() || 'demo',
+      name: String(body.name || '演示版块').trim() || '演示版块',
+      description: String(body.description || '').trim()
+    }
+  }
+
+  if (method === 'GET' && pathname === '/threads/hot') {
+    return { items: clone(forumThreads) }
+  }
+  if (method === 'GET' && pathname === '/threads') {
+    const categoryId = Number(url.searchParams.get('category_id') || 0)
+    const items = categoryId
+      ? forumThreads.filter((thread) => Number(thread.category_id) === categoryId)
+      : forumThreads
+    return { items: clone(items) }
+  }
+  if (method === 'GET' && pathname === '/search') {
+    const query = String(url.searchParams.get('q') || '').trim().toLowerCase()
+    const items = query
+      ? forumThreads.filter((thread) =>
+        `${thread.title} ${thread.content_md}`.toLowerCase().includes(query)
+      )
+      : forumThreads
+    return { items: clone(items) }
+  }
+  if (method === 'POST' && pathname === '/threads') {
+    return {
+      ...clone(forumThreads[0]),
+      id: 901,
+      category_id: Number(body.category_id || forumCategories[0].id),
+      title: String(body.title || '演示新帖').trim() || '演示新帖',
+      content_md: String(body.content_md || '演示账号本地发帖内容').trim(),
+      attachment_ids: Array.isArray(body.attachment_ids) ? clone(body.attachment_ids) : [],
+      reply_count: 0,
+      created_at: TEST_SYNC_TIME,
+      updated_at: TEST_SYNC_TIME
+    }
+  }
+
+  const threadMatch = pathname.match(/^\/threads\/([^/]+)$/)
+  if (method === 'GET' && threadMatch) {
+    const thread = findForumThread(threadMatch[1])
+    return {
+      thread: clone(thread),
+      replies: Number(thread.id) === 101 ? clone(forumReplies) : []
+    }
+  }
+
+  const replyMatch = pathname.match(/^\/threads\/([^/]+)\/replies$/)
+  if (method === 'POST' && replyMatch) {
+    return {
+      id: 902,
+      thread_id: Number(replyMatch[1] || 0),
+      content_md: String(body.content_md || '演示账号本地回复').trim(),
+      author_student_id: TEST_STUDENT_ID,
+      created_at: TEST_SYNC_TIME,
+      up_count: 0,
+      down_count: 0,
+      attachment_ids: Array.isArray(body.attachment_ids) ? clone(body.attachment_ids) : []
+    }
+  }
+
+  if (method === 'POST' && (
+    /^\/posts\/[^/]+\/reactions$/.test(pathname) ||
+    /^\/threads\/[^/]+\/bookmark$/.test(pathname) ||
+    pathname === '/follows' ||
+    pathname === '/reports' ||
+    pathname === '/messages' ||
+    pathname === '/checkins'
+  )) {
+    return { success: true, demo: true }
+  }
+
+  if (method === 'GET' && pathname === '/polls') {
+    return { items: clone(forumPolls) }
+  }
+  if (method === 'POST' && /^\/polls\/[^/]+\/votes$/.test(pathname)) {
+    return {
+      ...clone(forumPolls[0]),
+      my_vote_option_id: Number(body.option_id || forumPolls[0].options[0].id)
+    }
+  }
+  if (method === 'POST' && pathname === '/admin/polls') {
+    return {
+      id: 903,
+      title: String(body.title || '演示管理员投票').trim() || '演示管理员投票',
+      description: String(body.description || '').trim(),
+      status: 'active',
+      created_at: TEST_SYNC_TIME,
+      my_vote_option_id: null,
+      options: Array.isArray(body.options)
+        ? body.options.map((option, index) => ({
+          id: index + 1,
+          label: String(option.label || `选项 ${index + 1}`).trim(),
+          score: Number(option.score || 0),
+          votes: 0
+        }))
+        : clone(forumPolls[0].options)
+    }
+  }
+  if (method === 'POST' && /^\/admin\/polls\/[^/]+\/close$/.test(pathname)) {
+    return {
+      ...clone(forumPolls[0]),
+      status: 'closed'
+    }
+  }
+
+  if (method === 'GET' && pathname === '/me/summary') {
+    return {
+      profile: clone(forumProfile),
+      stats: clone(forumStats)
+    }
+  }
+  if (method === 'GET' && pathname === '/me/threads') return { items: clone(forumThreads.slice(0, 1)) }
+  if (method === 'GET' && pathname === '/me/replies') {
+    return {
+      items: forumReplies.map((reply) => ({
+        ...clone(reply),
+        thread_title: forumThreads.find((thread) => Number(thread.id) === Number(reply.thread_id))?.title || '演示帖子'
+      }))
+    }
+  }
+  if (method === 'GET' && pathname === '/me/bookmarks') return { items: clone(forumThreads.slice(1, 2)) }
+  if (method === 'GET' && pathname === '/notifications') {
+    return {
+      items: [
+        {
+          id: 401,
+          title: 'TestFlight 演示通知',
+          content: '这是本地演示社区通知。',
+          created_at: TEST_SYNC_TIME,
+          is_read: 0
+        }
+      ]
+    }
+  }
+  if (method === 'GET' && pathname === '/messages') {
+    return {
+      items: [
+        {
+          id: 501,
+          sender_student_id: '2026000002',
+          receiver_student_id: TEST_STUDENT_ID,
+          content: '欢迎体验 Mini-HBUT 社区演示。',
+          created_at: TEST_SYNC_TIME
+        }
+      ]
+    }
+  }
+  if (method === 'GET' && pathname === '/badges') return { items: clone(forumBadges) }
+
+  const userMatch = pathname.match(/^\/users\/([^/]+)$/)
+  if (method === 'GET' && userMatch) {
+    const target = decodeURIComponent(userMatch[1])
+    return {
+      profile: {
+        ...clone(forumProfile),
+        student_id: target,
+        nickname: target === TEST_STUDENT_ID ? TEST_ACCOUNT.displayName : `演示用户 ${target.slice(-4)}`
+      },
+      stats: clone(forumStats),
+      badges: clone(forumBadges)
+    }
+  }
+
+  if (method === 'POST' && pathname === '/attachments') {
+    return {
+      attachment_id: 'demo-forum-attachment',
+      url: 'data:text/plain;charset=utf-8,Mini-HBUT%20forum%20demo%20attachment'
+    }
+  }
+
+  if (method === 'GET' && pathname === '/backups') return { items: [] }
+  if (method === 'GET' && pathname === '/admin/reports') return { items: [] }
+  if (method === 'GET' && pathname === '/admin/users') return { items: [] }
+  if (method === 'GET' && pathname === '/admin/backups') return { items: [] }
+  if (method === 'POST' && pathname.startsWith('/admin/')) {
+    return { success: true, demo: true }
+  }
+
+  return forumDemoDisabled()
+}

--- a/src/utils/testflight_test_account_contract.spec.ts
+++ b/src/utils/testflight_test_account_contract.spec.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readSource = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8')
+
+describe('TestFlight 演示账号接入契约', () => {
+  it('LoginV3 在真实门户请求前处理测试账号登录', () => {
+    const source = readSource('src/components/LoginV3.vue')
+    const testAccountIndex = source.indexOf('handleTestAccountLogin')
+    const realLoginIndex = source.indexOf("axios.post(`${API_BASE}/v2/start_login`")
+
+    expect(source).toContain("from '../utils/test_account.js'")
+    expect(source).toContain('isTestAccountCredentials(username.value, password.value)')
+    expect(source).toContain('markTestAccountSession()')
+    expect(source).toContain('seedTestAccountCaches(setCachedData')
+    expect(testAccountIndex).toBeGreaterThanOrEqual(0)
+    expect(realLoginIndex).toBeGreaterThan(testAccountIndex)
+  })
+
+  it('App.vue 恢复测试账号会话并跳过真实后台副作用', () => {
+    const source = readSource('src/App.vue')
+
+    expect(source).toContain("from './utils/test_account.js'")
+    expect(source).toContain("from './utils/test_account_fixtures.js'")
+    expect(source).toContain('restoreTestAccountSession()')
+    expect(source).toContain('isTestAccountSession()')
+    expect(source).toContain('seedTestAccountCaches(setCachedData')
+    expect(source).toContain('if (!isTestAccountSession())')
+    expect(source).toContain('clearTestAccountSession()')
+    expect(source).toContain('clearTestAccountRuntimeCaches()')
+    expect(source).not.toContain("clearCacheByPrefix('semesters')")
+    expect(source).not.toContain("clearCacheByPrefix('classroom:buildings')")
+    expect(source).toMatch(/if \(!wasTestAccountSession\) \{\s*clearWidgetForLogout\(\)\.catch\(\(\) => \{\}\)\s*\}/)
+  })
+
+  it('缓存、HTTP 和 native 调用层均接入测试账号演示响应', () => {
+    const apiSource = readSource('src/utils/api.js')
+    const adapterSource = readSource('src/utils/axios_adapter.js')
+    const nativeSource = readSource('src/platform/native.ts')
+
+    expect(apiSource).toContain("from './test_account.js'")
+    expect(apiSource).toContain("from './test_account_fixtures.js'")
+    expect(apiSource).toContain('resolveTestAccountCachePayload(key)')
+    expect(adapterSource).toContain("from './test_account.js'")
+    expect(adapterSource).toContain('resolveTestAccountHttpResponse')
+    expect(nativeSource).toContain("from '../utils/test_account.js'")
+    expect(nativeSource).toContain('resolveTestAccountNativeResponse(command, args)')
+  })
+
+  it('直接 fetch 的资料分享和 AI 模块在测试账号下禁用真实网络动作', () => {
+    const resourceShareSource = readSource('src/components/ResourceShareView.vue')
+    const aiChatSource = readSource('src/components/AiChatView.vue')
+    const forumApiSource = readSource('src/utils/forum_api.js')
+    const fixtureSource = readSource('src/utils/test_account_fixtures.js')
+    const remoteConfigSource = readSource('src/utils/remote_config.js')
+
+    expect(resourceShareSource).toContain("from '../utils/test_account.js'")
+    expect(resourceShareSource).toContain('buildTestAccountResourceShareItems')
+    expect(resourceShareSource).toContain('if (isTestAccountSession())')
+    expect(resourceShareSource).toContain('return getTestAccountResourceDirectUrl')
+    expect(resourceShareSource).toContain('const buildPreviewUrlCandidates = (path, signed) => {')
+    expect(resourceShareSource).toContain('if (isTestAccountSession()) return [String(signed?.url || \'\').trim()].filter(Boolean)')
+    expect(resourceShareSource).toContain('const openDownload = async () => {')
+    expect(resourceShareSource).toContain('演示账号不下载真实资料')
+    expect(aiChatSource).toContain("from '../utils/test_account.js'")
+    expect(aiChatSource).toContain('buildTestAccountAiReply')
+    expect(aiChatSource).toContain('if (isTestAccountSession())')
+    expect(aiChatSource).toContain('token.value = \'test-account-token\'')
+    expect(aiChatSource).toMatch(/const postJson = async[\s\S]*if \(isTestAccountSession\(\)\)/)
+    expect(aiChatSource).toContain('const syncRemoteHistory = async () => {')
+    expect(aiChatSource).toContain('演示账号不会调用外部 AI 服务')
+    expect(forumApiSource).toContain("from './test_account.js'")
+    expect(forumApiSource).toContain("from './test_account_fixtures.js'")
+    expect(forumApiSource).toContain('resolveTestAccountForumResponse')
+    expect(forumApiSource).toContain('if (isTestAccountSession())')
+    expect(fixtureSource).toContain('未知测试账号 forum 请求已拦截')
+    expect(remoteConfigSource).toContain("from './test_account.js'")
+    expect(remoteConfigSource).toContain('if (isTestAccountSession())')
+  })
+
+  it('测试账号未知 HTTP 和 native 调用默认拒绝，不继续真实请求', () => {
+    const adapterSource = readSource('src/utils/axios_adapter.js')
+    const nativeSource = readSource('src/platform/native.ts')
+
+    expect(adapterSource).toContain('未知测试账号 HTTP 请求已拦截')
+    expect(adapterSource).toContain('demo_disabled: true')
+    expect(nativeSource).toContain('未知测试账号 invoke 已拦截')
+    expect(nativeSource).toContain('demo_disabled: true')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a TestFlight demo account: `reviewer` / `Test2026`, mapped to virtual student ID `2026000001`.
- Seed and resolve local demo fixtures for grades, schedule, exams, ranking, calendar, academic progress, training plan, electricity, classroom, library, course selection, campus code, school inbox, forum, AI, and resource sharing.
- Guard test-account sessions from real portal/WebDAV/AI/native/remote-config side effects and avoid overwriting real global caches.

## Test Plan
- [x] `npx vitest run src/utils/test_account.spec.ts src/utils/testflight_test_account_contract.spec.ts --testTimeout=60000`
- [x] `npx vitest run src/utils/widget_snapshot_mask_a11y.spec.ts --testTimeout=60000`
- [x] `npm run build`
- [x] `git diff --check` (only Windows CRLF warnings)
- [ ] `npm test -- --testTimeout=60000` currently has pre-existing failures in `forum_view_identity_contract.spec.ts`, `hbut_memory_match_game.spec.ts`, and `hbut_monopoly_game.spec.ts` (8 failed / 339 passed).

Closes #172