### PR TITLE
fix(grades): 防止教务已删除成绩经 SWR/云同步并集复活

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2055,7 +2055,22 @@ const fetchGradesFromAPI = async (sid, { force = false, teacherCurrentOnly = fal
     )
     lastGradeRefreshUsedOffline.value = !!data?.offline
     if (data?.success && !data.offline) {
+      // 整表替换：先清 grades:{sid}* 学期分片，再写主缓存，避免已删除成绩残留分片被云同步并回。
+      clearCacheByPrefix(`grades:${sid}`)
       setCachedData(`grades:${sid}`, data)
+      if (Array.isArray(data.data)) {
+        const bySem = {}
+        data.data.forEach((item) => {
+          const sem = String(item?.term || item?.xnxq || item?.semester || '').trim()
+          if (!sem) return
+          if (!Array.isArray(bySem[sem])) bySem[sem] = []
+          bySem[sem].push(item)
+        })
+        Object.entries(bySem).forEach(([sem, list]) => {
+          if (!list.length) return
+          setCachedData(`grades:${sid}:${sem}`, { success: true, data: list })
+        })
+      }
     }
     return applyGradesPayload(data)
   } catch (e) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import UpdateDialog from './components/UpdateDialog.vue'
 import Toast from './components/Toast.vue'
 import SplashScreen from './components/SplashScreen.vue'
 import WorkspaceLayoutEditor from './components/WorkspaceLayoutEditor.vue'
