### PR TITLE
chore(edgeone): add edgeone.json for custom domain build

### DIFF
--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,6 @@
+{
+  "installCommand": "cd website && npm ci",
+  "buildCommand": "node scripts/build_website_modules.mjs && cd website && npm run build",
+  "outputDirectory": "website/dist",
+  "nodeVersion": "20.18.0"
+}

--- a/edgeone.json
+++ b/edgeone.json
@@ -2,5 +2,5 @@
   "installCommand": "cd website && npm ci",
   "buildCommand": "node scripts/build_website_modules.mjs && cd website && npm run build",
   "outputDirectory": "website/dist",
-  "nodeVersion": "22.11.0"
+  "nodeVersion": "22.17.1"
 }

--- a/edgeone.json
+++ b/edgeone.json
@@ -2,5 +2,5 @@
   "installCommand": "cd website && npm ci",
   "buildCommand": "node scripts/build_website_modules.mjs && cd website && npm run build",
   "outputDirectory": "website/dist",
-  "nodeVersion": "20.18.0"
+  "nodeVersion": "22.11.0"
 }


### PR DESCRIPTION
## Summary
- Add `edgeone.json` to pin EdgeOne Pages build settings for `hbut.6661111.xyz`
- Build from `website/` on `main` without `GITHUB_PAGES` basePath
- Aligns install/build/output/node version with `.github/workflows/sync-website.yml`

## Test plan
- [ ] Merge to `main`
- [ ] EdgeOne redeploy from `main` succeeds
- [ ] https://hbut.6661111.xyz/ renders correctly (no `/mini-hbut/` prefix)
