### PR TITLE
feat(memory): game-rank upload and leaderboard

### DIFF
--- a/src/utils/hbut_memory_match_rank_contract.spec.ts
+++ b/src/utils/hbut_memory_match_rank_contract.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  canUseGameRank,
+  readGameModuleContext,
+  submitGameRank
+} from '../../website/modules-src/hbut_memory_match/project/src/utils/game_rank.js'
+
+const setSearch = (search = '') => {
+  // @ts-expect-error test window
+  globalThis.window = {
+    location: { search },
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout
+  }
+}
+
+const createStorage = () => {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => (values.has(key) ? values.get(key)! : null),
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+    removeItem: (key: string) => values.delete(key),
+    clear: () => values.clear()
+  }
+}
+
+describe('hbut_memory_match rank contract', () => {
+  beforeEach(() => {
+    // @ts-expect-error storage
+    globalThis.localStorage = createStorage()
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { platform: 'test' },
+      configurable: true
+    })
+    setSearch('')
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('submits memory score with game_id hbut_memory_match and retries once on 503', async () => {
+    setSearch(
+      '?student_id=20240111&player_name=记忆牌&class_name=机械2401&rank_api=https://rank.example/api/game-rank'
+    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: false, error: 'busy' }), { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const context = readGameModuleContext()
+    expect(canUseGameRank(context)).toBe(true)
+    const result = await submitGameRank(
+      context,
+      {
+        runId: 'run_memory_1',
+        score: 860,
+        maxLevel: 3,
+        durationMs: 54000,
+        moveCount: 22,
+        endedReason: 'lost',
+        extra: { mistakes: 4, levelIndex: 2 }
+      },
+      { retryDelaysMs: [0] }
+    )
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body))
+    expect(body.game_id).toBe('hbut_memory_match')
+    expect(body.score).toBe(860)
+    expect(body.run_id).toBe('run_memory_1')
+    expect(body.max_level).toBe(3)
+    expect(body.ended_reason).toBe('lost')
+  })
+
+  it('disables rank without student_id', () => {
+    setSearch('?rank_api=https://rank.example/api/game-rank')
+    const context = readGameModuleContext()
+    expect(canUseGameRank(context)).toBe(false)
+  })
+})

--- a/website/modules-src/hbut_memory_match/project/src/main.js
+++ b/website/modules-src/hbut_memory_match/project/src/main.js
@@ -7,12 +7,27 @@ import {
   restartMemoryGame,
   tickMemoryGame
 } from './game/memory.js'
+import {
+  canUseGameRank,
+  createRunId,
+  fetchGameLeaderboard,
+  readGameModuleContext,
+  submitGameRank
+} from './utils/game_rank.js'
 
 const MODULE_ID = 'hbut_memory_match'
 const app = document.getElementById('app')
 
+const moduleContext = readGameModuleContext()
+const rankEnabled = canUseGameRank(moduleContext)
+
 let state = createInitialMemoryState({ levelIndex: 0, seed: 9 })
 let lastFrame = performance.now()
