### PR TITLE
fix(docs): point README build badge to CI workflow on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
   <a href="https://github.com/superdaobo/mini-hbut/releases">
     <img src="https://img.shields.io/github/v/release/superdaobo/mini-hbut?style=flat-square" alt="Latest Release">
   </a>
-  <a href="https://github.com/superdaobo/mini-hbut/actions/workflows/release.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/superdaobo/mini-hbut/release.yml?style=flat-square" alt="Build Status">
+  <a href="https://github.com/superdaobo/mini-hbut/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/superdaobo/mini-hbut/ci.yml?branch=main&style=flat-square" alt="Build Status">
   </a>
   <a href="#license">
     <img src="https://img.shields.io/badge/license-GPL%20v3-blue?style=flat-square" alt="License">


### PR DESCRIPTION
## Summary

README 构建徽章改为指向 `ci.yml`（`main` 分支），修复始终显示 failing 的问题。

## Root cause

- `release.yml` 仅在推送 `v*` tag 时运行
- shields.io 默认取 **main 分支** 上该 workflow 的最近一次运行
- main 上最后一次 `release.yml` 运行是 2026-06-26 的失败记录（0s startup failure），因此徽章一直红

## Fix

- 徽章链接与状态改为 `ci.yml?branch=main`（当前为 passing）

## Test plan

- [x] 确认 shields.io URL 返回 passing
- [ ] 合并后 GitHub README 预览徽章为绿色
