### PR TITLE
fix(hecheng): 成绩上传对齐 2048 重试与进度态 (#278)

### DIFF
--- a/src/utils/hecheng_hugongda_rank_contract.spec.ts
+++ b/src/utils/hecheng_hugongda_rank_contract.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  canUseGameRank,
+  readGameModuleContext,
+  shouldRetryRequest,
+  submitGameRank
+} from '../../website/modules-src/hecheng_hugongda/project/src/utils/game_rank.js'
+
+const setSearch = (search = '') => {
+  // @ts-expect-error test window stub
+  globalThis.window = {
+    location: { search },
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout
+  }
+}
+
+const createStorage = () => {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => (values.has(key) ? values.get(key)! : null),
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear()
+  }
+}
+
+describe('hecheng_hugongda rank upload contract', () => {
+  beforeEach(() => {
+    // @ts-expect-error test storage stub
+    globalThis.localStorage = createStorage()
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { platform: 'test-platform' },
+      configurable: true
+    })
+    localStorage.clear()
+    setSearch('')
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not enable rank without student_id', () => {
+    setSearch('?rank_api=https://rank.example/api/game-rank')
+    expect(canUseGameRank(readGameModuleContext())).toBe(false)
+  })
+
+  it('retries transient submit failures with the same run_id and score payload', async () => {
+    setSearch(
+      '?student_id=20240088&player_name=合成玩家&class_name=软件2401&rank_api=https://rank.example/api/game-rank'
+    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: false, error: 'busy' }), { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, accepted: true, player: { score: 128 } }), { status: 200 })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await submitGameRank(
+      readGameModuleContext(),
+      {
+        runId: 'run_hecheng_retry',
+        score: 128,
+        maxLevel: 6,
+        durationMs: 45000,
+        moveCount: 20,
+        endedReason: 'failed'
+      },
+      { retryDelaysMs: [0] }
+    )
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body0 = JSON.parse(String(fetchMock.mock.calls[0][1].body))
+    const body1 = JSON.parse(String(fetchMock.mock.calls[1][1].body))
+    expect(body0.run_id).toBe('run_hecheng_retry')
+    expect(body1.run_id).toBe('run_hecheng_retry')
+    expect(body0.game_id).toBe('hecheng_hugongda')
+    expect(body0.score).toBe(128)
+  })
+
+  it('never posts submit without student context', async () => {
+    setSearch('?rank_api=https://rank.example/api/game-rank')
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(submitGameRank(readGameModuleContext(), { runId: 'x', score: 1 })).rejects.toThrow(/学号/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('classifies retriable errors like 2048 client', () => {
+    expect(shouldRetryRequest(Object.assign(new Error('network failed'), { status: 0 }))).toBe(true)
+    expect(shouldRetryRequest(Object.assign(new Error('server'), { status: 503 }))).toBe(true)
+    expect(shouldRetryRequest(Object.assign(new Error('rate'), { status: 429 }))).toBe(true)
+    expect(shouldRetryRequest(Object.assign(new Error('bad request'), { status: 400 }))).toBe(false)
+  })
+})

--- a/website/modules-src/hecheng_hugongda/project/package.json
+++ b/website/modules-src/hecheng_hugongda/project/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node ../../../../node_modules/vitest/vitest.mjs run --passWithNoTests"
   },
   "dependencies": {
     "vue": "^3.4.0",

--- a/website/modules-src/hecheng_hugongda/project/src/App.vue
+++ b/website/modules-src/hecheng_hugongda/project/src/App.vue
@@ -86,7 +86,13 @@
                 </div>
               </div>
 
-              <div v-if="rankSubmitBusy" class="sync-status">正在同步排行榜成绩...</div>
+              <div v-if="rankSubmitBusy" class="sync-status sync-status--uploading">正在上传成绩...</div>
+              <div
+                v-else-if="rankSubmitSuccess && (gameOver || hasWon)"
+                class="sync-status sync-status--success"
+              >
+                ✓ 成绩已上传
+              </div>
               <button
                 v-else-if="rankSubmitError && (gameOver || hasWon)"
                 class="sync-status sync-status--error"
@@ -106,6 +112,12 @@
                 <h2>挑战结束</h2>
                 <p class="final-score">最终得分 {{ score }}</p>
                 <p class="message">场上已经没有安全落点了。</p>
+                <p v-if="rankSubmitBusy" class="overlay-subtext">正在上传成绩...</p>
+                <p v-else-if="rankSubmitSuccess" class="overlay-subtext">✓ 成绩已上传</p>
+                <p v-else-if="rankSubmitError" class="overlay-subtext">
+                  上传失败：{{ rankSubmitError }}
+                  <button class="ghost-btn ghost-btn--warn" type="button" @click="retryRankSubmit">重试上传</button>
+                </p>
                 <p v-if="rankSummaryText" class="overlay-subtext">{{ rankSummaryText }}</p>
                 <div class="overlay-btns">
                   <button class="restart-btn" type="button" @click="forceRestart">再来一局</button>
@@ -117,6 +129,12 @@
                 <h2>成功合成湖工大</h2>
                 <p class="message">本局已自动记录，你可以直接查看排名。</p>
                 <p class="final-score">最终得分 {{ score }}</p>
+                <p v-if="rankSubmitBusy" class="overlay-subtext">正在上传成绩...</p>
+                <p v-else-if="rankSubmitSuccess" class="overlay-subtext">✓ 成绩已上传</p>
+                <p v-else-if="rankSubmitError" class="overlay-subtext">
+                  上传失败：{{ rankSubmitError }}
+                  <button class="ghost-btn ghost-btn--warn" type="button" @click="retryRankSubmit">重试上传</button>
+                </p>
                 <p v-if="rankSummaryText" class="overlay-subtext">{{ rankSummaryText }}</p>
                 <div class="overlay-btns">
                   <button class="restart-btn" type="button" @click="forceRestart">继续挑战</button>
@@ -354,12 +372,15 @@ export default {
       leaderboardUpdatedAt: '',
       rankSubmitBusy: false,
       rankSubmitError: '',
+      rankSubmitSuccess: false,
       lastRankSubmission: null,
+      pendingRankPayload: null,
       currentRunId: '',
       gameStartedAt: 0,
       moveCount: 0,
       bestLevelReached: 0,
       hasSubmittedResult: false,
+      rankSuccessTimer: null,
 
       toastMessage: '',
       showToast: false,
@@ -431,7 +452,8 @@ export default {
     },
     rankHintText() {
       if (!this.rankEnabled) return '当前未注入学号，排行榜会保持关闭。'
-      if (this.rankSubmitBusy) return '本局结束后正在同步成绩。'
+      if (this.rankSubmitBusy) return '正在上传成绩...'
+      if (this.rankSubmitSuccess) return '✓ 成绩已上传'
       if (this.rankSubmitError) return `成绩上传失败：${this.rankSubmitError}`
       if (!this.hasClassContext) return '当前未注入班级信息，排行榜默认显示全校榜。'
       return '本局结束后会自动上传最佳成绩。'
@@ -693,6 +715,10 @@ export default {
     },
 
     resetRunState() {
+      if (this.rankSuccessTimer) {
+        clearTimeout(this.rankSuccessTimer)
+        this.rankSuccessTimer = null
+      }
       this.currentRunId = createRunId()
       this.gameStartedAt = Date.now()
       this.moveCount = 0
@@ -700,6 +726,8 @@ export default {
       this.hasSubmittedResult = false
       this.rankSubmitBusy = false
       this.rankSubmitError = ''
+      this.rankSubmitSuccess = false
+      this.pendingRankPayload = null
       this.lastRankSubmission = null
     },
 
@@ -856,6 +884,8 @@ export default {
         this.hasSubmittedResult = !!data.hasSubmittedResult
         this.rankSubmitBusy = false
         this.rankSubmitError = ''
+        this.rankSubmitSuccess = !!data.hasSubmittedResult
+        this.pendingRankPayload = null
         this.lastRankSubmission = null
         this.gameOver = false
         this.hasWon = false
@@ -1060,40 +1090,63 @@ export default {
       }
     },
 
+    buildRankPayload(endedReason) {
+      return {
+        runId: this.currentRunId,
+        score: this.score,
+        maxLevel: this.computeCurrentMaxLevel(),
+        durationMs: Math.max(0, Date.now() - Number(this.gameStartedAt || Date.now())),
+        moveCount: this.moveCount,
+        endedReason,
+        extra: {
+          source: 'mini-hbut-module',
+          is_mobile: this.isMobile,
+          from: this.rankContext.from || '',
+          runtime: this.rankContext.runtime || ''
+        }
+      }
+    },
+
     async finalizeRankSubmission(endedReason) {
       if (!this.rankEnabled || this.rankSubmitBusy || this.hasSubmittedResult) return
+      const payload = this.pendingRankPayload || this.buildRankPayload(endedReason)
+      this.pendingRankPayload = payload
       this.rankSubmitBusy = true
       this.rankSubmitError = ''
+      this.rankSubmitSuccess = false
+      if (this.rankSuccessTimer) {
+        clearTimeout(this.rankSuccessTimer)
+        this.rankSuccessTimer = null
+      }
       try {
-        const result = await submitGameRank(this.rankContext, {
-          runId: this.currentRunId,
-          score: this.score,
-          maxLevel: this.computeCurrentMaxLevel(),
-          durationMs: Math.max(0, Date.now() - Number(this.gameStartedAt || Date.now())),
-          moveCount: this.moveCount,
-          endedReason,
-          extra: {
-            source: 'mini-hbut-module',
-            is_mobile: this.isMobile,
-            from: this.rankContext.from || '',
-            runtime: this.rankContext.runtime || ''
-          }
-        })
+        const result = await submitGameRank(this.rankContext, payload)
         this.lastRankSubmission = result?.player || null
         this.leaderboardPlayer = result?.player || this.leaderboardPlayer
         this.hasSubmittedResult = true
+        this.rankSubmitSuccess = true
+        this.pendingRankPayload = null
+        this.rankSuccessTimer = setTimeout(() => {
+          this.rankSubmitSuccess = false
+          this.rankSuccessTimer = null
+        }, 3000)
         if (this.showLeaderboard) {
           await this.loadLeaderboard(this.leaderboardScope, { silent: true })
         }
       } catch (error) {
         this.rankSubmitError = error?.message || '排行榜上传失败'
         this.hasSubmittedResult = false
+        this.rankSubmitSuccess = false
       } finally {
         this.rankSubmitBusy = false
       }
     },
 
     retryRankSubmit() {
+      if (this.rankSubmitBusy) return
+      if (this.pendingRankPayload) {
+        void this.finalizeRankSubmission(this.pendingRankPayload.endedReason)
+        return
+      }
       if (this.hasWon) {
         void this.finalizeRankSubmission('cleared')
       } else if (this.gameOver) {

--- a/website/modules-src/hecheng_hugongda/project/src/style.css
+++ b/website/modules-src/hecheng_hugongda/project/src/style.css
@@ -299,6 +299,15 @@ textarea {
   box-shadow: 0 8px 18px rgba(63, 68, 58, 0.12);
 }
 
+.sync-status--uploading {
+  color: var(--accent-strong);
+}
+
+.sync-status--success {
+  color: #1f7a4c;
+  border-color: rgba(31, 122, 76, 0.28);
+}
+
 .sync-status--error {
   color: var(--danger);
   border-color: rgba(153, 58, 46, 0.22);

--- a/website/modules-src/hecheng_hugongda/project/src/utils/game_rank.js
+++ b/website/modules-src/hecheng_hugongda/project/src/utils/game_rank.js
@@ -2,6 +2,7 @@ const DEFAULT_GAME_ID = 'hecheng_hugongda'
 const DEFAULT_GAME_RANK_API = 'https://mini-hbut-testocr1.hf.space/api/game-rank'
 const REQUEST_TIMEOUT_MS = 12000
 const MODULE_CONTEXT_STORAGE_KEY = 'hbut_game_rank_context_v1'
+const DEFAULT_RETRY_DELAYS_MS = [1200, 2600, 5200]
 
 const safeText = (value) => String(value ?? '').trim()
 const LEADERBOARD_TIMEOUT_MESSAGE = '排行榜请求超时，请稍后重试'
@@ -48,6 +49,15 @@ const normalizeRequestError = (error) => {
   return new Error(safeText(error) || '排行榜请求失败')
 }
 
+const wait = (ms) => new Promise((resolve) => window.setTimeout(resolve, Math.max(0, Number(ms || 0))))
+
+export const shouldRetryRequest = (error) => {
+  const status = Number(error?.status || 0)
+  if (status === 429) return true
+  if (status >= 500 && status <= 599) return true
+  return isAbortError(error) || /network|fetch|failed|timeout/i.test(safeText(error?.message || error))
+}
+
 const requestJson = async (url, init = {}) => {
   let response = null
   try {
@@ -73,21 +83,52 @@ const requestJson = async (url, init = {}) => {
     parsed = null
   }
   if (!response.ok) {
-    throw new Error(safeText(parsed?.error || parsed?.message || text) || `HTTP ${response.status}`)
+    const error = new Error(safeText(parsed?.error || parsed?.message || text) || `HTTP ${response.status}`)
+    error.status = response.status
+    throw error
   }
   if (!parsed || typeof parsed !== 'object') {
     throw new Error('排行榜服务返回了无效响应')
   }
   if (parsed.success === false) {
-    throw new Error(safeText(parsed.error || parsed.message) || '排行榜服务返回失败')
+    const error = new Error(safeText(parsed.error || parsed.message) || '排行榜服务返回失败')
+    error.status = Number(parsed.status || 0)
+    throw error
   }
   return parsed
+}
+
+const requestJsonWithRetry = async (url, init = {}, options = {}) => {
+  const retryDelays = Array.isArray(options.retryDelaysMs) ? options.retryDelaysMs : DEFAULT_RETRY_DELAYS_MS
+  let lastError = null
+  for (let attempt = 0; attempt <= retryDelays.length; attempt += 1) {
+    if (attempt > 0) await wait(retryDelays[attempt - 1])
+    try {
+      return await requestJson(url, init)
+    } catch (error) {
+      lastError = error
+      if (attempt >= retryDelays.length || !shouldRetryRequest(error)) {
+        throw error
+      }
+    }
+  }
+  throw lastError || new Error('排行榜请求失败')
 }
 
 const readStoredContext = () => {
   const stored = safeParseJson(localStorage.getItem(MODULE_CONTEXT_STORAGE_KEY), null)
   return stored && typeof stored === 'object' ? stored : {}
 }
+
+const pickText = (...values) => {
+  for (const value of values) {
+    const text = safeText(value)
+    if (text) return text
+  }
+  return ''
+}
+
+const pickStoredText = (stored, camelKey, snakeKey) => pickText(stored?.[camelKey], stored?.[snakeKey])
 
 const writeStoredContext = (context) => {
   const next = context && typeof context === 'object' ? context : {}
@@ -117,28 +158,21 @@ const writeStoredContext = (context) => {
   )
 }
 
-const pickText = (...values) => {
-  for (const value of values) {
-    const text = safeText(value)
-    if (text) return text
-  }
-  return ''
-}
-
 export const readGameModuleContext = () => {
   const params = new URLSearchParams(window.location.search || '')
   const stored = readStoredContext()
   const context = {
     gameId: pickText(params.get('game_id'), stored.gameId) || DEFAULT_GAME_ID,
-    studentId: pickText(params.get('student_id'), stored.studentId),
-    playerName: pickText(params.get('player_name'), stored.playerName),
-    className: pickText(params.get('class_name'), stored.className),
-    schoolName: pickText(params.get('school_name'), stored.schoolName) || '湖北工业大学',
+    studentId: pickText(params.get('student_id'), pickStoredText(stored, 'studentId', 'student_id')),
+    playerName: pickText(params.get('player_name'), pickStoredText(stored, 'playerName', 'player_name')),
+    className: pickText(params.get('class_name'), pickStoredText(stored, 'className', 'class_name')),
+    schoolName:
+      pickText(params.get('school_name'), pickStoredText(stored, 'schoolName', 'school_name')) || '湖北工业大学',
     major: pickText(params.get('major'), stored.major),
     runtime: pickText(params.get('runtime'), stored.runtime) || 'module-web',
-    appVersion: pickText(params.get('app_version'), stored.appVersion),
+    appVersion: pickText(params.get('app_version'), pickStoredText(stored, 'appVersion', 'app_version')),
     from: pickText(params.get('from'), stored.from),
-    rankApiBase: normalizeApiBase(pickText(params.get('rank_api'), stored.rankApiBase))
+    rankApiBase: normalizeApiBase(pickText(params.get('rank_api'), pickStoredText(stored, 'rankApiBase', 'rank_api')))
   }
   writeStoredContext(context)
   return context
@@ -149,8 +183,11 @@ export const canUseGameRank = (context) => {
   return !!safeText(profile.studentId) && !!normalizeApiBase(profile.rankApiBase)
 }
 
-export const submitGameRank = async (context, payload = {}) => {
+export const submitGameRank = async (context, payload = {}, options = {}) => {
   const profile = context && typeof context === 'object' ? context : readGameModuleContext()
+  if (!canUseGameRank(profile)) {
+    throw new Error('当前未注入学号，无法上传排行榜成绩')
+  }
   const body = {
     game_id: safeText(payload.gameId || profile.gameId || DEFAULT_GAME_ID),
     run_id: safeText(payload.runId),
@@ -169,10 +206,14 @@ export const submitGameRank = async (context, payload = {}) => {
     runtime: safeText(payload.runtime || profile.runtime),
     payload: payload.extra && typeof payload.extra === 'object' ? payload.extra : {}
   }
-  return requestJson(`${normalizeApiBase(profile.rankApiBase)}/submit`, {
-    method: 'POST',
-    body: JSON.stringify(body)
-  })
+  return requestJsonWithRetry(
+    `${normalizeApiBase(profile.rankApiBase)}/submit`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body)
+    },
+    options
+  )
 }
 
 export const fetchGameLeaderboard = async (context, options = {}) => {
@@ -198,3 +239,4 @@ export const createRunId = () => {
 }
 
 export const resolveRankApiBase = normalizeApiBase
+export const DEFAULT_HECHENG_RETRY_DELAYS_MS = DEFAULT_RETRY_DELAYS_MS

--- a/website/modules-src/hecheng_hugongda/project/src/utils/game_rank.test.js
+++ b/website/modules-src/hecheng_hugongda/project/src/utils/game_rank.test.js
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  canUseGameRank,
+  readGameModuleContext,
+  shouldRetryRequest,
+  submitGameRank
+} from './game_rank.js'
+
+const setSearch = (search = '') => {
+  globalThis.window = {
+    location: { search },
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout
+  }
+}
+
+const createStorage = () => {
+  const values = new Map()
+  return {
+    getItem: (key) => (values.has(key) ? values.get(key) : null),
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+    clear: () => values.clear()
+  }
+}
+
+describe('hecheng hugongda game rank client', () => {
+  beforeEach(() => {
+    globalThis.localStorage = createStorage()
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { platform: 'test-platform' },
+      configurable: true
+    })
+    localStorage.clear()
+    setSearch('')
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not treat missing student context as rank-enabled', () => {
+    setSearch('?rank_api=https://rank.example/api/game-rank')
+    const context = readGameModuleContext()
+    expect(canUseGameRank(context)).toBe(false)
+  })
+
+  it('retries transient score upload failures without changing the run id', async () => {
+    setSearch(
+      '?student_id=20240088&player_name=合成玩家&class_name=软件2401&rank_api=https://rank.example/api/game-rank'
+    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: false, error: 'busy' }), { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, accepted: true, player: { score: 128 } }), { status: 200 })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const context = readGameModuleContext()
+    const result = await submitGameRank(
+      context,
+      {
+        runId: 'run_hecheng_retry',
+        score: 128,
+        maxLevel: 6,
+        durationMs: 45000,
+        moveCount: 20,
+        endedReason: 'failed'
+      },
+      { retryDelaysMs: [0] }
+    )
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).run_id).toBe('run_hecheng_retry')
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).run_id).toBe('run_hecheng_retry')
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).game_id).toBe('hecheng_hugongda')
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).score).toBe(128)
+  })
+
+  it('rejects submit when student id is missing', async () => {
+    setSearch('?rank_api=https://rank.example/api/game-rank')
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      submitGameRank(readGameModuleContext(), { runId: 'run_no_student', score: 10 })
+    ).rejects.toThrow(/学号/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('classifies retriable network and server errors', () => {
+    expect(shouldRetryRequest(Object.assign(new Error('network failed'), { status: 0 }))).toBe(true)
+    expect(shouldRetryRequest(Object.assign(new Error('server'), { status: 503 }))).toBe(true)
+    expect(shouldRetryRequest(Object.assign(new Error('rate'), { status: 429 }))).toBe(true)
+    expect(shouldRetryRequest(Object.assign(new Error('bad request'), { status: 400 }))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- 合成湖工大 `game_rank` 增加与 2048 同级的自动退避重试（429/5xx/网络/超时）
- 结算 UI 明确「正在上传 / 成功 / 失败可点重试」，失败保留同一 `run_id` 与 score payload
- 无学号时拒绝 submit，避免伪成功
- 契约测试覆盖 retry 与无学号路径

## Test plan
- [x] `npx vitest run src/utils/hecheng_hugongda_rank_contract.spec.ts`
- [x] `website/modules-src/hecheng_hugongda/project` `npm run build`
- [ ] 弱网手动：终局失败可点重试成功

Closes #278