### PR TITLE
fix(campus-guide): 修复步行导航路线崩溃与外部腾讯地图找不到终点

### DIFF
--- a/src/features/campus-guide/map/polyline-decoder.spec.ts
+++ b/src/features/campus-guide/map/polyline-decoder.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { decodeDeltaPolyline, polylineToPoints } from './polyline-decoder'
 
 describe('campus guide polyline decoder', () => {
-  it('decodes incremental polyline values', () => {
+  it('decodes incremental polyline values in degree format', () => {
     const decoded = decodeDeltaPolyline([30.48, 114.31, 100, 200, 50, -100])
     expect(decoded[0]).toBeCloseTo(30.48, 5)
     expect(decoded[1]).toBeCloseTo(114.31, 5)
@@ -12,10 +12,29 @@ describe('campus guide polyline decoder', () => {
     expect(decoded[5]).toBeCloseTo(114.3101, 5)
   })
 
+  it('decodes tencent micro-degree polyline format', () => {
+    const decoded = decodeDeltaPolyline([30_480_000, 114_310_000, 100, 200])
+    expect(decoded[0]).toBeCloseTo(30.48, 5)
+    expect(decoded[1]).toBeCloseTo(114.31, 5)
+    expect(decoded[2]).toBeCloseTo(30.4801, 5)
+    expect(decoded[3]).toBeCloseTo(114.3102, 5)
+  })
+
   it('converts polyline array to lat/lng points', () => {
     const points = polylineToPoints([30.48, 114.31])
     expect(points).toHaveLength(1)
     expect(points[0].latitude).toBeCloseTo(30.48, 5)
     expect(points[0].longitude).toBeCloseTo(114.31, 5)
+  })
+
+  it('returns empty points for empty or invalid polyline', () => {
+    expect(polylineToPoints([])).toEqual([])
+    expect(polylineToPoints([Number.NaN, 114.31])).toEqual([])
+  })
+
+  it('skips invalid coordinate pairs without throwing', () => {
+    const points = polylineToPoints([30.48, 114.31, Number.NaN, 200, 50, -100])
+    expect(points.length).toBeGreaterThanOrEqual(1)
+    expect(points[0].latitude).toBeCloseTo(30.48, 5)
   })
 })

--- a/src/features/campus-guide/map/polyline-decoder.ts
+++ b/src/features/campus-guide/map/polyline-decoder.ts
@@ -1,10 +1,43 @@
 import type { GeoPoint } from '../types'
 
-/** 解压腾讯步行路线增量编码坐标（移植小程序 translateCoors） */
+const MICRO_DEGREE_THRESHOLD = 1000
+
+/** 判断 polyline 首对坐标是否为腾讯微度格式（* 1e6） */
+const isMicroDegreePolyline = (lat: number, lng: number) =>
+  Math.abs(lat) > MICRO_DEGREE_THRESHOLD || Math.abs(lng) > MICRO_DEGREE_THRESHOLD
+
+/** 解压腾讯步行路线坐标：兼容微度绝对坐标 + 增量，以及度坐标 + 增量（小程序 translateCoors） */
 export const decodeDeltaPolyline = (raw: Array<number | string>) => {
-  const values = raw.map((item) => Number(item)).filter((item) => Number.isFinite(item))
+  if (!Array.isArray(raw) || raw.length < 2) return [] as number[]
+  const coors = raw.map((item) => Number(item))
+
+  if (isMicroDegreePolyline(coors[0], coors[1])) {
+    const values: number[] = []
+    let lat = coors[0] / 1_000_000
+    let lng = coors[1] / 1_000_000
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return []
+    values.push(lat, lng)
+    for (let index = 2; index + 1 < coors.length; index += 2) {
+      const deltaLat = coors[index]
+      const deltaLng = coors[index + 1]
+      if (!Number.isFinite(deltaLat) || !Number.isFinite(deltaLng)) continue
+      lat += deltaLat / 1_000_000
+      lng += deltaLng / 1_000_000
+      values.push(lat, lng)
+    }
+    return values
+  }
+
+  const values = [...coors]
+  if (!Number.isFinite(values[0]) || !Number.isFinite(values[1])) return []
   for (let index = 2; index < values.length; index += 1) {
-    values[index] = values[index - 2] + values[index] / 1_000_000
+    const base = values[index - 2]
+    const delta = values[index]
+    if (!Number.isFinite(base) || !Number.isFinite(delta)) {
+      values[index] = NaN
+      continue
+    }
+    values[index] = base + delta / 1_000_000
   }
   return values
 }
@@ -12,8 +45,11 @@ export const decodeDeltaPolyline = (raw: Array<number | string>) => {
 export const polylineToPoints = (raw: Array<number | string>): GeoPoint[] => {
   const values = decodeDeltaPolyline(raw)
   const points: GeoPoint[] = []
-  for (let index = 0; index < values.length - 1; index += 2) {
-    points.push({ latitude: values[index], longitude: values[index + 1] })
+  for (let index = 0; index + 1 < values.length; index += 2) {
+    const latitude = values[index]
+    const longitude = values[index + 1]
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) continue
+    points.push({ latitude, longitude })
   }
   return points
 }

--- a/src/features/campus-guide/services/navigation-service.spec.ts
+++ b/src/features/campus-guide/services/navigation-service.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { CAMPUS_GUIDE_CONFIG } from '../config'
+import {
+  buildTencentWalkRouteUrl,
+  isValidGeoPoint,
+  openExternalMapNavigation,
+  resolveNavEndPoint
+} from './navigation-service'
+
+describe('campus guide navigation service', () => {
+  it('resolves end point from spot fields with fallbacks', () => {
+    const fromPoint = resolveNavEndPoint({
+      spot_id: 1,
+      name: '图书馆',
+      point: { latitude: 30.48, longitude: 114.31 }
+    })
+    expect(fromPoint).toEqual({ latitude: 30.48, longitude: 114.31 })
+
+    const fromLatLng = resolveNavEndPoint({
+      spot_id: 2,
+      name: '南门',
+      latitude: 30.49,
+      longitude: 114.32
+    })
+    expect(fromLatLng).toEqual({ latitude: 30.49, longitude: 114.32 })
+  })
+
+  it('rejects invalid geo points', () => {
+    expect(isValidGeoPoint({ latitude: 91, longitude: 114.31 })).toBe(false)
+    expect(isValidGeoPoint({ latitude: 30.48, longitude: Number.NaN })).toBe(false)
+    expect(resolveNavEndPoint({ spot_id: 3, name: '无效点' })).toBeNull()
+  })
+
+  it('builds tencent walk url with encoded chinese name and referer key', () => {
+    const url = buildTencentWalkRouteUrl(
+      { latitude: 30.48, longitude: 114.31 },
+      '图书馆'
+    )
+    expect(url).toContain('to=' + encodeURIComponent('图书馆'))
+    expect(url).toContain('tocoord=30.48,114.31')
+    expect(url).toContain('referer=' + encodeURIComponent(CAMPUS_GUIDE_CONFIG.qqMapKey))
+  })
+
+  it('includes fromcoord when start point is valid', () => {
+    const url = buildTencentWalkRouteUrl(
+      { latitude: 30.48, longitude: 114.31 },
+      '图书馆',
+      { latitude: 30.47, longitude: 114.3 }
+    )
+    expect(url).toContain('fromcoord=30.47,114.3')
+  })
+
+  it('returns null url for invalid end coordinates', () => {
+    expect(
+      buildTencentWalkRouteUrl({ latitude: Number.NaN, longitude: 114.31 }, '图书馆')
+    ).toBeNull()
+  })
+
+  it('openExternalMapNavigation returns false for invalid end', async () => {
+    await expect(
+      openExternalMapNavigation({ latitude: 999, longitude: 114.31 }, '图书馆')
+    ).resolves.toBe(false)
+  })
+})

--- a/src/features/campus-guide/services/navigation-service.ts
+++ b/src/features/campus-guide/services/navigation-service.ts
@@ -1,13 +1,41 @@
 import { openExternal } from '../../../utils/external_link'
 import { campusGuideApi } from '../api/wisdom_client'
+import { CAMPUS_GUIDE_CONFIG } from '../config'
 import { polylineToPoints } from '../map/polyline-decoder'
-import type { GeoPoint, WalkRouteResult } from '../types'
+import type { CampusSpot, GeoPoint, WalkRouteResult } from '../types'
 
 export type WalkNavigationResult = {
   points: GeoPoint[]
   distance?: string | number
   duration?: string | number
   raw?: WalkRouteResult
+}
+
+const toCoord = (value: unknown) => {
+  const num = Number(value)
+  return Number.isFinite(num) ? num : NaN
+}
+
+/** 校验经纬度是否在合法范围内 */
+export const isValidGeoPoint = (point: GeoPoint | null | undefined): point is GeoPoint => {
+  if (!point) return false
+  const lat = toCoord(point.latitude)
+  const lng = toCoord(point.longitude)
+  return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180
+}
+
+/** 统一解析步行导航终点：显式 endPoint → spot.point → spot.latitude/longitude */
+export const resolveNavEndPoint = (
+  spot?: CampusSpot | null,
+  explicitEndPoint?: GeoPoint | null
+): GeoPoint | null => {
+  if (isValidGeoPoint(explicitEndPoint)) return explicitEndPoint
+  if (isValidGeoPoint(spot?.point)) return spot!.point!
+  const lat = toCoord(spot?.latitude)
+  const lng = toCoord(spot?.longitude)
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  const point = { latitude: lat, longitude: lng }
+  return isValidGeoPoint(point) ? point : null
 }
 
 export const fetchCampusWalkRoute = async (start: GeoPoint, end: GeoPoint) => {
@@ -19,7 +47,14 @@ export const fetchCampusWalkRoute = async (start: GeoPoint, end: GeoPoint) => {
   })
   const data = (Array.isArray(raw) ? raw[0] : raw) as WalkRouteResult
   const polyline = data?.polyline
-  const points = Array.isArray(polyline) ? polylineToPoints(polyline) : []
+  let points: GeoPoint[] = []
+  if (Array.isArray(polyline)) {
+    try {
+      points = polylineToPoints(polyline)
+    } catch {
+      points = []
+    }
+  }
   return {
     points,
     distance: data?.distance,
@@ -28,15 +63,38 @@ export const fetchCampusWalkRoute = async (start: GeoPoint, end: GeoPoint) => {
   } satisfies WalkNavigationResult
 }
 
-export const openExternalMapNavigation = async (end: GeoPoint, name = '目的地') => {
+export const buildTencentWalkRouteUrl = (
+  end: GeoPoint,
+  name = '目的地',
+  from?: GeoPoint
+) => {
+  if (!isValidGeoPoint(end)) return null
   const lat = Number(end.latitude)
   const lng = Number(end.longitude)
   const label = encodeURIComponent(name)
+  const referer = encodeURIComponent(CAMPUS_GUIDE_CONFIG.qqMapKey)
+  const fromPart =
+    from && isValidGeoPoint(from)
+      ? `&fromcoord=${Number(from.latitude)},${Number(from.longitude)}`
+      : ''
+  return `https://apis.map.qq.com/uri/v1/routeplan?type=walk&to=${label}&tocoord=${lat},${lng}${fromPart}&referer=${referer}`
+}
+
+export const openExternalMapNavigation = async (
+  end: GeoPoint,
+  name = '目的地',
+  from?: GeoPoint
+) => {
+  if (!isValidGeoPoint(end)) return false
+  const lat = Number(end.latitude)
+  const lng = Number(end.longitude)
+  const label = encodeURIComponent(name)
+  const tencentUrl = buildTencentWalkRouteUrl(end, name, from)
   const candidates = [
-    `https://apis.map.qq.com/uri/v1/routeplan?type=walk&to=${name}&tocoord=${lat},${lng}&referer=mini-hbut`,
+    tencentUrl,
     `https://uri.amap.com/navigation?to=${lng},${lat},${label}&mode=walk&coordinate=gaode`,
     `https://map.baidu.com/mobile/webapp/search/search/qt=nav&sn=0&en=1&end=${lat},${lng}`
-  ]
+  ].filter(Boolean) as string[]
   for (const url of candidates) {
     if (await openExternal(url)) return true
   }

--- a/src/features/campus-guide/views/CampusGuideHome.vue
+++ b/src/features/campus-guide/views/CampusGuideHome.vue
@@ -9,6 +9,7 @@ import { CAMPUS_GUIDE_CONFIG } from '../config'
 import { CampusMapCore } from '../map/campus-map-core'
 import { CAMPUS_GUIDE_VIEWS } from '../navigation'
 import { playCampusSpeech } from '../services/audio-service'
+import { resolveNavEndPoint } from '../services/navigation-service'
 import { hasSeenYunyouIntro, readYunyouUser } from '../services/phase2-storage'
 import { useCampusGuideStore } from '../store/campus-guide-store'
 import type { CampusSpot } from '../types'
@@ -120,11 +121,7 @@ const closePoiCard = () => {
 
 const startNavigation = () => {
   const spot = activePoi.value
-  const endPoint =
-    spot?.point ||
-    (Number.isFinite(Number(spot?.latitude)) && Number.isFinite(Number(spot?.longitude))
-      ? { latitude: Number(spot?.latitude), longitude: Number(spot?.longitude) }
-      : null)
+  const endPoint = resolveNavEndPoint(spot)
   if (!spot || !endPoint) {
     showToast('该点位缺少坐标，无法导航', 'warning', 1800)
     return

--- a/src/features/campus-guide/views/CampusGuidePoiDetail.vue
+++ b/src/features/campus-guide/views/CampusGuidePoiDetail.vue
@@ -4,6 +4,7 @@ import GuidePageLayout from '../components/GuidePageLayout.vue'
 import { showToast } from '../../../utils/toast'
 import { CAMPUS_GUIDE_VIEWS } from '../navigation'
 import { playCampusSpeech } from '../services/audio-service'
+import { resolveNavEndPoint } from '../services/navigation-service'
 import { useCampusGuideStore } from '../store/campus-guide-store'
 
 const emit = defineEmits(['back'])
@@ -40,7 +41,12 @@ onMounted(async () => {
         <button
           type="button"
           class="primary"
-          @click="store.navigateTo(CAMPUS_GUIDE_VIEWS.walkline, { spot: detail, endPoint: detail.point })"
+          @click="
+            store.navigateTo(CAMPUS_GUIDE_VIEWS.walkline, {
+              spot: detail,
+              endPoint: resolveNavEndPoint(detail)
+            })
+          "
         >
           导航
         </button>

--- a/src/features/campus-guide/views/CampusGuideWalkLine.vue
+++ b/src/features/campus-guide/views/CampusGuideWalkLine.vue
@@ -6,7 +6,9 @@ import { CampusMapCore } from '../map/campus-map-core'
 import {
   fetchCampusWalkRoute,
   formatWalkDuration,
-  openExternalMapNavigation
+  isValidGeoPoint,
+  openExternalMapNavigation,
+  resolveNavEndPoint
 } from '../services/navigation-service'
 import { useCampusGuideStore } from '../store/campus-guide-store'
 
@@ -18,13 +20,16 @@ const routeText = ref('')
 const loadingRoute = ref(true)
 const routeReady = ref(false)
 
-const endPoint = computed(() => store.navParams.endPoint || store.navParams.spot?.point)
+const endPoint = computed(() => resolveNavEndPoint(store.navParams.spot, store.navParams.endPoint))
 const endName = computed(() => store.navParams.spot?.name || '目的地')
 
 const openExternalNav = async () => {
   const end = endPoint.value
-  if (!end) return
-  const ok = await openExternalMapNavigation(end, endName.value)
+  if (!end || !isValidGeoPoint(end)) {
+    showToast('该点位缺少坐标，无法打开外部地图', 'warning', 2200)
+    return
+  }
+  const ok = await openExternalMapNavigation(end, endName.value, store.userLocation)
   if (!ok) showToast('无法打开外部地图', 'error', 2200)
 }
 


### PR DESCRIPTION
## Summary

- 修复校园导览步行导航 polyline 解码：兼容腾讯微度格式，解码失败时降级为空路线，避免页面崩溃
- 修复外部腾讯地图导航：URL 编码中文终点名称、使用 `qqMapKey` 作为 referer、补充起点坐标与坐标校验
- 统一 `resolveNavEndPoint` 终点解析逻辑，并补充 11 项单元测试

## Test plan

- [x] `npm run test -- --run src/features/campus-guide/map/polyline-decoder.spec.ts src/features/campus-guide/services/navigation-service.spec.ts`
- [ ] 手动：校园导览 → 选择中文 POI → 步行导航 → 确认路线绘制
- [ ] 手动：点击「打开外部地图导航」，腾讯地图应识别终点

Closes #221
