### PR TITLE
feat(update): 可选接收开发版（CDN dev-latest）更新

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2192,13 +2192,15 @@ const dismissSplash = () => {
   splashRef.value?.dismiss()
 }
 
-// 自动检查更新
+// 自动检查更新（尊重用户频道：默认 stable，开启 dev 后才查 beta）
 const autoCheckUpdate = async () => {
   try {
+    const { getUpdateChannel, getSkippedVersion } = await import('./utils/updater.js')
     const currentVersion = await getCurrentVersion()
-    const skippedVersion = localStorage.getItem('hbu_skipped_version')
+    const channel = getUpdateChannel()
+    const skippedVersion = getSkippedVersion(channel)
     
-    const result = await checkForUpdates(currentVersion)
+    const result = await checkForUpdates(currentVersion, { channel })
     if (result?.hasUpdate && result.latestVersion !== skippedVersion) {
       showUpdateDialog.value = true
     }

--- a/src/components/UpdateDialog.vue
+++ b/src/components/UpdateDialog.vue
@@ -5,6 +5,9 @@ import {
   describeUpdateDownloadSource,
   downloadUpdate,
   getCurrentVersion,
+  getUpdateChannel,
+  setSkippedVersion,
+  setUpdateChannel,
   isOfficialDownloadUrl
 } from '../utils/updater.js'
 
@@ -16,19 +19,25 @@ const downloading = ref(false)
 const downloadProgress = ref(0)
 const error = ref('')
 const currentVersion = ref('')
+const updateChannel = ref(getUpdateChannel())
 
 // 下载源速度测试
 const sourceSpeedResults = ref({}) // { url: { ms: number, status: 'testing'|'ok'|'fail'|'slow' } }
 const showSourceTable = ref(false)
 
+const isDevChannel = computed(() => updateChannel.value === 'dev')
+const channelBadge = computed(() => (isDevChannel.value ? '开发版' : '正式版'))
+
 const checkUpdate = async () => {
   checking.value = true
   error.value = ''
+  showSourceTable.value = false
+  sourceSpeedResults.value = {}
   
   try {
     const version = currentVersion.value || await getCurrentVersion()
     currentVersion.value = version
-    const result = await checkForUpdates(version)
+    const result = await checkForUpdates(version, { channel: updateChannel.value })
     updateInfo.value = result
   } catch (e) {
     error.value = '检查更新失败，请稍后重试'
@@ -36,6 +45,12 @@ const checkUpdate = async () => {
   } finally {
     checking.value = false
   }
+}
+
+const handleChannelToggle = () => {
+  const next = isDevChannel.value ? 'stable' : 'dev'
+  updateChannel.value = setUpdateChannel(next)
+  void checkUpdate()
 }
 
 // 构建带标签的下载源列表
@@ -137,7 +152,7 @@ const handleDownloadFromSource = async (url) => {
 
 const handleSkip = () => {
   if (updateInfo.value?.latestVersion) {
-    localStorage.setItem('hbu_skipped_version', updateInfo.value.latestVersion)
+    setSkippedVersion(updateInfo.value.latestVersion, updateChannel.value)
   }
   emit('close')
 }
@@ -156,10 +171,30 @@ onMounted(() => {
       </div>
 
       <div class="dialog-content">
+        <!-- 频道选择：用户可选接收开发版推送 -->
+        <div class="channel-row">
+          <div class="channel-copy">
+            <strong>接收开发版更新（Beta）</strong>
+            <p>开启后从 CDN / GitHub <code>dev-latest</code> 检查预发布构建，可能不稳定。</p>
+          </div>
+          <button
+            type="button"
+            class="channel-switch"
+            :class="{ on: isDevChannel }"
+            :aria-pressed="isDevChannel"
+            @click="handleChannelToggle"
+          >
+            <span class="channel-knob" />
+          </button>
+        </div>
+        <div class="channel-badge-row">
+          <span class="channel-pill" :data-channel="updateChannel">当前频道：{{ channelBadge }}</span>
+        </div>
+
         <!-- 检查中 -->
         <div v-if="checking" class="checking">
           <div class="spinner"></div>
-          <p>正在检查更新...</p>
+          <p>正在检查{{ isDevChannel ? '开发版' : '正式版' }}更新...</p>
         </div>
 
         <!-- 有更新 -->
@@ -167,7 +202,10 @@ onMounted(() => {
           <div class="version-info">
             <div class="version-badge current">当前 v{{ currentVersion }}</div>
             <span class="arrow">→</span>
-            <div class="version-badge new">新版本 v{{ updateInfo.latestVersion }}</div>
+            <div class="version-badge new" :data-channel="updateInfo.channel || updateChannel">
+              {{ updateInfo.isPrerelease || isDevChannel ? '开发版' : '新版本' }}
+              v{{ updateInfo.latestVersion }}
+            </div>
           </div>
           
           <div class="release-notes">
@@ -230,8 +268,9 @@ onMounted(() => {
         <template v-else-if="updateInfo && !updateInfo.hasUpdate && !updateInfo.error">
           <div class="up-to-date">
             <span class="material-symbols-outlined status-icon status-icon--success">check_circle</span>
-            <p>已是最新版本</p>
+            <p>{{ isDevChannel ? '已是最新开发版' : '已是最新正式版' }}</p>
             <span class="version">v{{ currentVersion }}</span>
+            <span v-if="updateInfo.latestVersion" class="version muted">远端 {{ updateInfo.latestVersion }}</span>
           </div>
         </template>
 
@@ -297,6 +336,105 @@ onMounted(() => {
   font-variation-settings: 'FILL' 0, 'wght' 500, 'GRAD' 0, 'opsz' 24;
 }
 .dialog-header h3 { margin: 0; font-size: 20px; font-weight: 700; }
+
+.channel-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(99, 102, 241, 0.06);
+  border: 1px solid rgba(99, 102, 241, 0.12);
+}
+
+.channel-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.channel-copy strong {
+  display: block;
+  font-size: 14px;
+  color: #0f172a;
+}
+
+.channel-copy p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #64748b;
+}
+
+.channel-copy code {
+  font-size: 11px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.channel-switch {
+  position: relative;
+  width: 48px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: #cbd5e1;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 160ms ease;
+}
+
+.channel-switch.on {
+  background: #7c3aed;
+}
+
+.channel-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.25);
+  transition: transform 160ms ease;
+}
+
+.channel-switch.on .channel-knob {
+  transform: translateX(20px);
+}
+
+.channel-badge-row {
+  margin-bottom: 12px;
+}
+
+.channel-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #eef2ff;
+  color: #4338ca;
+}
+
+.channel-pill[data-channel='dev'] {
+  background: #f5f3ff;
+  color: #6d28d9;
+}
+
+.version-badge.new[data-channel='dev'] {
+  background: linear-gradient(135deg, #7c3aed, #a855f7);
+}
+
+.version.muted {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  opacity: 0.65;
+}
 
 .dialog-content {
   padding: 20px;

--- a/src/utils/hbut_match3_game.spec.ts
+++ b/src/utils/hbut_match3_game.spec.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyGravity,
+  createInitialMatch3State,
   createSeededRandom,
   findMatches,
   resolveBoard,
+  selectCell,
+  swipeFromCell,
   trySwap
 } from '../../website/modules-src/hbut_match3/project/src/game/match3.js'
 
@@ -49,12 +52,6 @@ describe('hbut_match3 pure board functions', () => {
   })
 
   it('accepts swap that creates a match and scores with chain multiplier', () => {
-    const board = [
-      ['x', 'a', 'a'],
-      ['b', 'c', 'd'],
-      ['e', 'f', 'g']
-    ]
-    // swap x with a would need setup: place so swap creates three a's
     const setup = [
       ['a', 'x', 'a'],
       ['b', 'a', 'c'],
@@ -76,5 +73,64 @@ describe('hbut_match3 pure board functions', () => {
     const resolved = resolveBoard(board, createSeededRandom(7))
     expect(findMatches(resolved.board).length).toBe(0)
     expect(resolved.scoreGained).toBeGreaterThan(0)
+  })
+
+  it('selectCell marks selection and invalid feedback without spending a move', () => {
+    let state = createInitialMatch3State({ seed: 1, size: 4, movesLeft: 10 })
+    state = {
+      ...state,
+      board: [
+        ['a', 'b', 'c', 'd'],
+        ['e', 'f', 'g', 'h'],
+        ['i', 'j', 'k', 'l'],
+        ['m', 'n', 'o', 'p']
+      ]
+    }
+    state = selectCell(state, 0, 0)
+    expect(state.selected).toEqual({ row: 0, col: 0 })
+    expect(state.feedback?.type).toBe('select')
+    expect(state.movesLeft).toBe(10)
+
+    state = selectCell(state, 0, 2) // not adjacent
+    expect(state.feedback?.type).toBe('invalid')
+    expect(state.feedback?.reason).toBe('not_adjacent')
+    expect(state.movesLeft).toBe(10)
+    expect(state.selected).toEqual({ row: 0, col: 2 })
+  })
+
+  it('swipeFromCell swaps adjacent tiles that form a match', () => {
+    let state = createInitialMatch3State({ seed: 9, size: 3, movesLeft: 5 })
+    state = {
+      ...state,
+      board: [
+        ['a', 'x', 'a'],
+        ['b', 'a', 'c'],
+        ['d', 'e', 'f']
+      ],
+      selected: null,
+      score: 0
+    }
+    // from (0,1) swipe down toward (1,1) => three a's on top after swap
+    const next = swipeFromCell(state, 0, 1, 'down')
+    expect(next.movesLeft).toBe(4)
+    expect(next.score).toBeGreaterThan(0)
+    expect(next.feedback?.type).toBe('matched')
+    expect(next.selected).toBeNull()
+  })
+
+  it('swipeFromCell reports invalid when no match forms', () => {
+    let state = createInitialMatch3State({ seed: 3, size: 3, movesLeft: 8 })
+    state = {
+      ...state,
+      board: [
+        ['a', 'b', 'c'],
+        ['d', 'e', 'f'],
+        ['g', 'h', 'i']
+      ]
+    }
+    const next = swipeFromCell(state, 0, 0, 'right')
+    expect(next.movesLeft).toBe(8)
+    expect(next.feedback?.type).toBe('invalid')
+    expect(next.feedback?.reason).toBe('no_match')
   })
 })

--- a/src/utils/updater.js
+++ b/src/utils/updater.js
@@ -9,10 +9,56 @@ const GH_DOWNLOAD_PROXY_PREFIX = 'https://gh-proxy.org/'
 // 腾讯云 EdgeOne Pages CDN 域名（部署后填写实际域名，留空则跳过 CDN 优先逻辑）
 const EDGEONE_CDN_BASE = 'https://hbut.6661111.xyz'
 const STABLE_MANIFEST_URL = EDGEONE_CDN_BASE ? `${EDGEONE_CDN_BASE}/releases/stable-latest.json` : ''
+const DEV_MANIFEST_URL = EDGEONE_CDN_BASE ? `${EDGEONE_CDN_BASE}/releases/dev-latest.json` : ''
+const UPDATE_CHANNEL_KEY = 'hbu_update_channel'
+const SKIPPED_VERSION_STABLE_KEY = 'hbu_skipped_version'
+const SKIPPED_VERSION_DEV_KEY = 'hbu_skipped_version_dev'
+const DEV_RELEASE_TAG = 'dev-latest'
+
+/** 无 localStorage 时（部分测试环境）的内存回退 */
+const memoryPrefs = {
+  channel: 'stable',
+  skippedStable: '',
+  skippedDev: ''
+}
+
+const storageGet = (key) => {
+  try {
+    if (typeof localStorage !== 'undefined' && localStorage) {
+      return localStorage.getItem(key)
+    }
+  } catch {
+    // ignore
+  }
+  if (key === UPDATE_CHANNEL_KEY) return memoryPrefs.channel
+  if (key === SKIPPED_VERSION_STABLE_KEY) return memoryPrefs.skippedStable
+  if (key === SKIPPED_VERSION_DEV_KEY) return memoryPrefs.skippedDev
+  return null
+}
+
+const storageSet = (key, value) => {
+  try {
+    if (typeof localStorage !== 'undefined' && localStorage) {
+      localStorage.setItem(key, value)
+      return
+    }
+  } catch {
+    // fall through to memory
+  }
+  if (key === UPDATE_CHANNEL_KEY) memoryPrefs.channel = value
+  if (key === SKIPPED_VERSION_STABLE_KEY) memoryPrefs.skippedStable = value
+  if (key === SKIPPED_VERSION_DEV_KEY) memoryPrefs.skippedDev = value
+}
+
 const API_PROXIES = [
   `${GH_API_PROXY_PREFIX}https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
   `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
   `https://cdn.jsdelivr.net/gh/${GITHUB_REPO}@latest/package.json`
+]
+
+const DEV_API_PROXIES = [
+  `${GH_API_PROXY_PREFIX}https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${DEV_RELEASE_TAG}`,
+  `https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${DEV_RELEASE_TAG}`
 ]
 
 const DOWNLOAD_PROXIES = [
@@ -218,6 +264,33 @@ function isPrereleaseVersion(version) {
   return parseVersion(version).isPrerelease
 }
 
+/** 归一化用户更新频道：stable | dev */
+export const normalizeUpdateChannel = (value) => {
+  const text = String(value || '').trim().toLowerCase()
+  if (text === 'dev' || text === 'beta' || text === 'development' || text === 'nightly') return 'dev'
+  return 'stable'
+}
+
+export const getUpdateChannel = () => normalizeUpdateChannel(storageGet(UPDATE_CHANNEL_KEY))
+
+export const setUpdateChannel = (channel) => {
+  const next = normalizeUpdateChannel(channel)
+  storageSet(UPDATE_CHANNEL_KEY, next)
+  return next
+}
+
+export const getSkippedVersionKey = (channel = getUpdateChannel()) =>
+  normalizeUpdateChannel(channel) === 'dev' ? SKIPPED_VERSION_DEV_KEY : SKIPPED_VERSION_STABLE_KEY
+
+export const getSkippedVersion = (channel = getUpdateChannel()) =>
+  String(storageGet(getSkippedVersionKey(channel)) || '').trim()
+
+export const setSkippedVersion = (version, channel = getUpdateChannel()) => {
+  const text = String(version || '').trim()
+  if (!text) return
+  storageSet(getSkippedVersionKey(channel), text)
+}
+
 function isStableRelease(release) {
   const latestVersion = String(release?.version || release?.tag_name || '').replace(/^v/i, '')
   if (!latestVersion) return false
@@ -237,12 +310,55 @@ function isStableRelease(release) {
   return true
 }
 
-function shouldOfferRelease(release, currentVersion) {
+/** 是否为开发版/滚动 beta 产物（CDN channel=dev 或 tag=dev-latest） */
+export function isDevRelease(release) {
+  if (!release) return false
+  const channel = String(release?.channel || '').trim().toLowerCase()
+  if (channel === 'dev' || channel === 'beta') return true
+  const tag = String(release?.tag_name || '').trim().toLowerCase()
+  if (tag === DEV_RELEASE_TAG || tag === 'beta-latest') return true
+  if (release?.prerelease) return true
+  const version = String(release?.version || tag).replace(/^v/i, '')
+  return isPrereleaseVersion(version)
+}
+
+/**
+ * 是否应对用户提示更新。
+ * - stable：仅正式版且版本更高（含「当前为 beta、远端同 core 正式版」可提示回落）
+ * - dev：允许 prerelease；完整 semver 比较；core 低于当前安装的 dev 不提示
+ */
+export function shouldOfferRelease(release, currentVersion, channel = 'stable') {
+  const preferred = normalizeUpdateChannel(channel)
   const latestVersion = String(release?.version || release?.tag_name || '').replace(/^v/i, '')
   const currentText = String(currentVersion || '').replace(/^v/i, '')
   if (!latestVersion) return false
-  if (!isStableRelease(release)) return false
+
+  if (preferred === 'stable') {
+    if (!isStableRelease(release)) return false
+    if (!currentText) return true
+    return compareVersions(latestVersion, currentText) > 0
+  }
+
+  // 开发频道只跟踪 dev 滚动产物，避免把 /latest 稳定包误当 dev
+  if (!isDevRelease(release)) return false
   if (!currentText) return true
+
+  const latest = parseVersion(latestVersion)
+  const current = parseVersion(currentText)
+  // 远端 core 落后于当前安装（例如装了 1.4.4 却只剩 1.4.3-beta）→ 不提示
+  const coreCmp = (() => {
+    const len = Math.max(latest.core.length, current.core.length)
+    for (let i = 0; i < len; i += 1) {
+      const lv = latest.core[i] || 0
+      const rv = current.core[i] || 0
+      if (lv > rv) return 1
+      if (lv < rv) return -1
+    }
+    return 0
+  })()
+  if (coreCmp < 0) return false
+  // 同 core：用户已装正式版，远端为更新/任意 beta → 允许（主动开 dev）
+  if (coreCmp === 0 && !current.isPrerelease && latest.isPrerelease) return true
   return compareVersions(latestVersion, currentText) > 0
 }
 
@@ -265,7 +381,8 @@ function getAssetPatterns(platform) {
     case 'windows':
       return [/x64-setup\.exe$/i, /\.msi$/i, /\.exe$/i]
     case 'macos':
-      return [/\.dmg$/i]
+      // dev-latest 常为 .app.zip，稳定版多为 .dmg
+      return [/\.dmg$/i, /\.app\.zip$/i, /universal\.app\.zip$/i, /\.zip$/i]
     case 'linux':
       return [/\.AppImage$/i, /\.deb$/i]
     default:
@@ -287,11 +404,13 @@ const normalizePackageJsonAsRelease = (data) => {
   }
 }
 
-function buildExpectedAssetName(platform, version) {
+function buildExpectedAssetName(platform, version, { preferDevZip = false } = {}) {
   const v = String(version).replace(/^v/, '')
   switch (platform) {
     case 'windows': return `Mini-HBUT_${v}_x64-setup.exe`
-    case 'macos': return `Mini-HBUT_${v}_universal.dmg`
+    case 'macos': return preferDevZip
+      ? `Mini-HBUT_${v}_universal.app.zip`
+      : `Mini-HBUT_${v}_universal.dmg`
     case 'linux': return `Mini-HBUT_${v}_amd64.AppImage`
     case 'android': return `Mini-HBUT_${v}_arm64.apk`
     case 'ios': return `Mini-HBUT_${v}_iOS.ipa`
@@ -343,6 +462,7 @@ export const normalizeCdnManifestAsRelease = (manifest) => {
     version,
     prerelease: !!manifest.prerelease,
     channel: String(manifest.channel || '').trim(),
+    downloadDir,
     __fromCdnManifest: true,
     __staleReleaseNotes: Boolean(rawBody && !body)
   }
@@ -365,19 +485,22 @@ export const mergeCdnReleaseWithApiNotes = (cdnRelease, apiRelease) => {
   }
 }
 
-async function fetchReleaseInfo(currentVersion) {
+async function fetchStableReleaseInfo(currentVersion) {
   let cdnCandidate = null
   if (STABLE_MANIFEST_URL) {
     try {
-      // 自动更新只允许读取稳定版 manifest，避免 dev alias 触发错误下载。
+      // 稳定频道只读 stable-latest，避免误用 dev alias。
       const manifest = await fetchJson(STABLE_MANIFEST_URL, 6000)
       const release = normalizeCdnManifestAsRelease(manifest)
-      if (release && shouldOfferRelease(release, currentVersion)) {
+      if (release && shouldOfferRelease(release, currentVersion, 'stable')) {
         if (release.__staleReleaseNotes) {
           cdnCandidate = release
         } else {
           return release
         }
+      } else if (release) {
+        // 即使无需升级也保留 candidate，供 UI 展示 latestVersion
+        cdnCandidate = release
       }
     } catch (_) {
       // stable manifest 不可用，继续 fallback
@@ -394,7 +517,7 @@ async function fetchReleaseInfo(currentVersion) {
       if (!fallback || (release.assets?.length || 0) > (fallback.assets?.length || 0)) {
         fallback = release
       }
-      if (shouldOfferRelease(release, currentVersion)) {
+      if (shouldOfferRelease(release, currentVersion, 'stable')) {
         return mergeCdnReleaseWithApiNotes(cdnCandidate, release)
       }
     } catch (_) {
@@ -404,94 +527,183 @@ async function fetchReleaseInfo(currentVersion) {
   return cdnCandidate || fallback
 }
 
-export async function checkForUpdates(currentVersion) {
-  try {
-    const release = await fetchReleaseInfo(currentVersion)
-    if (!release) {
-      return {
-        error: true,
-        message: '无法连接更新服务',
-        currentVersion
-      }
-    }
-    if (!isStableRelease(release)) {
-      return {
-        hasUpdate: false,
-        currentVersion,
-        latestVersion: ''
-      }
-    }
-
-    const tagName = release.tag_name || release.name || ''
-    const latestVersion = String(release.version || tagName).replace(/^v/, '')
-    const currentText = String(currentVersion || '').replace(/^v/, '')
-    if (!shouldOfferRelease(release, currentText)) {
-      return { hasUpdate: false, currentVersion, latestVersion }
-    }
-
-    const platform = getPlatform()
-    const patterns = getAssetPatterns(platform)
-    let asset = null
-
-    if (Array.isArray(release.assets) && release.assets.length > 0) {
-      for (const pattern of patterns) {
-        asset = release.assets.find((item) => pattern.test(item.name))
-        if (asset) break
-      }
-    }
-
-    if (!asset) {
-      // 当 API 未返回资产列表时（如仅 jsdelivr 可用），根据命名规则构造下载链接
-      const expectedName = buildExpectedAssetName(platform, tagName)
-      if (expectedName) {
-        const downloadUrls = buildUpdateDownloadUrls(tagName, expectedName)
-        return {
-          hasUpdate: true,
-          currentVersion,
-          latestVersion,
-          tagName,
-          releaseNotes: release.body || '暂无更新说明',
-          releaseUrl: toGhProxyUrl(release.html_url) || release.html_url || `${GH_DOWNLOAD_PROXY_PREFIX}${GITHUB_RELEASES_URL}`,
-          downloadUrls,
-          preferredDownloadUrl: downloadUrls[0] || '',
-          assetName: expectedName,
-          platform,
-          publishedAt: release.published_at
+async function fetchDevReleaseInfo(currentVersion) {
+  let cdnCandidate = null
+  if (DEV_MANIFEST_URL) {
+    try {
+      const manifest = await fetchJson(DEV_MANIFEST_URL, 6000)
+      const release = normalizeCdnManifestAsRelease(manifest)
+      if (release) {
+        // 强制标记为 dev，避免旧 manifest 缺 channel
+        release.channel = release.channel || 'dev'
+        release.prerelease = true
+        if (!release.tag_name) release.tag_name = DEV_RELEASE_TAG
+        cdnCandidate = release
+        if (shouldOfferRelease(release, currentVersion, 'dev') && !release.__staleReleaseNotes) {
+          return release
         }
       }
+    } catch (_) {
+      // dev CDN 不可用，走 GH tag
+    }
+  }
+
+  let fallback = null
+  for (const url of DEV_API_PROXIES) {
+    try {
+      const data = await fetchJson(url, 9000)
+      if (!data?.tag_name && !data?.assets) continue
+      const release = {
+        ...data,
+        prerelease: true,
+        channel: 'dev',
+        version: String(data.tag_name || DEV_RELEASE_TAG).replace(/^v/i, '')
+      }
+      // tag 固定为 dev-latest，版本号尽量从 asset 名解析
+      if (Array.isArray(data.assets) && data.assets.length) {
+        const sample = String(data.assets[0]?.name || '')
+        const m = sample.match(/Mini-HBUT_([^_]+)_/i)
+        if (m?.[1]) release.version = m[1]
+      }
+      if (!fallback || (release.assets?.length || 0) > (fallback.assets?.length || 0)) {
+        fallback = release
+      }
+      if (shouldOfferRelease(release, currentVersion, 'dev')) {
+        return mergeCdnReleaseWithApiNotes(cdnCandidate, release)
+      }
+    } catch (_) {
+      // try next
+    }
+  }
+  return cdnCandidate || fallback
+}
+
+async function fetchReleaseInfo(currentVersion, channel = 'stable') {
+  const preferred = normalizeUpdateChannel(channel)
+  if (preferred === 'dev') return fetchDevReleaseInfo(currentVersion)
+  return fetchStableReleaseInfo(currentVersion)
+}
+
+const buildUpdateResultFromRelease = (release, currentVersion, channel) => {
+  const preferred = normalizeUpdateChannel(channel)
+  const tagName = release.tag_name || release.name || ''
+  const latestVersion = String(release.version || tagName).replace(/^v/, '')
+  const currentText = String(currentVersion || '').replace(/^v/, '')
+  const platform = getPlatform()
+  const patterns = getAssetPatterns(platform)
+  const isPrerelease = preferred === 'dev' || isDevRelease(release) || isPrereleaseVersion(latestVersion)
+
+  if (!shouldOfferRelease(release, currentText, preferred)) {
+    return {
+      hasUpdate: false,
+      currentVersion: currentText,
+      latestVersion,
+      tagName,
+      channel: preferred,
+      isPrerelease,
+      platform
+    }
+  }
+
+  let asset = null
+  if (Array.isArray(release.assets) && release.assets.length > 0) {
+    for (const pattern of patterns) {
+      asset = release.assets.find((item) => pattern.test(item.name))
+      if (asset) break
+    }
+  }
+
+  // 下载 tag：CDN/GH 滚动 dev 使用 dev-latest 目录名
+  const downloadTag = preferred === 'dev'
+    ? (String(release.downloadDir || tagName || DEV_RELEASE_TAG).trim() || DEV_RELEASE_TAG)
+    : tagName
+
+  if (!asset) {
+    const versionForName = preferred === 'dev' ? latestVersion : tagName
+    const expectedName = buildExpectedAssetName(platform, versionForName, {
+      preferDevZip: preferred === 'dev'
+    })
+    if (expectedName) {
+      const downloadUrls = buildUpdateDownloadUrls(downloadTag, expectedName)
       return {
-        hasUpdate: false,
-        pending: true,
-        currentVersion,
+        hasUpdate: true,
+        currentVersion: currentText,
         latestVersion,
         tagName,
+        channel: preferred,
+        isPrerelease,
         releaseNotes: release.body || '暂无更新说明',
         releaseUrl: toGhProxyUrl(release.html_url) || release.html_url || `${GH_DOWNLOAD_PROXY_PREFIX}${GITHUB_RELEASES_URL}`,
+        downloadUrls,
+        preferredDownloadUrl: downloadUrls[0] || '',
+        assetName: expectedName,
         platform,
         publishedAt: release.published_at
       }
     }
-
-    const downloadUrls = buildUpdateDownloadUrls(tagName, asset.name, asset.browser_download_url)
-
     return {
-      hasUpdate: true,
-      currentVersion,
+      hasUpdate: false,
+      pending: true,
+      currentVersion: currentText,
       latestVersion,
       tagName,
+      channel: preferred,
+      isPrerelease,
       releaseNotes: release.body || '暂无更新说明',
       releaseUrl: toGhProxyUrl(release.html_url) || release.html_url || `${GH_DOWNLOAD_PROXY_PREFIX}${GITHUB_RELEASES_URL}`,
-      downloadUrls,
-      preferredDownloadUrl: downloadUrls[0] || '',
-      assetName: asset.name,
       platform,
       publishedAt: release.published_at
     }
+  }
+
+  const downloadUrls = buildUpdateDownloadUrls(downloadTag, asset.name, asset.browser_download_url)
+  return {
+    hasUpdate: true,
+    currentVersion: currentText,
+    latestVersion,
+    tagName,
+    channel: preferred,
+    isPrerelease,
+    releaseNotes: release.body || '暂无更新说明',
+    releaseUrl: toGhProxyUrl(release.html_url) || release.html_url || `${GH_DOWNLOAD_PROXY_PREFIX}${GITHUB_RELEASES_URL}`,
+    downloadUrls,
+    preferredDownloadUrl: downloadUrls[0] || '',
+    assetName: asset.name,
+    platform,
+    publishedAt: release.published_at
+  }
+}
+
+export async function checkForUpdates(currentVersion, options = {}) {
+  const channel = normalizeUpdateChannel(options.channel ?? getUpdateChannel())
+  try {
+    const release = await fetchReleaseInfo(currentVersion, channel)
+    if (!release) {
+      return {
+        error: true,
+        message: '无法连接更新服务',
+        currentVersion,
+        channel
+      }
+    }
+
+    // stable 频道若只拿到 prerelease，视为无正式更新
+    if (channel === 'stable' && !isStableRelease(release) && !shouldOfferRelease(release, currentVersion, 'stable')) {
+      return {
+        hasUpdate: false,
+        currentVersion,
+        latestVersion: String(release.version || release.tag_name || '').replace(/^v/, ''),
+        channel
+      }
+    }
+
+    return buildUpdateResultFromRelease(release, currentVersion, channel)
   } catch (error) {
     return {
       error: true,
       message: error?.message || '检查更新失败',
-      currentVersion
+      currentVersion,
+      channel
     }
   }
 }
@@ -540,5 +752,12 @@ export default {
   downloadUpdate,
   getCurrentVersion,
   compareVersions,
-  toGhProxyUrl
+  toGhProxyUrl,
+  getUpdateChannel,
+  setUpdateChannel,
+  normalizeUpdateChannel,
+  getSkippedVersion,
+  setSkippedVersion,
+  shouldOfferRelease,
+  isDevRelease
 }

--- a/src/utils/updater_channel.spec.ts
+++ b/src/utils/updater_channel.spec.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  buildUpdateDownloadUrls,
+  getSkippedVersionKey,
+  getUpdateChannel,
+  isDevRelease,
+  normalizeCdnManifestAsRelease,
+  normalizeUpdateChannel,
+  setUpdateChannel,
+  shouldOfferRelease
+} from './updater.js'
+
+const readSource = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8')
+
+describe('update channel (stable / dev)', () => {
+  afterEach(() => {
+    setUpdateChannel('stable')
+    try {
+      localStorage?.removeItem?.('hbu_update_channel')
+      localStorage?.removeItem?.('hbu_skipped_version')
+      localStorage?.removeItem?.('hbu_skipped_version_dev')
+    } catch {
+      // ignore
+    }
+  })
+
+  it('defaults channel to stable and normalizes aliases', () => {
+    setUpdateChannel('stable')
+    expect(normalizeUpdateChannel('')).toBe('stable')
+    expect(normalizeUpdateChannel('stable')).toBe('stable')
+    expect(normalizeUpdateChannel('dev')).toBe('dev')
+    expect(normalizeUpdateChannel('beta')).toBe('dev')
+    expect(getUpdateChannel()).toBe('stable')
+    expect(setUpdateChannel('dev')).toBe('dev')
+    expect(getUpdateChannel()).toBe('dev')
+    expect(getSkippedVersionKey('stable')).toBe('hbu_skipped_version')
+    expect(getSkippedVersionKey('dev')).toBe('hbu_skipped_version_dev')
+  })
+
+  it('normalizes CDN dev-latest manifest for beta assets', () => {
+    const release = normalizeCdnManifestAsRelease({
+      version: '1.4.3-beta.29136065697',
+      tag: 'dev-latest',
+      downloadDir: 'dev-latest',
+      prerelease: true,
+      channel: 'dev',
+      assets: {
+        android_apk: 'Mini-HBUT_1.4.3-beta.29136065697_arm64.apk',
+        windows_exe: 'Mini-HBUT_1.4.3-beta.29136065697_x64-setup.exe'
+      }
+    })
+    expect(release).toBeTruthy()
+    expect(release?.tag_name).toBe('dev-latest')
+    expect(release?.channel).toBe('dev')
+    expect(release?.prerelease).toBe(true)
+    expect(release?.downloadDir).toBe('dev-latest')
+    expect(isDevRelease(release)).toBe(true)
+    expect(release?.assets?.[0]?.browser_download_url).toContain(
+      '/releases/dev-latest/Mini-HBUT_1.4.3-beta.29136065697_arm64.apk'
+    )
+  })
+
+  it('offers stable only for real stable upgrades', () => {
+    const stable = {
+      tag_name: 'v1.4.4',
+      version: '1.4.4',
+      prerelease: false,
+      channel: 'main'
+    }
+    const beta = {
+      tag_name: 'dev-latest',
+      version: '1.4.3-beta.9',
+      prerelease: true,
+      channel: 'dev'
+    }
+    expect(shouldOfferRelease(stable, '1.4.3', 'stable')).toBe(true)
+    expect(shouldOfferRelease(beta, '1.4.3', 'stable')).toBe(false)
+    expect(shouldOfferRelease(stable, '1.4.4', 'stable')).toBe(false)
+  })
+
+  it('offers dev builds when user opts into beta channel', () => {
+    const beta = {
+      tag_name: 'dev-latest',
+      version: '1.4.3-beta.29136065697',
+      prerelease: true,
+      channel: 'dev'
+    }
+    // 用户装正式 1.4.3，主动开 dev 时可升到同 core 的更新 beta
+    expect(shouldOfferRelease(beta, '1.4.3', 'dev')).toBe(true)
+    // 已是同一 beta 则不提示
+    expect(shouldOfferRelease(beta, '1.4.3-beta.29136065697', 'dev')).toBe(false)
+    // 当前 core 更新则不降级提示
+    expect(shouldOfferRelease(beta, '1.4.4', 'dev')).toBe(false)
+    // 更新的 beta 应提示
+    expect(
+      shouldOfferRelease(
+        { ...beta, version: '1.4.3-beta.29136065698' },
+        '1.4.3-beta.29136065697',
+        'dev'
+      )
+    ).toBe(true)
+  })
+
+  it('builds download proxies for dev-latest tag', () => {
+    const name = 'Mini-HBUT_1.4.3-beta.1_arm64.apk'
+    const urls = buildUpdateDownloadUrls('dev-latest', name)
+    expect(urls[0]).toContain('/releases/download/dev-latest/')
+    expect(urls.some((u) => u.includes('github.com/superdaobo/mini-hbut/releases/download/dev-latest/'))).toBe(
+      true
+    )
+  })
+
+  it('wires UpdateDialog channel toggle and App autoCheck channel options', () => {
+    const dialog = readSource('src/components/UpdateDialog.vue')
+    const app = readSource('src/App.vue')
+    const updater = readSource('src/utils/updater.js')
+
+    expect(dialog).toContain('接收开发版更新（Beta）')
+    expect(dialog).toContain('setUpdateChannel')
+    expect(dialog).toContain('setSkippedVersion')
+    expect(dialog).toContain('getUpdateChannel')
+    expect(dialog).toContain('dev-latest')
+    expect(dialog).toContain('handleChannelToggle')
+    expect(app).toContain('checkForUpdates(currentVersion, { channel })')
+    expect(app).toContain('getSkippedVersion')
+    expect(updater).toContain('DEV_MANIFEST_URL')
+    expect(updater).toContain('dev-latest.json')
+    expect(updater).toContain('hbu_update_channel')
+    expect(updater).toContain('fetchDevReleaseInfo')
+    expect(updater).toContain('app.zip')
+    expect(updater).toContain('preferDevZip')
+  })
+})

--- a/src/utils/updater_download_sources.spec.ts
+++ b/src/utils/updater_download_sources.spec.ts
@@ -83,7 +83,8 @@ describe('update download sources', () => {
 
     expect(source).toContain('<div class="version-badge current">当前 v{{ currentVersion }}</div>')
     expect(source).toContain('<span class="arrow">→</span>')
-    expect(source).toContain('<div class="version-badge new">新版本 v{{ updateInfo.latestVersion }}</div>')
+    expect(source).toContain('version-badge new')
+    expect(source).toContain('updateInfo.latestVersion')
     expect(source).not.toContain('<div class="version-badge new">v{{ updateInfo.latestVersion }}</div>')
   })
 

--- a/website/modules-src/hbut_match3/project/src/game/match3.js
+++ b/website/modules-src/hbut_match3/project/src/game/match3.js
@@ -201,7 +201,9 @@ export function createInitialMatch3State(options = {}) {
     selected: null,
     seed,
     chainPeak: 0,
-    log: ['限步 30：点两格相邻交换，三连消除。']
+    /** UI 反馈：select | deselect | invalid | matched */
+    feedback: null,
+    log: ['限步 30：点选或滑动交换相邻格，三连消除。']
   }
 }
 
@@ -213,21 +215,47 @@ function addLog(state, message) {
   return { ...state, log: [message, ...(state.log || [])].slice(0, 6) }
 }
 
+/**
+ * 点选/滑动共用：首次选中；同格取消；相邻合法交换；非法则反馈并改选目标格。
+ */
 export function selectCell(state, row, col) {
   if (!state || state.status !== 'playing') return state
   const r = clampIndex(row, state.size)
   const c = clampIndex(col, state.size)
   const selected = state.selected
   if (!selected) {
-    return { ...state, selected: { row: r, col: c } }
+    return {
+      ...state,
+      selected: { row: r, col: c },
+      feedback: { type: 'select', at: { row: r, col: c }, token: Date.now() }
+    }
   }
   if (selected.row === r && selected.col === c) {
-    return { ...state, selected: null }
+    return {
+      ...state,
+      selected: null,
+      feedback: { type: 'deselect', at: { row: r, col: c }, token: Date.now() }
+    }
   }
   const random = createSeededRandom(state.seed + state.movesLeft * 17 + r * 31 + c)
   const result = trySwap(state.board, selected, { row: r, col: c }, random)
   if (!result.ok) {
-    return addLog({ ...state, selected: { row: r, col: c } }, result.reason === 'not_adjacent' ? '只能交换相邻格子。' : '这样交换不会形成三连。')
+    const message =
+      result.reason === 'not_adjacent' ? '只能交换相邻格子。' : '这样交换不会形成三连。'
+    return addLog(
+      {
+        ...state,
+        selected: { row: r, col: c },
+        feedback: {
+          type: 'invalid',
+          reason: result.reason,
+          from: { ...selected },
+          at: { row: r, col: c },
+          token: Date.now()
+        }
+      },
+      message
+    )
   }
   const movesLeft = state.movesLeft - 1
   let next = {
@@ -237,7 +265,15 @@ export function selectCell(state, row, col) {
     movesLeft,
     selected: null,
     chainPeak: Math.max(state.chainPeak, result.chainCount || 0),
-    seed: state.seed + 1
+    seed: state.seed + 1,
+    feedback: {
+      type: 'matched',
+      scoreGained: result.scoreGained,
+      chainCount: result.chainCount || 0,
+      from: { ...selected },
+      at: { row: r, col: c },
+      token: Date.now()
+    }
   }
   next = addLog(next, `消除 +${result.scoreGained}（连锁 x${result.chainCount}）`)
   if (movesLeft <= 0) {
@@ -245,4 +281,45 @@ export function selectCell(state, row, col) {
     next = addLog(next, `步数用尽，最终得分 ${next.score}。`)
   }
   return next
+}
+
+/**
+ * 从起点格向主方向滑动一格并尝试交换（供 pointer 手势调用）。
+ * @returns 新 state；方向无效时返回原 state
+ */
+export function swipeFromCell(state, row, col, direction) {
+  if (!state || state.status !== 'playing') return state
+  const r = clampIndex(row, state.size)
+  const c = clampIndex(col, state.size)
+  let tr = r
+  let tc = c
+  switch (direction) {
+    case 'up':
+      tr -= 1
+      break
+    case 'down':
+      tr += 1
+      break
+    case 'left':
+      tc -= 1
+      break
+    case 'right':
+      tc += 1
+      break
+    default:
+      return state
+  }
+  if (tr < 0 || tr >= state.size || tc < 0 || tc >= state.size) {
+    return {
+      ...state,
+      selected: { row: r, col: c },
+      feedback: { type: 'invalid', reason: 'out_of_bounds', at: { row: r, col: c }, token: Date.now() }
+    }
+  }
+  const primed = {
+    ...state,
+    selected: { row: r, col: c },
+    feedback: null
+  }
+  return selectCell(primed, tr, tc)
 }

--- a/website/modules-src/hbut_match3/project/src/main.js
+++ b/website/modules-src/hbut_match3/project/src/main.js
@@ -4,7 +4,8 @@ import {
   TILE_TYPES,
   createInitialMatch3State,
   restartMatch3Game,
-  selectCell
+  selectCell,
+  swipeFromCell
 } from './game/match3.js'
 import {
   canUseGameRank,
@@ -27,6 +28,9 @@ let submitPending = null
 let lastTerminalStatus = ''
 let lastSubmitUiStatus = ''
 let currentLeaderboardScope = moduleContext.className ? 'class' : 'school'
+/** pointer 手势：点击双选 / 滑动交换 */
+let boardGesture = null
+const SWIPE_THRESHOLD_PX = 28
 
 function syncViewport() {
   const viewportHeight = window.visualViewport?.height || window.innerHeight || document.documentElement.clientHeight
@@ -196,39 +200,157 @@ function afterChange() {
   render()
 }
 
+function tileExtraClass(r, c) {
+  const classes = []
+  if (state.selected && state.selected.row === r && state.selected.col === c) {
+    classes.push('selected')
+  }
+  const fb = state.feedback
+  if (!fb) return classes.join(' ')
+  if (fb.type === 'invalid' && fb.at && fb.at.row === r && fb.at.col === c) {
+    classes.push('invalid')
+  }
+  if (fb.type === 'invalid' && fb.from && fb.from.row === r && fb.from.col === c) {
+    classes.push('invalid')
+  }
+  if (fb.type === 'matched' && fb.at && fb.at.row === r && fb.at.col === c) {
+    classes.push('pulse')
+  }
+  if (fb.type === 'matched' && fb.from && fb.from.row === r && fb.from.col === c) {
+    classes.push('pulse')
+  }
+  return classes.join(' ')
+}
+
+function feedbackBanner() {
+  const fb = state.feedback
+  if (!fb) {
+    return `<div class="feedback-banner idle" role="status">点选两格交换，或按住格子向相邻方向滑动</div>`
+  }
+  if (fb.type === 'invalid') {
+    const text =
+      fb.reason === 'not_adjacent'
+        ? '只能交换相邻格子'
+        : fb.reason === 'out_of_bounds'
+          ? '已经到边界了'
+          : '这样交换不会形成三连'
+    return `<div class="feedback-banner invalid" role="status">${text}</div>`
+  }
+  if (fb.type === 'matched') {
+    return `<div class="feedback-banner matched" role="status">消除 +${fb.scoreGained || 0} · 连锁 x${fb.chainCount || 1}</div>`
+  }
+  if (fb.type === 'select') {
+    return `<div class="feedback-banner select" role="status">已选中 · 点相邻格或向相邻方向滑动</div>`
+  }
+  if (fb.type === 'deselect') {
+    return `<div class="feedback-banner idle" role="status">已取消选中</div>`
+  }
+  return `<div class="feedback-banner idle" role="status">点选两格交换，或按住格子向相邻方向滑动</div>`
+}
+
 function renderBoard() {
   const cells = []
   for (let r = 0; r < state.size; r += 1) {
     for (let c = 0; c < state.size; c += 1) {
       const id = state.board[r][c]
       const meta = typeMap.get(id) || { label: '?', color: '#94a3b8' }
-      const selected =
-        state.selected && state.selected.row === r && state.selected.col === c ? 'selected' : ''
+      const extra = tileExtraClass(r, c)
       cells.push(
-        `<button type="button" class="tile ${selected}" data-row="${r}" data-col="${c}" style="--tile:${meta.color}" aria-label="${meta.label}">${meta.label.slice(0, 2)}</button>`
+        `<button type="button" class="tile ${extra}" data-row="${r}" data-col="${c}" style="--tile:${meta.color}" aria-label="${meta.label}" aria-pressed="${extra.includes('selected') ? 'true' : 'false'}">${meta.label.slice(0, 2)}</button>`
       )
     }
   }
-  return `<div class="match-grid" style="--size:${state.size}">${cells.join('')}</div>`
+  return `<div class="match-grid" style="--size:${state.size}" data-feedback="${state.feedback?.type || ''}">${cells.join('')}</div>`
+}
+
+function applyBoardChange(nextState) {
+  state = nextState
+  afterChange()
+}
+
+function directionFromDelta(dx, dy) {
+  if (Math.abs(dx) < SWIPE_THRESHOLD_PX && Math.abs(dy) < SWIPE_THRESHOLD_PX) return null
+  if (Math.abs(dx) >= Math.abs(dy)) return dx > 0 ? 'right' : 'left'
+  return dy > 0 ? 'down' : 'up'
+}
+
+function bindBoardGestures() {
+  const grid = app.querySelector('.match-grid')
+  if (!grid) return
+
+  const readCell = (target) => {
+    const button = target?.closest?.('[data-row]')
+    if (!button || !grid.contains(button)) return null
+    return { row: Number(button.dataset.row), col: Number(button.dataset.col) }
+  }
+
+  grid.addEventListener('pointerdown', (event) => {
+    if (state.status !== 'playing') return
+    if (event.button != null && event.button !== 0) return
+    const cell = readCell(event.target)
+    if (!cell) return
+    boardGesture = {
+      start: cell,
+      x: event.clientX,
+      y: event.clientY,
+      done: false,
+      pointerId: event.pointerId
+    }
+    try {
+      grid.setPointerCapture(event.pointerId)
+    } catch {
+      /* ignore */
+    }
+    event.preventDefault()
+  })
+
+  grid.addEventListener('pointermove', (event) => {
+    if (!boardGesture || boardGesture.done || state.status !== 'playing') return
+    const direction = directionFromDelta(event.clientX - boardGesture.x, event.clientY - boardGesture.y)
+    if (!direction) return
+    const start = boardGesture.start
+    boardGesture.done = true
+    boardGesture = null
+    applyBoardChange(swipeFromCell(state, start.row, start.col, direction))
+  })
+
+  const endGesture = () => {
+    if (!boardGesture) return
+    const gesture = boardGesture
+    boardGesture = null
+    if (gesture.done || state.status !== 'playing') return
+    // 未滑动：按点击双选逻辑
+    applyBoardChange(selectCell(state, gesture.start.row, gesture.start.col))
+  }
+
+  grid.addEventListener('pointerup', endGesture)
+  grid.addEventListener('pointercancel', () => {
+    boardGesture = null
+  })
 }
 
 function render() {
+  const tip =
+    state.status === 'lost'
+      ? `最终得分 ${state.score} · 点「重新开始」再来一局`
+      : '点选两格交换，或按住格子向相邻方向滑动'
+
   app.innerHTML = `
     <main class="match-shell">
       <section class="metric-strip" aria-label="消消乐状态">
-        <div>
+        <div class="metric-card metric-score">
           <span>得分</span>
           <strong data-mcp-metric="score">${state.score}</strong>
         </div>
-        <div>
+        <div class="metric-card metric-moves">
           <span>剩余步数</span>
           <strong data-mcp-metric="moves_left">${state.movesLeft}</strong>
         </div>
-        <div>
+        <div class="metric-card metric-chain">
           <span>最高连锁</span>
           <strong data-mcp-metric="chain_peak">x${state.chainPeak}</strong>
         </div>
-        <div>
+        <div class="metric-card metric-limit">
           <span>限步</span>
           <strong data-mcp-metric="move_limit">${MOVE_LIMIT}</strong>
         </div>
@@ -238,13 +360,15 @@ function render() {
         <div>
           <p class="kicker">湖工消消乐</p>
           <h1>${state.status === 'lost' ? '本局结束' : '交换相邻校园格'}</h1>
-          <p class="status-detail">${state.status === 'lost' ? `最终得分 ${state.score}` : '点选两格相邻交换，三连消除，连锁加分'}</p>
+          <p class="status-detail">${tip}</p>
         </div>
         <div class="count-card">
           <span>棋盘</span>
           <strong>${state.size}×${state.size}</strong>
         </div>
       </section>
+
+      ${feedbackBanner()}
 
       <section class="board-panel" aria-label="三消棋盘">${renderBoard()}</section>
 
@@ -283,13 +407,7 @@ function render() {
     </div>` : ''}
   `
 
-  for (const button of app.querySelectorAll('[data-row]')) {
-    button.addEventListener('click', () => {
-      if (state.status !== 'playing') return
-      state = selectCell(state, Number(button.dataset.row), Number(button.dataset.col))
-      afterChange()
-    })
-  }
+  bindBoardGestures()
 
   document.getElementById('restart-button')?.addEventListener('click', () => {
     state = restartMatch3Game({ seed: Date.now() % 100000 })
@@ -298,6 +416,7 @@ function render() {
     lastTerminalStatus = ''
     submitPending = null
     lastSubmitUiStatus = ''
+    boardGesture = null
     afterChange()
   })
 

--- a/website/modules-src/hbut_match3/project/src/style.css
+++ b/website/modules-src/hbut_match3/project/src/style.css
@@ -11,7 +11,10 @@ body {
   overflow-x: hidden;
   overflow-y: hidden;
   overscroll-behavior: none;
-  background: #f8f5ff;
+  background:
+    radial-gradient(120% 90% at 12% -10%, rgba(167, 139, 250, 0.28), transparent 48%),
+    radial-gradient(90% 70% at 100% 0%, rgba(244, 114, 182, 0.16), transparent 42%),
+    linear-gradient(180deg, #f5f3ff 0%, #faf8ff 55%, #f8f5ff 100%);
   color: #1e1b4b;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Microsoft YaHei", sans-serif;
   -webkit-user-select: none;
@@ -41,7 +44,7 @@ button {
   height: 100%;
   margin: 0 auto;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto auto minmax(72px, auto);
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto auto minmax(64px, auto);
   gap: 8px;
 }
 
@@ -55,14 +58,26 @@ button {
 .hero-panel,
 .board-panel,
 .log-panel {
-  border: 1px solid rgba(30, 27, 75, 0.08);
-  background: #fff;
-  box-shadow: 0 10px 26px rgba(76, 29, 149, 0.08);
+  border: 1px solid rgba(91, 33, 182, 0.1);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 10px 28px rgba(76, 29, 149, 0.1);
+  backdrop-filter: blur(8px);
 }
 
 .metric-strip > div {
-  border-radius: 8px;
-  padding: 7px 8px;
+  border-radius: 12px;
+  padding: 8px 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.metric-strip > div::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: linear-gradient(180deg, #a78bfa, #7c3aed);
+  opacity: 0.9;
 }
 
 .metric-strip span,
@@ -76,47 +91,109 @@ button {
 .metric-strip strong {
   display: block;
   margin-top: 2px;
-  font-size: 1rem;
+  font-size: 1.05rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .hero-panel {
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 14px;
+  padding: 11px 13px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 104px;
   gap: 10px;
   align-items: center;
+  background:
+    linear-gradient(135deg, rgba(237, 233, 254, 0.95), rgba(255, 255, 255, 0.95));
 }
 
 .hero-panel h1 {
   margin: 2px 0 0;
-  font-size: 1.24rem;
+  font-size: 1.22rem;
+  letter-spacing: -0.02em;
 }
 
 .status-detail {
   margin: 5px 0 0;
   color: #64748b;
   font-size: 0.8rem;
+  line-height: 1.35;
 }
 
 .count-card {
   min-height: 66px;
-  border-radius: 8px;
-  background: #7c3aed;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #8b5cf6, #6d28d9 55%, #5b21b6);
   color: #fff;
   display: grid;
   place-items: center;
   text-align: center;
+  box-shadow: 0 8px 18px rgba(109, 40, 217, 0.28);
 }
 
 .count-card span {
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.count-card strong {
+  font-size: 1.15rem;
+}
+
+.feedback-banner {
+  border-radius: 10px;
+  padding: 7px 11px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: banner-in 180ms ease-out;
+}
+
+.feedback-banner.idle {
+  background: rgba(255, 255, 255, 0.72);
+  color: #64748b;
+  border: 1px solid rgba(100, 116, 139, 0.14);
+  font-weight: 600;
+}
+
+.feedback-banner.select {
+  background: #ede9fe;
+  color: #5b21b6;
+  border: 1px solid rgba(124, 58, 237, 0.22);
+}
+
+.feedback-banner.invalid {
+  background: #fef2f2;
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.28);
+}
+
+.feedback-banner.matched {
+  background: #ecfdf5;
+  color: #047857;
+  border: 1px solid rgba(16, 185, 129, 0.28);
+}
+
+@keyframes banner-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .board-panel {
-  border-radius: 8px;
-  padding: 8px;
+  border-radius: 16px;
+  padding: 10px;
   min-height: 0;
+  background:
+    radial-gradient(80% 70% at 50% 0%, rgba(167, 139, 250, 0.12), transparent 60%),
+    rgba(255, 255, 255, 0.95);
 }
 
 .match-grid {
@@ -125,25 +202,93 @@ button {
   display: grid;
   grid-template-columns: repeat(var(--size), minmax(0, 1fr));
   grid-template-rows: repeat(var(--size), minmax(0, 1fr));
-  gap: 4px;
+  gap: 5px;
+  touch-action: none;
+  user-select: none;
 }
 
 .tile {
+  position: relative;
   border: 0;
-  border-radius: 8px;
-  background: var(--tile, #94a3b8);
+  border-radius: 12px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.28), transparent 42%),
+    var(--tile, #94a3b8);
   color: #fff;
   font-weight: 800;
-  font-size: 0.62rem;
+  font-size: clamp(0.58rem, 2.4vw, 0.72rem);
   line-height: 1.1;
   padding: 2px;
   cursor: pointer;
-  touch-action: manipulation;
+  touch-action: none;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    0 3px 0 rgba(15, 23, 42, 0.12);
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease,
+    filter 120ms ease;
+  text-shadow: 0 1px 1px rgba(15, 23, 42, 0.25);
+}
+
+.tile:active {
+  transform: scale(0.96);
 }
 
 .tile.selected {
   outline: 3px solid #fbbf24;
   outline-offset: 1px;
+  transform: scale(1.06);
+  z-index: 2;
+  box-shadow:
+    0 0 0 4px rgba(251, 191, 36, 0.28),
+    0 8px 16px rgba(124, 58, 237, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  filter: brightness(1.08);
+}
+
+.tile.invalid {
+  animation: tile-shake 360ms ease;
+  outline: 2px solid #f87171;
+  outline-offset: 0;
+}
+
+.tile.pulse {
+  animation: tile-pulse 420ms ease;
+}
+
+@keyframes tile-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+}
+
+@keyframes tile-pulse {
+  0% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  35% {
+    transform: scale(1.08);
+    filter: brightness(1.15);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
 }
 
 .control-panel {
@@ -156,15 +301,16 @@ button {
 .secondary-action {
   min-height: 44px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 0 14px;
   font-weight: 800;
   cursor: pointer;
 }
 
 .primary-action {
-  background: #7c3aed;
+  background: linear-gradient(135deg, #8b5cf6, #6d28d9);
   color: #fff;
+  box-shadow: 0 8px 16px rgba(109, 40, 217, 0.25);
 }
 
 .secondary-action {
@@ -193,7 +339,7 @@ button {
 }
 
 .log-panel {
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 9px 11px;
   overflow: hidden;
 }
@@ -227,9 +373,10 @@ button {
   width: min(100%, 380px);
   max-height: min(78vh, 560px);
   overflow: auto;
-  border-radius: 12px;
+  border-radius: 14px;
   background: #fff;
   padding: 14px;
+  box-shadow: 0 20px 48px rgba(30, 27, 75, 0.22);
 }
 
 .leaderboard-header {


### PR DESCRIPTION
## Summary
在「检查更新」中增加用户可选的 **开发版（Beta）** 频道：

- 默认仍只检查正式版（CDN `stable-latest.json`）
- 开启后优先读 CDN `https://hbut.6661111.xyz/releases/dev-latest.json`，回退 GitHub `releases/tags/dev-latest`
- 下载线路沿用现有代理链，tag/目录为 `dev-latest`
- 跳过版本按频道分离（`hbu_skipped_version` / `hbu_skipped_version_dev`）
- 自动检查尊重用户频道偏好

## Test plan
- [x] `npx vitest run src/utils/updater_channel.spec.ts src/utils/updater_download_sources.spec.ts` (15)
- [ ] 打开检查更新，默认正式版；开启 Beta 后应出现 dev 版本号
- [ ] 关闭开关后恢复正式频道