### PR TITLE
fix(edgeone): restore website-pages CDN assets before build

### DIFF
--- a/edgeone.json
+++ b/edgeone.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "cd website && npm ci",
-  "buildCommand": "node scripts/build_website_modules.mjs && cd website && npm run build",
+  "buildCommand": "node scripts/restore_website_cdn_assets.mjs && MODULE_MERGE_CATALOG=1 node scripts/build_website_modules.mjs && cd website && npm run build",
   "outputDirectory": "website/dist",
   "nodeVersion": "22.17.1"
 }

--- a/scripts/restore_website_cdn_assets.mjs
+++ b/scripts/restore_website_cdn_assets.mjs
@@ -1,0 +1,105 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+export const CDN_ASSET_DIRS = Object.freeze(['releases', 'modules', 'app-resources'])
+
+const DEFAULT_REPO = 'superdaobo/mini-hbut'
+const DEFAULT_BRANCH = 'website-pages'
+const DEFAULT_PUBLIC_ROOT = 'website/public'
+
+const safeText = (value) => String(value ?? '').trim()
+
+const ensureDir = (dir) => {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+const copyDirContents = (sourceDir, targetDir) => {
+  ensureDir(targetDir)
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name)
+    const targetPath = path.join(targetDir, entry.name)
+    if (entry.isDirectory()) {
+      copyDirContents(sourcePath, targetPath)
+      continue
+    }
+    if (entry.isFile()) {
+      ensureDir(path.dirname(targetPath))
+      fs.copyFileSync(sourcePath, targetPath)
+    }
+  }
+}
+
+export const resolveWebsitePagesAssetDir = (checkoutRoot, assetDir) => {
+  const normalizedRoot = path.resolve(checkoutRoot)
+  const normalizedAsset = safeText(assetDir)
+  if (!normalizedAsset) return ''
+
+  const candidates = [
+    path.join(normalizedRoot, normalizedAsset),
+    path.join(normalizedRoot, 'dist', normalizedAsset)
+  ]
+  return candidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) || ''
+}
+
+export const restoreWebsiteCdnAssets = ({
+  checkoutRoot,
+  publicRoot = DEFAULT_PUBLIC_ROOT,
+  assetDirs = CDN_ASSET_DIRS
+} = {}) => {
+  const resolvedPublicRoot = path.resolve(publicRoot)
+  const restored = []
+
+  for (const assetDir of assetDirs) {
+    const sourceDir = resolveWebsitePagesAssetDir(checkoutRoot, assetDir)
+    if (!sourceDir) {
+      console.log(`[cdn-restore] skip missing asset dir: ${assetDir}`)
+      continue
+    }
+    const targetDir = path.join(resolvedPublicRoot, assetDir)
+    copyDirContents(sourceDir, targetDir)
+    restored.push(assetDir)
+    console.log(`[cdn-restore] restored ${assetDir} from ${sourceDir} -> ${targetDir}`)
+  }
+
+  return restored
+}
+
+const cloneWebsitePages = ({
+  repo = process.env.GITHUB_REPOSITORY || DEFAULT_REPO,
+  branch = process.env.WEBSITE_PAGES_BRANCH || DEFAULT_BRANCH,
+  cloneUrl = process.env.WEBSITE_PAGES_CLONE_URL || ''
+} = {}) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-hbut-website-pages-'))
+  const remote = safeText(cloneUrl) || `https://github.com/${safeText(repo) || DEFAULT_REPO}.git`
+  const targetBranch = safeText(branch) || DEFAULT_BRANCH
+
+  console.log(`[cdn-restore] cloning ${remote}#${targetBranch}`)
+  execFileSync('git', ['clone', '--depth', '1', '--branch', targetBranch, remote, tempDir], {
+    stdio: 'inherit'
+  })
+  return tempDir
+}
+
+const main = () => {
+  const publicRoot = path.resolve(process.env.WEBSITE_PUBLIC_ROOT || DEFAULT_PUBLIC_ROOT)
+  const checkoutRoot = safeText(process.env.WEBSITE_PAGES_CHECKOUT_ROOT)
+
+  if (checkoutRoot) {
+    restoreWebsiteCdnAssets({ checkoutRoot, publicRoot })
+    return
+  }
+
+  const tempDir = cloneWebsitePages()
+  try {
+    restoreWebsiteCdnAssets({ checkoutRoot: tempDir, publicRoot })
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/src/utils/restore_website_cdn_assets_contract.spec.ts
+++ b/src/utils/restore_website_cdn_assets_contract.spec.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  CDN_ASSET_DIRS,
+  resolveWebsitePagesAssetDir,
+  restoreWebsiteCdnAssets
+} from '../../scripts/restore_website_cdn_assets.mjs'
+
+const tempDirs: string[] = []
+
+const makeTempDir = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdn-restore-spec-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+describe('restore_website_cdn_assets', () => {
+  it('resolves asset directories from website-pages root and dist fallback', () => {
+    const root = makeTempDir()
+    const releasesRoot = path.join(root, 'releases')
+    const modulesDist = path.join(root, 'dist', 'modules')
+    fs.mkdirSync(path.join(releasesRoot, 'v1.0.0'), { recursive: true })
+    fs.mkdirSync(path.join(modulesDist, 'main'), { recursive: true })
+
+    expect(resolveWebsitePagesAssetDir(root, 'releases')).toBe(releasesRoot)
+    expect(resolveWebsitePagesAssetDir(root, 'modules')).toBe(modulesDist)
+    expect(resolveWebsitePagesAssetDir(root, 'missing')).toBe('')
+  })
+
+  it('merges releases/modules/app-resources into website/public without deleting unrelated files', () => {
+    const checkoutRoot = makeTempDir()
+    const publicRoot = makeTempDir()
+
+    fs.mkdirSync(path.join(checkoutRoot, 'releases'), { recursive: true })
+    fs.writeFileSync(
+      path.join(checkoutRoot, 'releases', 'stable-latest.json'),
+      '{"channel":"main"}\n'
+    )
+    fs.mkdirSync(path.join(checkoutRoot, 'modules', 'main', 'jump_out_hbut', 'old-version'), {
+      recursive: true
+    })
+    fs.writeFileSync(
+      path.join(checkoutRoot, 'modules', 'main', 'jump_out_hbut', 'old-version', 'bundle.zip'),
+      'zip'
+    )
+    fs.mkdirSync(path.join(checkoutRoot, 'app-resources', 'dormitory'), { recursive: true })
+    fs.writeFileSync(
+      path.join(checkoutRoot, 'app-resources', 'dormitory', 'manifest.json'),
+      '{"resource":"dormitory_data"}\n'
+    )
+    fs.mkdirSync(path.join(publicRoot, 'images'), { recursive: true })
+    fs.writeFileSync(path.join(publicRoot, 'images', 'logo.txt'), 'keep')
+
+    const restored = restoreWebsiteCdnAssets({ checkoutRoot, publicRoot, assetDirs: CDN_ASSET_DIRS })
+
+    expect(restored).toEqual(['releases', 'modules', 'app-resources'])
+    expect(fs.readFileSync(path.join(publicRoot, 'releases', 'stable-latest.json'), 'utf8')).toContain(
+      '"channel":"main"'
+    )
+    expect(
+      fs.existsSync(
+        path.join(publicRoot, 'modules', 'main', 'jump_out_hbut', 'old-version', 'bundle.zip')
+      )
+    ).toBe(true)
+    expect(fs.readFileSync(path.join(publicRoot, 'images', 'logo.txt'), 'utf8')).toBe('keep')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #225

EdgeOne 从 `main` 源码构建时未包含 `website-pages` 上的 CDN 静态资源，导致：

- `/releases/stable-latest.json` 404（应用更新检查失效）
- 历史游戏模块 `bundle.zip` 404（更多页小游戏重新下载失败）

本 PR 在 EdgeOne 构建前从 `website-pages` 恢复 `releases/`、`modules/`、`app-resources/` 到 `website/public/`，并启用 `MODULE_MERGE_CATALOG=1` 合并模块 catalog。

## Changes

- 新增 `scripts/restore_website_cdn_assets.mjs`
- 更新 `edgeone.json` 构建命令
- 新增契约测试 `restore_website_cdn_assets_contract.spec.ts`

## Test plan

- [x] `npx vitest run src/utils/restore_website_cdn_assets_contract.spec.ts`
- [ ] 合并后触发 EdgeOne 重新部署
- [ ] 验证 `https://hbut.6661111.xyz/releases/stable-latest.json` 返回 200
- [ ] 验证历史模块 bundle 与最新 catalog 可访问

## 部署说明

合并到 `main` 后需在 EdgeOne 触发一次生产部署（或等待自动部署），新构建才会带上恢复的 CDN 资源。