+let currentRunId = createRunId()
+let runStartedAt = Date.now()
+let submitPending = null
+let lastTerminalStatus = ''
+let currentLeaderboardScope = moduleContext.className ? 'class' : 'school'
 
 function syncViewport() {
   const viewportHeight = window.visualViewport?.height || window.innerHeight || document.documentElement.clientHeight
@@ -109,6 +124,132 @@ function renderLog() {
   return state.log.map((item) => `<li>${item}</li>`).join('')
 }
 
+function showSubmitStatus(status) {
+  const el = document.getElementById('submit-status')
+  if (!el) return
+  switch (status) {
+    case 'uploading':
+      el.textContent = '正在上传成绩...'
+      el.className = 'submit-status uploading'
+      el.onclick = null
+      break
+    case 'success':
+      el.textContent = '✓ 成绩已上传'
+      el.className = 'submit-status success'
+      el.onclick = null
+      setTimeout(() => {
+        if (el.classList.contains('success')) {
+          el.textContent = ''
+          el.className = 'submit-status'
+        }
+      }, 3000)
+      break
+    case 'failed':
+      el.textContent = '上传失败，点此重试'
+      el.className = 'submit-status failed'
+      el.onclick = () => {
+        void retrySubmit()
+      }
+      break
+    default:
+      el.textContent = ''
+      el.className = 'submit-status'
+      el.onclick = null
+  }
+}
+
+async function submitTerminalScore(endedReason) {
+  if (!rankEnabled) return
+  const payload = {
+    runId: currentRunId,
+    score: state.score,
+    maxLevel: state.levelNumber || 1,
+    durationMs: Math.max(0, Date.now() - runStartedAt),
+    moveCount: Number(state.moves || 0),
+    endedReason,
+    extra: {
+      mistakes: state.mistakes || 0,
+      levelIndex: state.levelIndex || 0,
+      combo: state.combo || 0
+    }
+  }
+  submitPending = payload
+  showSubmitStatus('uploading')
+  try {
+    await submitGameRank(moduleContext, payload)
+    submitPending = null
+    showSubmitStatus('success')
+  } catch (error) {
+    console.warn('[hbut_memory_match] rank submit failed', error)
+    showSubmitStatus('failed')
+  }
+}
+
+async function retrySubmit() {
+  if (!submitPending || !rankEnabled) return
+  showSubmitStatus('uploading')
+  try {
+    await submitGameRank(moduleContext, submitPending)
+    submitPending = null
+    showSubmitStatus('success')
+  } catch (error) {
+    console.warn('[hbut_memory_match] rank retry failed', error)
+    showSubmitStatus('failed')
+  }
+}
+
+function setupLeaderboard() {
+  if (!rankEnabled) return
+  const overlay = document.getElementById('leaderboard-overlay')
+  const openBtn = document.getElementById('leaderboard-button')
+  const closeBtn = document.getElementById('leaderboard-close')
+  openBtn?.addEventListener('click', () => {
+    if (overlay) overlay.style.display = 'flex'
+    void loadLeaderboard(currentLeaderboardScope)
+  })
+  closeBtn?.addEventListener('click', () => {
+    if (overlay) overlay.style.display = 'none'
+  })
+  overlay?.addEventListener('click', (event) => {
+    if (event.target === overlay) overlay.style.display = 'none'
+  })
+  document.querySelectorAll('.tab-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach((item) => item.classList.remove('active'))
+      btn.classList.add('active')
+      currentLeaderboardScope = btn.dataset.scope || 'class'
+      void loadLeaderboard(currentLeaderboardScope)
+    })
+  })
+}
+
+async function loadLeaderboard(scope) {
+  const content = document.getElementById('leaderboard-content')
+  if (!content) return
+  content.innerHTML = '<div class="leaderboard-loading">加载中...</div>'
+  try {
+    const data = await fetchGameLeaderboard(moduleContext, { scope, limit: 20 })
+    const list = data.leaderboard || data.data || []
+    if (!list.length) {
+      content.innerHTML = '<div class="leaderboard-empty">暂无数据</div>'
+      return
+    }
+    const isClassTotal = scope === 'class_total'
+    content.innerHTML = `<div class="leaderboard-list">${list
+      .map((item, index) => {
+        const rank = item.rank || index + 1
+        const name = isClassTotal
+          ? item.class_name || item.className || '未知班级'
+          : item.player_name || item.playerName || item.student_id || '匿名'
+        const score = isClassTotal ? item.total_score ?? item.totalScore ?? 0 : item.score ?? 0
+        return `<div class="leaderboard-item"><span class="rank-badge">${rank}</span><span class="rank-name">${name}</span><span class="rank-score">${score}</span></div>`
+      })
+      .join('')}</div>`
+  } catch (error) {
+    content.innerHTML = `<div class="leaderboard-error">加载失败: ${error?.message || '未知错误'}</div>`
+  }
+}
+
 function updateUi() {
   app.querySelector('[data-level]').textContent = `${state.levelNumber}/${state.totalLevels}`
   app.querySelector('[data-pairs]').textContent = `${state.matchedPairs}/${state.pairs.length}`
@@ -131,10 +272,18 @@ function updateUi() {
   for (const button of app.querySelectorAll('[data-card-id]')) {
     button.addEventListener('click', () => {
       state = flipMemoryCard(state, button.dataset.cardId)
+      maybeSubmitTerminal()
       updateUi()
     })
   }
   notifyHostHeight()
+}
+
+function maybeSubmitTerminal() {
+  if ((state.status === 'won' || state.status === 'lost') && state.status !== lastTerminalStatus) {
+    lastTerminalStatus = state.status
+    void submitTerminalScore(state.status === 'won' ? 'won' : 'lost')
+  }
 }
 
 function renderShell() {
@@ -181,7 +330,10 @@ function renderShell() {
           <span>错配 <strong data-mistakes>0</strong></span>
         </div>
         <button id="restart-button" class="primary-action" type="button"><span data-restart-label>重新开始</span></button>
+        ${rankEnabled ? '<button id="leaderboard-button" class="secondary-action" type="button">排行榜</button>' : ''}
       </section>
+
+      <div id="submit-status" class="submit-status" aria-live="polite"></div>
 
       <section class="log-panel" aria-label="配对记录">
         <div class="log-heading">
@@ -191,14 +343,37 @@ function renderShell() {
         <ol data-log></ol>
       </section>
     </main>
+
+    ${rankEnabled ? `
+    <div class="leaderboard-overlay" id="leaderboard-overlay" style="display:none">
+      <div class="leaderboard-modal">
+        <div class="leaderboard-header">
+          <h2>🏆 排行榜</h2>
+          <button class="leaderboard-close" id="leaderboard-close" type="button">&times;</button>
+        </div>
+        <div class="leaderboard-tabs">
+          <button class="tab-btn ${currentLeaderboardScope === 'class' ? 'active' : ''}" data-scope="class" type="button">班级榜</button>
+          <button class="tab-btn ${currentLeaderboardScope === 'school' ? 'active' : ''}" data-scope="school" type="button">全校榜</button>
+          <button class="tab-btn ${currentLeaderboardScope === 'class_total' ? 'active' : ''}" data-scope="class_total" type="button">班级总分榜</button>
+        </div>
+        <div class="leaderboard-content" id="leaderboard-content">
+          <div class="leaderboard-loading">加载中...</div>
+        </div>
+      </div>
+    </div>` : ''}
   `
 
   document.getElementById('restart-button')?.addEventListener('click', () => {
     state = restartMemoryGame(state, { levelIndex: 0, seed: Date.now() % 100000 })
+    currentRunId = createRunId()
+    runStartedAt = Date.now()
+    lastTerminalStatus = ''
+    submitPending = null
+    showSubmitStatus('')
     lastFrame = performance.now()
     updateUi()
   })
-
+  setupLeaderboard()
   updateUi()
 }
 
@@ -209,6 +384,7 @@ function tick(now) {
   const previousSecond =
     state.status === 'preview' ? Math.ceil(state.previewLeftMs / 1000) : Math.ceil(state.timeLeftMs / 1000)
   state = tickMemoryGame(state, delta)
+  maybeSubmitTerminal()
   const currentSecond =
     state.status === 'preview' ? Math.ceil(state.previewLeftMs / 1000) : Math.ceil(state.timeLeftMs / 1000)
   if (state.status !== previousStatus || currentSecond !== previousSecond) {

--- a/website/modules-src/hbut_memory_match/project/src/style.css
+++ b/website/modules-src/hbut_memory_match/project/src/style.css
@@ -41,7 +41,7 @@ button {
   height: 100%;
   margin: 0 auto;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto minmax(82px, auto);
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto minmax(82px, auto);
   gap: 8px;
 }
 
@@ -262,7 +262,7 @@ button {
 
 .control-panel {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 116px;
+  grid-template-columns: minmax(0, 1fr) 116px auto;
   gap: 8px;
   align-items: center;
 }
@@ -289,21 +289,157 @@ button {
   color: #1e293b;
 }
 
-.primary-action {
+.primary-action,
+.secondary-action {
   min-height: 44px;
   border: 0;
   border-radius: 8px;
   padding: 0 14px;
-  background: #f97316;
-  color: #ffffff;
   font-weight: 800;
   cursor: pointer;
   transition: background 160ms ease, box-shadow 160ms ease;
 }
 
+.primary-action {
+  background: #f97316;
+  color: #ffffff;
+}
+
 .primary-action:focus-visible {
   outline: 3px solid rgba(249, 115, 22, 0.38);
   outline-offset: 2px;
+}
+
+.secondary-action {
+  background: #dbeafe;
+  color: #1e3a5f;
+}
+
+.secondary-action:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.submit-status {
+  margin: 0 2px;
+  min-height: 20px;
+  font-size: 0.78rem;
+  color: #415164;
+}
+
+.submit-status.uploading {
+  color: #235f76;
+}
+
+.submit-status.success {
+  color: #1f7a4c;
+}
+
+.submit-status.failed {
+  color: #b42318;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.leaderboard-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(12, 20, 28, 0.48);
+  padding: 16px;
+}
+
+.leaderboard-modal {
+  width: min(100%, 380px);
+  max-height: min(78vh, 560px);
+  overflow: auto;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 18px 40px rgba(20, 34, 51, 0.22);
+  padding: 14px;
+}
+
+.leaderboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.leaderboard-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.leaderboard-close {
+  border: 0;
+  background: transparent;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.leaderboard-tabs {
+  display: flex;
+  gap: 6px;
+  margin: 12px 0;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: #f3f7fb;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.tab-btn.active {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.leaderboard-list {
+  display: grid;
+  gap: 8px;
+}
+
+.leaderboard-item {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #f6faf8;
+}
+
+.rank-badge {
+  font-weight: 800;
+  color: #2563eb;
+}
+
+.rank-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rank-score {
+  font-weight: 800;
+}
+
+.leaderboard-loading,
+.leaderboard-empty,
+.leaderboard-error {
+  padding: 18px 8px;
+  text-align: center;
+  color: #5b6b7a;
 }
 
 .log-panel {
@@ -397,7 +533,7 @@ button {
   }
 
   .control-panel {
-    grid-template-columns: minmax(0, 1fr) 104px;
+    grid-template-columns: minmax(0, 1fr) 96px auto;
   }
 }
 

--- a/website/modules-src/hbut_memory_match/project/src/utils/game_rank.js
+++ b/website/modules-src/hbut_memory_match/project/src/utils/game_rank.js
@@ -1,0 +1,233 @@
+const DEFAULT_GAME_ID = 'hbut_memory_match'
+const DEFAULT_GAME_RANK_API = 'https://mini-hbut-testocr1.hf.space/api/game-rank'
+const REQUEST_TIMEOUT_MS = 12000
+const MODULE_CONTEXT_STORAGE_KEY = 'hbut_memory_match_rank_context_v1'
+const DEFAULT_RETRY_DELAYS_MS = [1200, 2600, 5200]
+
+const safeText = (value) => String(value ?? '').trim()
+const LEADERBOARD_TIMEOUT_MESSAGE = '排行榜请求超时，请稍后重试'
+
+const safeParseJson = (raw, fallback = null) => {
+  try {
+    return JSON.parse(raw || '')
+  } catch {
+    return fallback
+  }
+}
+
+const normalizeApiBase = (value) => {
+  const text = safeText(value)
+  if (!text) return DEFAULT_GAME_RANK_API
+  const withProtocol = /^https?:\/\//i.test(text) ? text : `https://${text}`
+  const normalized = withProtocol.replace(/\/+$/, '')
+  if (/\/api\/game-rank$/i.test(normalized)) return normalized
+  if (/\/api$/i.test(normalized)) return `${normalized}/game-rank`
+  return `${normalized}/api/game-rank`
+}
+
+const withTimeout = async (executor, timeoutMs = REQUEST_TIMEOUT_MS) => {
+  const controller = typeof AbortController === 'function' ? new AbortController() : null
+  let timer = null
+  try {
+    if (controller) {
+      timer = window.setTimeout(() => controller.abort(), timeoutMs)
+    }
+    return await executor(controller?.signal)
+  } finally {
+    if (timer) window.clearTimeout(timer)
+  }
+}
+
+const isAbortError = (error) => {
+  const text = `${safeText(error?.name)} ${safeText(error?.message || error)}`.toLowerCase()
+  return text.includes('abort') || text.includes('timeout') || text.includes('signal is aborted')
+}
+
+const normalizeRequestError = (error) => {
+  if (isAbortError(error)) return new Error(LEADERBOARD_TIMEOUT_MESSAGE)
+  if (error instanceof Error) return error
+  return new Error(safeText(error) || '排行榜请求失败')
+}
+
+const wait = (ms) => new Promise((resolve) => window.setTimeout(resolve, Math.max(0, Number(ms || 0))))
+
+const shouldRetryRequest = (error) => {
+  const status = Number(error?.status || 0)
+  if (status === 429) return true
+  if (status >= 500 && status <= 599) return true
+  return isAbortError(error) || /network|fetch|failed|timeout/i.test(safeText(error?.message || error))
+}
+
+const requestJson = async (url, init = {}) => {
+  let response = null
+  try {
+    response = await withTimeout((signal) =>
+      fetch(url, {
+        ...init,
+        signal,
+        headers: {
+          Accept: 'application/json',
+          ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+          ...(init?.headers || {})
+        }
+      })
+    )
+  } catch (error) {
+    throw normalizeRequestError(error)
+  }
+  const text = await response.text()
+  let parsed = null
+  try {
+    parsed = JSON.parse(text || '{}')
+  } catch {
+    parsed = null
+  }
+  if (!response.ok) {
+    const error = new Error(safeText(parsed?.error || parsed?.message || text) || `HTTP ${response.status}`)
+    error.status = response.status
+    throw error
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('排行榜服务返回了无效响应')
+  }
+  if (parsed.success === false) {
+    const error = new Error(safeText(parsed.error || parsed.message) || '排行榜服务返回失败')
+    error.status = Number(parsed.status || 0)
+    throw error
+  }
+  return parsed
+}
+
+const requestJsonWithRetry = async (url, init = {}, options = {}) => {
+  const retryDelays = Array.isArray(options.retryDelaysMs) ? options.retryDelaysMs : DEFAULT_RETRY_DELAYS_MS
+  let lastError = null
+  for (let attempt = 0; attempt <= retryDelays.length; attempt += 1) {
+    if (attempt > 0) await wait(retryDelays[attempt - 1])
+    try {
+      return await requestJson(url, init)
+    } catch (error) {
+      lastError = error
+      if (attempt >= retryDelays.length || !shouldRetryRequest(error)) {
+        throw error
+      }
+    }
+  }
+  throw lastError || new Error('排行榜请求失败')
+}
+
+const readStoredContext = () => {
+  const stored = safeParseJson(localStorage.getItem(MODULE_CONTEXT_STORAGE_KEY), null)
+  return stored && typeof stored === 'object' ? stored : {}
+}
+
+const pickStoredText = (stored, camelKey, snakeKey) => pickText(stored?.[camelKey], stored?.[snakeKey])
+
+const writeStoredContext = (context) => {
+  const next = context && typeof context === 'object' ? context : {}
+  if (
+    !safeText(next.studentId) &&
+    !safeText(next.playerName) &&
+    !safeText(next.className) &&
+    !safeText(next.major)
+  ) {
+    return
+  }
+  localStorage.setItem(
+    MODULE_CONTEXT_STORAGE_KEY,
+    JSON.stringify({
+      gameId: safeText(next.gameId || DEFAULT_GAME_ID),
+      studentId: safeText(next.studentId),
+      playerName: safeText(next.playerName),
+      className: safeText(next.className),
+      schoolName: safeText(next.schoolName || '湖北工业大学'),
+      major: safeText(next.major),
+      runtime: safeText(next.runtime),
+      appVersion: safeText(next.appVersion),
+      from: safeText(next.from),
+      rankApiBase: safeText(next.rankApiBase || DEFAULT_GAME_RANK_API)
+    })
+  )
+}
+
+const pickText = (...values) => {
+  for (const value of values) {
+    const text = safeText(value)
+    if (text) return text
+  }
+  return ''
+}
+
+export const readGameModuleContext = () => {
+  const params = new URLSearchParams(window.location.search || '')
+  const stored = readStoredContext()
+  const context = {
+    gameId: DEFAULT_GAME_ID,
+    studentId: pickText(params.get('student_id'), pickStoredText(stored, 'studentId', 'student_id')),
+    playerName: pickText(params.get('player_name'), pickStoredText(stored, 'playerName', 'player_name')),
+    className: pickText(params.get('class_name'), pickStoredText(stored, 'className', 'class_name')),
+    schoolName: pickText(params.get('school_name'), pickStoredText(stored, 'schoolName', 'school_name')) || '湖北工业大学',
+    major: pickText(params.get('major'), stored.major),
+    runtime: pickText(params.get('runtime'), stored.runtime) || 'module-web',
+    appVersion: pickText(params.get('app_version'), pickStoredText(stored, 'appVersion', 'app_version')),
+    from: pickText(params.get('from'), stored.from),
+    rankApiBase: normalizeApiBase(pickText(params.get('rank_api'), pickStoredText(stored, 'rankApiBase', 'rank_api')))
+  }
+  writeStoredContext(context)
+  return context
+}
+
+export const canUseGameRank = (context) => {
+  const profile = context && typeof context === 'object' ? context : {}
+  return !!safeText(profile.studentId) && !!normalizeApiBase(profile.rankApiBase)
+}
+
+export const submitGameRank = async (context, payload = {}, options = {}) => {
+  const profile = context && typeof context === 'object' ? context : readGameModuleContext()
+  const body = {
+    game_id: safeText(payload.gameId || profile.gameId || DEFAULT_GAME_ID),
+    run_id: safeText(payload.runId),
+    student_id: safeText(profile.studentId),
+    player_name: safeText(payload.playerName || profile.playerName || profile.studentId),
+    class_name: safeText(payload.className || profile.className),
+    school_name: safeText(payload.schoolName || profile.schoolName || '湖北工业大学'),
+    major: safeText(payload.major || profile.major),
+    score: Number(payload.score || 0) || 0,
+    max_level: Number(payload.maxLevel || 0) || 0,
+    duration_ms: Number(payload.durationMs || 0) || 0,
+    move_count: Number(payload.moveCount || 0) || 0,
+    ended_reason: safeText(payload.endedReason || 'finished'),
+    client_version: safeText(payload.clientVersion || profile.appVersion),
+    platform: safeText(payload.platform || navigator.platform),
+    runtime: safeText(payload.runtime || profile.runtime),
+    payload: payload.extra && typeof payload.extra === 'object' ? payload.extra : {}
+  }
+  return requestJsonWithRetry(`${normalizeApiBase(profile.rankApiBase)}/submit`, {
+    method: 'POST',
+    body: JSON.stringify(body)
+  }, options)
+}
+
+export const fetchGameLeaderboard = async (context, options = {}) => {
+  const profile = context && typeof context === 'object' ? context : readGameModuleContext()
+  const scope = safeText(options.scope || 'class') || 'class'
+  const query = new URLSearchParams({
+    game_id: safeText(options.gameId || profile.gameId || DEFAULT_GAME_ID),
+    scope,
+    limit: String(Number(options.limit || 20) || 20)
+  })
+  const studentId = safeText(options.studentId || profile.studentId)
+  const className = safeText(options.className || profile.className)
+  const schoolName = safeText(options.schoolName || profile.schoolName)
+  if (studentId) query.set('student_id', studentId)
+  if (className) query.set('class_name', className)
+  if (schoolName) query.set('school_name', schoolName)
+  return requestJson(`${normalizeApiBase(profile.rankApiBase)}/leaderboard?${query.toString()}`)
+}
+
+export const createRunId = () => {
+  const random = Math.random().toString(36).slice(2, 10)
+  return `run_${Date.now()}_${random}`
+}
+
+export const resolveRankApiBase = normalizeApiBase
+


### PR DESCRIPTION
## Summary
- Wire hbut_memory_match terminal won/lost score submit via game_rank client (game_id=hbut_memory_match)
- Upload status UI (uploading/success/retry) and class/school/class_total leaderboard overlay
- Restart resets run_id; contract tests for submit payload and no-student_id degrade

Closes #283

## Test plan
- [x] vitest: hbut_memory_match_rank_contract.spec.ts
- [x] node scripts/build_website_modules.mjs --modules=hbut_memory_match --merge-catalog
