### PR TITLE
fix(jump): 下一平台入画约束 (#279)

### DIFF
--- a/website/modules-src/jump_out_hbut/project/src/game/PlatformGenerator.js
+++ b/website/modules-src/jump_out_hbut/project/src/game/PlatformGenerator.js
@@ -1,6 +1,7 @@
 /**
  * 平台生成器
  * 负责生成下一个跳跃目标平台，包括方向、距离、建筑类型选择
+ * 生成距离受相机可见性约束，避免目标平台整块出画
  */
 import { randomRange } from '../utils/math.js'
 import {
@@ -11,7 +12,10 @@ import {
   PLATFORM_DISTANCE_MAX_FACTOR,
   HIGH_SCORE_SCALE_MIN,
   HIGH_SCORE_SCALE_MAX,
-  HIGH_SCORE_THRESHOLD
+  HIGH_SCORE_THRESHOLD,
+  PLATFORM_VISIBILITY,
+  MIN_JUMP_DISTANCE,
+  MAX_JUMP_DISTANCE
 } from '../utils/constants.js'
 
 /** 平台 ID 计数器 */
@@ -74,6 +78,46 @@ function pickTypeFromCategory(category) {
   return candidates[idx]
 }
 
+/**
+ * 计算两点平面距离
+ * @param {{x:number,z:number}} a
+ * @param {{x:number,z:number}} b
+ * @returns {number}
+ */
+export function planarDistance(a, b) {
+  const dx = Number(a?.x || 0) - Number(b?.x || 0)
+  const dz = Number(a?.z || 0) - Number(b?.z || 0)
+  return Math.sqrt(dx * dx + dz * dz)
+}
+
+/**
+ * 将生成距离钳制到「可跳 + 可入画」区间
+ * @param {number} distance
+ * @returns {number}
+ */
+export function clampPlatformDistance(distance) {
+  const minDist = Math.max(MIN_JUMP_DISTANCE, 4.5 * PLATFORM_DISTANCE_MIN_FACTOR)
+  const maxDist = Math.min(
+    MAX_JUMP_DISTANCE,
+    PLATFORM_VISIBILITY.maxGenerateDistance,
+    PLATFORM_VISIBILITY.maxCenterDistance
+  )
+  const value = Number(distance)
+  if (!Number.isFinite(value)) return minDist
+  return Math.min(maxDist, Math.max(minDist, value))
+}
+
+/**
+ * 判断下一平台中心是否相对相机目标入画（简化：平面距离阈值）
+ * @param {{x:number,z:number}} cameraTarget
+ * @param {{x:number,z:number}} platformCenter
+ * @param {number} [radius]
+ * @returns {boolean}
+ */
+export function isPlatformCenterOnScreen(cameraTarget, platformCenter, radius = PLATFORM_VISIBILITY.visibleRadiusFromCameraTarget) {
+  return planarDistance(cameraTarget, platformCenter) <= Number(radius || 0)
+}
+
 export class PlatformGenerator {
   constructor() {
     this._idCounter = 0
@@ -113,18 +157,19 @@ export class PlatformGenerator {
     const type = pickTypeFromCategory(category)
     const data = BUILDING_DATA[type]
 
-    // 3. 计算距离（使用固定基准距离，不依赖当前平台宽度）
-    // 基准距离 = 跳跃范围的中间值附近，确保大部分跳跃可达
+    // 3. 计算距离（使用固定基准距离，再钳制到可见/可跳范围）
     const baseDistance = 4.5 // 跳跃范围 2.0~8.0 的中间偏下
     let distance = baseDistance * randomRange(
       PLATFORM_DISTANCE_MIN_FACTOR,
       PLATFORM_DISTANCE_MAX_FACTOR
     )
 
-    // 高分时增加距离缩放
+    // 高分时轻微增加距离，但仍受入画硬上限约束
     if (score >= HIGH_SCORE_THRESHOLD) {
       distance *= randomRange(HIGH_SCORE_SCALE_MIN, HIGH_SCORE_SCALE_MAX)
     }
+
+    distance = clampPlatformDistance(distance)
 
     // 4. 计算位置
     // 方向角度：left = -30°, right = +30°（相对 Z 轴正方向，60° zigzag）

--- a/website/modules-src/jump_out_hbut/project/src/game/PlatformGenerator.test.js
+++ b/website/modules-src/jump_out_hbut/project/src/game/PlatformGenerator.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { PlatformGenerator } from './PlatformGenerator.js'
+import {
+  PlatformGenerator,
+  clampPlatformDistance,
+  isPlatformCenterOnScreen,
+  planarDistance
+} from './PlatformGenerator.js'
 import {
   BUILDING_DATA,
   BUILDING_TYPES,
@@ -7,7 +12,8 @@ import {
   PLATFORM_DISTANCE_MAX_FACTOR,
   HIGH_SCORE_SCALE_MAX,
   HIGH_SCORE_THRESHOLD,
-  PLATFORM_PROBABILITY
+  PLATFORM_PROBABILITY,
+  PLATFORM_VISIBILITY
 } from '../utils/constants.js'
 
 describe('PlatformGenerator', () => {
@@ -89,38 +95,60 @@ describe('PlatformGenerator', () => {
   })
 
   describe('距离约束', () => {
-    it('score < 1500 时距离在固定基础距离倍率范围内', () => {
+    it('score < 1500 时距离在固定基础距离倍率与入画上限内', () => {
       const initial = generator.getInitialPlatform()
       const baseDistance = 4.5
       const minDist = PLATFORM_DISTANCE_MIN_FACTOR * baseDistance
-      const maxDist = PLATFORM_DISTANCE_MAX_FACTOR * baseDistance
+      const maxDist = Math.min(
+        PLATFORM_DISTANCE_MAX_FACTOR * baseDistance,
+        PLATFORM_VISIBILITY.maxGenerateDistance
+      )
 
       for (let i = 0; i < 50; i++) {
         const next = generator.generateNext(initial, 100)
-        const dx = next.position.x - initial.position.x
-        const dz = next.position.z - initial.position.z
-        const distance = Math.sqrt(dx * dx + dz * dz)
+        const distance = planarDistance(next.position, initial.position)
 
         expect(distance).toBeGreaterThanOrEqual(minDist - 0.001)
         expect(distance).toBeLessThanOrEqual(maxDist + 0.001)
       }
     })
 
-    it('score >= 1500 时距离在固定基础距离倍率和高分缩放范围内', () => {
+    it('score >= 1500 时距离仍受入画硬上限约束', () => {
       const initial = generator.getInitialPlatform()
       const baseDistance = 4.5
       const minDist = PLATFORM_DISTANCE_MIN_FACTOR * baseDistance
-      const maxDist = PLATFORM_DISTANCE_MAX_FACTOR * baseDistance * HIGH_SCORE_SCALE_MAX
+      const maxDist = PLATFORM_VISIBILITY.maxGenerateDistance
 
       for (let i = 0; i < 50; i++) {
         const next = generator.generateNext(initial, 2000)
-        const dx = next.position.x - initial.position.x
-        const dz = next.position.z - initial.position.z
-        const distance = Math.sqrt(dx * dx + dz * dz)
+        const distance = planarDistance(next.position, initial.position)
 
         expect(distance).toBeGreaterThanOrEqual(minDist - 0.001)
         expect(distance).toBeLessThanOrEqual(maxDist + 0.001)
       }
+    })
+
+    it('连续生成时下一平台中心相对当前平台始终入画', () => {
+      let current = generator.getInitialPlatform()
+      for (let i = 0; i < 80; i++) {
+        const next = generator.generateNext(current, i * 30)
+        expect(
+          isPlatformCenterOnScreen(
+            current.position,
+            next.position,
+            PLATFORM_VISIBILITY.visibleRadiusFromCameraTarget
+          )
+        ).toBe(true)
+        expect(planarDistance(current.position, next.position)).toBeLessThanOrEqual(
+          PLATFORM_VISIBILITY.maxCenterDistance + 0.001
+        )
+        current = next
+      }
+    })
+
+    it('clampPlatformDistance 钳制超大距离', () => {
+      expect(clampPlatformDistance(99)).toBeLessThanOrEqual(PLATFORM_VISIBILITY.maxGenerateDistance)
+      expect(clampPlatformDistance(0)).toBeGreaterThanOrEqual(4.5 * PLATFORM_DISTANCE_MIN_FACTOR - 0.001)
     })
   })
 
@@ -155,10 +183,10 @@ describe('PlatformGenerator', () => {
 
         const baseDistance = 4.5
         const minDist = PLATFORM_DISTANCE_MIN_FACTOR * baseDistance
-        let maxDist = PLATFORM_DISTANCE_MAX_FACTOR * baseDistance
-        if (score >= HIGH_SCORE_THRESHOLD) {
-          maxDist *= HIGH_SCORE_SCALE_MAX
-        }
+        const maxDist = Math.min(
+          PLATFORM_DISTANCE_MAX_FACTOR * baseDistance * (score >= HIGH_SCORE_THRESHOLD ? HIGH_SCORE_SCALE_MAX : 1),
+          PLATFORM_VISIBILITY.maxGenerateDistance
+        )
 
         expect(distance).toBeGreaterThanOrEqual(minDist - 0.001)
         expect(distance).toBeLessThanOrEqual(maxDist + 0.001)

--- a/website/modules-src/jump_out_hbut/project/src/utils/constants.js
+++ b/website/modules-src/jump_out_hbut/project/src/utils/constants.js
@@ -156,6 +156,20 @@ export const CAMERA_CONFIG = {
   followDuration: 300
 }
 
+/**
+ * 下一平台入画约束（相对当前站立平台 / 相机 lookAt）
+ * 正交相机 frustumSize=12 时半高 6；竖屏半宽更窄，取保守半径。
+ * 目标：落跳前下一平台中心主要落在可见区内。
+ */
+export const PLATFORM_VISIBILITY = {
+  /** 相对当前平台中心，下一平台中心允许的最大平面距离 */
+  maxCenterDistance: 6.0,
+  /** 生成距离硬上限（同时受跳跃上限约束） */
+  maxGenerateDistance: 6.0,
+  /** 窄屏/默认 aspect 下用于测试的可见半径（世界单位，与生成上限一致） */
+  visibleRadiusFromCameraTarget: 6.0
+}
+
 // ========== 落点判定阈值 ==========
 /** 完美着陆阈值（距中心 35% 以内） */
 export const PERFECT_LANDING_THRESHOLD = 0.35


### PR DESCRIPTION
## Summary
- 平台生成距离增加 `PLATFORM_VISIBILITY` 硬上限与 `clampPlatformDistance`
- 连续生成时下一平台中心相对当前平台保持在可见半径内
- 单测覆盖入画与距离钳制

## Test plan
- [x] `website/modules-src/jump_out_hbut/project` `npx vitest --run` (165 passed)

Closes #279