-import { fetchWithCache, getStaleCachedData, setCachedData, DEFAULT_SWR_OPTIONS, clearUserScopedCaches, clearCacheByPrefix } from './utils/api.js'
+import { fetchWithCache, getStaleCachedData, setCachedData, clearUserScopedCaches, clearCacheByPrefix } from './utils/api.js'
 import {
   readScheduleRenderSnapshot,
   clearScheduleRenderSnapshot,
@@ -2045,13 +2045,13 @@ const fetchGradesFromAPI = async (sid, { force = false, teacherCurrentOnly = fal
     isLoading.value = true
   }
   try {
+    // 成绩必须以教务完整列表为权威源：始终 forceRemote，避免 SWR/TTL 命中
+    // 把已删除成绩（如故障 0 分）从本地缓存复活到 UI（对齐 v1.4.2）。
     const { data } = await fetchWithCache(
       `grades:${sid}`,
       () => fetchGradesRemote(sid, { teacherCurrentOnly }),
       undefined,
-      force
-        ? { forceRemote: true, priority: 'foreground' }
-        : { ...DEFAULT_SWR_OPTIONS, priority: 'foreground' }
+      { forceRemote: true, priority: 'foreground' }
     )
     lastGradeRefreshUsedOffline.value = !!data?.offline
     if (data?.success && !data.offline) {

--- a/src/utils/cloud_sync.js
+++ b/src/utils/cloud_sync.js
@@ -4,7 +4,7 @@ import { applyUiSettingsSnapshot } from './ui_settings'
 import { applyFontSettingsSnapshot } from './font_settings'
 import { normalizeSemesterList } from './semester'
 import { pushDebugLog } from './debug_logger'
-import { setCachedData } from './api.js'
+import { clearCacheByPrefix, setCachedData } from './api.js'
 import { getCurrentVersion } from './updater'
 import { detectRuntime } from '../platform/runtime'
 import {
@@ -666,22 +666,7 @@ const makeGradeFingerprint = (item, semester = '') => {
   return `${sem}|${gradeId}|${code}|${name}|${score}|${credit}`
 }
 
-const buildGradeSnapshot = (studentId, latestGrades = []) => {
-  const sid = toSafeText(studentId)
-  const prefix = `grades:${sid}`
-  const sourceEntries = []
-  if (Array.isArray(latestGrades) && latestGrades.length > 0) {
-    sourceEntries.push({
-      semester: '',
-      list: toArrayOfObjects(latestGrades)
-    })
-  }
-  readCachedEntriesByPrefix(prefix).forEach((entry) => {
-    sourceEntries.push({
-      semester: normalizeSemesterFromText(extractSuffixFromKey(entry.key, prefix)),
-      list: toArrayOfObjects(extractDataArray(entry.data))
-    })
-  })
+const accumulateGradeSnapshot = (sourceEntries = []) => {
   const all = []
   const bySemester = {}
   const seen = new Set()
@@ -706,6 +691,51 @@ const buildGradeSnapshot = (studentId, latestGrades = []) => {
     all,
     bySemester
   }
+}
+
+/**
+ * 构建成绩快照。
+ * 当 latestGrades 为非空数组时，视作教务完整权威列表：仅基于它构建，
+ * 不再并入本地 grades:{sid}* 缓存，避免已删除成绩（如故障 0 分）复活。
+ * 仅在无权威列表时，才回退到本地缓存拼快照（离线上传场景）。
+ */
+const buildGradeSnapshot = (studentId, latestGrades = []) => {
+  const sid = toSafeText(studentId)
+  const prefix = `grades:${sid}`
+  const hasAuthoritativeList = Array.isArray(latestGrades) && latestGrades.length > 0
+  const sourceEntries = []
+  if (hasAuthoritativeList) {
+    sourceEntries.push({
+      semester: '',
+      list: toArrayOfObjects(latestGrades)
+    })
+    return accumulateGradeSnapshot(sourceEntries)
+  }
+  readCachedEntriesByPrefix(prefix).forEach((entry) => {
+    sourceEntries.push({
+      semester: normalizeSemesterFromText(extractSuffixFromKey(entry.key, prefix)),
+      list: toArrayOfObjects(extractDataArray(entry.data))
+    })
+  })
+  return accumulateGradeSnapshot(sourceEntries)
+}
+
+/** 用权威成绩列表整表替换本地 grades 缓存（含学期分片），清除陈旧 key。 */
+const replaceAuthoritativeGradeCaches = (studentId, grades = []) => {
+  const sid = toSafeText(studentId)
+  if (!sid) return { all: [], bySemester: {} }
+  const list = toArrayOfObjects(grades)
+  const gradesSnapshot = buildGradeSnapshot(sid, list)
+  // 先清掉同前缀分片，避免教务已删除学期/成绩残留。
+  clearCacheByPrefix(`grades:${sid}`)
+  setCachedData(`grades:${sid}`, { success: true, data: gradesSnapshot.all })
+  Object.entries(gradesSnapshot.bySemester).forEach(([semester, semesterList]) => {
+    const sem = normalizeSemesterFromText(semester)
+    const gradeList = toArrayOfObjects(semesterList)
+    if (!sem || !gradeList.length) return
+    setCachedData(`grades:${sid}:${sem}`, { success: true, data: gradeList })
+  })
+  return gradesSnapshot
 }
 
 const normalizePersonalInfoPayload = (payload, fallbackStudentId = '') => {
@@ -1028,17 +1058,16 @@ const primeAcademicCaches = async (studentId, seedGrades = [], options = {}) => 
   if (!sid) return grades
   const skipSemesterRankingWarmup = options?.skipSemesterRankingWarmup !== false
   const semesters = skipSemesterRankingWarmup ? [] : await fetchSemestersForSync(sid)
+  let authoritativeGrades = null
   try {
     if (!grades.length) {
       const gradeRes = await axios.post(`${API_BASE}/v2/quick_fetch`, { student_id: sid })
       if (gradeRes?.data?.success && Array.isArray(gradeRes?.data?.data)) {
         grades = gradeRes.data.data
-      }
-      if (gradeRes?.data?.success) {
-        setCachedData(`grades:${sid}`, gradeRes.data)
+        authoritativeGrades = grades
       }
     } else {
-      setCachedData(`grades:${sid}`, { success: true, data: grades })
+      authoritativeGrades = grades
     }
   } catch {
     // ignore
@@ -1084,22 +1113,16 @@ const primeAcademicCaches = async (studentId, seedGrades = [], options = {}) => 
   } catch {
     // ignore
   }
-  const gradesSnapshot = buildGradeSnapshot(sid, grades)
-  if (gradesSnapshot.all.length > 0) {
-    setCachedData(`grades:${sid}`, { success: true, data: gradesSnapshot.all })
-    Object.entries(gradesSnapshot.bySemester).forEach(([semester, list]) => {
-      const sem = normalizeSemesterFromText(semester)
-      const gradeList = toArrayOfObjects(list)
-      if (!sem || !gradeList.length) return
-      setCachedData(`grades:${sid}:${sem}`, { success: true, data: gradeList })
-    })
-  }
+  // 有教务权威列表时整表替换；否则仅用本地缓存拼快照（可能为空，不强行并集复活）。
+  const gradesSnapshot = authoritativeGrades
+    ? replaceAuthoritativeGradeCaches(sid, authoritativeGrades)
+    : buildGradeSnapshot(sid, [])
   pushDebugLog(
     'CloudSync',
-    `学业缓存预热完成 student=${sid} semesters=${semesters.length} grades=${gradesSnapshot.all.length}`,
+    `学业缓存预热完成 student=${sid} semesters=${semesters.length} grades=${gradesSnapshot.all.length} authoritative=${authoritativeGrades ? 1 : 0}`,
     'debug'
   )
-  return grades
+  return authoritativeGrades || gradesSnapshot.all || grades
 }
 
 const shouldAttachChallenge = (path) => {

--- a/src/utils/cloud_sync.js
+++ b/src/utils/cloud_sync.js
@@ -695,14 +695,15 @@ const accumulateGradeSnapshot = (sourceEntries = []) => {
 
 /**
  * 构建成绩快照。
- * 当 latestGrades 为非空数组时，视作教务完整权威列表：仅基于它构建，
- * 不再并入本地 grades:{sid}* 缓存，避免已删除成绩（如故障 0 分）复活。
- * 仅在无权威列表时，才回退到本地缓存拼快照（离线上传场景）。
+ * 三态语义：
+ * - latestGrades 为 Array（含空数组 []）：视作教务完整权威列表，仅基于它构建，不并本地缓存
+ * - latestGrades 为 undefined/null/非数组：无权威列表，回退本地 grades:{sid}* 拼快照（离线上传）
+ * 注意：默认参数不能是 []，否则会把「未提供」误判为「权威为空」。
  */
-const buildGradeSnapshot = (studentId, latestGrades = []) => {
+const buildGradeSnapshot = (studentId, latestGrades = undefined) => {
   const sid = toSafeText(studentId)
   const prefix = `grades:${sid}`
-  const hasAuthoritativeList = Array.isArray(latestGrades) && latestGrades.length > 0
+  const hasAuthoritativeList = Array.isArray(latestGrades)
   const sourceEntries = []
   if (hasAuthoritativeList) {
     sourceEntries.push({
@@ -720,12 +721,13 @@ const buildGradeSnapshot = (studentId, latestGrades = []) => {
   return accumulateGradeSnapshot(sourceEntries)
 }
 
-/** 用权威成绩列表整表替换本地 grades 缓存（含学期分片），清除陈旧 key。 */
+/** 用权威成绩列表整表替换本地 grades 缓存（含学期分片），清除陈旧 key。允许空数组清空。 */
 const replaceAuthoritativeGradeCaches = (studentId, grades = []) => {
   const sid = toSafeText(studentId)
   if (!sid) return { all: [], bySemester: {} }
   const list = toArrayOfObjects(grades)
-  const gradesSnapshot = buildGradeSnapshot(sid, list)
+  // 直接按权威列表累积，避免再走「无列表回退本地」分支。
+  const gradesSnapshot = accumulateGradeSnapshot([{ semester: '', list }])
   // 先清掉同前缀分片，避免教务已删除学期/成绩残留。
   clearCacheByPrefix(`grades:${sid}`)
   setCachedData(`grades:${sid}`, { success: true, data: gradesSnapshot.all })
@@ -1113,16 +1115,17 @@ const primeAcademicCaches = async (studentId, seedGrades = [], options = {}) => 
   } catch {
     // ignore
   }
-  // 有教务权威列表时整表替换；否则仅用本地缓存拼快照（可能为空，不强行并集复活）。
-  const gradesSnapshot = authoritativeGrades
+  // 有教务权威列表（含空数组）时整表替换；否则仅用本地缓存拼快照（离线）。
+  // 必须用 != null 判断：[] 为 truthy 但 empty authority 也应 clear，不能走并集回退。
+  const gradesSnapshot = authoritativeGrades != null
     ? replaceAuthoritativeGradeCaches(sid, authoritativeGrades)
-    : buildGradeSnapshot(sid, [])
+    : buildGradeSnapshot(sid)
   pushDebugLog(
     'CloudSync',
-    `学业缓存预热完成 student=${sid} semesters=${semesters.length} grades=${gradesSnapshot.all.length} authoritative=${authoritativeGrades ? 1 : 0}`,
+    `学业缓存预热完成 student=${sid} semesters=${semesters.length} grades=${gradesSnapshot.all.length} authoritative=${authoritativeGrades != null ? 1 : 0}`,
     'debug'
   )
-  return authoritativeGrades || gradesSnapshot.all || grades
+  return authoritativeGrades != null ? authoritativeGrades : (gradesSnapshot.all || grades)
 }
 
 const shouldAttachChallenge = (path) => {
@@ -1391,7 +1394,6 @@ const applyAcademicFromCloud = (studentId, academic) => {
       const sem = normalizeSemesterFromText(semester)
       const gradeList = toArrayOfObjects(list)
       if (!sem || !gradeList.length) return
-      setCachedData(`grades:${sid}:${sem}`, { success: true, data: gradeList })
       addGradeItems(gradeList, sem)
       gradesCached = true
     })
@@ -1401,8 +1403,19 @@ const applyAcademicFromCloud = (studentId, academic) => {
     ? academic.grades
     : (Array.isArray(academic?.grades_all) ? academic.grades_all : [])
   addGradeItems(grades)
-  if (mergedGrades.length > 0) {
-    setCachedData(`grades:${sid}`, { success: true, data: mergedGrades })
+  // 云端学业含成绩字段时整表替换本地前缀：不与脏分片并集、也不残留已删除条目。
+  // 后续 primeAcademicCaches 若拿到教务权威列表会再次覆盖。
+  const hasCloudGradesPayload =
+    Array.isArray(academic?.grades) ||
+    Array.isArray(academic?.grades_all) ||
+    (
+      gradesBySemester &&
+      typeof gradesBySemester === 'object' &&
+      !Array.isArray(gradesBySemester) &&
+      Object.keys(gradesBySemester).length > 0
+    )
+  if (hasCloudGradesPayload) {
+    replaceAuthoritativeGradeCaches(sid, mergedGrades)
     gradesCached = true
   }
 

--- a/src/utils/cloud_sync_grades_authority_contract.spec.ts
+++ b/src/utils/cloud_sync_grades_authority_contract.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const readText = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+
+describe('cloud sync grades authority contract', () => {
+  it('treats non-empty latestGrades as full authority without unioning local cache', () => {
+    const source = readText('src/utils/cloud_sync.js')
+    const buildBlock =
+      source.match(
+        /const buildGradeSnapshot = \(studentId, latestGrades = \[\]\) => \{[\s\S]*?^const replaceAuthoritativeGradeCaches/m
+      )?.[0] || ''
+
+    expect(buildBlock).toContain(
+      'const hasAuthoritativeList = Array.isArray(latestGrades) && latestGrades.length > 0'
+    )
+    expect(buildBlock).toContain('if (hasAuthoritativeList)')
+    expect(buildBlock).toContain('return accumulateGradeSnapshot(sourceEntries)')
+
+    // 有权威列表时 early return，不得再 readCachedEntriesByPrefix 做并集
+    const authoritativeBranch = buildBlock.split('if (hasAuthoritativeList)')[1] || ''
+    const beforeFallback = authoritativeBranch.split('readCachedEntriesByPrefix')[0] || ''
+    expect(beforeFallback).toContain('return accumulateGradeSnapshot(sourceEntries)')
+    expect(beforeFallback).not.toContain('readCachedEntriesByPrefix')
+  })
+
+  it('replaces local grade caches via clearCacheByPrefix before rewriting shards', () => {
+    const source = readText('src/utils/cloud_sync.js')
+    const replaceBlock =
+      source.match(
+        /const replaceAuthoritativeGradeCaches = \(studentId, grades = \[\]\) => \{[\s\S]*?^const normalizePersonalInfoPayload/m
+      )?.[0] || ''
+
+    expect(replaceBlock).toContain('clearCacheByPrefix(`grades:${sid}`)')
+    expect(replaceBlock).toContain('setCachedData(`grades:${sid}`, { success: true, data: gradesSnapshot.all })')
+    expect(replaceBlock).toContain('setCachedData(`grades:${sid}:${sem}`, { success: true, data: gradeList })')
+  })
+
+  it('primes academic caches from authoritative list without union rewrite', () => {
+    const source = readText('src/utils/cloud_sync.js')
+    const primeBlock =
+      source.match(
+        /const primeAcademicCaches = async \(studentId, seedGrades = \[\], options = \{\}\) => \{[\s\S]*?^const shouldAttachChallenge/m
+      )?.[0] || ''
+
+    expect(primeBlock).toContain('authoritativeGrades')
+    expect(primeBlock).toContain('replaceAuthoritativeGradeCaches(sid, authoritativeGrades)')
+    // 禁止回到并集后写回：buildGradeSnapshot(sid, grades) + setCachedData 旧路径
+    expect(primeBlock).not.toMatch(
+      /const gradesSnapshot = buildGradeSnapshot\(sid, grades\)\s*\n\s*if \(gradesSnapshot\.all\.length > 0\)/
+    )
+  })
+
+  it('imports clearCacheByPrefix for grade authority replace', () => {
+    const source = readText('src/utils/cloud_sync.js')
+    expect(source).toMatch(
+      /import\s*\{\s*clearCacheByPrefix\s*,\s*setCachedData\s*\}\s*from\s*['"]\.\/api\.js['"]/
+    )
+  })
+})

--- a/src/utils/cloud_sync_grades_authority_contract.spec.ts
+++ b/src/utils/cloud_sync_grades_authority_contract.spec.ts
@@ -7,16 +7,15 @@ const readText = (relativePath: string) =>
   fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
 
 describe('cloud sync grades authority contract', () => {
-  it('treats non-empty latestGrades as full authority without unioning local cache', () => {
+  it('treats Array latestGrades (including empty) as full authority without unioning local cache', () => {
     const source = readText('src/utils/cloud_sync.js')
     const buildBlock =
       source.match(
-        /const buildGradeSnapshot = \(studentId, latestGrades = \[\]\) => \{[\s\S]*?^const replaceAuthoritativeGradeCaches/m
+        /const buildGradeSnapshot = \(studentId, latestGrades = undefined\) => \{[\s\S]*?^const replaceAuthoritativeGradeCaches/m
       )?.[0] || ''
 
-    expect(buildBlock).toContain(
-      'const hasAuthoritativeList = Array.isArray(latestGrades) && latestGrades.length > 0'
-    )
+    expect(buildBlock).toContain('const hasAuthoritativeList = Array.isArray(latestGrades)')
+    expect(buildBlock).not.toContain('latestGrades.length > 0')
     expect(buildBlock).toContain('if (hasAuthoritativeList)')
     expect(buildBlock).toContain('return accumulateGradeSnapshot(sourceEntries)')
 
@@ -35,11 +34,14 @@ describe('cloud sync grades authority contract', () => {
       )?.[0] || ''
 
     expect(replaceBlock).toContain('clearCacheByPrefix(`grades:${sid}`)')
+    expect(replaceBlock).toContain('accumulateGradeSnapshot([{ semester: \'\', list }])')
     expect(replaceBlock).toContain('setCachedData(`grades:${sid}`, { success: true, data: gradesSnapshot.all })')
     expect(replaceBlock).toContain('setCachedData(`grades:${sid}:${sem}`, { success: true, data: gradeList })')
+    // 不得再经 buildGradeSnapshot(sid, list) 以免空数组误回退本地
+    expect(replaceBlock).not.toContain('buildGradeSnapshot(sid, list)')
   })
 
-  it('primes academic caches from authoritative list without union rewrite', () => {
+  it('primes academic caches with null-check so empty authority still replaces', () => {
     const source = readText('src/utils/cloud_sync.js')
     const primeBlock =
       source.match(
@@ -47,11 +49,26 @@ describe('cloud sync grades authority contract', () => {
       )?.[0] || ''
 
     expect(primeBlock).toContain('authoritativeGrades')
+    expect(primeBlock).toContain('authoritativeGrades != null')
     expect(primeBlock).toContain('replaceAuthoritativeGradeCaches(sid, authoritativeGrades)')
-    // 禁止回到并集后写回：buildGradeSnapshot(sid, grades) + setCachedData 旧路径
+    expect(primeBlock).toContain('buildGradeSnapshot(sid)')
     expect(primeBlock).not.toMatch(
       /const gradesSnapshot = buildGradeSnapshot\(sid, grades\)\s*\n\s*if \(gradesSnapshot\.all\.length > 0\)/
     )
+  })
+
+  it('applies cloud academic grades via authoritative replace instead of raw setCachedData merge', () => {
+    const source = readText('src/utils/cloud_sync.js')
+    const applyBlock =
+      source.match(
+        /const applyAcademicFromCloud = \(studentId, academic\) => \{[\s\S]*?^const extractCloudData/m
+      )?.[0] || ''
+
+    expect(applyBlock).toContain('hasCloudGradesPayload')
+    expect(applyBlock).toContain('replaceAuthoritativeGradeCaches(sid, mergedGrades)')
+    // 旧路径：按学期直接 setCachedData 分片 + 主 key 并集写回
+    expect(applyBlock).not.toContain('setCachedData(`grades:${sid}:${sem}`, { success: true, data: gradeList })')
+    expect(applyBlock).not.toContain('setCachedData(`grades:${sid}`, { success: true, data: mergedGrades })')
   })
 
   it('imports clearCacheByPrefix for grade authority replace', () => {

--- a/src/utils/grade_view_header_contract.spec.ts
+++ b/src/utils/grade_view_header_contract.spec.ts
@@ -51,6 +51,10 @@ describe('grade view header contract', () => {
     expect(appSource).not.toMatch(
       /import\s*\{[^}]*DEFAULT_SWR_OPTIONS[^}]*\}\s*from\s*['"]\.\/utils\/api\.js['"]/
     )
+    // 在线成功后整表替换：清分片再写主缓存，避免学期 key 残留已删除成绩
+    expect(fetchGradesBlock).toContain('clearCacheByPrefix(`grades:${sid}`)')
+    expect(fetchGradesBlock).toContain('setCachedData(`grades:${sid}`, data)')
+    expect(fetchGradesBlock).toContain('setCachedData(`grades:${sid}:${sem}`, { success: true, data: list })')
   })
 
   it('refreshes grades every time the grades view is opened, even when old data exists', () => {

--- a/src/utils/grade_view_header_contract.spec.ts
+++ b/src/utils/grade_view_header_contract.spec.ts
@@ -37,9 +37,20 @@ describe('grade view header contract', () => {
     expect(appSource).toContain('fetchGradesFromAPI(studentId.value, { force: true, teacherCurrentOnly: true })')
     expect(appSource).toContain('const fetchGradesFromAPI = async (sid, { force = false, teacherCurrentOnly = false, silent = false } = {})')
     expect(appSource).toContain('const showedStaleSnapshot = !force ? applyStaleGradesSnapshot(sid) : false')
-    expect(appSource).toContain('forceRemote: true')
     expect(appSource).toContain('setCachedData(`grades:${sid}`, data)')
     expect(appSource).not.toContain('const { data } = await fetchWithCache(`grades:${sid}`, () => fetchGradesRemote(sid))')
+
+    // 成绩必须以教务完整列表为权威源：始终 forceRemote，禁止 SWR 三元分支复活已删除成绩。
+    const fetchGradesBlock =
+      appSource.match(
+        /const fetchGradesFromAPI = async \(sid, \{ force = false, teacherCurrentOnly = false, silent = false \} = \{\}\) => \{[\s\S]*?^const handleRequireLogin/m
+      )?.[0] || ''
+    expect(fetchGradesBlock).toContain("{ forceRemote: true, priority: 'foreground' }")
+    expect(fetchGradesBlock).not.toContain('DEFAULT_SWR_OPTIONS')
+    expect(fetchGradesBlock).not.toMatch(/force\s*\?\s*\{\s*forceRemote:\s*true/)
+    expect(appSource).not.toMatch(
+      /import\s*\{[^}]*DEFAULT_SWR_OPTIONS[^}]*\}\s*from\s*['"]\.\/utils\/api\.js['"]/
+    )
   })
 
   it('refreshes grades every time the grades view is opened, even when old data exists', () => {


### PR DESCRIPTION
## Summary
- 恢复成绩查询始终 `forceRemote`（对齐 v1.4.2），避免 SWR/TTL 命中把本地历史 0 分画回 UI
- 云同步 `buildGradeSnapshot` 在权威成绩列表非空时不再并入本地 `grades:{sid}*` 缓存；`primeAcademicCaches` 整表替换并清理陈旧学期分片
- 收紧契约测试，防止再退回 `force ? forceRemote : DEFAULT_SWR_OPTIONS` 或并集写回

Fixes #231

## Root cause
v1.4.3（PR #122 / `b2e773ab`）将 `fetchGradesFromAPI` 改为非强制路径走 `DEFAULT_SWR_OPTIONS`。本地/云端缓存若仍含故障期 0 分，进入成绩页可能不再以教务完整列表覆盖，已删除成绩会“复活”。云同步并集逻辑会放大该问题。

## Test plan
- [x] `npx vitest run src/utils/grade_view_header_contract.spec.ts src/utils/cloud_sync_grades_authority_contract.spec.ts src/utils/performance_request_contract.spec.ts`（18 passed）
- [ ] 预置本地缓存含已删除 0 分 → 打开成绩查询且远端成功 → UI/缓存不再含该 0 分
- [ ] 教务不可用时仍可离线回退缓存
- [ ] 手动刷新仍与教务一致