### PR TITLE
fix(campus-guide): 修复移动端校园导览 API 返回非 JSON 导致地图无法加载

### DIFF
--- a/src/features/campus-guide/api/wisdom_client.ts
+++ b/src/features/campus-guide/api/wisdom_client.ts
@@ -1,4 +1,4 @@
-import { CAMPUS_GUIDE_CONFIG } from '../config'
+import { resolveCampusGuideBaseUrl } from '../config'
 import type { WisdomApiResponse } from '../types'
 import { CAMPUS_GUIDE_ENDPOINTS } from './endpoints'
 
@@ -18,7 +18,7 @@ export class WisdomApiError extends Error {
 }
 
 const joinUrl = (path: string) => {
-  const base = CAMPUS_GUIDE_CONFIG.apiBase.replace(/\/$/, '')
+  const base = resolveCampusGuideBaseUrl().replace(/\/$/, '')
   const normalized = path.startsWith('/') ? path : `/${path}`
   return `${base}${normalized}`
 }

--- a/src/features/campus-guide/config.ts
+++ b/src/features/campus-guide/config.ts
@@ -8,6 +8,7 @@ export const CAMPUS_GUIDE_CONFIG = Object.freeze({
   customLayerId: '6913dc019029',
   themeColor: '#0074CF',
   apiBase: '/campus-guide',
+  localBridgeBaseUrl: 'http://127.0.0.1:4399/campus-guide',
   minZoom: 15,
   maxZoom: 20,
   defaultZoom: 16,
@@ -18,6 +19,15 @@ export const CAMPUS_GUIDE_CONFIG = Object.freeze({
   markerDodge: false,
   cdnBase: 'https://industry.map.qq.com/cloud/hugongda/2022/09/05'
 })
+
+export const resolveCampusGuideBaseUrl = () => {
+  const win = typeof window === 'undefined' ? null : window as Window & {
+    __TAURI_INTERNALS__?: unknown
+    __TAURI__?: unknown
+  }
+  if (win?.__TAURI_INTERNALS__ || win?.__TAURI__) return CAMPUS_GUIDE_CONFIG.localBridgeBaseUrl
+  return CAMPUS_GUIDE_CONFIG.apiBase
+}
 
 const GUIDE_MODE_KEY = 'campus_guide_use_tencent'
 

--- a/src/utils/campus_guide_bridge_contract.spec.ts
+++ b/src/utils/campus_guide_bridge_contract.spec.ts
@@ -51,4 +51,15 @@ describe('campus guide bridge contract', () => {
     expect(home).toContain('openYunyou')
     expect(home).toContain('openPunch')
   })
+
+  it('resolves campus-guide API base through tauri loopback bridge on mobile', () => {
+    const config = read('src/features/campus-guide/config.ts')
+    const client = read('src/features/campus-guide/api/wisdom_client.ts')
+
+    expect(config).toContain("localBridgeBaseUrl: 'http://127.0.0.1:4399/campus-guide'")
+    expect(config).toContain('resolveCampusGuideBaseUrl')
+    expect(config).toContain('__TAURI_INTERNALS__')
+    expect(client).toContain('resolveCampusGuideBaseUrl')
+    expect(client).not.toContain('CAMPUS_GUIDE_CONFIG.apiBase.replace')
+  })
 })


### PR DESCRIPTION
## Summary

- 修复 Tauri 移动端校园导览 API 请求命中 WebView 静态资源、返回 HTML 导致「非 JSON（HTTP 200）」的问题
- 新增 `resolveCampusGuideBaseUrl()`，在 Tauri 运行时改用 `http://127.0.0.1:4399/campus-guide`（对齐小塔出行 Bridge 模式）
- 扩展 bridge 契约测试，确保前端不再直接拼接相对 `apiBase`

Closes #217

## Test plan

- [x] `npx vitest run src/utils/campus_guide_bridge_contract.spec.ts src/features/campus-guide/api/sign.spec.ts` 通过（4/4）
- [ ] Tauri iOS 真机：进入校园导览地图页，确认无「非 JSON」错误，POI 与分类正常加载
- [ ] 抽查搜索、打卡、云游子页面 API
- [ ] Web 开发环境与桌面端无回归

## 已知边界

- Tauri Android Release 默认不启 loopback Bridge，若仍复现需另开 issue
- Capacitor 无 loopback bridge，不在本轮范围
