### PR TITLE
feat(me): 学校官网与快捷链接需登录后才显示

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,7 @@ import {
   MAIN_TABS,
   ME_SUB_VIEWS,
   HIERARCHICAL_PARENT_VIEW_MAP,
+  isLoginRequiredView,
   normalizeViewName
 } from './navigation/app_navigation.ts'
 import {
@@ -1358,6 +1359,15 @@ const ensureProtectedViewAccess = (
   return false
 }
 
+const ensureLoginRequiredViewAccess = (view) => {
+  const normalized = normalizeViewName(view)
+  if (!isLoginRequiredView(normalized) || isLoggedIn.value) {
+    return true
+  }
+  handleRequireLogin()
+  return false
+}
+
 const goToViewInternal = (view, { push = true, restoreScroll = false } = {}) => {
   const normalized = normalizeViewName(view)
   const fromView = currentView.value
@@ -1383,6 +1393,9 @@ const goToViewInternal = (view, { push = true, restoreScroll = false } = {}) => 
 
 const goToView = (view, { push = true, restoreScroll = false } = {}) => {
   const normalized = normalizeViewName(view)
+  if (!ensureLoginRequiredViewAccess(normalized)) {
+    return false
+  }
   if (!ensureProtectedViewAccess(normalized, { push, fallbackView: currentView.value })) {
     return false
   }
@@ -3099,12 +3112,12 @@ onBeforeUnmount(() => {
       />
 
       <SchoolWebsiteView
-        v-else-if="currentView === 'school_website'"
+        v-else-if="currentView === 'school_website' && isLoggedIn"
         @back="handleBackToMe"
       />
 
       <QuickLinksView
-        v-else-if="currentView === 'quick_links'"
+        v-else-if="currentView === 'quick_links' && isLoggedIn"
         @back="handleBackToMe"
       />
 

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -165,13 +165,13 @@ const handleShowLegal = async (tab) => {
         </div>
         <span class="grid-label">导出中心</span>
       </button>
-      <button class="grid-item" @click="handleOpenSchoolWebsite">
+      <button v-if="isLoggedIn" class="grid-item" @click="handleOpenSchoolWebsite">
         <div class="grid-icon-box" style="background: #E8EAF6;">
           <span class="material-symbols-outlined" style="color: #3949AB;">language</span>
         </div>
         <span class="grid-label">学校官网</span>
       </button>
-      <button class="grid-item" @click="handleOpenQuickLinks">
+      <button v-if="isLoggedIn" class="grid-item" @click="handleOpenQuickLinks">
         <div class="grid-icon-box" style="background: #E0F7FA;">
           <span class="material-symbols-outlined" style="color: #00838F;">link</span>
         </div>

--- a/src/navigation/app_navigation.ts
+++ b/src/navigation/app_navigation.ts
@@ -18,6 +18,14 @@ export const ME_SUB_VIEWS = [
   'more_chaoxing_checkin'
 ] as const
 
+/** 需登录后才能访问的「我的」子页面 */
+export const LOGIN_REQUIRED_ME_VIEWS = ['school_website', 'quick_links'] as const
+
+export const isLoginRequiredView = (view: unknown): boolean => {
+  const normalized = String(view || '').trim()
+  return (LOGIN_REQUIRED_ME_VIEWS as readonly string[]).includes(normalized)
+}
+
 export const HIERARCHICAL_PARENT_VIEW_MAP: Readonly<Record<string, string>> = Object.freeze({
   schedule: 'home',
   forum: 'home',

--- a/src/utils/me_quick_links_contract.spec.ts
+++ b/src/utils/me_quick_links_contract.spec.ts
@@ -14,10 +14,21 @@ describe('me quick links frontend contract', () => {
 
     expect(source).toContain("const handleOpenSchoolWebsite = () => emit('navigate', 'school_website')")
     expect(source).toContain("const handleOpenQuickLinks = () => emit('navigate', 'quick_links')")
-    expect(source).toContain('@click="handleOpenSchoolWebsite"')
-    expect(source).toContain('@click="handleOpenQuickLinks"')
+    expect(source).toContain('v-if="isLoggedIn" class="grid-item" @click="handleOpenSchoolWebsite"')
+    expect(source).toContain('v-if="isLoggedIn" class="grid-item" @click="handleOpenQuickLinks"')
     expect(source).toContain('学校官网')
     expect(source).toContain('快捷链接')
+  })
+
+  it('requires login before entering school_website or quick_links', () => {
+    const appSource = readSource('src/App.vue')
+    const navSource = readSource('src/navigation/app_navigation.ts')
+
+    expect(navSource).toContain('LOGIN_REQUIRED_ME_VIEWS')
+    expect(navSource).toContain('isLoginRequiredView')
+    expect(appSource).toContain('ensureLoginRequiredViewAccess')
+    expect(appSource).toContain("currentView === 'school_website' && isLoggedIn")
+    expect(appSource).toContain("currentView === 'quick_links' && isLoggedIn")
   })
 
   it('registers school_website and quick_links as Me sub views in App.vue', () => {
@@ -34,8 +45,8 @@ describe('me quick links frontend contract', () => {
     expect(navSource).toMatch(/HIERARCHICAL_PARENT_VIEW_MAP[\s\S]*quick_links:\s*'me'/)
     expect(appSource).toMatch(/VIEW_PREFETCHERS[\s\S]*school_website:\s*loadSchoolWebsiteView/)
     expect(appSource).toMatch(/VIEW_PREFETCHERS[\s\S]*quick_links:\s*loadQuickLinksView/)
-    expect(appSource).toContain("v-else-if=\"currentView === 'school_website'\"")
-    expect(appSource).toContain("v-else-if=\"currentView === 'quick_links'\"")
+    expect(appSource).toContain("v-else-if=\"currentView === 'school_website' && isLoggedIn\"")
+    expect(appSource).toContain("v-else-if=\"currentView === 'quick_links' && isLoggedIn\"")
     expect(appSource).toContain('<SchoolWebsiteView')
     expect(appSource).toContain('<QuickLinksView')
     expect(appSource).toContain('@back="handleBackToMe"')


### PR DESCRIPTION
## Summary

- 未登录时隐藏「我的」页的「学校官网」「快捷链接」入口
- 导航至 school_website / quick_links 时校验登录，未登录则提示
- 页面渲染增加 isLoggedIn 条件，防止深链绕过

Closes #202

## Test plan

- [x] pnpm test src/utils/me_quick_links_contract.spec.ts
- [x] pnpm run build
- [ ] 未登录时「我的」页不显示两个入口
- [ ] 登录后入口正常显示并可打开

Made with [Cursor](https://cursor.com)