### PR TITLE
fix(stack): 塔升高相机跟随 (#300)

### DIFF
--- a/src/utils/hbut_stack_game.spec.ts
+++ b/src/utils/hbut_stack_game.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  BLOCK_HEIGHT,
+  computeCameraOffsetY,
   cutBlockAgainstBase,
   createInitialStackState,
   dropStackBlock,
@@ -33,6 +35,33 @@ describe('hbut_stack pure cut/score', () => {
     expect(scoreForSuccessfulDrop({ perfect: false })).toBe(100)
     expect(scoreForSuccessfulDrop({ perfect: true, perfectCombo: 1 })).toBe(150)
     expect(scoreForSuccessfulDrop({ perfect: true, perfectCombo: 3 })).toBe(200)
+  })
+
+  it('camera offset keeps tall towers in the upper viewport', () => {
+    const viewportHeight = 400
+    const blockHeightPx = BLOCK_HEIGHT * 2
+    const groundY = viewportHeight * 0.88
+    const low = computeCameraOffsetY({
+      blockCount: 1,
+      blockHeightPx,
+      viewportHeight,
+      groundY,
+      focusRatio: 0.36
+    })
+    const high = computeCameraOffsetY({
+      blockCount: 30,
+      blockHeightPx,
+      viewportHeight,
+      groundY,
+      focusRatio: 0.36
+    })
+    expect(low).toBe(0)
+    expect(high).toBeGreaterThan(low)
+    // with offset, top layer y lands near focus band
+    const topLayerIndex = 30
+    const rawTopY = groundY - (topLayerIndex + 1) * blockHeightPx
+    const drawnTopY = rawTopY + high
+    expect(drawnTopY).toBeCloseTo(viewportHeight * 0.36, 0)
   })
 
   it('drops increase score/layers and miss ends the run', () => {

--- a/website/modules-src/hbut_stack/project/src/game/stack.js
+++ b/website/modules-src/hbut_stack/project/src/game/stack.js
@@ -87,6 +87,33 @@ export function speedForLayer(layerIndex) {
   return clamp(MIN_SPEED + layerIndex * SPEED_STEP, MIN_SPEED, MAX_SPEED)
 }
 
+/**
+ * 计算叠塔画布的相机纵向偏移（向下为正时用于 y' = y + offset）。
+ * 目标：让「当前可玩层 / 移动块」落在视口上部区域，塔升高时视野上移。
+ *
+ * @param {{ blockCount: number, blockHeightPx: number, viewportHeight: number, groundY?: number, focusRatio?: number }} opts
+ * @returns {number} cameraOffsetY（加到绘制 y 上）
+ */
+export function computeCameraOffsetY({
+  blockCount = 1,
+  blockHeightPx = BLOCK_HEIGHT,
+  viewportHeight = 400,
+  groundY,
+  focusRatio = 0.38
+} = {}) {
+  const h = Math.max(1, finiteOr(viewportHeight, 400))
+  const bh = Math.max(1, finiteOr(blockHeightPx, BLOCK_HEIGHT))
+  const count = Math.max(1, Math.trunc(finiteOr(blockCount, 1)))
+  // 包含尚未落下的移动层：可玩顶 = 已放置块数（底座+已叠）对应移动块层索引
+  const topLayerIndex = count // moving sits on top of blocks.length
+  const gy = Number.isFinite(groundY) ? Number(groundY) : h * 0.88
+  const rawTopY = gy - (topLayerIndex + 1) * bh
+  const desiredTopY = h * clamp(finiteOr(focusRatio, 0.38), 0.2, 0.55)
+  // 若顶层仍在 desired 之下，无需上移（offset=0）；否则把顶层拉到 desired
+  const offset = desiredTopY - rawTopY
+  return Math.max(0, offset)
+}
+
 function makeBlock({ left, width, layerIndex, perfect = false }) {
   return {
     left: finiteOr(left, (WORLD_WIDTH - BASE_BLOCK_WIDTH) / 2),

--- a/website/modules-src/hbut_stack/project/src/main.js
+++ b/website/modules-src/hbut_stack/project/src/main.js
@@ -2,6 +2,7 @@ import './style.css'
 import {
   BLOCK_HEIGHT,
   WORLD_WIDTH,
+  computeCameraOffsetY,
   createInitialStackState,
   dropStackBlock,
   restartStackGame,
@@ -320,56 +321,115 @@ function drawScene() {
   const h = canvas.height
   const scaleX = w / WORLD_WIDTH
   const scaleY = Math.min(scaleX, h / 180)
+  const blockH = BLOCK_HEIGHT * scaleY
   const groundY = h * 0.88
+  // 相机：塔升高时把「移动层」固定在视口上部，避免高层冲出画布
+  const cameraOffsetY = computeCameraOffsetY({
+    blockCount: state.blocks.length,
+    blockHeightPx: blockH,
+    viewportHeight: h,
+    groundY,
+    focusRatio: 0.36
+  })
+  const gy = groundY + cameraOffsetY
 
   ctx.clearRect(0, 0, w, h)
   const sky = ctx.createLinearGradient(0, 0, 0, h)
-  sky.addColorStop(0, '#d7ebff')
-  sky.addColorStop(0.55, '#eef6f0')
-  sky.addColorStop(1, '#c9e0cf')
+  sky.addColorStop(0, '#cfe8ff')
+  sky.addColorStop(0.45, '#eef7f2')
+  sky.addColorStop(1, '#d5e8db')
   ctx.fillStyle = sky
   ctx.fillRect(0, 0, w, h)
 
-  ctx.fillStyle = 'rgba(35, 95, 118, 0.12)'
-  ctx.fillRect(0, groundY, w, h - groundY)
+  // 远景软装饰
+  ctx.fillStyle = 'rgba(37, 99, 235, 0.08)'
+  ctx.beginPath()
+  ctx.ellipse(w * 0.18, h * 0.22, w * 0.16, h * 0.05, 0, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.fillStyle = 'rgba(15, 118, 110, 0.1)'
+  ctx.beginPath()
+  ctx.ellipse(w * 0.78, h * 0.28, w * 0.2, h * 0.06, 0, 0, Math.PI * 2)
+  ctx.fill()
 
-  const visible = state.blocks.slice(-12)
+  ctx.fillStyle = 'rgba(35, 95, 118, 0.16)'
+  ctx.fillRect(0, gy, w, Math.max(0, h - gy + 4))
+  ctx.fillStyle = 'rgba(255,255,255,0.35)'
+  ctx.fillRect(0, gy, w, 2)
+
+  const maxVisible = Math.max(8, Math.floor((gy - h * 0.08) / blockH) + 2)
+  const visible = state.blocks.slice(-maxVisible)
   const startIndex = Math.max(0, state.blocks.length - visible.length)
 
   visible.forEach((block, i) => {
     const layerFromBottom = startIndex + i
-    const y = groundY - (layerFromBottom + 1) * BLOCK_HEIGHT * scaleY
+    const y = gy - (layerFromBottom + 1) * blockH
     const x = block.left * scaleX
     const bw = block.width * scaleX
-    const bh = BLOCK_HEIGHT * scaleY * 0.92
-    ctx.fillStyle = block.perfect ? '#2f9b69' : layerFromBottom % 2 === 0 ? '#2563eb' : '#164f90'
-    ctx.fillRect(x, y, bw, bh)
+    const bh = blockH * 0.92
+    const grad = ctx.createLinearGradient(x, y, x, y + bh)
+    if (block.perfect) {
+      grad.addColorStop(0, '#3ecf8e')
+      grad.addColorStop(1, '#1f9b63')
+    } else if (layerFromBottom % 2 === 0) {
+      grad.addColorStop(0, '#3b82f6')
+      grad.addColorStop(1, '#1d4ed8')
+    } else {
+      grad.addColorStop(0, '#2563eb')
+      grad.addColorStop(1, '#1e3a8a')
+    }
+    ctx.fillStyle = grad
+    roundRect(ctx, x, y, bw, bh, Math.min(6, bh * 0.25))
+    ctx.fill()
     ctx.strokeStyle = 'rgba(255,255,255,0.55)'
-    ctx.strokeRect(x + 0.5, y + 0.5, bw - 1, bh - 1)
+    ctx.stroke()
+    if (block.label && bw > 28 * scaleX) {
+      ctx.fillStyle = 'rgba(255,255,255,0.9)'
+      ctx.font = `${Math.max(9, Math.min(12, bh * 0.55))}px "Microsoft YaHei", sans-serif`
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText(String(block.label).slice(0, 6), x + bw / 2, y + bh / 2)
+    }
   })
 
   if (state.moving && state.status === 'playing') {
     const topLayer = state.blocks.length
-    const y = groundY - (topLayer + 1) * BLOCK_HEIGHT * scaleY
+    const y = gy - (topLayer + 1) * blockH
     const x = state.moving.left * scaleX
     const bw = state.moving.width * scaleX
-    const bh = BLOCK_HEIGHT * scaleY * 0.92
-    ctx.fillStyle = '#f97316'
-    ctx.fillRect(x, y, bw, bh)
-    ctx.strokeStyle = 'rgba(255,255,255,0.8)'
-    ctx.strokeRect(x + 0.5, y + 0.5, bw - 1, bh - 1)
+    const bh = blockH * 0.92
+    const grad = ctx.createLinearGradient(x, y, x, y + bh)
+    grad.addColorStop(0, '#fb923c')
+    grad.addColorStop(1, '#ea580c')
+    ctx.fillStyle = grad
+    roundRect(ctx, x, y, bw, bh, Math.min(6, bh * 0.25))
+    ctx.fill()
+    ctx.strokeStyle = 'rgba(255,255,255,0.85)'
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+    ctx.lineWidth = 1
   }
 
   if (state.status === 'lost') {
-    ctx.fillStyle = 'rgba(15, 23, 42, 0.42)'
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.45)'
     ctx.fillRect(0, 0, w, h)
     ctx.fillStyle = '#fff'
-    ctx.font = `${Math.max(16, 18 * scaleY)}px "Microsoft YaHei", sans-serif`
+    ctx.font = `600 ${Math.max(16, 18 * scaleY)}px "Microsoft YaHei", sans-serif`
     ctx.textAlign = 'center'
-    ctx.fillText('Game Over', w / 2, h * 0.42)
+    ctx.fillText('挑战结束', w / 2, h * 0.42)
     ctx.font = `${Math.max(12, 13 * scaleY)}px "Microsoft YaHei", sans-serif`
     ctx.fillText(`得分 ${state.score} · ${state.layers} 层`, w / 2, h * 0.5)
   }
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+  const radius = Math.max(0, Math.min(r, w / 2, h / 2))
+  ctx.beginPath()
+  ctx.moveTo(x + radius, y)
+  ctx.arcTo(x + w, y, x + w, y + h, radius)
+  ctx.arcTo(x + w, y + h, x, y + h, radius)
+  ctx.arcTo(x, y + h, x, y, radius)
+  ctx.arcTo(x, y, x + w, y, radius)
+  ctx.closePath()
 }
 
 function updateUi() {

--- a/website/modules-src/hbut_stack/project/src/style.css
+++ b/website/modules-src/hbut_stack/project/src/style.css
@@ -42,7 +42,22 @@ button {
   margin: 0 auto;
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto auto minmax(82px, auto);
-  gap: 8px;
+  gap: 10px;
+}
+
+.scene-panel {
+  border-radius: 14px !important;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 80% at 50% 0%, rgba(59, 130, 246, 0.12), transparent 55%),
+    #f8fafc !important;
+}
+
+.scene-panel canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
 }
 
 .metric-strip {


### PR DESCRIPTION
## Summary
- `computeCameraOffsetY` 让移动层固定在视口上部
- 圆角方块与轻远景，提升可读性
- 单测覆盖低/高层相机偏移

## Test plan
- [x] vitest hbut_stack_game.spec.ts
- [x] module build

Closes #300