### PR TITLE
fix(ci): Dev Build macOS PEP 668 Pillow 安装失败

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -249,7 +249,9 @@ jobs:
 
       - name: Generate, sync, and verify Android launcher icons
         run: |
-          python -m pip install --quiet Pillow
+          set -euo pipefail
+          PYTHON_BIN=python source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
           python scripts/fix_android_adaptive_icons.py
           node scripts/sync_tauri_platform_icons.mjs android
           npx vitest run src/utils/android_launcher_icon_contract.spec.ts
@@ -444,8 +446,10 @@ jobs:
 
       - name: Regenerate and verify official desktop icons
         run: |
-          python3 -m pip install Pillow
-          python3 scripts/regenerate_official_icons.py
+          set -euo pipefail
+          source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
+          python scripts/regenerate_official_icons.py
           npx vitest run src/utils/windows_taskbar_icon_contract.spec.ts src/utils/ios_launcher_icon_contract.spec.ts src/utils/android_launcher_icon_contract.spec.ts
 
       - name: Build macOS app (universal, app only)
@@ -561,7 +565,8 @@ jobs:
           console.log('Patched tauri.conf.json for iOS CI.');
           NODE
 
-          python -m pip install --quiet Pillow
+          PYTHON_BIN=python source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
           python scripts/fix_ios_app_icons.py
           npx vitest run src/utils/ios_launcher_icon_contract.spec.ts
 
@@ -732,8 +737,10 @@ jobs:
 
       - name: Regenerate and verify official desktop icons
         run: |
-          python3 -m pip install Pillow
-          python3 scripts/regenerate_official_icons.py
+          set -euo pipefail
+          source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
+          python scripts/regenerate_official_icons.py
           npx vitest run src/utils/windows_taskbar_icon_contract.spec.ts src/utils/ios_launcher_icon_contract.spec.ts src/utils/android_launcher_icon_contract.spec.ts
 
       - name: Build Linux app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,9 @@ jobs:
 
       - name: Generate, sync, and verify Android launcher icons
         run: |
-          python -m pip install --quiet Pillow
+          set -euo pipefail
+          PYTHON_BIN=python source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
           python scripts/fix_android_adaptive_icons.py
           node scripts/sync_tauri_platform_icons.mjs android
           npx vitest run src/utils/android_launcher_icon_contract.spec.ts
@@ -463,8 +465,10 @@ jobs:
 
       - name: Regenerate and verify official desktop icons
         run: |
-          python3 -m pip install Pillow
-          python3 scripts/regenerate_official_icons.py
+          set -euo pipefail
+          source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
+          python scripts/regenerate_official_icons.py
           npx vitest run src/utils/windows_taskbar_icon_contract.spec.ts src/utils/ios_launcher_icon_contract.spec.ts src/utils/android_launcher_icon_contract.spec.ts
 
       - name: Build macOS App (Universal, app only)
@@ -578,7 +582,8 @@ jobs:
           });
           NODE
 
-          python -m pip install --quiet Pillow
+          PYTHON_BIN=python source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
           python scripts/fix_ios_app_icons.py
           npx vitest run src/utils/ios_launcher_icon_contract.spec.ts
 
@@ -750,8 +755,10 @@ jobs:
 
       - name: Regenerate and verify official desktop icons
         run: |
-          python3 -m pip install Pillow
-          python3 scripts/regenerate_official_icons.py
+          set -euo pipefail
+          source scripts/ci/setup_python_venv.sh
+          pip install --quiet Pillow
+          python scripts/regenerate_official_icons.py
           npx vitest run src/utils/windows_taskbar_icon_contract.spec.ts src/utils/ios_launcher_icon_contract.spec.ts src/utils/android_launcher_icon_contract.spec.ts
 
       - name: Build Linux App

--- a/scripts/ci/setup_python_venv.sh
+++ b/scripts/ci/setup_python_venv.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# 在 CI/macOS 等 externally-managed Python 环境中创建并激活虚拟环境。
+set -euo pipefail
+
+VENV_DIR="${CI_PYTHON_VENV:-.ci-python-venv}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+python -m pip install --quiet --upgrade pip


### PR DESCRIPTION
## Summary

- 新增 `scripts/ci/setup_python_venv.sh`，在 CI 中通过虚拟环境安装 Python 依赖
- 更新 `dev-build.yml` / `release.yml` 中 macOS、Linux、Android、iOS 任务的 Pillow 安装方式，避免 PEP 668 `externally-managed-environment` 错误

## Test plan

- [ ] Dev Build `build-macos` 通过
- [ ] Dev Build 全平台任务通过

Closes #223
