### PR TITLE
fix(match3): 选中/滑动交换与反馈动效 (#302)

### DIFF
--- a/src/utils/hbut_match3_game.spec.ts
+++ b/src/utils/hbut_match3_game.spec.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyGravity,
+  createInitialMatch3State,
   createSeededRandom,
   findMatches,
   resolveBoard,
+  selectCell,
+  swipeFromCell,
   trySwap
 } from '../../website/modules-src/hbut_match3/project/src/game/match3.js'
 
@@ -49,12 +52,6 @@ describe('hbut_match3 pure board functions', () => {
   })
 
   it('accepts swap that creates a match and scores with chain multiplier', () => {
-    const board = [
-      ['x', 'a', 'a'],
-      ['b', 'c', 'd'],
-      ['e', 'f', 'g']
-    ]
-    // swap x with a would need setup: place so swap creates three a's
     const setup = [
       ['a', 'x', 'a'],
       ['b', 'a', 'c'],
@@ -76,5 +73,64 @@ describe('hbut_match3 pure board functions', () => {
     const resolved = resolveBoard(board, createSeededRandom(7))
     expect(findMatches(resolved.board).length).toBe(0)
     expect(resolved.scoreGained).toBeGreaterThan(0)
+  })
+
+  it('selectCell marks selection and invalid feedback without spending a move', () => {
+    let state = createInitialMatch3State({ seed: 1, size: 4, movesLeft: 10 })
+    state = {
+      ...state,
+      board: [
+        ['a', 'b', 'c', 'd'],
+        ['e', 'f', 'g', 'h'],
+        ['i', 'j', 'k', 'l'],
+        ['m', 'n', 'o', 'p']
+      ]
+    }
+    state = selectCell(state, 0, 0)
+    expect(state.selected).toEqual({ row: 0, col: 0 })
+    expect(state.feedback?.type).toBe('select')
+    expect(state.movesLeft).toBe(10)
+
+    state = selectCell(state, 0, 2) // not adjacent
+    expect(state.feedback?.type).toBe('invalid')
+    expect(state.feedback?.reason).toBe('not_adjacent')
+    expect(state.movesLeft).toBe(10)
+    expect(state.selected).toEqual({ row: 0, col: 2 })
+  })
+
+  it('swipeFromCell swaps adjacent tiles that form a match', () => {
+    let state = createInitialMatch3State({ seed: 9, size: 3, movesLeft: 5 })
+    state = {
+      ...state,
+      board: [
+        ['a', 'x', 'a'],
+        ['b', 'a', 'c'],
+        ['d', 'e', 'f']
+      ],
+      selected: null,
+      score: 0
+    }
+    // from (0,1) swipe down toward (1,1) => three a's on top after swap
+    const next = swipeFromCell(state, 0, 1, 'down')
+    expect(next.movesLeft).toBe(4)
+    expect(next.score).toBeGreaterThan(0)
+    expect(next.feedback?.type).toBe('matched')
+    expect(next.selected).toBeNull()
+  })
+
+  it('swipeFromCell reports invalid when no match forms', () => {
+    let state = createInitialMatch3State({ seed: 3, size: 3, movesLeft: 8 })
+    state = {
+      ...state,
+      board: [
+        ['a', 'b', 'c'],
+        ['d', 'e', 'f'],
+        ['g', 'h', 'i']
+      ]
+    }
+    const next = swipeFromCell(state, 0, 0, 'right')
+    expect(next.movesLeft).toBe(8)
+    expect(next.feedback?.type).toBe('invalid')
+    expect(next.feedback?.reason).toBe('no_match')
   })
 })

--- a/website/modules-src/hbut_match3/project/src/game/match3.js
+++ b/website/modules-src/hbut_match3/project/src/game/match3.js
@@ -201,7 +201,9 @@ export function createInitialMatch3State(options = {}) {
     selected: null,
     seed,
     chainPeak: 0,
-    log: ['限步 30：点两格相邻交换，三连消除。']
+    /** UI 反馈：select | deselect | invalid | matched */
+    feedback: null,
+    log: ['限步 30：点选或滑动交换相邻格，三连消除。']
   }
 }
 
