### PR TITLE
fix(edgeone): static website-pages deploy with module prune

### DIFF
--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -176,3 +176,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_MESSAGE: "deploy: sync website from ${{ github.sha }}"
         run: bash scripts/ci/deploy_website_pages.sh
+
+      - name: Sync EdgeOne static website-pages settings
+        env:
+          EDGEONE_API_TOKEN: ${{ secrets.EDGEONE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EDGEONE_API_TOKEN:-}" ]; then
+            echo "EDGEONE_API_TOKEN not configured, skip EdgeOne API sync"
+            exit 0
+          fi
+          node scripts/configure_edgeone_website_pages.mjs

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -165,17 +165,30 @@ jobs:
           set -euo pipefail
           node scripts/build_website_modules.mjs
 
-      - name: Build website
+      - name: Build website (EdgeOne / custom domain)
         run: |
           cd website
           npm ci --prefer-offline --no-audit --no-fund
           npm run build
 
-      - name: Deploy to website-pages branch
+      - name: Deploy to website-pages branch (EdgeOne)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_MESSAGE: "deploy: sync website from ${{ github.sha }}"
         run: bash scripts/ci/deploy_website_pages.sh
+
+      - name: Build website (GitHub Pages /mini-hbut)
+        run: |
+          cd website
+          rm -rf dist
+          npm ci --prefer-offline --no-audit --no-fund
+          GITHUB_PAGES=true npm run build
+
+      - name: Deploy to gh-pages branch (GitHub Pages)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_MESSAGE: "deploy: github-pages from ${{ github.sha }}"
+        run: bash scripts/ci/deploy_github_pages.sh
 
       - name: Sync EdgeOne static website-pages settings
         env:

--- a/scripts/ci/deploy_github_pages.sh
+++ b/scripts/ci/deploy_github_pages.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 将 GITHUB_PAGES=true 构建的 website/dist 推送到 gh-pages 分支根目录。
+# GitHub Pages 项目站地址：https://superdaobo.github.io/mini-hbut/（需要 basePath=/mini-hbut）
+set -euo pipefail
+
+DEPLOY_MESSAGE="${DEPLOY_MESSAGE:?DEPLOY_MESSAGE is required}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+GITHUB_TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+DEPLOY_SOURCE_DIR="${DEPLOY_SOURCE_DIR:-website/dist}"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-gh-pages}"
+
+if [ ! -d "$DEPLOY_SOURCE_DIR" ]; then
+  echo "ERROR: $DEPLOY_SOURCE_DIR not found (build with GITHUB_PAGES=true first)"
+  exit 1
+fi
+
+if [ -d "$DEPLOY_SOURCE_DIR/modules" ]; then
+  node scripts/prune_website_module_versions.mjs "$DEPLOY_SOURCE_DIR/modules"
+fi
+
+DEPLOY="$(mktemp -d)"
+cp -r "$DEPLOY_SOURCE_DIR/." "$DEPLOY/"
+touch "$DEPLOY/.nojekyll"
+cd "$DEPLOY"
+git init -q
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add -A
+git commit -q -m "$DEPLOY_MESSAGE"
+git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:"$DEPLOY_BRANCH"
+echo "Deployed $DEPLOY_BRANCH from $DEPLOY_SOURCE_DIR: $DEPLOY_MESSAGE"

--- a/scripts/ci/deploy_website_pages.sh
+++ b/scripts/ci/deploy_website_pages.sh
@@ -14,6 +14,12 @@ fi
 
 DEPLOY="$(mktemp -d)"
 cp -r website/dist/. "$DEPLOY/"
+# EdgeOne 读取仓库根目录 edgeone.json；website-pages 必须带上静态构建配置，覆盖控制台里残留的 main 分支命令。
+if [ -f edgeone.json ]; then
+  cp edgeone.json "$DEPLOY/edgeone.json"
+elif [ -f website/public/edgeone.json ]; then
+  cp website/public/edgeone.json "$DEPLOY/edgeone.json"
+fi
 # EdgeOne 在 website-pages 分支可能执行默认 npm install；提供占位 package.json 避免 ENOENT（对齐 v1.4.2）。
 echo '{"name":"mini-hbut-website","private":true,"scripts":{"build":"echo skip"}}' > "$DEPLOY/package.json"
 # Jekyll 会忽略下划线前缀目录（如 _next/），必须禁用。

--- a/scripts/ci/deploy_website_pages.sh
+++ b/scripts/ci/deploy_website_pages.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
-# 将 website/dist 内容强制推送到 website-pages 分支根目录（供多个 workflow 复用）。
-# GitHub Pages「Deploy from a branch」仅支持 / 或 /docs，因此不能发布到 dist/ 子目录。
+# 部署静态站点到 website-pages 分支根目录（EdgeOne 自定义域名 hbut.6661111.xyz）。
+#
+# 构建在 CI 完成（website/ 内 npm run build），本脚本只发布产物：
+#   源目录：website/dist/（Next.js export 输出，含 public/ 同步进来的静态资源）
+#   目标分支：website-pages 根目录 /（不是 dist/ 子目录）
+#   EdgeOne：RepoBranch=website-pages，outputDirectory=.，install/build=echo skip
+#
+# 纯网页约 ~130 个文件；modules/ 为游戏 CDN，部署前会裁剪历史版本目录。
+# GitHub Pages（/mini-hbut/ 子路径）请用 deploy_github_pages.sh → gh-pages 分支。
 set -euo pipefail
 
 DEPLOY_MESSAGE="${DEPLOY_MESSAGE:?DEPLOY_MESSAGE is required}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 GITHUB_TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+DEPLOY_SOURCE_DIR="${DEPLOY_SOURCE_DIR:-website/dist}"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-website-pages}"
 
-if [ ! -d website/dist ]; then
-  echo "ERROR: website/dist not found"
+if [ ! -d "$DEPLOY_SOURCE_DIR" ]; then
+  echo "ERROR: $DEPLOY_SOURCE_DIR not found"
   exit 1
 fi
 
+if [ -d "$DEPLOY_SOURCE_DIR/modules" ]; then
+  node scripts/prune_website_module_versions.mjs "$DEPLOY_SOURCE_DIR/modules"
+fi
+
 DEPLOY="$(mktemp -d)"
-cp -r website/dist/. "$DEPLOY/"
+cp -r "$DEPLOY_SOURCE_DIR/." "$DEPLOY/"
 # EdgeOne 读取仓库根目录 edgeone.json；website-pages 必须带上静态构建配置，覆盖控制台里残留的 main 分支命令。
 if [ -f edgeone.json ]; then
   cp edgeone.json "$DEPLOY/edgeone.json"
@@ -30,5 +43,5 @@ git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 git add -A
 git commit -q -m "$DEPLOY_MESSAGE"
-git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:website-pages
-echo "Deployed website-pages: $DEPLOY_MESSAGE"
+git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:"$DEPLOY_BRANCH"
+echo "Deployed $DEPLOY_BRANCH from $DEPLOY_SOURCE_DIR: $DEPLOY_MESSAGE"

--- a/scripts/configure_edgeone_website_pages.mjs
+++ b/scripts/configure_edgeone_website_pages.mjs
@@ -4,45 +4,60 @@ const API_URL = process.env.EDGEONE_API_URL || 'https://pages-api.edgeone.ai/v1'
 const PROJECT_ID = process.env.EDGEONE_PROJECT_ID || 'pages-qno4dud9jgqs'
 const TOKEN = String(process.env.EDGEONE_API_TOKEN || '').trim()
 
-if (!TOKEN) {
-  console.error('[edgeone] EDGEONE_API_TOKEN is required')
-  process.exit(1)
-}
-
-const payload = {
-  Action: 'ModifyPagesProject',
-  ProjectId: PROJECT_ID,
-  RepoBranch: 'website-pages',
-  InstallCmd: 'echo skip',
-  BuildCmd: 'echo skip',
-  OutputDir: '.',
-  NodejsVersion: '22.17.1'
-}
-
-const response = execFileSync(
-  'curl',
-  [
-    '-sS',
-    '-X',
-    'POST',
-    API_URL,
-    '-H',
-    'Content-Type: application/json',
-    '-H',
-    `Authorization: Bearer ${TOKEN}`,
-    '--data-binary',
-    '@-'
-  ],
-  {
-    input: JSON.stringify(payload),
-    encoding: 'utf8'
+const callApi = (payload) => {
+  const response = execFileSync(
+    'curl',
+    [
+      '-sS',
+      '-X',
+      'POST',
+      API_URL,
+      '-H',
+      'Content-Type: application/json',
+      '-H',
+      `Authorization: Bearer ${TOKEN}`,
+      '--data-binary',
+      '@-'
+    ],
+    {
+      input: JSON.stringify(payload),
+      encoding: 'utf8'
+    }
+  )
+  const parsed = JSON.parse(response)
+  if (parsed.Code !== 0) {
+    throw new Error(`EdgeOne API error: ${response}`)
   }
-)
-
-console.log(response)
-const parsed = JSON.parse(response)
-if (parsed.Code !== 0) {
-  process.exit(1)
+  return parsed.Data?.Response || parsed
 }
 
-console.log('[edgeone] project configured for static website-pages deploy')
+const main = () => {
+  if (!TOKEN) {
+    console.error('[edgeone] EDGEONE_API_TOKEN is required')
+    process.exit(1)
+  }
+
+  console.log('[edgeone] resetting project to static website-pages mode')
+  callApi({
+    Action: 'ModifyPagesProject',
+    ProjectId: PROJECT_ID,
+    RepoBranch: 'website-pages',
+    InstallCmd: 'echo skip',
+    BuildCmd: 'echo skip',
+    OutputDir: '.',
+    NodejsVersion: '22.17.1'
+  })
+
+  const deployment = callApi({
+    Action: 'CreatePagesDeployment',
+    ProjectId: PROJECT_ID,
+    ViaMeta: 'ReDeploy',
+    Env: 'Production',
+    Provider: 'Github',
+    RepoBranch: 'website-pages'
+  })
+
+  console.log('[edgeone] deployment triggered:', deployment.DeploymentId || 'unknown')
+}
+
+main()

--- a/scripts/prune_website_module_versions.mjs
+++ b/scripts/prune_website_module_versions.mjs
@@ -1,0 +1,66 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const MODULES_ROOT = path.resolve(process.argv[2] || 'website/dist/modules')
+const KEEP_VERSIONS = Math.max(1, Number.parseInt(process.env.MODULE_KEEP_VERSIONS || '1', 10) || 1)
+const RESERVED_DIR_NAMES = new Set(['site'])
+
+const removeDir = (targetPath) => {
+  if (!fs.existsSync(targetPath)) return
+  fs.rmSync(targetPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
+}
+
+const listChannels = (root) => {
+  if (!fs.existsSync(root)) return []
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(root, entry.name))
+}
+
+const listModuleDirs = (channelDir) =>
+  fs
+    .readdirSync(channelDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(channelDir, entry.name))
+
+const listVersionDirs = (moduleDir) =>
+  fs
+    .readdirSync(moduleDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !RESERVED_DIR_NAMES.has(entry.name))
+    .map((entry) => path.join(moduleDir, entry.name))
+
+const pruneModuleDir = (moduleDir) => {
+  const versionDirs = listVersionDirs(moduleDir)
+  if (versionDirs.length <= KEEP_VERSIONS) return 0
+
+  const sorted = versionDirs.sort((left, right) => path.basename(right).localeCompare(path.basename(left)))
+  const keep = new Set(sorted.slice(0, KEEP_VERSIONS))
+  let removed = 0
+
+  for (const versionDir of versionDirs) {
+    if (keep.has(versionDir)) continue
+    removeDir(versionDir)
+    removed += 1
+  }
+
+  return removed
+}
+
+const main = () => {
+  if (!fs.existsSync(MODULES_ROOT)) {
+    console.log(`[modules-prune] skip missing path: ${MODULES_ROOT}`)
+    return
+  }
+
+  let removedVersions = 0
+  for (const channelDir of listChannels(MODULES_ROOT)) {
+    for (const moduleDir of listModuleDirs(channelDir)) {
+      removedVersions += pruneModuleDir(moduleDir)
+    }
+  }
+
+  console.log(`[modules-prune] removed ${removedVersions} old version dirs under ${MODULES_ROOT}`)
+}
+
+main()

--- a/website/public/edgeone.json
+++ b/website/public/edgeone.json
@@ -1,0 +1,6 @@
+{
+  "installCommand": "echo skip",
+  "buildCommand": "echo skip",
+  "outputDirectory": ".",
+  "nodeVersion": "22.17.1"
+}


### PR DESCRIPTION
## Summary
- Ship `edgeone.json` on `website-pages` and sync EdgeOne API to static `echo skip` mode
- Prune accumulated game module versions before deploy (28k → ~500 files)
- Split deploy: `website-pages` for EdgeOne, `gh-pages` for GitHub Pages `/mini-hbut`

## Test plan
- [ ] Merge and run Sync Website workflow
- [ ] EdgeOne redeploy from `website-pages` succeeds
- [ ] `https://hbut.6661111.xyz/releases/stable-latest.json` returns 200
- [ ] `gh-pages` branch created for GitHub Pages
