### PR TITLE
feat(usage-stats): track local module usage and sync to server

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -324,7 +324,11 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> Result<()> {
 
     ensure_schema_migration(&conn, 1, "WAL journal_mode (open_connection)")?;
     ensure_schema_migration(&conn, 2, "chaoxing_checkin_log")?;
-    ensure_schema_migration(&conn, 3, "app_usage_events/sessions/daily_rollup/device_profile")?;
+    ensure_schema_migration(
+        &conn,
+        3,
+        "app_usage_events/sessions/daily_rollup/device_profile",
+    )?;
 
     Ok(())
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -320,11 +320,18 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> Result<()> {
     )?;
 
     migrate_add_chaoxing_checkin_log(&conn)?;
+    migrate_add_app_usage_tables(&conn)?;
 
     ensure_schema_migration(&conn, 1, "WAL journal_mode (open_connection)")?;
     ensure_schema_migration(&conn, 2, "chaoxing_checkin_log")?;
+    ensure_schema_migration(&conn, 3, "app_usage_events/sessions/daily_rollup/device_profile")?;
 
     Ok(())
+}
+
+/// 打开 SQLite 连接（供 usage_stats 等模块复用 HBUT_DB_PATH）。
+pub fn open_db_connection<P: AsRef<Path>>(path: P) -> Result<Connection> {
+    open_connection(path)
 }
 
 /// 记录已应用的 schema 版本，便于追溯与回滚说明。
@@ -351,6 +358,79 @@ fn ensure_schema_migration(conn: &Connection, version: i64, description: &str) -
             params![version, description],
         )?;
     }