@@ -213,21 +215,47 @@ function addLog(state, message) {
   return { ...state, log: [message, ...(state.log || [])].slice(0, 6) }
 }
 
+/**
+ * 点选/滑动共用：首次选中；同格取消；相邻合法交换；非法则反馈并改选目标格。
+ */
 export function selectCell(state, row, col) {
   if (!state || state.status !== 'playing') return state
   const r = clampIndex(row, state.size)
   const c = clampIndex(col, state.size)
   const selected = state.selected
   if (!selected) {
-    return { ...state, selected: { row: r, col: c } }
+    return {
+      ...state,
+      selected: { row: r, col: c },
+      feedback: { type: 'select', at: { row: r, col: c }, token: Date.now() }
+    }
   }
   if (selected.row === r && selected.col === c) {
-    return { ...state, selected: null }
+    return {
+      ...state,
+      selected: null,
+      feedback: { type: 'deselect', at: { row: r, col: c }, token: Date.now() }
+    }
   }
   const random = createSeededRandom(state.seed + state.movesLeft * 17 + r * 31 + c)
   const result = trySwap(state.board, selected, { row: r, col: c }, random)
   if (!result.ok) {
-    return addLog({ ...state, selected: { row: r, col: c } }, result.reason === 'not_adjacent' ? '只能交换相邻格子。' : '这样交换不会形成三连。')
+    const message =
+      result.reason === 'not_adjacent' ? '只能交换相邻格子。' : '这样交换不会形成三连。'
+    return addLog(
+      {
+        ...state,
+        selected: { row: r, col: c },
+        feedback: {
+          type: 'invalid',
+          reason: result.reason,
+          from: { ...selected },
+          at: { row: r, col: c },
+          token: Date.now()
+        }
+      },
+      message
+    )
   }
   const movesLeft = state.movesLeft - 1
   let next = {
@@ -237,7 +265,15 @@ export function selectCell(state, row, col) {
     movesLeft,
     selected: null,
     chainPeak: Math.max(state.chainPeak, result.chainCount || 0),
-    seed: state.seed + 1
+    seed: state.seed + 1,
+    feedback: {
+      type: 'matched',
+      scoreGained: result.scoreGained,
+      chainCount: result.chainCount || 0,
+      from: { ...selected },
+      at: { row: r, col: c },
+      token: Date.now()
+    }
   }
   next = addLog(next, `消除 +${result.scoreGained}（连锁 x${result.chainCount}）`)
   if (movesLeft <= 0) {
@@ -245,4 +281,45 @@ export function selectCell(state, row, col) {
     next = addLog(next, `步数用尽，最终得分 ${next.score}。`)
   }
   return next
+}
+
+/**
+ * 从起点格向主方向滑动一格并尝试交换（供 pointer 手势调用）。
+ * @returns 新 state；方向无效时返回原 state
+ */
+export function swipeFromCell(state, row, col, direction) {
+  if (!state || state.status !== 'playing') return state
+  const r = clampIndex(row, state.size)
+  const c = clampIndex(col, state.size)
+  let tr = r
+  let tc = c
+  switch (direction) {
+    case 'up':
+      tr -= 1
+      break
+    case 'down':
+      tr += 1
+      break
+    case 'left':
+      tc -= 1
+      break
+    case 'right':
+      tc += 1
+      break
+    default:
+      return state
+  }
+  if (tr < 0 || tr >= state.size || tc < 0 || tc >= state.size) {
+    return {
+      ...state,
+      selected: { row: r, col: c },
+      feedback: { type: 'invalid', reason: 'out_of_bounds', at: { row: r, col: c }, token: Date.now() }
+    }
+  }
+  const primed = {
+    ...state,
+    selected: { row: r, col: c },
+    feedback: null
+  }
+  return selectCell(primed, tr, tc)
 }

--- a/website/modules-src/hbut_match3/project/src/main.js
+++ b/website/modules-src/hbut_match3/project/src/main.js
@@ -4,7 +4,8 @@ import {
   TILE_TYPES,
   createInitialMatch3State,
   restartMatch3Game,
-  selectCell
+  selectCell,
+  swipeFromCell
 } from './game/match3.js'
 import {
   canUseGameRank,
@@ -27,6 +28,9 @@ let submitPending = null
 let lastTerminalStatus = ''
 let lastSubmitUiStatus = ''
 let currentLeaderboardScope = moduleContext.className ? 'class' : 'school'
+/** pointer 手势：点击双选 / 滑动交换 */
+let boardGesture = null
+const SWIPE_THRESHOLD_PX = 28
 
 function syncViewport() {
   const viewportHeight = window.visualViewport?.height || window.innerHeight || document.documentElement.clientHeight
@@ -196,39 +200,157 @@ function afterChange() {
   render()
 }
 
+function tileExtraClass(r, c) {
+  const classes = []
+  if (state.selected && state.selected.row === r && state.selected.col === c) {
+    classes.push('selected')
+  }
+  const fb = state.feedback
+  if (!fb) return classes.join(' ')
+  if (fb.type === 'invalid' && fb.at && fb.at.row === r && fb.at.col === c) {
+    classes.push('invalid')
+  }
+  if (fb.type === 'invalid' && fb.from && fb.from.row === r && fb.from.col === c) {
+    classes.push('invalid')
+  }
+  if (fb.type === 'matched' && fb.at && fb.at.row === r && fb.at.col === c) {
+    classes.push('pulse')
+  }
+  if (fb.type === 'matched' && fb.from && fb.from.row === r && fb.from.col === c) {
+    classes.push('pulse')
+  }
+  return classes.join(' ')
+}
+
+function feedbackBanner() {
+  const fb = state.feedback
+  if (!fb) {
+    return `<div class="feedback-banner idle" role="status">点选两格交换，或按住格子向相邻方向滑动</div>`
+  }
+  if (fb.type === 'invalid') {
+    const text =
+      fb.reason === 'not_adjacent'
+        ? '只能交换相邻格子'
+        : fb.reason === 'out_of_bounds'
+          ? '已经到边界了'
+          : '这样交换不会形成三连'
+    return `<div class="feedback-banner invalid" role="status">${text}</div>`
+  }
+  if (fb.type === 'matched') {
+    return `<div class="feedback-banner matched" role="status">消除 +${fb.scoreGained || 0} · 连锁 x${fb.chainCount || 1}</div>`
+  }
+  if (fb.type === 'select') {
+    return `<div class="feedback-banner select" role="status">已选中 · 点相邻格或向相邻方向滑动</div>`
+  }
+  if (fb.type === 'deselect') {
+    return `<div class="feedback-banner idle" role="status">已取消选中</div>`
+  }
+  return `<div class="feedback-banner idle" role="status">点选两格交换，或按住格子向相邻方向滑动</div>`
+}
+
 function renderBoard() {
   const cells = []
   for (let r = 0; r < state.size; r += 1) {
     for (let c = 0; c < state.size; c += 1) {
       const id = state.board[r][c]
       const meta = typeMap.get(id) || { label: '?', color: '#94a3b8' }
-      const selected =
-        state.selected && state.selected.row === r && state.selected.col === c ? 'selected' : ''
+      const extra = tileExtraClass(r, c)
       cells.push(
-        `<button type="button" class="tile ${selected}" data-row="${r}" data-col="${c}" style="--tile:${meta.color}" aria-label="${meta.label}">${meta.label.slice(0, 2)}</button>`
+        `<button type="button" class="tile ${extra}" data-row="${r}" data-col="${c}" style="--tile:${meta.color}" aria-label="${meta.label}" aria-pressed="${extra.includes('selected') ? 'true' : 'false'}">${meta.label.slice(0, 2)}</button>`
       )
     }
   }
-  return `<div class="match-grid" style="--size:${state.size}">${cells.join('')}</div>`
+  return `<div class="match-grid" style="--size:${state.size}" data-feedback="${state.feedback?.type || ''}">${cells.join('')}</div>`
+}
+
+function applyBoardChange(nextState) {
+  state = nextState
+  afterChange()
+}
+
+function directionFromDelta(dx, dy) {
+  if (Math.abs(dx) < SWIPE_THRESHOLD_PX && Math.abs(dy) < SWIPE_THRESHOLD_PX) return null
+  if (Math.abs(dx) >= Math.abs(dy)) return dx > 0 ? 'right' : 'left'
+  return dy > 0 ? 'down' : 'up'
+}
+
+function bindBoardGestures() {
+  const grid = app.querySelector('.match-grid')
+  if (!grid) return
+
+  const readCell = (target) => {
+    const button = target?.closest?.('[data-row]')
+    if (!button || !grid.contains(button)) return null
+    return { row: Number(button.dataset.row), col: Number(button.dataset.col) }
+  }
+
+  grid.addEventListener('pointerdown', (event) => {
+    if (state.status !== 'playing') return
+    if (event.button != null && event.button !== 0) return
+    const cell = readCell(event.target)
+    if (!cell) return
+    boardGesture = {
+      start: cell,
+      x: event.clientX,
+      y: event.clientY,
+      done: false,
+      pointerId: event.pointerId
+    }
+    try {
+      grid.setPointerCapture(event.pointerId)
+    } catch {
+      /* ignore */
+    }
+    event.preventDefault()
+  })
+
+  grid.addEventListener('pointermove', (event) => {
+    if (!boardGesture || boardGesture.done || state.status !== 'playing') return
+    const direction = directionFromDelta(event.clientX - boardGesture.x, event.clientY - boardGesture.y)
+    if (!direction) return
+    const start = boardGesture.start
+    boardGesture.done = true
+    boardGesture = null
+    applyBoardChange(swipeFromCell(state, start.row, start.col, direction))
+  })
+
+  const endGesture = () => {
+    if (!boardGesture) return
+    const gesture = boardGesture
+    boardGesture = null
+    if (gesture.done || state.status !== 'playing') return
+    // 未滑动：按点击双选逻辑
+    applyBoardChange(selectCell(state, gesture.start.row, gesture.start.col))
+  }
+
+  grid.addEventListener('pointerup', endGesture)
+  grid.addEventListener('pointercancel', () => {
+    boardGesture = null
+  })
 }
 
 function render() {
+  const tip =
+    state.status === 'lost'
+      ? `最终得分 ${state.score} · 点「重新开始」再来一局`
+      : '点选两格交换，或按住格子向相邻方向滑动'
+
   app.innerHTML = `
     <main class="match-shell">
       <section class="metric-strip" aria-label="消消乐状态">
-        <div>
+        <div class="metric-card metric-score">
           <span>得分</span>
           <strong data-mcp-metric="score">${state.score}</strong>
         </div>
-        <div>
+        <div class="metric-card metric-moves">
           <span>剩余步数</span>
           <strong data-mcp-metric="moves_left">${state.movesLeft}</strong>
         </div>
-        <div>
+        <div class="metric-card metric-chain">
           <span>最高连锁</span>
           <strong data-mcp-metric="chain_peak">x${state.chainPeak}</strong>
         </div>
-        <div>
+        <div class="metric-card metric-limit">
           <span>限步</span>
           <strong data-mcp-metric="move_limit">${MOVE_LIMIT}</strong>
         </div>
@@ -238,13 +360,15 @@ function render() {
         <div>
           <p class="kicker">湖工消消乐</p>
           <h1>${state.status === 'lost' ? '本局结束' : '交换相邻校园格'}</h1>
-          <p class="status-detail">${state.status === 'lost' ? `最终得分 ${state.score}` : '点选两格相邻交换，三连消除，连锁加分'}</p>
+          <p class="status-detail">${tip}</p>
         </div>
         <div class="count-card">
           <span>棋盘</span>
           <strong>${state.size}×${state.size}</strong>
         </div>
       </section>
+
+      ${feedbackBanner()}
 
       <section class="board-panel" aria-label="三消棋盘">${renderBoard()}</section>
 
@@ -283,13 +407,7 @@ function render() {
     </div>` : ''}
   `
 
-  for (const button of app.querySelectorAll('[data-row]')) {
-    button.addEventListener('click', () => {
-      if (state.status !== 'playing') return
-      state = selectCell(state, Number(button.dataset.row), Number(button.dataset.col))
-      afterChange()
-    })
-  }
+  bindBoardGestures()
 
   document.getElementById('restart-button')?.addEventListener('click', () => {
     state = restartMatch3Game({ seed: Date.now() % 100000 })
@@ -298,6 +416,7 @@ function render() {
     lastTerminalStatus = ''
     submitPending = null
     lastSubmitUiStatus = ''
+    boardGesture = null
     afterChange()
   })
 

--- a/website/modules-src/hbut_match3/project/src/style.css
+++ b/website/modules-src/hbut_match3/project/src/style.css
@@ -11,7 +11,10 @@ body {
   overflow-x: hidden;
   overflow-y: hidden;
   overscroll-behavior: none;
-  background: #f8f5ff;
+  background:
+    radial-gradient(120% 90% at 12% -10%, rgba(167, 139, 250, 0.28), transparent 48%),
+    radial-gradient(90% 70% at 100% 0%, rgba(244, 114, 182, 0.16), transparent 42%),
+    linear-gradient(180deg, #f5f3ff 0%, #faf8ff 55%, #f8f5ff 100%);
   color: #1e1b4b;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Microsoft YaHei", sans-serif;
   -webkit-user-select: none;
@@ -41,7 +44,7 @@ button {
   height: 100%;
   margin: 0 auto;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto auto minmax(72px, auto);
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto auto minmax(64px, auto);
   gap: 8px;
 }
 
@@ -55,14 +58,26 @@ button {
 .hero-panel,
 .board-panel,
 .log-panel {
-  border: 1px solid rgba(30, 27, 75, 0.08);
-  background: #fff;
-  box-shadow: 0 10px 26px rgba(76, 29, 149, 0.08);
+  border: 1px solid rgba(91, 33, 182, 0.1);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 10px 28px rgba(76, 29, 149, 0.1);
+  backdrop-filter: blur(8px);
 }
 
 .metric-strip > div {
-  border-radius: 8px;
-  padding: 7px 8px;
+  border-radius: 12px;
+  padding: 8px 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.metric-strip > div::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, #a78bfa, #7c3aed);
+  opacity: 0.9;
 }
 
 .metric-strip span,
@@ -76,47 +91,109 @@ button {
 .metric-strip strong {
   display: block;
   margin-top: 2px;
-  font-size: 1rem;
+  font-size: 1.05rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .hero-panel {
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 14px;
+  padding: 11px 13px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 104px;
   gap: 10px;
   align-items: center;
+  background:
+    linear-gradient(135deg, rgba(237, 233, 254, 0.95), rgba(255, 255, 255, 0.95));
 }
 
 .hero-panel h1 {
   margin: 2px 0 0;
-  font-size: 1.24rem;
+  font-size: 1.22rem;
+  letter-spacing: -0.02em;
 }
 
 .status-detail {
   margin: 5px 0 0;
   color: #64748b;
   font-size: 0.8rem;
+  line-height: 1.35;
 }
 
 .count-card {
   min-height: 66px;
-  border-radius: 8px;
-  background: #7c3aed;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #8b5cf6, #6d28d9 55%, #5b21b6);
   color: #fff;
   display: grid;
   place-items: center;
   text-align: center;
+  box-shadow: 0 8px 18px rgba(109, 40, 217, 0.28);
 }
 
 .count-card span {
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.count-card strong {
+  font-size: 1.15rem;
+}
+
+.feedback-banner {
+  border-radius: 10px;
+  padding: 7px 11px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: banner-in 180ms ease-out;
+}
+
+.feedback-banner.idle {
+  background: rgba(255, 255, 255, 0.72);
+  color: #64748b;
+  border: 1px solid rgba(100, 116, 139, 0.14);
+  font-weight: 600;
+}
+
+.feedback-banner.select {
+  background: #ede9fe;
+  color: #5b21b6;
+  border: 1px solid rgba(124, 58, 237, 0.22);
+}
+
+.feedback-banner.invalid {
+  background: #fef2f2;
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.28);
+}
+
+.feedback-banner.matched {
+  background: #ecfdf5;
+  color: #047857;
+  border: 1px solid rgba(16, 185, 129, 0.28);
+}
+
+@keyframes banner-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .board-panel {
-  border-radius: 8px;
-  padding: 8px;
+  border-radius: 16px;
+  padding: 10px;
   min-height: 0;
+  background:
+    radial-gradient(80% 70% at 50% 0%, rgba(167, 139, 250, 0.12), transparent 60%),
+    rgba(255, 255, 255, 0.95);
 }
 
 .match-grid {
@@ -125,25 +202,93 @@ button {
   display: grid;
   grid-template-columns: repeat(var(--size), minmax(0, 1fr));
   grid-template-rows: repeat(var(--size), minmax(0, 1fr));
-  gap: 4px;
+  gap: 5px;
+  touch-action: none;
+  user-select: none;
 }
 
 .tile {
+  position: relative;
   border: 0;
-  border-radius: 8px;
-  background: var(--tile, #94a3b8);
+  border-radius: 12px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.28), transparent 42%),
+    var(--tile, #94a3b8);
   color: #fff;
   font-weight: 800;
-  font-size: 0.62rem;
+  font-size: clamp(0.58rem, 2.4vw, 0.72rem);
   line-height: 1.1;
   padding: 2px;
   cursor: pointer;
-  touch-action: manipulation;
+  touch-action: none;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    0 3px 0 rgba(15, 23, 42, 0.12);
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease,
+    filter 120ms ease;
+  text-shadow: 0 1px 1px rgba(15, 23, 42, 0.25);
+}
+
+.tile:active {
+  transform: scale(0.96);
 }
 
 .tile.selected {
   outline: 3px solid #fbbf24;
   outline-offset: 1px;
+  transform: scale(1.06);
+  z-index: 2;
+  box-shadow:
+    0 0 0 4px rgba(251, 191, 36, 0.28),
+    0 8px 16px rgba(124, 58, 237, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  filter: brightness(1.08);
+}
+
+.tile.invalid {
+  animation: tile-shake 360ms ease;
+  outline: 2px solid #f87171;
+  outline-offset: 0;
+}
+
+.tile.pulse {
+  animation: tile-pulse 420ms ease;
+}
+
+@keyframes tile-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+}
+
+@keyframes tile-pulse {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  35% {
+    transform: scale(1.08);
+    filter: brightness(1.15);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
 }
 
 .control-panel {
@@ -156,15 +301,16 @@ button {
 .secondary-action {
   min-height: 44px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 0 14px;
   font-weight: 800;
   cursor: pointer;
 }
 
 .primary-action {
-  background: #7c3aed;
+  background: linear-gradient(135deg, #8b5cf6, #6d28d9);
   color: #fff;
+  box-shadow: 0 8px 16px rgba(109, 40, 217, 0.25);
 }
 
 .secondary-action {
@@ -193,7 +339,7 @@ button {
 }
 
 .log-panel {
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 9px 11px;
   overflow: hidden;
 }
@@ -227,9 +373,10 @@ button {
   width: min(100%, 380px);
   max-height: min(78vh, 560px);
   overflow: auto;
-  border-radius: 12px;
+  border-radius: 14px;
   background: #fff;
   padding: 14px;
+  box-shadow: 0 20px 48px rgba(30, 27, 75, 0.22);
 }
 
 .leaderboard-header {


### PR DESCRIPTION
## Summary
- 选中态更明显（缩放 + 金色描边 + 光晕）
- 支持 pointer 滑动/拖拽与相邻格交换，同时保留点击双选
- 非法交换即时横幅 + 格子抖动；合法消除有脉冲与得分提示
- 棋盘与面板视觉层次轻量美化
- 补充 `selectCell` / `swipeFromCell` 单测

Closes #302

## Test plan
- [x] `npx vitest run src/utils/hbut_match3_game.spec.ts src/utils/hbut_match3_rank_contract.spec.ts`
- [x] `website/modules-src/hbut_match3/project` 下 `npm run build`
- [ ] 浏览器：点选高亮 → 点相邻合法交换 → 非法交换抖动与文案
- [ ] 浏览器：按住格子向四向滑动触发交换