### PR TITLE
fix(edgeone): restore static website-pages deploy like v1.4.2

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -946,8 +946,6 @@ jobs:
           node scripts/build_website_modules.mjs
 
       - name: Build website
-        env:
-          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -937,8 +937,6 @@ jobs:
           node scripts/build_website_modules.mjs
 
       - name: Build website
-        env:
-          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -166,8 +166,6 @@ jobs:
           node scripts/build_website_modules.mjs
 
       - name: Build website
-        env:
-          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/website-modules.yml
+++ b/.github/workflows/website-modules.yml
@@ -141,8 +141,6 @@ jobs:
           exit 1
 
       - name: Build website
-        env:
-          GITHUB_PAGES: 'true'
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund

--- a/edgeone.json
+++ b/edgeone.json
@@ -1,6 +1,6 @@
 {
-  "installCommand": "cd website && npm ci",
-  "buildCommand": "node scripts/restore_website_cdn_assets.mjs && MODULE_MERGE_CATALOG=1 node scripts/build_website_modules.mjs && cd website && npm run build",
-  "outputDirectory": "website/dist",
+  "installCommand": "echo skip",
+  "buildCommand": "echo skip",
+  "outputDirectory": ".",
   "nodeVersion": "22.17.1"
 }

--- a/scripts/ci/deploy_website_pages.sh
+++ b/scripts/ci/deploy_website_pages.sh
@@ -14,6 +14,8 @@ fi
 
 DEPLOY="$(mktemp -d)"
 cp -r website/dist/. "$DEPLOY/"
+# EdgeOne 在 website-pages 分支可能执行默认 npm install；提供占位 package.json 避免 ENOENT（对齐 v1.4.2）。
+echo '{"name":"mini-hbut-website","private":true,"scripts":{"build":"echo skip"}}' > "$DEPLOY/package.json"
 # Jekyll 会忽略下划线前缀目录（如 _next/），必须禁用。
 touch "$DEPLOY/.nojekyll"
 cd "$DEPLOY"

--- a/scripts/configure_edgeone_website_pages.mjs
+++ b/scripts/configure_edgeone_website_pages.mjs
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process'
+
+const API_URL = process.env.EDGEONE_API_URL || 'https://pages-api.edgeone.ai/v1'
+const PROJECT_ID = process.env.EDGEONE_PROJECT_ID || 'pages-qno4dud9jgqs'
+const TOKEN = String(process.env.EDGEONE_API_TOKEN || '').trim()
+
+if (!TOKEN) {
+  console.error('[edgeone] EDGEONE_API_TOKEN is required')
+  process.exit(1)
+}
+
+const payload = {
+  Action: 'ModifyPagesProject',
+  ProjectId: PROJECT_ID,
+  RepoBranch: 'website-pages',
+  InstallCmd: 'echo skip',
+  BuildCmd: 'echo skip',
+  OutputDir: '.',
+  NodejsVersion: '22.17.1'
+}
+
+const response = execFileSync(
+  'curl',
+  [
+    '-sS',
+    '-X',
+    'POST',
+    API_URL,
+    '-H',
+    'Content-Type: application/json',
+    '-H',
+    `Authorization: Bearer ${TOKEN}`,
+    '--data-binary',
+    '@-'
+  ],
+  {
+    input: JSON.stringify(payload),
+    encoding: 'utf8'
+  }
+)
+
+console.log(response)
+const parsed = JSON.parse(response)
+if (parsed.Code !== 0) {
+  process.exit(1)
+}
+
+console.log('[edgeone] project configured for static website-pages deploy')


### PR DESCRIPTION
## Summary

Fixes #225

恢复 **v1.4.2 时期 EdgeOne 部署模型**：从 `website-pages` 静态分支直接发布，不在 EdgeOne 上构建 `main` monorepo。

根因：`edgeone.json` / API 配置了 `cd website && npm ci`，但 `website-pages` 分支只有静态产物，没有 `website/` 目录。

## Changes

- `edgeone.json`：改为 `echo skip` + `outputDirectory: "."`（纯静态）
- `deploy_website_pages.sh`：恢复 v1.4.2 占位 `package.json`，避免 EdgeOne 默认 `npm install` ENOENT
- CI 构建 website-pages 时**不再**设置 `GITHUB_PAGES=true`，资源路径回到 `/_next/...`（适配 `hbut.6661111.xyz` 根路径）
- 新增 `scripts/configure_edgeone_website_pages.mjs`：一键将 EdgeOne 项目 API 配置改回 `website-pages` 静态模式

## 合并后操作

1. 在本地或 CI 运行（需 `EDGEONE_API_TOKEN`）：
   ```bash
   node scripts/configure_edgeone_website_pages.mjs
   ```
2. EdgeOne 控制台对 `website-pages` 重新部署一次
3. 或手动触发 `Sync Website` workflow 刷新 `website-pages` 内容

## Test plan

- [ ] EdgeOne 构建日志不再出现 `cd: website: No such file or directory`
- [ ] `https://hbut.6661111.xyz/releases/stable-latest.json` 返回 200，版本为 1.4.3
- [ ] 首页资源路径为 `/_next/...`（无 `/mini-hbut/` 前缀）
- [ ] `/modules/` 游戏 bundle 可下载