+    Ok(())
+}
+
+/// 创建本地试用频率统计相关表（幂等迁移）。
+fn migrate_add_app_usage_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS app_usage_events (
+            event_id TEXT PRIMARY KEY,
+            student_id TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            target_kind TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            load_mode TEXT NOT NULL DEFAULT 'native',
+            launch_mode TEXT NOT NULL DEFAULT '',
+            duration_ms INTEGER NOT NULL DEFAULT 0,
+            app_version TEXT NOT NULL DEFAULT '',
+            runtime TEXT NOT NULL DEFAULT '',
+            platform TEXT NOT NULL DEFAULT '',
+            extra_json TEXT NOT NULL DEFAULT '{}',
+            occurred_at INTEGER NOT NULL,
+            uploaded_at INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_app_usage_events_student_time
+            ON app_usage_events (student_id, occurred_at DESC);
+
+        CREATE INDEX IF NOT EXISTS idx_app_usage_events_upload
+            ON app_usage_events (uploaded_at, occurred_at ASC);
+
+        CREATE TABLE IF NOT EXISTS app_usage_sessions (
+            session_id TEXT PRIMARY KEY,
+            student_id TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER NOT NULL,
+            duration_ms INTEGER NOT NULL DEFAULT 0,
+            app_version TEXT NOT NULL DEFAULT '',
+            runtime TEXT NOT NULL DEFAULT '',
+            platform TEXT NOT NULL DEFAULT '',
+            uploaded_at INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_app_usage_sessions_upload
+            ON app_usage_sessions (uploaded_at, started_at ASC);
+
+        CREATE TABLE IF NOT EXISTS app_usage_daily_rollup (
+            student_id TEXT NOT NULL,
+            stat_date TEXT NOT NULL,
+            target_kind TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            load_mode TEXT NOT NULL DEFAULT 'native',
+            open_count INTEGER NOT NULL DEFAULT 0,
+            duration_ms_total INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (student_id, stat_date, target_kind, target_id, load_mode)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_app_usage_daily_rollup_student_date
+            ON app_usage_daily_rollup (student_id, stat_date DESC);
+
+        CREATE TABLE IF NOT EXISTS app_usage_device_profile (
+            device_id TEXT PRIMARY KEY,
+            student_id TEXT NOT NULL,
+            app_version TEXT NOT NULL DEFAULT '',
+            runtime TEXT NOT NULL DEFAULT '',
+            platform TEXT NOT NULL DEFAULT '',
+            os_version TEXT NOT NULL DEFAULT '',
+            arch TEXT NOT NULL DEFAULT '',
+            locale TEXT NOT NULL DEFAULT '',
+            updated_at INTEGER NOT NULL DEFAULT 0
+        );",
+    )?;
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,9 +55,9 @@ use http_client::HbutClient;
 
 use modules::ai::*;
 use modules::chaoxing_checkin::commands as chaoxing_checkin_cmd;
-use modules::usage_stats::commands as usage_stats_cmd;
 use modules::module_bundle::OpenModuleBundleWindowRequest;
 use modules::one_code::*;
+use modules::usage_stats::commands as usage_stats_cmd;
 
 // ... imports
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ use http_client::HbutClient;
 
 use modules::ai::*;
 use modules::chaoxing_checkin::commands as chaoxing_checkin_cmd;
+use modules::usage_stats::commands as usage_stats_cmd;
 use modules::module_bundle::OpenModuleBundleWindowRequest;
 use modules::one_code::*;
 
@@ -6649,6 +6650,12 @@ pub fn run() {
             chaoxing_checkin_cmd::chaoxing_checkin_decode_qr_image,
             chaoxing_checkin_cmd::chaoxing_checkin_capture_screen_qr,
             chaoxing_checkin_cmd::clear_chaoxing_data,
+            usage_stats_cmd::usage_stats_record_event,
+            usage_stats_cmd::usage_stats_end_session,
+            usage_stats_cmd::usage_stats_upsert_device_profile,
+            usage_stats_cmd::usage_stats_get_personal_summary,
+            usage_stats_cmd::usage_stats_list_pending_upload,
+            usage_stats_cmd::usage_stats_mark_uploaded,
             modules::weather::fetch_weather,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -23,4 +23,5 @@ pub mod school_website_embed;
 pub mod student_info;
 pub mod training_plan;
 pub mod transaction;
+pub mod usage_stats;
 pub mod weather;

--- a/src-tauri/src/modules/usage_stats/commands.rs
+++ b/src-tauri/src/modules/usage_stats/commands.rs
@@ -1,0 +1,74 @@
+//! 本地试用频率统计 — Tauri 命令层。
+
+use crate::db;
+
+use super::log_repo;
+use super::types::{
+    UsageDeviceProfileInput, UsageEventInput, UsagePersonalSummary, UsagePendingUploadBatch,
+    UsageSessionInput,
+};
+
+const DB_FILENAME: &str = "grades.db";
+
+fn db_conn() -> Result<rusqlite::Connection, String> {
+    db::open_db_connection(DB_FILENAME).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn usage_stats_record_event(event: UsageEventInput) -> Result<bool, String> {
+    let conn = db_conn()?;
+    log_repo::append_event(&conn, &event).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
+#[tauri::command]
+pub fn usage_stats_end_session(session: UsageSessionInput) -> Result<bool, String> {
+    let conn = db_conn()?;
+    log_repo::append_session(&conn, &session).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
+#[tauri::command]
+pub fn usage_stats_upsert_device_profile(profile: UsageDeviceProfileInput) -> Result<bool, String> {
+    let conn = db_conn()?;
+    log_repo::upsert_device_profile(&conn, &profile).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
+#[tauri::command]
+pub fn usage_stats_get_personal_summary(student_id: String) -> Result<UsagePersonalSummary, String> {
+    let sid = student_id.trim();
+    if sid.is_empty() {
+        return Err("student_id 不能为空".to_string());
+    }
+    let conn = db_conn()?;
+    log_repo::get_personal_summary(&conn, sid).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn usage_stats_list_pending_upload(
+    student_id: String,
+    device_id: String,
+    limit: Option<u32>,
+) -> Result<UsagePendingUploadBatch, String> {
+    let sid = student_id.trim();
+    let did = device_id.trim();
+    if sid.is_empty() || did.is_empty() {
+        return Err("student_id 与 device_id 不能为空".to_string());
+    }
+    let conn = db_conn()?;
+    log_repo::list_pending_upload(&conn, sid, did, limit.unwrap_or(200))
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn usage_stats_mark_uploaded(
+    event_ids: Vec<String>,
+    session_ids: Vec<String>,
+    uploaded_at: i64,
+) -> Result<bool, String> {
+    let conn = db_conn()?;
+    log_repo::mark_uploaded(&conn, &event_ids, &session_ids, uploaded_at)
+        .map_err(|e| e.to_string())?;
+    Ok(true)
+}

--- a/src-tauri/src/modules/usage_stats/commands.rs
+++ b/src-tauri/src/modules/usage_stats/commands.rs
@@ -4,7 +4,7 @@ use crate::db;
 
 use super::log_repo;
 use super::types::{
-    UsageDeviceProfileInput, UsageEventInput, UsagePersonalSummary, UsagePendingUploadBatch,
+    UsageDeviceProfileInput, UsageEventInput, UsagePendingUploadBatch, UsagePersonalSummary,
     UsageSessionInput,
 };
 
@@ -36,7 +36,9 @@ pub fn usage_stats_upsert_device_profile(profile: UsageDeviceProfileInput) -> Re
 }
 
 #[tauri::command]
-pub fn usage_stats_get_personal_summary(student_id: String) -> Result<UsagePersonalSummary, String> {
+pub fn usage_stats_get_personal_summary(
+    student_id: String,
+) -> Result<UsagePersonalSummary, String> {
     let sid = student_id.trim();
     if sid.is_empty() {
         return Err("student_id 不能为空".to_string());
@@ -57,8 +59,7 @@ pub fn usage_stats_list_pending_upload(
         return Err("student_id 与 device_id 不能为空".to_string());
     }
     let conn = db_conn()?;
-    log_repo::list_pending_upload(&conn, sid, did, limit.unwrap_or(200))
-        .map_err(|e| e.to_string())
+    log_repo::list_pending_upload(&conn, sid, did, limit.unwrap_or(200)).map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/modules/usage_stats/log_repo.rs
+++ b/src-tauri/src/modules/usage_stats/log_repo.rs
@@ -4,9 +4,8 @@ use chrono::{Local, TimeZone};
 use rusqlite::{params, Connection, Result};
 
 use super::types::{
-    UsageDailyTrendRow, UsageDeviceProfileInput, UsageEventInput, UsageLoadModeRow,
+    UsageCountRow, UsageDailyTrendRow, UsageDeviceProfileInput, UsageEventInput, UsageLoadModeRow,
     UsagePendingUploadBatch, UsagePersonalSummary, UsageSessionInput, UsageTodaySummary,
-    UsageCountRow,
 };
 
 const RETENTION_DAYS: i64 = 180;
@@ -189,8 +188,8 @@ pub fn get_personal_summary(conn: &Connection, student_id: &str) -> Result<Usage
     let today = today_key();
     let today_start = start_of_today_ms();
 
-    let (open_count, duration_ms, module_open_count, view_open_count): (i64, i64, i64, i64) =
-        conn.query_row(
+    let (open_count, duration_ms, module_open_count, view_open_count): (i64, i64, i64, i64) = conn
+        .query_row(
             "SELECT
                 COALESCE(SUM(open_count), 0),
                 COALESCE(SUM(duration_ms_total), 0),

--- a/src-tauri/src/modules/usage_stats/log_repo.rs
+++ b/src-tauri/src/modules/usage_stats/log_repo.rs
@@ -1,0 +1,396 @@
+//! 本地试用频率统计持久化。
+
+use chrono::{Local, TimeZone};
+use rusqlite::{params, Connection, Result};
+
+use super::types::{
+    UsageDailyTrendRow, UsageDeviceProfileInput, UsageEventInput, UsageLoadModeRow,
+    UsagePendingUploadBatch, UsagePersonalSummary, UsageSessionInput, UsageTodaySummary,
+    UsageCountRow,
+};
+
+const RETENTION_DAYS: i64 = 180;
+
+fn stat_date_from_ms(ms: i64) -> String {
+    Local
+        .timestamp_millis_opt(ms)
+        .single()
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| Local::now().format("%Y-%m-%d").to_string())
+}
+
+fn today_key() -> String {
+    Local::now().format("%Y-%m-%d").to_string()
+}
+
+fn start_of_today_ms() -> i64 {
+    let now = Local::now();
+    now.date_naive()
+        .and_hms_opt(0, 0, 0)
+        .and_then(|dt| Local.from_local_datetime(&dt).single())
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or(0)
+}
+
+fn upsert_daily_rollup(
+    conn: &Connection,
+    student_id: &str,
+    stat_date: &str,
+    target_kind: &str,
+    target_id: &str,
+    load_mode: &str,
+    open_delta: i64,
+    duration_delta: i64,
+) -> Result<()> {
+    if open_delta <= 0 && duration_delta <= 0 {
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO app_usage_daily_rollup (
+            student_id, stat_date, target_kind, target_id, load_mode,
+            open_count, duration_ms_total, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        ON CONFLICT(student_id, stat_date, target_kind, target_id, load_mode) DO UPDATE SET
+            open_count = open_count + excluded.open_count,
+            duration_ms_total = duration_ms_total + excluded.duration_ms_total,
+            updated_at = excluded.updated_at",
+        params![
+            student_id,
+            stat_date,
+            target_kind,
+            target_id,
+            load_mode,
+            open_delta.max(0),
+            duration_delta.max(0),
+            chrono::Utc::now().timestamp_millis()
+        ],
+    )?;
+    Ok(())
+}
+
+fn apply_event_rollup(conn: &Connection, event: &UsageEventInput) -> Result<()> {
+    let stat_date = stat_date_from_ms(event.occurred_at);
+    let event_type = event.event_type.as_str();
+    let open_delta = if matches!(event_type, "view_open" | "module_open" | "app_foreground") {
+        1
+    } else {
+        0
+    };
+    let duration_delta = if event.duration_ms > 0
+        && matches!(event_type, "view_close" | "module_close" | "app_background")
+    {
+        event.duration_ms
+    } else {
+        0
+    };
+    upsert_daily_rollup(
+        conn,
+        &event.student_id,
+        &stat_date,
+        &event.target_kind,
+        &event.target_id,
+        &event.load_mode,
+        open_delta,
+        duration_delta,
+    )
+}
+
+fn cleanup_old_events(conn: &Connection, student_id: &str) -> Result<()> {
+    let cutoff = chrono::Utc::now().timestamp_millis() - RETENTION_DAYS * 86_400_000;
+    conn.execute(
+        "DELETE FROM app_usage_events
+         WHERE student_id = ?1 AND occurred_at < ?2 AND uploaded_at IS NOT NULL",
+        params![student_id, cutoff],
+    )?;
+    Ok(())
+}
+
+pub fn append_event(conn: &Connection, event: &UsageEventInput) -> Result<()> {
+    conn.execute(
+        "INSERT INTO app_usage_events (
+            event_id, student_id, device_id, event_type, target_kind, target_id,
+            load_mode, launch_mode, duration_ms, app_version, runtime, platform,
+            extra_json, occurred_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            event.event_id,
+            event.student_id,
+            event.device_id,
+            event.event_type,
+            event.target_kind,
+            event.target_id,
+            event.load_mode,
+            event.launch_mode,
+            event.duration_ms.max(0),
+            event.app_version,
+            event.runtime,
+            event.platform,
+            event.extra_json,
+            event.occurred_at,
+        ],
+    )?;
+    apply_event_rollup(conn, event)?;
+    cleanup_old_events(conn, &event.student_id)?;
+    Ok(())
+}
+
+pub fn append_session(conn: &Connection, session: &UsageSessionInput) -> Result<()> {
+    conn.execute(
+        "INSERT INTO app_usage_sessions (
+            session_id, student_id, device_id, started_at, ended_at, duration_ms,
+            app_version, runtime, platform
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            session.session_id,
+            session.student_id,
+            session.device_id,
+            session.started_at,
+            session.ended_at,
+            session.duration_ms.max(0),
+            session.app_version,
+            session.runtime,
+            session.platform,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn upsert_device_profile(conn: &Connection, profile: &UsageDeviceProfileInput) -> Result<()> {
+    conn.execute(
+        "INSERT INTO app_usage_device_profile (
+            device_id, student_id, app_version, runtime, platform,
+            os_version, arch, locale, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ON CONFLICT(device_id) DO UPDATE SET
+            student_id = excluded.student_id,
+            app_version = excluded.app_version,
+            runtime = excluded.runtime,
+            platform = excluded.platform,
+            os_version = excluded.os_version,
+            arch = excluded.arch,
+            locale = excluded.locale,
+            updated_at = excluded.updated_at",
+        params![
+            profile.device_id,
+            profile.student_id,
+            profile.app_version,
+            profile.runtime,
+            profile.platform,
+            profile.os_version,
+            profile.arch,
+            profile.locale,
+            profile.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get_personal_summary(conn: &Connection, student_id: &str) -> Result<UsagePersonalSummary> {
+    let today = today_key();
+    let today_start = start_of_today_ms();
+
+    let (open_count, duration_ms, module_open_count, view_open_count): (i64, i64, i64, i64) =
+        conn.query_row(
+            "SELECT
+                COALESCE(SUM(open_count), 0),
+                COALESCE(SUM(duration_ms_total), 0),
+                COALESCE(SUM(CASE WHEN target_kind = 'module' THEN open_count ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN target_kind = 'view' THEN open_count ELSE 0 END), 0)
+             FROM app_usage_daily_rollup
+             WHERE student_id = ?1 AND stat_date = ?2",
+            params![student_id, today],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap_or((0, 0, 0, 0));
+
+    let mut top_modules_stmt = conn.prepare(
+        "SELECT target_id, COUNT(*) AS open_count, COALESCE(SUM(duration_ms), 0) AS duration_ms
+         FROM app_usage_events
+         WHERE student_id = ?1
+           AND target_kind = 'module'
+           AND event_type = 'module_open'
+           AND occurred_at >= ?2
+         GROUP BY target_id
+         ORDER BY open_count DESC, duration_ms DESC
+         LIMIT 5",
+    )?;
+    let top_modules = top_modules_stmt
+        .query_map(params![student_id, today_start], |row| {
+            Ok(UsageCountRow {
+                target_id: row.get(0)?,
+                open_count: row.get(1)?,
+                duration_ms_total: row.get(2)?,
+            })
+        })?
+        .filter_map(|item| item.ok())
+        .collect::<Vec<_>>();
+
+    let mut load_mode_stmt = conn.prepare(
+        "SELECT load_mode, COUNT(*) AS open_count
+         FROM app_usage_events
+         WHERE student_id = ?1
+           AND event_type IN ('view_open', 'module_open')
+           AND occurred_at >= ?2
+         GROUP BY load_mode
+         ORDER BY open_count DESC",
+    )?;
+    let load_mode_split = load_mode_stmt
+        .query_map(params![student_id, today_start], |row| {
+            Ok(UsageLoadModeRow {
+                load_mode: row.get(0)?,
+                open_count: row.get(1)?,
+            })
+        })?
+        .filter_map(|item| item.ok())
+        .collect::<Vec<_>>();
+
+    let mut trend_stmt = conn.prepare(
+        "SELECT stat_date,
+                COALESCE(SUM(open_count), 0),
+                COALESCE(SUM(duration_ms_total), 0)
+         FROM app_usage_daily_rollup
+         WHERE student_id = ?1
+           AND stat_date >= date('now', '-6 day')
+         GROUP BY stat_date
+         ORDER BY stat_date ASC",
+    )?;
+    let daily_trend = trend_stmt
+        .query_map(params![student_id], |row| {
+            Ok(UsageDailyTrendRow {
+                stat_date: row.get(0)?,
+                open_count: row.get(1)?,
+                duration_ms: row.get(2)?,
+            })
+        })?
+        .filter_map(|item| item.ok())
+        .collect::<Vec<_>>();
+
+    Ok(UsagePersonalSummary {
+        today: UsageTodaySummary {
+            stat_date: today,
+            open_count,
+            duration_ms,
+            module_open_count,
+            view_open_count,
+        },
+        top_modules,
+        load_mode_split,
+        daily_trend,
+    })
+}
+
+pub fn list_pending_upload(
+    conn: &Connection,
+    student_id: &str,
+    device_id: &str,
+    limit: u32,
+) -> Result<UsagePendingUploadBatch> {
+    let safe_limit = limit.clamp(1, 500);
+
+    let mut events_stmt = conn.prepare(
+        "SELECT event_id, student_id, device_id, event_type, target_kind, target_id,
+                load_mode, launch_mode, duration_ms, app_version, runtime, platform,
+                extra_json, occurred_at
+         FROM app_usage_events
+         WHERE student_id = ?1 AND device_id = ?2 AND uploaded_at IS NULL
+         ORDER BY occurred_at ASC
+         LIMIT ?3",
+    )?;
+    let events = events_stmt
+        .query_map(params![student_id, device_id, safe_limit], |row| {
+            Ok(UsageEventInput {
+                event_id: row.get(0)?,
+                student_id: row.get(1)?,
+                device_id: row.get(2)?,
+                event_type: row.get(3)?,
+                target_kind: row.get(4)?,
+                target_id: row.get(5)?,
+                load_mode: row.get(6)?,
+                launch_mode: row.get(7)?,
+                duration_ms: row.get(8)?,
+                app_version: row.get(9)?,
+                runtime: row.get(10)?,
+                platform: row.get(11)?,
+                extra_json: row.get(12)?,
+                occurred_at: row.get(13)?,
+            })
+        })?
+        .filter_map(|item| item.ok())
+        .collect::<Vec<_>>();
+
+    let mut sessions_stmt = conn.prepare(
+        "SELECT session_id, student_id, device_id, started_at, ended_at, duration_ms,
+                app_version, runtime, platform
+         FROM app_usage_sessions
+         WHERE student_id = ?1 AND device_id = ?2 AND uploaded_at IS NULL
+         ORDER BY started_at ASC
+         LIMIT ?3",
+    )?;
+    let sessions = sessions_stmt
+        .query_map(params![student_id, device_id, safe_limit], |row| {
+            Ok(UsageSessionInput {
+                session_id: row.get(0)?,
+                student_id: row.get(1)?,
+                device_id: row.get(2)?,
+                started_at: row.get(3)?,
+                ended_at: row.get(4)?,
+                duration_ms: row.get(5)?,
+                app_version: row.get(6)?,
+                runtime: row.get(7)?,
+                platform: row.get(8)?,
+            })
+        })?
+        .filter_map(|item| item.ok())
+        .collect::<Vec<_>>();
+
+    let device_profile = conn
+        .query_row(
+            "SELECT device_id, student_id, app_version, runtime, platform,
+                    os_version, arch, locale, updated_at
+             FROM app_usage_device_profile
+             WHERE device_id = ?1 AND student_id = ?2
+             LIMIT 1",
+            params![device_id, student_id],
+            |row| {
+                Ok(UsageDeviceProfileInput {
+                    device_id: row.get(0)?,
+                    student_id: row.get(1)?,
+                    app_version: row.get(2)?,
+                    runtime: row.get(3)?,
+                    platform: row.get(4)?,
+                    os_version: row.get(5)?,
+                    arch: row.get(6)?,
+                    locale: row.get(7)?,
+                    updated_at: row.get(8)?,
+                })
+            },
+        )
+        .ok();
+
+    Ok(UsagePendingUploadBatch {
+        events,
+        sessions,
+        device_profile,
+    })
+}
+
+pub fn mark_uploaded(
+    conn: &Connection,
+    event_ids: &[String],
+    session_ids: &[String],
+    uploaded_at: i64,
+) -> Result<()> {
+    for event_id in event_ids {
+        conn.execute(
+            "UPDATE app_usage_events SET uploaded_at = ?2 WHERE event_id = ?1",
+            params![event_id, uploaded_at],
+        )?;
+    }
+    for session_id in session_ids {
+        conn.execute(
+            "UPDATE app_usage_sessions SET uploaded_at = ?2 WHERE session_id = ?1",
+            params![session_id, uploaded_at],
+        )?;
+    }
+    Ok(())
+}

--- a/src-tauri/src/modules/usage_stats/mod.rs
+++ b/src-tauri/src/modules/usage_stats/mod.rs
@@ -1,0 +1,7 @@
+//! 本地试用频率统计模块。
+
+pub mod commands;
+pub mod log_repo;
+pub mod types;
+
+pub use commands::*;

--- a/src-tauri/src/modules/usage_stats/types.rs
+++ b/src-tauri/src/modules/usage_stats/types.rs
@@ -1,0 +1,107 @@
+//! 本地试用频率统计 DTO。
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageEventInput {
+    pub event_id: String,
+    pub student_id: String,
+    pub device_id: String,
+    pub event_type: String,
+    pub target_kind: String,
+    pub target_id: String,
+    #[serde(default)]
+    pub load_mode: String,
+    #[serde(default)]
+    pub launch_mode: String,
+    #[serde(default)]
+    pub duration_ms: i64,
+    #[serde(default)]
+    pub app_version: String,
+    #[serde(default)]
+    pub runtime: String,
+    #[serde(default)]
+    pub platform: String,
+    #[serde(default)]
+    pub extra_json: String,
+    pub occurred_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageSessionInput {
+    pub session_id: String,
+    pub student_id: String,
+    pub device_id: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub duration_ms: i64,
+    #[serde(default)]
+    pub app_version: String,
+    #[serde(default)]
+    pub runtime: String,
+    #[serde(default)]
+    pub platform: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageDeviceProfileInput {
+    pub device_id: String,
+    pub student_id: String,
+    #[serde(default)]
+    pub app_version: String,
+    #[serde(default)]
+    pub runtime: String,
+    #[serde(default)]
+    pub platform: String,
+    #[serde(default)]
+    pub os_version: String,
+    #[serde(default)]
+    pub arch: String,
+    #[serde(default)]
+    pub locale: String,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageCountRow {
+    pub target_id: String,
+    pub open_count: i64,
+    pub duration_ms_total: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageLoadModeRow {
+    pub load_mode: String,
+    pub open_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageDailyTrendRow {
+    pub stat_date: String,
+    pub open_count: i64,
+    pub duration_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageTodaySummary {
+    pub stat_date: String,
+    pub open_count: i64,
+    pub duration_ms: i64,
+    pub module_open_count: i64,
+    pub view_open_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsagePersonalSummary {
+    pub today: UsageTodaySummary,
+    pub top_modules: Vec<UsageCountRow>,
+    pub load_mode_split: Vec<UsageLoadModeRow>,
+    pub daily_trend: Vec<UsageDailyTrendRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsagePendingUploadBatch {
+    pub events: Vec<UsageEventInput>,
+    pub sessions: Vec<UsageSessionInput>,
+    pub device_profile: Option<UsageDeviceProfileInput>,
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,16 @@ import {
 } from './utils/remote_config.js'
 import { resetCloudSyncCooldownForSession, runAutoCloudSyncAfterLogin } from './utils/cloud_sync.js'
 import {
+  initUsageTracker,
+  setUsageTrackingStudentId,
+  trackViewNavigation
+} from './utils/usage_tracker.js'
+import {
+  scheduleUsageUpload,
+  startUsageUploadScheduler,
+  stopUsageUploadScheduler
+} from './utils/usage_uploader.js'
+import {
   loadChaoxingStoredPassword,
   loadPortalStoredPassword
 } from './composables/useSessionCredentials.js'
@@ -1336,6 +1346,7 @@ const ensureProtectedViewAccess = (
 
 const goToViewInternal = (view, { push = true, restoreScroll = false } = {}) => {
   const normalized = normalizeViewName(view)
+  const fromView = currentView.value
   if (currentView.value === 'home' && normalized !== 'home') {
     rememberHomeScrollPosition()
   }
@@ -1353,6 +1364,7 @@ const goToViewInternal = (view, { push = true, restoreScroll = false } = {}) => 
   } else {
     recoverViewportAfterTransition({ scrollToTop: true, blurActive: true })
   }
+  void trackViewNavigation(fromView, normalized)
 }
 
 const goToView = (view, { push = true, restoreScroll = false } = {}) => {
@@ -1474,6 +1486,9 @@ const handleLoginSuccess = (data) => {
     }).catch((e) => {
       console.warn('[CloudSync] 登录后自动同步失败:', e)
     })
+    setUsageTrackingStudentId(studentId.value)
+    initUsageTracker({ studentId: studentId.value })
+    scheduleUsageUpload({ studentId: studentId.value, reason: 'login', force: true })
   }
   clearJwxtMaintenance()
   stopJwxtRecoveryPolling()
@@ -2801,6 +2816,8 @@ onMounted(async () => {
 
   // 延迟检查更新
   window.setTimeout(() => { autoCheckUpdate() }, 1500)
+  initUsageTracker({ studentId: studentId.value })
+  startUsageUploadScheduler(() => studentId.value)
   console.timeEnd('[Boot] total')
 
   // Capacitor 环境注册原生 appStateChange 事件（补充浏览器 visibilitychange 的盲区）
@@ -2821,6 +2838,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  stopUsageUploadScheduler()
   document.removeEventListener('click', handleGlobalLinkClick, true)
   document.removeEventListener('visibilitychange', handleVisibilityChange)
   window.removeEventListener('popstate', handlePopState)
@@ -2998,6 +3016,7 @@ onBeforeUnmount(() => {
 
       <ServiceStatsView
         v-else-if="currentView === 'service_stats'"
+        :student-id="studentId"
         @back="handleBackToMe"
       />
 

--- a/src/components/MoreView.vue
+++ b/src/components/MoreView.vue
@@ -18,6 +18,7 @@ import {
   buildModuleCenterCards,
   normalizeModuleCenterChannel as normalizeChannel
 } from '../utils/module_center.js'
+import { trackModuleOpen } from '../utils/usage_tracker.js'
 
 const props = defineProps({
   studentId: { type: String, default: '' }
@@ -312,6 +313,13 @@ const emitPreparedModuleNavigate = (moduleItem, prepared, manifest, sessionMeta 
         ? 'tauri-bridge-blocked'
         : '')
   )
+  void trackModuleOpen({
+    moduleId,
+    loadMode: previewMode || sessionPayload.preview_mode || 'remote-site',
+    launchMode: safeText(prepared?.launch_mode || prepared?.source || ''),
+    moduleVersion: sessionPayload.version,
+    channel: sessionPayload.channel
+  })
   emit('navigate', {
     view: 'more_module_host',
     payload: {

--- a/src/components/ServiceStatsView.vue
+++ b/src/components/ServiceStatsView.vue
@@ -1,5 +1,14 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { fetchPersonalUsageSummary } from '../utils/usage_tracker.js'
+import { fetchRemotePersonalUsageSummary } from '../utils/usage_uploader.js'
+
+const props = defineProps({
+  studentId: {
+    type: String,
+    default: ''
+  }
+})
 
 const emit = defineEmits(['back'])
 
@@ -25,6 +34,91 @@ const formatDuration = (seconds) => {
   if (days > 0) return `${days}天 ${hours}小时`
   if (hours > 0) return `${hours}小时 ${minutes}分钟`
   return `${minutes}分钟`
+}
+
+const formatDurationMs = (ms) => formatDuration(Math.floor(toNumber(ms) / 1000))
+
+const normalizeClientUsage = (raw = {}) => ({
+  today_active_users: toNumber(raw?.today_active_users),
+  today_total_events: toNumber(raw?.today_total_events),
+  today_duration_hours: toNumber(raw?.today_duration_hours),
+  today_app_opens: toNumber(raw?.today_app_opens),
+  top_modules_today: Array.isArray(raw?.top_modules_today)
+    ? raw.top_modules_today.map((item) => ({
+        module_id: String(item?.module_id || '').trim(),
+        open_count: toNumber(item?.open_count),
+        duration_ms_total: toNumber(item?.duration_ms_total),
+        remote_count: toNumber(item?.remote_count),
+        local_count: toNumber(item?.local_count)
+      })).filter((item) => item.module_id)
+    : [],
+  load_mode_split_today: raw?.load_mode_split_today && typeof raw.load_mode_split_today === 'object'
+    ? raw.load_mode_split_today
+    : {},
+  trend_last_7_days: Array.isArray(raw?.trend_last_7_days)
+    ? raw.trend_last_7_days.map((row) => ({
+        date: row?.date || '',
+        active_users: toNumber(row?.active_users),
+        total_events: toNumber(row?.total_events),
+        total_duration_ms: toNumber(row?.total_duration_ms),
+        app_opens: toNumber(row?.app_opens)
+      }))
+    : []
+})
+
+const normalizePersonalUsage = (raw = null) => {
+  if (!raw || typeof raw !== 'object') return null
+  const today = raw?.today || {}
+  return {
+    today: {
+      stat_date: today?.stat_date || '',
+      open_count: toNumber(today?.open_count),
+      duration_ms: toNumber(today?.duration_ms),
+      module_open_count: toNumber(today?.module_open_count),
+      view_open_count: toNumber(today?.view_open_count)
+    },
+    top_modules: Array.isArray(raw?.top_modules)
+      ? raw.top_modules.map((item) => ({
+          target_id: String(item?.target_id || '').trim(),
+          open_count: toNumber(item?.open_count),
+          duration_ms_total: toNumber(item?.duration_ms_total)
+        })).filter((item) => item.target_id)
+      : [],
+    load_mode_split: Array.isArray(raw?.load_mode_split)
+      ? raw.load_mode_split.map((item) => ({
+          load_mode: String(item?.load_mode || 'native').trim() || 'native',
+          open_count: toNumber(item?.open_count)
+        }))
+      : [],
+    daily_trend: Array.isArray(raw?.daily_trend)
+      ? raw.daily_trend.map((row) => ({
+          stat_date: row?.stat_date || '',
+          open_count: toNumber(row?.open_count),
+          duration_ms: toNumber(row?.duration_ms)
+        }))
+      : []
+  }
+}
+
+const mergePersonalUsage = (localRaw, remoteRaw) => {
+  const local = normalizePersonalUsage(localRaw)
+  const remote = normalizePersonalUsage(remoteRaw?.success === false ? null : remoteRaw)
+  if (!local && !remote) return null
+  if (!remote) return local
+  if (!local) return remote
+  const pickMax = (a, b) => Math.max(toNumber(a), toNumber(b))
+  return {
+    today: {
+      stat_date: remote.today.stat_date || local.today.stat_date,
+      open_count: pickMax(local.today.open_count, remote.today.open_count),
+      duration_ms: pickMax(local.today.duration_ms, remote.today.duration_ms),
+      module_open_count: pickMax(local.today.module_open_count, remote.today.module_open_count),
+      view_open_count: pickMax(local.today.view_open_count, remote.today.view_open_count)
+    },
+    top_modules: remote.top_modules.length ? remote.top_modules : local.top_modules,
+    load_mode_split: remote.load_mode_split.length ? remote.load_mode_split : local.load_mode_split,
+    daily_trend: remote.daily_trend.length ? remote.daily_trend : local.daily_trend
+  }
 }
 
 const normalizeTrendRows = (rows) => {
@@ -87,7 +181,8 @@ const normalizeServiceHealth = (raw = {}) => {
       last_archive_at: archiveStatus.last_archive_at || '',
       last_archive_path: archiveStatus.last_archive_path || '',
       last_error: archiveStatus.last_error || ''
-    }
+    },
+    client_usage: normalizeClientUsage(raw?.client_usage || {})
   }
 }
 
@@ -95,8 +190,30 @@ const loading = ref(false)
 const error = ref('')
 const lastUpdatedAt = ref('')
 const health = ref(normalizeServiceHealth())
+const personalUsage = ref(null)
+const personalLoading = ref(false)
 let refreshTimer = null
 let healthRequestSeq = 0
+
+const loadPersonalUsage = async () => {
+  const sid = String(props.studentId || '').trim()
+  if (!sid) {
+    personalUsage.value = null
+    return
+  }
+  personalLoading.value = true
+  try {
+    const [localSummary, remoteSummary] = await Promise.all([
+      fetchPersonalUsageSummary(sid),
+      fetchRemotePersonalUsageSummary(sid)
+    ])
+    personalUsage.value = mergePersonalUsage(localSummary, remoteSummary)
+  } catch {
+    personalUsage.value = null
+  } finally {
+    personalLoading.value = false
+  }
+}
 
 const readCachedHealth = () => {
   try {
@@ -150,6 +267,56 @@ const statusClass = computed(() => ({
 }))
 
 const displayClientVersion = computed(() => health.value.cloud_sync.latest_version || '')
+
+const clientUsage = computed(() => health.value.client_usage || normalizeClientUsage())
+
+const hasClientUsage = computed(() => (
+  clientUsage.value.today_total_events > 0
+  || clientUsage.value.today_active_users > 0
+  || clientUsage.value.top_modules_today.length > 0
+))
+
+const loadModeLabel = (mode) => {
+  const key = String(mode || '').trim()
+  if (key === 'remote-site') return '服务器软加载'
+  if (key === 'tauri-local' || key === 'capacitor-local') return '本地直接加载'
+  if (key === 'native') return '原生页面'
+  return key || '未知'
+}
+
+const personalOverviewItems = computed(() => {
+  const today = personalUsage.value?.today
+  if (!today) return []
+  return [
+    { label: '今日打开', value: formatNumber(today.open_count), icon: 'touch_app' },
+    { label: '今日时长', value: formatDurationMs(today.duration_ms), icon: 'schedule' },
+    { label: '模块打开', value: formatNumber(today.module_open_count), icon: 'extension' },
+    { label: '页面打开', value: formatNumber(today.view_open_count), icon: 'web' }
+  ]
+})
+
+const globalUsageOverviewItems = computed(() => [
+  { label: '今日活跃', value: formatNumber(clientUsage.value.today_active_users), icon: 'groups' },
+  { label: '今日事件', value: formatNumber(clientUsage.value.today_total_events), icon: 'analytics' },
+  { label: '今日时长', value: `${clientUsage.value.today_duration_hours.toFixed(1)} 小时`, icon: 'timer' },
+  { label: '应用打开', value: formatNumber(clientUsage.value.today_app_opens), icon: 'smartphone' }
+])
+
+const loadModeSplitRows = computed(() => {
+  const split = clientUsage.value.load_mode_split_today || {}
+  return Object.entries(split)
+    .map(([mode, count]) => ({
+      mode,
+      label: loadModeLabel(mode),
+      open_count: toNumber(count)
+    }))
+    .filter((item) => item.open_count > 0)
+    .sort((a, b) => b.open_count - a.open_count)
+})
+
+const personalLoadModeRows = computed(() => personalUsage.value?.load_mode_split || [])
+
+const hasPersonalUsage = computed(() => Boolean(personalUsage.value?.today))
 
 const overviewItems = computed(() => [
   {
@@ -354,14 +521,23 @@ const loadHealth = async ({ silent = false } = {}) => {
 
 const refreshNow = () => {
   void loadHealth()
+  void loadPersonalUsage()
 }
 
 onMounted(() => {
   void loadHealth()
+  void loadPersonalUsage()
   refreshTimer = setInterval(() => {
     void loadHealth({ silent: true })
   }, REFRESH_INTERVAL_MS)
 })
+
+watch(
+  () => props.studentId,
+  () => {
+    void loadPersonalUsage()
+  }
+)
 
 onBeforeUnmount(() => {
   if (refreshTimer) {
@@ -408,6 +584,59 @@ onBeforeUnmount(() => {
         <span class="metric-label">{{ item.label }}</span>
         <strong class="metric-value">{{ item.value }}</strong>
       </article>
+    </section>
+
+    <section v-if="hasPersonalUsage" class="usage-card" aria-label="我的使用">
+      <div class="section-title">
+        <span class="material-symbols-outlined">person</span>
+        <h2>我的使用</h2>
+      </div>
+      <div class="overview-grid personal-grid">
+        <article v-for="item in personalOverviewItems" :key="item.label" class="metric-card">
+          <span class="material-symbols-outlined metric-icon">{{ item.icon }}</span>
+          <span class="metric-label">{{ item.label }}</span>
+          <strong class="metric-value">{{ item.value }}</strong>
+        </article>
+      </div>
+      <ul v-if="personalUsage?.top_modules?.length" class="version-list">
+        <li v-for="item in personalUsage.top_modules" :key="item.target_id" class="version-row">
+          <span class="version-name">{{ item.target_id }}</span>
+          <strong class="version-count">{{ formatNumber(item.open_count) }} 次</strong>
+        </li>
+      </ul>
+      <ul v-if="personalLoadModeRows.length" class="version-list">
+        <li v-for="item in personalLoadModeRows" :key="item.load_mode" class="version-row">
+          <span class="version-name">{{ loadModeLabel(item.load_mode) }}</span>
+          <strong class="version-count">{{ formatNumber(item.open_count) }}</strong>
+        </li>
+      </ul>
+      <p v-else-if="personalLoading" class="empty-hint">正在加载个人统计…</p>
+    </section>
+
+    <section v-if="hasClientUsage" class="usage-card" aria-label="全站试用概况">
+      <div class="section-title">
+        <span class="material-symbols-outlined">public</span>
+        <h2>全站试用概况</h2>
+      </div>
+      <div class="overview-grid personal-grid">
+        <article v-for="item in globalUsageOverviewItems" :key="item.label" class="metric-card">
+          <span class="material-symbols-outlined metric-icon">{{ item.icon }}</span>
+          <span class="metric-label">{{ item.label }}</span>
+          <strong class="metric-value">{{ item.value }}</strong>
+        </article>
+      </div>
+      <ul v-if="clientUsage.top_modules_today.length" class="version-list">
+        <li v-for="item in clientUsage.top_modules_today" :key="item.module_id" class="version-row">
+          <span class="version-name">{{ item.module_id }}</span>
+          <strong class="version-count">{{ formatNumber(item.open_count) }} 次</strong>
+        </li>
+      </ul>
+      <ul v-if="loadModeSplitRows.length" class="version-list">
+        <li v-for="item in loadModeSplitRows" :key="item.mode" class="version-row">
+          <span class="version-name">{{ item.label }}</span>
+          <strong class="version-count">{{ formatNumber(item.open_count) }}</strong>
+        </li>
+      </ul>
     </section>
 
     <section v-if="hasVersionUserCounts" class="version-card" aria-label="各版本人数">
@@ -549,6 +778,7 @@ onBeforeUnmount(() => {
 
 .status-card,
 .version-card,
+.usage-card,
 .trend-card,
 .metric-card {
   background: #ffffff;
@@ -560,6 +790,25 @@ onBeforeUnmount(() => {
   padding: 16px;
   border-radius: 22px;
   margin-bottom: 12px;
+}
+
+.usage-card {
+  padding: 16px;
+  border-radius: 22px;
+  margin-bottom: 12px;
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+}
+
+.personal-grid {
+  margin-bottom: 8px;
+}
+
+.empty-hint {
+  margin: 0;
+  color: #64748b;
+  font-size: 13px;
 }
 
 .version-list {

--- a/src/utils/service_stats_view_contract.spec.ts
+++ b/src/utils/service_stats_view_contract.spec.ts
@@ -86,4 +86,15 @@ describe('service stats frontend contract', () => {
     expect(source).toContain('formatAxisVersion')
     expect(source).toContain("axisLabelKey === 'latest_version'")
   })
+
+  it('shows personal and global client usage sections', () => {
+    const source = readSource('src/components/ServiceStatsView.vue')
+
+    expect(source).toContain('我的使用')
+    expect(source).toContain('全站试用概况')
+    expect(source).toContain('client_usage')
+    expect(source).toContain('fetchPersonalUsageSummary')
+    expect(source).toContain('fetchRemotePersonalUsageSummary')
+    expect(source).toContain('studentId')
+  })
 })

--- a/src/utils/usage_tracker.js
+++ b/src/utils/usage_tracker.js
@@ -1,0 +1,389 @@
+import { invokeNative, isTauriRuntime } from '../platform/native'
+import { detectRuntime } from '../platform/runtime'
+import { getCurrentVersion } from './updater'
+import { scheduleUsageUpload } from './usage_uploader'
+
+const CLOUD_SYNC_DEVICE_ID_KEY = 'hbu_cloud_sync_device_id'
+const WEB_QUEUE_KEY = 'hbu_usage_events_queue_v1'
+const WEB_SESSIONS_KEY = 'hbu_usage_sessions_queue_v1'
+const DAILY_EVENT_LIMIT = 5000
+const STUDENT_ID_RE = /^\d{10}$/
+
+const toSafeText = (value) => String(value || '').trim()
+const isValidStudentId = (value) => STUDENT_ID_RE.test(toSafeText(value))
+
+let clientMetaCache = null
+let clientMetaCacheAt = 0
+let activeView = { id: '', startedAt: 0 }
+let activeModule = { id: '', loadMode: '', launchMode: '', startedAt: 0 }
+let activeSession = { sessionId: '', startedAt: 0 }
+let initialized = false
+let currentStudentId = 'anonymous'
+let dailyEventCount = 0
+let dailyEventDate = ''
+
+const ensureDeviceId = () => {
+  let id = toSafeText(localStorage.getItem(CLOUD_SYNC_DEVICE_ID_KEY))
+  if (id) return id
+  try {
+    id = (crypto?.randomUUID?.() || '').trim()
+  } catch {
+    id = ''
+  }
+  if (!id) {
+    id = `device-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  }
+  localStorage.setItem(CLOUD_SYNC_DEVICE_ID_KEY, id)
+  return id
+}
+
+const createEventId = () => {
+  try {
+    const id = crypto?.randomUUID?.()
+    if (id) return id
+  } catch {
+    // ignore
+  }
+  return `evt-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+const createSessionId = () => {
+  try {
+    const id = crypto?.randomUUID?.()
+    if (id) return id
+  } catch {
+    // ignore
+  }
+  return `sess-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+const todayKey = () => {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+const bumpDailyCounter = () => {
+  const today = todayKey()
+  if (dailyEventDate !== today) {
+    dailyEventDate = today
+    dailyEventCount = 0
+  }
+  dailyEventCount += 1
+  return dailyEventCount <= DAILY_EVENT_LIMIT
+}
+
+const readWebQueue = (key) => {
+  try {
+    const raw = localStorage.getItem(key)
+    const parsed = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+const writeWebQueue = (key, items) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(items.slice(-2000)))
+  } catch {
+    // ignore quota errors
+  }
+}
+
+const getClientMeta = async () => {
+  const now = Date.now()
+  if (clientMetaCache && now - clientMetaCacheAt < 60_000) {
+    return clientMetaCache
+  }
+  let version = ''
+  try {
+    version = toSafeText(await getCurrentVersion())
+  } catch {
+    version = ''
+  }
+  const runtime = detectRuntime()
+  const platform = typeof navigator !== 'undefined'
+    ? toSafeText(navigator.platform || navigator.userAgent || '')
+    : ''
+  clientMetaCache = {
+    app_version: version,
+    runtime,
+    platform,
+    os_version: typeof navigator !== 'undefined' ? toSafeText(navigator.userAgent || '') : '',
+    arch: '',
+    locale: typeof navigator !== 'undefined' ? toSafeText(navigator.language || '') : ''
+  }
+  clientMetaCacheAt = now
+  return clientMetaCache
+}
+
+const resolveStudentId = () => {
+  const sid = toSafeText(currentStudentId)
+  if (isValidStudentId(sid)) return sid
+  const stored = toSafeText(localStorage.getItem('hbu_username'))
+  if (isValidStudentId(stored)) return stored
+  return 'anonymous'
+}
+
+const persistEvent = async (event) => {
+  if (!bumpDailyCounter()) return false
+  if (isTauriRuntime()) {
+    await invokeNative('usage_stats_record_event', { event })
+    return true
+  }
+  const queue = readWebQueue(WEB_QUEUE_KEY)
+  queue.push(event)
+  writeWebQueue(WEB_QUEUE_KEY, queue)
+  return true
+}
+
+const persistSession = async (session) => {
+  if (isTauriRuntime()) {
+    await invokeNative('usage_stats_end_session', { session })
+    return true
+  }
+  const queue = readWebQueue(WEB_SESSIONS_KEY)
+  queue.push(session)
+  writeWebQueue(WEB_SESSIONS_KEY, queue)
+  return true
+}
+
+const upsertDeviceProfile = async () => {
+  const meta = await getClientMeta()
+  const profile = {
+    device_id: ensureDeviceId(),
+    student_id: resolveStudentId(),
+    app_version: meta.app_version,
+    runtime: meta.runtime,
+    platform: meta.platform,
+    os_version: meta.os_version,
+    arch: meta.arch,
+    locale: meta.locale,
+    updated_at: Date.now()
+  }
+  if (isTauriRuntime()) {
+    await invokeNative('usage_stats_upsert_device_profile', { profile })
+    return profile
+  }
+  try {
+    localStorage.setItem('hbu_usage_device_profile_v1', JSON.stringify(profile))
+  } catch {
+    // ignore
+  }
+  return profile
+}
+
+const buildEvent = async ({
+  eventType,
+  targetKind,
+  targetId,
+  loadMode = 'native',
+  launchMode = '',
+  durationMs = 0,
+  extra = {}
+}) => {
+  const meta = await getClientMeta()
+  return {
+    event_id: createEventId(),
+    student_id: resolveStudentId(),
+    device_id: ensureDeviceId(),
+    event_type: eventType,
+    target_kind: targetKind,
+    target_id: toSafeText(targetId) || 'unknown',
+    load_mode: toSafeText(loadMode) || 'native',
+    launch_mode: toSafeText(launchMode),
+    duration_ms: Math.max(0, Number(durationMs) || 0),
+    app_version: meta.app_version,
+    runtime: meta.runtime,
+    platform: meta.platform,
+    extra_json: JSON.stringify(extra || {}),
+    occurred_at: Date.now()
+  }
+}
+
+const maybeScheduleUpload = (reason = 'event') => {
+  const sid = resolveStudentId()
+  if (!isValidStudentId(sid)) return
+  scheduleUsageUpload({ studentId: sid, reason })
+}
+
+export const setUsageTrackingStudentId = (studentId) => {
+  currentStudentId = toSafeText(studentId) || 'anonymous'
+}
+
+export const trackViewNavigation = async (fromView, toView) => {
+  if (!initialized) return
+  const from = toSafeText(fromView)
+  const to = toSafeText(toView)
+  const now = Date.now()
+
+  if (from && from !== to && activeView.id === from && activeView.startedAt > 0) {
+    const durationMs = now - activeView.startedAt
+    const closeEvent = await buildEvent({
+      eventType: 'view_close',
+      targetKind: 'view',
+      targetId: from,
+      loadMode: 'native',
+      durationMs,
+      extra: { next_view: to }
+    })
+    await persistEvent(closeEvent)
+  }
+
+  if (from === 'more_module_host' && to !== 'more_module_host' && activeModule.startedAt > 0) {
+    const durationMs = now - activeModule.startedAt
+    const moduleClose = await buildEvent({
+      eventType: 'module_close',
+      targetKind: 'module',
+      targetId: activeModule.id,
+      loadMode: activeModule.loadMode,
+      launchMode: activeModule.launchMode,
+      durationMs,
+      extra: { next_view: to }
+    })
+    await persistEvent(moduleClose)
+    activeModule = { id: '', loadMode: '', launchMode: '', startedAt: 0 }
+  }
+
+  if (to && to !== from) {
+    const openEvent = await buildEvent({
+      eventType: 'view_open',
+      targetKind: 'view',
+      targetId: to,
+      loadMode: 'native',
+      extra: { previous_view: from }
+    })
+    await persistEvent(openEvent)
+    activeView = { id: to, startedAt: now }
+    maybeScheduleUpload('view-nav')
+  }
+}
+
+export const trackModuleOpen = async ({
+  moduleId,
+  loadMode = '',
+  launchMode = '',
+  moduleVersion = '',
+  channel = ''
+} = {}) => {
+  if (!initialized) return
+  const id = toSafeText(moduleId)
+  if (!id) return
+  const now = Date.now()
+  const event = await buildEvent({
+    eventType: 'module_open',
+    targetKind: 'module',
+    targetId: id,
+    loadMode: loadMode || 'remote-site',
+    launchMode,
+    extra: { module_version: moduleVersion, channel }
+  })
+  await persistEvent(event)
+  activeModule = {
+    id,
+    loadMode: loadMode || 'remote-site',
+    launchMode: toSafeText(launchMode),
+    startedAt: now
+  }
+  maybeScheduleUpload('module-open')
+}
+
+export const trackAppForeground = async () => {
+  if (!initialized) return
+  const now = Date.now()
+  activeSession = { sessionId: createSessionId(), startedAt: now }
+  const event = await buildEvent({
+    eventType: 'app_foreground',
+    targetKind: 'app',
+    targetId: 'mini-hbut',
+    loadMode: 'native'
+  })
+  await persistEvent(event)
+  await upsertDeviceProfile()
+}
+
+export const trackAppBackground = async () => {
+  if (!initialized) return
+  const now = Date.now()
+  if (activeSession.startedAt > 0 && activeSession.sessionId) {
+    const meta = await getClientMeta()
+    const durationMs = now - activeSession.startedAt
+    await persistSession({
+      session_id: activeSession.sessionId,
+      student_id: resolveStudentId(),
+      device_id: ensureDeviceId(),
+      started_at: activeSession.startedAt,
+      ended_at: now,
+      duration_ms: durationMs,
+      app_version: meta.app_version,
+      runtime: meta.runtime,
+      platform: meta.platform
+    })
+    const event = await buildEvent({
+      eventType: 'app_background',
+      targetKind: 'app',
+      targetId: 'mini-hbut',
+      loadMode: 'native',
+      durationMs
+    })
+    await persistEvent(event)
+    activeSession = { sessionId: '', startedAt: 0 }
+    maybeScheduleUpload('app-background')
+  }
+}
+
+export const initUsageTracker = ({ studentId = '' } = {}) => {
+  if (studentId) setUsageTrackingStudentId(studentId)
+  if (initialized) return
+  initialized = true
+
+  const onVisibility = () => {
+    if (document.hidden) {
+      void trackAppBackground()
+      return
+    }
+    void trackAppForeground()
+  }
+
+  document.addEventListener('visibilitychange', onVisibility)
+  if (!document.hidden) {
+    void trackAppForeground()
+  }
+}
+
+export const getWebUsagePendingQueues = () => ({
+  events: readWebQueue(WEB_QUEUE_KEY),
+  sessions: readWebQueue(WEB_SESSIONS_KEY),
+  deviceProfile: (() => {
+    try {
+      const raw = localStorage.getItem('hbu_usage_device_profile_v1')
+      return raw ? JSON.parse(raw) : null
+    } catch {
+      return null
+    }
+  })()
+})
+
+export const clearWebUsagePendingQueues = ({ eventIds = [], sessionIds = [] } = {}) => {
+  if (eventIds.length) {
+    const idSet = new Set(eventIds)
+    writeWebQueue(WEB_QUEUE_KEY, readWebQueue(WEB_QUEUE_KEY).filter((item) => !idSet.has(item?.event_id)))
+  }
+  if (sessionIds.length) {
+    const idSet = new Set(sessionIds)
+    writeWebQueue(WEB_SESSIONS_KEY, readWebQueue(WEB_SESSIONS_KEY).filter((item) => !idSet.has(item?.session_id)))
+  }
+}
+
+export const fetchPersonalUsageSummary = async (studentId) => {
+  const sid = toSafeText(studentId)
+  if (!sid || !isTauriRuntime()) return null
+  try {
+    return await invokeNative('usage_stats_get_personal_summary', { studentId: sid })
+  } catch {
+    return null
+  }
+}

--- a/src/utils/usage_tracking_contract.spec.ts
+++ b/src/utils/usage_tracking_contract.spec.ts
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const sourcePath = (path: string) => resolve(process.cwd(), path)
+const readSource = (path: string) => {
+  const resolved = sourcePath(path)
+  return existsSync(resolved) ? readFileSync(resolved, 'utf8') : ''
+}
+
+describe('usage tracking contract', () => {
+  it('hooks view navigation and module open tracking in App.vue and MoreView.vue', () => {
+    const appSource = readSource('src/App.vue')
+    const moreSource = readSource('src/components/MoreView.vue')
+
+    expect(appSource).toContain('initUsageTracker')
+    expect(appSource).toContain('trackViewNavigation')
+    expect(appSource).toContain('startUsageUploadScheduler')
+    expect(appSource).toContain('void trackViewNavigation(fromView, normalized)')
+    expect(appSource).toContain("scheduleUsageUpload({ studentId: studentId.value, reason: 'login', force: true })")
+    expect(appSource).toContain(':student-id="studentId"')
+
+    expect(moreSource).toContain("import { trackModuleOpen } from '../utils/usage_tracker.js'")
+    expect(moreSource).toContain('void trackModuleOpen({')
+    expect(moreSource).toContain('loadMode:')
+  })
+
+  it('defines usage tracker and uploader with challenge upload flow', () => {
+    const trackerSource = readSource('src/utils/usage_tracker.js')
+    const uploaderSource = readSource('src/utils/usage_uploader.js')
+
+    expect(trackerSource).toContain('usage_stats_record_event')
+    expect(trackerSource).toContain('trackViewNavigation')
+    expect(trackerSource).toContain('trackModuleOpen')
+    expect(trackerSource).toContain('trackAppForeground')
+    expect(trackerSource).toContain('trackAppBackground')
+
+    expect(uploaderSource).toContain('/api/usage-stats')
+    expect(uploaderSource).toContain('x-usage-stats-challenge')
+    expect(uploaderSource).toContain('usage_stats_list_pending_upload')
+    expect(uploaderSource).toContain('fetchRemotePersonalUsageSummary')
+  })
+
+  it('registers usage_stats tauri commands in lib.rs', () => {
+    const libSource = readSource('src-tauri/src/lib.rs')
+    const dbSource = readSource('src-tauri/src/db.rs')
+
+    expect(libSource).toContain('usage_stats_record_event')
+    expect(libSource).toContain('usage_stats_get_personal_summary')
+    expect(libSource).toContain('usage_stats_list_pending_upload')
+    expect(dbSource).toContain('app_usage_events')
+    expect(dbSource).toContain('ensure_schema_migration(&conn, 3,')
+  })
+})

--- a/src/utils/usage_uploader.js
+++ b/src/utils/usage_uploader.js
@@ -1,0 +1,280 @@
+import { invokeNative, isTauriRuntime } from '../platform/native'
+import { getCloudSyncRuntimeConfig } from './cloud_sync'
+import { pushDebugLog } from './debug_logger'
+import {
+  clearWebUsagePendingQueues,
+  getWebUsagePendingQueues
+} from './usage_tracker'
+
+const CLOUD_SYNC_DEVICE_ID_KEY = 'hbu_cloud_sync_device_id'
+const USAGE_UPLOAD_LAST_SUCCESS_PREFIX = 'hbu_usage_upload_last_success:'
+const DEFAULT_TIMEOUT_MS = 12000
+const DEFAULT_UPLOAD_COOLDOWN_MS = 15 * 60 * 1000
+const CHALLENGE_SKEW_MS = 3000
+const CHALLENGE_FALLBACK_TTL_MS = 60 * 1000
+const BATCH_LIMIT = 200
+const STUDENT_ID_RE = /^\d{10}$/
+
+const challengeState = {
+  token: '',
+  expiresAt: 0,
+  endpoint: ''
+}
+
+let uploadTimer = null
+let uploadInFlight = null
+
+const toSafeText = (value) => String(value || '').trim()
+const isValidStudentId = (value) => STUDENT_ID_RE.test(toSafeText(value))
+
+const safeParseJson = (raw, fallback = null) => {
+  if (!raw) return fallback
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return fallback
+  }
+}
+
+const ensureDeviceId = () => {
+  let id = toSafeText(localStorage.getItem(CLOUD_SYNC_DEVICE_ID_KEY))
+  if (id) return id
+  try {
+    id = (crypto?.randomUUID?.() || '').trim()
+  } catch {
+    id = ''
+  }
+  if (!id) {
+    id = `device-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  }
+  localStorage.setItem(CLOUD_SYNC_DEVICE_ID_KEY, id)
+  return id
+}
+
+const normalizeUsageStatsEndpoint = (value) => {
+  const text = toSafeText(value)
+  if (!text) return ''
+  const withProtocol = /^https?:\/\//i.test(text) ? text : `https://${text}`
+  const normalized = withProtocol.replace(/\/+$/, '')
+  if (/\/api\/usage-stats$/i.test(normalized)) return normalized
+  if (/\/api\/cloud-sync$/i.test(normalized)) {
+    return normalized.replace(/\/api\/cloud-sync$/i, '/api/usage-stats')
+  }
+  return `${normalized}/api/usage-stats`
+}
+
+export const getUsageStatsRuntimeConfig = () => {
+  const cloudCfg = getCloudSyncRuntimeConfig()
+  const endpoint = normalizeUsageStatsEndpoint(cloudCfg.proxyEndpoint || cloudCfg.endpoint)
+  return {
+    enabled: Boolean(endpoint) && cloudCfg.enabled !== false,
+    endpoint,
+    secretRef: toSafeText(cloudCfg.secretRef) || 'kv1-main',
+    timeoutMs: Math.max(3000, Number(cloudCfg.timeoutMs || DEFAULT_TIMEOUT_MS))
+  }
+}
+
+const getLastUploadTs = (studentId) => {
+  const sid = toSafeText(studentId)
+  if (!sid) return 0
+  return Number(localStorage.getItem(`${USAGE_UPLOAD_LAST_SUCCESS_PREFIX}${sid}`) || 0) || 0
+}
+
+const setLastUploadTs = (studentId, ts = Date.now()) => {
+  const sid = toSafeText(studentId)
+  if (!sid) return
+  localStorage.setItem(`${USAGE_UPLOAD_LAST_SUCCESS_PREFIX}${sid}`, String(ts))
+}
+
+const canReuseChallenge = (config) => {
+  const endpoint = toSafeText(config?.endpoint)
+  if (!endpoint) return false
+  if (challengeState.endpoint !== endpoint) return false
+  if (!challengeState.token) return false
+  return challengeState.expiresAt > Date.now() + CHALLENGE_SKEW_MS
+}
+
+const loadUsageStatsChallenge = async (config, force = false) => {
+  if (!force && canReuseChallenge(config)) {
+    return challengeState.token
+  }
+  const secretRef = toSafeText(config?.secretRef) || 'kv1-main'
+  const query = new URLSearchParams({ secret_ref: secretRef }).toString()
+  const url = `${config.endpoint.replace(/\/+$/, '')}/ping?${query}`
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
+  const timer = window.setTimeout(() => controller?.abort?.(), config.timeoutMs)
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller?.signal
+    })
+    const parsed = safeParseJson(await response.text(), null)
+    if (!response.ok) {
+      throw new Error(toSafeText(parsed?.error) || `usage-stats ping 失败 (${response.status})`)
+    }
+    const token = toSafeText(parsed?.challenge)
+    if (!token) throw new Error('usage-stats 鉴权挑战获取失败')
+    const ttlSec = Number(parsed?.challenge_expires_in || 0)
+    const ttlMs = Number.isFinite(ttlSec) && ttlSec > 0
+      ? Math.max(10_000, Math.round(ttlSec * 1000))
+      : CHALLENGE_FALLBACK_TTL_MS
+    challengeState.token = token
+    challengeState.endpoint = config.endpoint
+    challengeState.expiresAt = Date.now() + ttlMs
+    return token
+  } finally {
+    window.clearTimeout(timer)
+  }
+}
+
+const requestUsageStats = async (path, { method = 'GET', body, config, skipChallenge = false } = {}) => {
+  const endpoint = toSafeText(config?.endpoint)
+  if (!endpoint) throw new Error('usage-stats 服务地址未配置')
+  const url = `${endpoint.replace(/\/+$/, '')}${path}`
+  const challengeToken = skipChallenge ? '' : await loadUsageStatsChallenge(config)
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
+  const timer = window.setTimeout(() => controller?.abort?.(), config.timeoutMs)
+  try {
+    const headers = { Accept: 'application/json' }
+    if (body !== undefined) headers['Content-Type'] = 'application/json'
+    if (challengeToken) headers['x-usage-stats-challenge'] = challengeToken
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller?.signal
+    })
+    const parsed = safeParseJson(await response.text(), null)
+    if (!response.ok) {
+      throw new Error(toSafeText(parsed?.error) || `usage-stats 请求失败 (${response.status})`)
+    }
+    return parsed
+  } finally {
+    window.clearTimeout(timer)
+  }
+}
+
+const collectPendingBatch = async (studentId, deviceId) => {
+  if (isTauriRuntime()) {
+    return await invokeNative('usage_stats_list_pending_upload', {
+      studentId,
+      deviceId,
+      limit: BATCH_LIMIT
+    })
+  }
+  const web = getWebUsagePendingQueues()
+  return {
+    events: (web.events || []).slice(0, BATCH_LIMIT),
+    sessions: (web.sessions || []).slice(0, BATCH_LIMIT),
+    device_profile: web.deviceProfile || null
+  }
+}
+
+const markBatchUploaded = async (studentId, eventIds, sessionIds) => {
+  const uploadedAt = Date.now()
+  if (isTauriRuntime()) {
+    await invokeNative('usage_stats_mark_uploaded', {
+      eventIds,
+      sessionIds,
+      uploadedAt
+    })
+    return
+  }
+  clearWebUsagePendingQueues({ eventIds, sessionIds })
+}
+
+export const runUsageStatsUpload = async ({
+  studentId,
+  reason = 'manual',
+  force = false
+} = {}) => {
+  const sid = toSafeText(studentId)
+  if (!isValidStudentId(sid)) {
+    return { success: false, error: '学号无效，跳过 usage 上传' }
+  }
+  const cfg = getUsageStatsRuntimeConfig()
+  if (!cfg.enabled) {
+    return { success: false, error: 'usage-stats 未启用' }
+  }
+  if (!force) {
+    const lastTs = getLastUploadTs(sid)
+    const remain = DEFAULT_UPLOAD_COOLDOWN_MS - (Date.now() - lastTs)
+    if (lastTs > 0 && remain > 0) {
+      return { success: false, cooldown: true, remainingMs: remain, error: 'usage 上传冷却中' }
+    }
+  }
+
+  const deviceId = ensureDeviceId()
+  const batch = await collectPendingBatch(sid, deviceId)
+  const events = Array.isArray(batch?.events) ? batch.events : []
+  const sessions = Array.isArray(batch?.sessions) ? batch.sessions : []
+  if (!events.length && !sessions.length && !batch?.device_profile) {
+    return { success: true, skipped: true, accepted: 0 }
+  }
+
+  pushDebugLog('UsageStats', `开始上传 student=${sid} reason=${reason} events=${events.length}`, 'info')
+  try {
+    const response = await requestUsageStats('/upload', {
+      method: 'POST',
+      config: cfg,
+      body: {
+        student_id: sid,
+        device_id: deviceId,
+        secret_ref: cfg.secretRef,
+        client_time: Date.now(),
+        events,
+        sessions,
+        device_profile: batch?.device_profile || null
+      }
+    })
+    const acceptedEventIds = events.map((item) => toSafeText(item?.event_id)).filter(Boolean)
+    const acceptedSessionIds = sessions.map((item) => toSafeText(item?.session_id)).filter(Boolean)
+    await markBatchUploaded(sid, acceptedEventIds, acceptedSessionIds)
+    setLastUploadTs(sid)
+    pushDebugLog('UsageStats', `上传成功 student=${sid} accepted=${response?.accepted ?? acceptedEventIds.length}`, 'info')
+    return { success: true, response }
+  } catch (error) {
+    pushDebugLog('UsageStats', `上传失败 student=${sid}`, 'warn', error)
+    return { success: false, error: String(error?.message || error || 'usage 上传失败') }
+  }
+}
+
+export const fetchRemotePersonalUsageSummary = async (studentId) => {
+  const sid = toSafeText(studentId)
+  if (!isValidStudentId(sid)) return null
+  const cfg = getUsageStatsRuntimeConfig()
+  if (!cfg.enabled) return null
+  try {
+    const query = new URLSearchParams({ student_id: sid, secret_ref: cfg.secretRef }).toString()
+    return await requestUsageStats(`/personal?${query}`, { method: 'GET', config: cfg })
+  } catch {
+    return null
+  }
+}
+
+export const scheduleUsageUpload = ({ studentId, reason = 'scheduled', force = false } = {}) => {
+  const sid = toSafeText(studentId)
+  if (!isValidStudentId(sid)) return
+  if (uploadInFlight) return
+  uploadInFlight = runUsageStatsUpload({ studentId: sid, reason, force })
+    .catch(() => ({ success: false }))
+    .finally(() => {
+      uploadInFlight = null
+    })
+}
+
+export const startUsageUploadScheduler = (getStudentId) => {
+  if (uploadTimer) return
+  const tick = () => {
+    const sid = toSafeText(typeof getStudentId === 'function' ? getStudentId() : getStudentId)
+    if (sid) scheduleUsageUpload({ studentId: sid, reason: 'interval' })
+  }
+  uploadTimer = window.setInterval(tick, DEFAULT_UPLOAD_COOLDOWN_MS)
+}
+
+export const stopUsageUploadScheduler = () => {
+  if (!uploadTimer) return
+  window.clearInterval(uploadTimer)
+  uploadTimer = null
+}


### PR DESCRIPTION
## Summary
- Add SQLite-backed local usage tracking for views, modules, and app foreground sessions (open counts, duration, load mode).
- Upload batched usage events to ocr-service `/api/usage-stats` with challenge auth, reusing cloud-sync endpoint config.
- Extend ServiceStatsView with personal usage and global `client_usage` sections from `/health`.

## Server deploy (ocr-service)
- Production `mini-hbut/ocr-service` and staging `mini-hbut/testocr1` are on commit `3f622ce` (`feat(usage-stats): add client usage upload API with Turso and SQLPub aggregates`).
- Verified after restart: `/health` returns `client_usage`; `/api/usage-stats/ping` issues challenge on both environments.

## Test plan
- [x] `vitest run usage_tracking_contract service_stats_view_contract` (11 passed)
- [x] `cargo check` in `src-tauri`
- [x] ocr-service `pytest` (118 passed)
- [x] Production `https://mini-hbut-ocr-service.hf.space/health` — `status: ok`, `client_usage` present
- [x] testocr1 `https://mini-hbut-testocr1.hf.space/api/usage-stats/ping` — challenge OK
- [ ] Login, navigate modules, confirm local stats appear under 我的使用 (manual QA after merge)
