### PR TITLE
fix(games): data-mcp-metric hooks for parking/match3/stack E2E

### DIFF
--- a/website/modules-src/hbut_match3/project/src/main.js
+++ b/website/modules-src/hbut_match3/project/src/main.js
@@ -218,19 +218,19 @@ function render() {
       <section class="metric-strip" aria-label="消消乐状态">
         <div>
           <span>得分</span>
-          <strong>${state.score}</strong>
+          <strong data-mcp-metric="score">${state.score}</strong>
         </div>
         <div>
           <span>剩余步数</span>
-          <strong>${state.movesLeft}</strong>
+          <strong data-mcp-metric="moves_left">${state.movesLeft}</strong>
         </div>
         <div>
           <span>最高连锁</span>
-          <strong>x${state.chainPeak}</strong>
+          <strong data-mcp-metric="chain_peak">x${state.chainPeak}</strong>
         </div>
         <div>
           <span>限步</span>
-          <strong>${MOVE_LIMIT}</strong>
+          <strong data-mcp-metric="move_limit">${MOVE_LIMIT}</strong>
         </div>
       </section>
 

--- a/website/modules-src/hbut_parking/project/src/main.js
+++ b/website/modules-src/hbut_parking/project/src/main.js
@@ -266,19 +266,19 @@ function render() {
       <section class="metric-strip" aria-label="挪车状态">
         <div>
           <span>关卡</span>
-          <strong>${state.levelNumber}/${state.totalLevels}</strong>
+          <strong data-mcp-metric="level">${state.levelNumber}/${state.totalLevels}</strong>
         </div>
         <div>
           <span>通关</span>
-          <strong>${state.clearedLevels}</strong>
+          <strong data-mcp-metric="cleared">${state.clearedLevels}</strong>
         </div>
         <div>
           <span>步数</span>
-          <strong>${state.totalSteps}</strong>
+          <strong data-mcp-metric="steps">${state.totalSteps}</strong>
         </div>
         <div>
           <span>得分</span>
-          <strong>${liveScore()}</strong>
+          <strong data-mcp-metric="score">${liveScore()}</strong>
         </div>
       </section>
 

--- a/website/modules-src/hbut_stack/project/src/main.js
+++ b/website/modules-src/hbut_stack/project/src/main.js
@@ -211,19 +211,19 @@ function renderShell() {
       <section class="metric-strip" aria-label="叠塔状态">
         <div>
           <span>层数</span>
-          <strong data-layers>0</strong>
+          <strong data-layers data-mcp-metric="layers">0</strong>
         </div>
         <div>
           <span>得分</span>
-          <strong data-score>0</strong>
+          <strong data-score data-mcp-metric="score">0</strong>
         </div>
         <div>
           <span>完美</span>
-          <strong data-perfect>0</strong>
+          <strong data-perfect data-mcp-metric="perfect">0</strong>
         </div>
         <div>
           <span>连击</span>
-          <strong data-combo>0</strong>
+          <strong data-combo data-mcp-metric="combo">0</strong>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Add `data-mcp-metric` on stack/parking/match3 metric strip values
- Enables atomic Playwright full-flow evidence (DOM metrics == screenshot)

## Test plan
- [x] rebuild module dists; bundles contain data-mcp-metric
- [x] `mcp_full_flow.mjs` exit 0: metrics change + body contains values + console 0