### PR TITLE
fix(website): 修复 GitHub Pages 空白页（basePath + .nojekyll）

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -939,6 +939,8 @@ jobs:
           node scripts/build_website_modules.mjs
 
       - name: Build website
+        env:
+          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -930,6 +930,8 @@ jobs:
           node scripts/build_website_modules.mjs
 
       - name: Build website
+        env:
+          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -166,6 +166,8 @@ jobs:
           node scripts/build_website_modules.mjs
 
       - name: Build website
+        env:
+          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/website-modules.yml
+++ b/.github/workflows/website-modules.yml
@@ -141,6 +141,8 @@ jobs:
           exit 1
 
       - name: Build website
+        env:
+          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/scripts/ci/deploy_website_pages.sh
+++ b/scripts/ci/deploy_website_pages.sh
@@ -14,6 +14,8 @@ fi
 
 DEPLOY="$(mktemp -d)"
 cp -r website/dist/. "$DEPLOY/"
+# Jekyll 会忽略下划线前缀目录（如 _next/），必须禁用。
+touch "$DEPLOY/.nojekyll"
 cd "$DEPLOY"
 git init -q
 git config user.name "github-actions[bot]"

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -4,7 +4,13 @@ import { fileURLToPath } from 'url';
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url));
 
+// GitHub Pages 项目站点部署在 /mini-hbut/ 子路径；自定义域名构建不设置 GITHUB_PAGES。
+const isGitHubPages = process.env.GITHUB_PAGES === 'true';
+const basePath = isGitHubPages ? '/mini-hbut' : '';
+
 const nextConfig: NextConfig = {
+  basePath,
+  assetPrefix: basePath || undefined,
   output: 'export',
   distDir: 'dist',
   images: { unoptimized: true },


### PR DESCRIPTION
## Summary

- 为 GitHub Pages 项目站点（`/mini-hbut/`）添加 `basePath` / `assetPrefix` 配置，通过 CI 环境变量 `GITHUB_PAGES=true` 启用
- 新增 `website/public/.nojekyll` 并在部署脚本中兜底创建，防止 Jekyll 剥离 `_next/` 目录
- 更新 4 个 website 部署 workflow，确保 CI 构建使用正确的子路径

Fixes #208

## Test plan

- [x] `GITHUB_PAGES=true npm run build` 构建成功
- [x] `dist/index.html` 资源路径为 `/mini-hbut/_next/...`
- [x] `dist/.nojekyll` 存在
- [x] `npm run test:docs-ia` 通过
- [x] 本地 serve（`/mini-hbut/` 子路径）首页 3D 场景与文档页可正常渲染
- [ ] 合并后 CI 部署 `website-pages` 分支
- [ ] 线上验证 `https://superdaobo.github.io/mini-hbut/` JS/CSS 200、页面完整渲染
