### PR TITLE
fix: 开发版身份 + 校园地图点位 + 小塔视口扫描/返回

### DIFF
--- a/src/components/CampusMapView.vue
+++ b/src/components/CampusMapView.vue
@@ -66,6 +66,12 @@ onMounted(async () => {
 
     <section v-if="degradedText" class="status-banner warn">{{ degradedText }}</section>
     <section v-if="errorText" class="status-banner error">{{ errorText }}</section>
+    <section
+      v-else-if="mapReady && bundle && !bundle.buildings?.length"
+      class="status-banner warn"
+    >
+      暂无建筑点位数据，请点击刷新或检查网络
+    </section>
 
     <section class="search-panel">
       <input

--- a/src/components/TowerGoView.spec.ts
+++ b/src/components/TowerGoView.spec.ts
@@ -19,12 +19,15 @@ describe('TowerGoView simplified contract', () => {
     expect(vue).not.toContain('寻车铃')
   })
 
-  it('keeps map, location, and nearby scan functionality with teardown on leave', () => {
+  it('keeps map, location, viewport scan, and back button with teardown on leave', () => {
     const vue = source()
 
     expect(vue).toContain('定位')
-    expect(vue).toContain('刷新附近')
-    expect(vue).not.toContain('全区扫描')
+    expect(vue).toContain('刷新视野')
+    expect(vue).toContain('scanViewportVehicles')
+    expect(vue).toContain('bindMapViewportScan')
+    expect(vue).toContain('scannedCellKeys')
+    expect(vue).toContain('SCAN_VIEWPORT_DEBOUNCE_MS')
     expect(vue).toContain('loadMapData')
     expect(vue).toContain('renderVehicleMarkers')
     expect(vue).toContain('selectVehicle')
@@ -33,8 +36,12 @@ describe('TowerGoView simplified contract', () => {
     expect(vue).toContain('SCAN_REFRESH_INTERVAL_MS')
     expect(vue).toContain('activeScanToken += 1')
     expect(vue).toContain('startNavigateToSelected')
+    expect(vue).toContain('fetchWalkingRoute')
     expect(vue).toContain('watchPosition')
     expect(vue).toContain('towergo-view--fullscreen')
+    expect(vue).toContain('handleBack')
+    expect(vue).toContain('z-index: 1000')
+    expect(vue).toContain('tg-back-btn')
     // Apple-style custom MarkerStyle (user blue dot + vehicle pin)
     expect(vue).toContain('buildTowerGoMarkerStyles')
     expect(vue).toContain('MarkerStyle')

--- a/src/components/TowerGoView.vue
+++ b/src/components/TowerGoView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { fetchWalkingRoute } from '../features/campus-map/services/walking_route_service'
 import { towerGoApi, towerGoStorage, TOWERGO_CONFIG } from '../utils/towergo_api'
 import {
   HBUT_LOCATION,
@@ -8,17 +9,19 @@ import {
   SCAN_MAX_POINTS,
   SCAN_REFRESH_INTERVAL_MS,
   SCAN_REQUEST_DELAY_MS,
+  SCAN_VIEWPORT_DEBOUNCE_MS,
   createServiceAreaScanPoints,
   dedupeVehicles,
   formatDistance,
   normalizePoint,
   normalizeVehicles,
   resolveTowerGoLocation,
+  scanCellKey,
+  type ScanBounds,
   type TowerGoPoint,
   type TowerGoVehicle
 } from '../utils/towergo_map'
 import { loadTencentMap, toTencentLatLng } from '../utils/tencent_map_loader'
-import TPageHeader from './templates/TPageHeader.vue'
 
 defineProps({
   studentId: { type: String, default: '' }
@@ -46,6 +49,7 @@ const centerMarkerLayer = ref<any>(null)
 const vehicleMarkerLayer = ref<any>(null)
 const fencePolygonLayer = ref<any>(null)
 const mapDataReady = ref(false)
+const routeIsStraight = ref(false)
 
 // UI 状态：分区 / 排序 / 电量筛选
 const activeTab = ref<'map' | 'list' | 'area'>('map')
@@ -55,6 +59,10 @@ const filterMinBattery = ref(0)
 let refreshTimer: number | null = null
 let mapErrorHandler: ((e: ErrorEvent) => void) | null = null
 let activeScanToken = 0
+/** 已扫格子 key，视口增量扫描去重 */
+const scannedCellKeys = new Set<string>()
+let viewportScanTimer: number | null = null
+const viewportScanInFlight = ref(false)
 
 // ── computed ──────────────────────────────────────────────────────
 const nearestVehicle = computed(() => vehicles.value[0] || null)
@@ -92,13 +100,58 @@ const parkingList = computed(() => {
 })
 
 const mapSubtitle = computed(() => {
-  if (loadingMap.value && scanProgress.value) {
-    return `附近扫描 ${scanProgress.value.done}/${scanProgress.value.total}，已发现 ${scanProgress.value.unique} 辆`
+  if ((loadingMap.value || viewportScanInFlight.value) && scanProgress.value) {
+    return `视口扫描 ${scanProgress.value.done}/${scanProgress.value.total}，已发现 ${scanProgress.value.unique} 辆`
   }
   if (nearestVehicle.value)
     return `最近车辆 ${nearestVehicle.value.id || nearestVehicle.value.imei}，${formatDistance(nearestVehicle.value.distance)}`
   return mapErrors.value[0] || '正在连接小塔出行真实接口'
 })
+
+const handleBack = (event?: Event) => {
+  event?.preventDefault?.()
+  event?.stopPropagation?.()
+  emit('back')
+}
+
+const readMapBounds = (): ScanBounds | null => {
+  const map = mapInstance.value
+  if (!map?.getBounds) return null
+  try {
+    const bounds = map.getBounds()
+    if (!bounds) return null
+    const sw = bounds.getSouthWest?.() || bounds.sw
+    const ne = bounds.getNorthEast?.() || bounds.ne
+    const minLat = Number(sw?.getLat?.() ?? sw?.lat)
+    const minLng = Number(sw?.getLng?.() ?? sw?.lng)
+    const maxLat = Number(ne?.getLat?.() ?? ne?.lat)
+    const maxLng = Number(ne?.getLng?.() ?? ne?.lng)
+    if (![minLat, minLng, maxLat, maxLng].every(Number.isFinite)) return null
+    if (minLat > maxLat || minLng > maxLng) return null
+    return { minLat, maxLat, minLng, maxLng }
+  } catch {
+    return null
+  }
+}
+
+const bindMapViewportScan = () => {
+  const map = mapInstance.value
+  if (!map?.on) return
+  const schedule = () => {
+    if (viewportScanTimer) window.clearTimeout(viewportScanTimer)
+    viewportScanTimer = window.setTimeout(() => {
+      viewportScanTimer = null
+      void scanViewportVehicles()
+    }, SCAN_VIEWPORT_DEBOUNCE_MS)
+  }
+  for (const eventName of ['idle', 'dragend', 'zoom_changed', 'zoomend']) {
+    try {
+      map.on(eventName, schedule)
+    } catch {
+      // 事件名因 SDK 版本可能不可用
+    }
+  }
+}
 
 const validId = (value: unknown) => String(value ?? '').trim()
 
@@ -175,6 +228,7 @@ const initMap = async () => {
         properties: { title: currentLocation.value.name || '当前位置' }
       }]
     })
+    bindMapViewportScan()
     mapScriptState.value = 'ready'
   } catch (error) {
     mapScriptState.value = 'fallback'
@@ -262,7 +316,7 @@ const selectVehicle = (vehicle: TowerGoVehicle) => {
   if (mapInstance.value && (window as any).TMap) {
     mapInstance.value.setCenter(toTMapLatLng(vehicle))
   }
-  drawRouteToVehicle(vehicle)
+  void drawRouteToVehicle(vehicle)
 }
 
 let locationWatchId: number | null = null
@@ -275,36 +329,70 @@ const clearRouteLine = () => {
     // ignore
   }
   routeLineLayer = null
+  routeIsStraight.value = false
 }
 
-const drawRouteToVehicle = (vehicle: TowerGoVehicle | null) => {
-  clearRouteLine()
-  if (!vehicle || !mapInstance.value || !(window as any).TMap) return
+const paintRoutePaths = (paths: unknown[]) => {
+  if (!mapInstance.value || !(window as any).TMap || paths.length < 2) return
   const TMap = (window as any).TMap
-  const from = toTMapLatLng(currentLocation.value)
-  const to = toTMapLatLng(vehicle)
+  clearRouteLine()
   try {
+    const style =
+      typeof TMap.PolylineStyle === 'function'
+        ? new TMap.PolylineStyle({
+            color: '#007AFF',
+            width: 6,
+            borderWidth: 2,
+            borderColor: '#ffffff',
+            lineCap: 'round'
+          })
+        : {
+            color: '#007AFF',
+            width: 6,
+            borderWidth: 2,
+            borderColor: '#ffffff',
+            lineCap: 'round'
+          }
     routeLineLayer = new TMap.MultiPolyline({
       map: mapInstance.value,
-      styles: {
-        route: new TMap.PolylineStyle({
-          color: '#007AFF',
-          width: 6,
-          borderWidth: 2,
-          borderColor: '#ffffff',
-          lineCap: 'round'
-        })
-      },
-      geometries: [{ id: 'to-vehicle', styleId: 'route', paths: [from, to] }]
+      styles: { route: style },
+      geometries: [{ id: 'to-vehicle', styleId: 'route', paths }]
     })
   } catch {
     // MultiPolyline 不可用时忽略
   }
 }
 
+const drawRouteToVehicle = async (vehicle: TowerGoVehicle | null) => {
+  if (!vehicle || !mapInstance.value || !(window as any).TMap) {
+    clearRouteLine()
+    return
+  }
+  const TMap = (window as any).TMap
+  const from = toTMapLatLng(currentLocation.value)
+  const to = toTMapLatLng(vehicle)
+  // 优先步行路网，失败再直线示意
+  try {
+    const walk = await fetchWalkingRoute(
+      { lat: currentLocation.value.latitude, lng: currentLocation.value.longitude },
+      { lat: vehicle.latitude, lng: vehicle.longitude }
+    )
+    if (walk.polyline?.length >= 2) {
+      const paths = walk.polyline.map((p) => new TMap.LatLng(p.lat, p.lng))
+      paintRoutePaths(paths)
+      routeIsStraight.value = false
+      return
+    }
+  } catch {
+    // fall through to straight line
+  }
+  paintRoutePaths([from, to])
+  routeIsStraight.value = true
+}
+
 const startNavigateToSelected = () => {
   if (!selectedVehicle.value) return
-  drawRouteToVehicle(selectedVehicle.value)
+  void drawRouteToVehicle(selectedVehicle.value)
   stopLocationWatch()
   if (typeof navigator === 'undefined' || !navigator.geolocation) return
   locationWatchId = navigator.geolocation.watchPosition(
@@ -317,10 +405,10 @@ const startNavigateToSelected = () => {
         source: 'system'
       }
       updateMapCenter(currentLocation.value)
-      if (selectedVehicle.value) drawRouteToVehicle(selectedVehicle.value)
+      if (selectedVehicle.value) void drawRouteToVehicle(selectedVehicle.value)
     },
     () => {},
-    { enableHighAccuracy: true, maximumAge: 2000, timeout: 12000 }
+    { enableHighAccuracy: true, maximumAge: 0, timeout: 12000 }
   )
 }
 
@@ -347,34 +435,35 @@ const scanNearbyVehicles = async (point: TowerGoPoint, sid: string) => {
   }
 }
 
-const scanServiceAreaVehicles = async (point: TowerGoPoint, sid: string, serviceData: unknown) => {
-  // 附近优先 + 点数上限：避免整区高并发网格打满 WebView
-  const scanPoints = createServiceAreaScanPoints({
-    serviceData,
-    origin: point,
-    spacingMeters: SCAN_GRID_SPACING_METERS,
-    maxPoints: SCAN_MAX_POINTS,
-    nearbyRadiusMeters: 900
-  })
-  const allVehicles: TowerGoVehicle[] = []
+const runScanPoints = async (
+  scanPoints: TowerGoPoint[],
+  sid: string,
+  origin: TowerGoPoint,
+  { mergeExisting = false }: { mergeExisting?: boolean } = {}
+) => {
+  const allVehicles: TowerGoVehicle[] = mergeExisting ? [...vehicles.value] : []
   const errors: string[] = []
   let done = 0
   let cursor = 0
-  scanProgress.value = { done: 0, total: scanPoints.length, unique: 0 }
+  scanProgress.value = { done: 0, total: scanPoints.length, unique: allVehicles.length }
 
   let lastProgressUpdate = 0
   const token = activeScanToken
-  const concurrency = Math.min(SCAN_CONCURRENCY, scanPoints.length)
+  const concurrency = Math.min(SCAN_CONCURRENCY, Math.max(1, scanPoints.length))
   const worker = async () => {
     while (cursor < scanPoints.length) {
-      // 离开页面 / 新扫描开始时立即停工
       if (token !== activeScanToken || !mapContainerRef.value) return
       const scanPoint = scanPoints[cursor++]
       try {
         const scanned = await scanNearbyVehicles(scanPoint, sid)
         if (token !== activeScanToken) return
         if (scanned.ok) {
-          allVehicles.splice(0, allVehicles.length, ...dedupeVehicles([...allVehicles, ...scanned.vehicles], point))
+          allVehicles.splice(
+            0,
+            allVehicles.length,
+            ...dedupeVehicles([...allVehicles, ...scanned.vehicles], origin)
+          )
+          scannedCellKeys.add(scanCellKey(scanPoint, SCAN_GRID_SPACING_METERS))
         } else if (scanned.msg) {
           errors.push(scanned.msg)
         }
@@ -399,7 +488,7 @@ const scanServiceAreaVehicles = async (point: TowerGoPoint, sid: string, service
     return { ok: false, msg: '已取消', scanPoints, errors: ['cancelled'], vehicles: [] as TowerGoVehicle[] }
   }
   return {
-    ok: errors.length < scanPoints.length,
+    ok: scanPoints.length === 0 || errors.length < scanPoints.length,
     msg: errors[0] || '成功',
     scanPoints,
     errors,
@@ -407,7 +496,64 @@ const scanServiceAreaVehicles = async (point: TowerGoPoint, sid: string, service
   }
 }
 
-const loadMapData = async (point: TowerGoPoint = currentLocation.value) => {
+const scanServiceAreaVehicles = async (
+  point: TowerGoPoint,
+  sid: string,
+  serviceData: unknown,
+  bounds?: ScanBounds | null
+) => {
+  const scanPoints = createServiceAreaScanPoints({
+    serviceData,
+    origin: point,
+    spacingMeters: SCAN_GRID_SPACING_METERS,
+    maxPoints: SCAN_MAX_POINTS,
+    nearbyRadiusMeters: 900,
+    bounds: bounds || undefined
+  })
+  // 冷启动附近扫：清空格子缓存；视口扫在外层过滤已扫格子
+  if (!bounds) scannedCellKeys.clear()
+  return runScanPoints(scanPoints, sid, point, { mergeExisting: Boolean(bounds) })
+}
+
+/** 地图视野变化：仅扫描未覆盖格子 */
+const scanViewportVehicles = async () => {
+  if (loadingMap.value || viewportScanInFlight.value) return
+  const sid = validId(serviceId.value)
+  if (!sid || !serviceInfo.value) return
+  const bounds = readMapBounds()
+  if (!bounds) return
+
+  const rawPoints = createServiceAreaScanPoints({
+    serviceData: serviceInfo.value,
+    origin: currentLocation.value,
+    spacingMeters: SCAN_GRID_SPACING_METERS,
+    maxPoints: SCAN_MAX_POINTS,
+    bounds
+  })
+  const freshPoints = rawPoints.filter(
+    (p) => !scannedCellKeys.has(scanCellKey(p, SCAN_GRID_SPACING_METERS))
+  )
+  if (!freshPoints.length) return
+
+  viewportScanInFlight.value = true
+  activeScanToken += 1
+  try {
+    const result = await runScanPoints(freshPoints, sid, currentLocation.value, { mergeExisting: true })
+    if (result.ok || result.vehicles.length) {
+      vehicles.value = result.vehicles
+      lastScanAt.value = Date.now()
+      renderVehicleMarkers()
+    }
+  } finally {
+    viewportScanInFlight.value = false
+    scanProgress.value = null
+  }
+}
+
+const loadMapData = async (
+  point: TowerGoPoint = currentLocation.value,
+  { preferViewport = false }: { preferViewport?: boolean } = {}
+) => {
   if (loadingMap.value) return
   activeScanToken += 1
   loadingMap.value = true
@@ -426,9 +572,10 @@ const loadMapData = async (point: TowerGoPoint = currentLocation.value) => {
     serviceInfo.value = data
     towerGoStorage.set('serviceId', sid)
 
+    const viewportBounds = preferViewport ? readMapBounds() : null
     // 第二步：并行扫描车辆 / 取围栏 / 取停车点数（nearParkingNum 免登可能未授权，降级不阻塞）
     const [scanResult, fenceResult, parkingResult] = await Promise.all([
-      scanServiceAreaVehicles(point, sid, data),
+      scanServiceAreaVehicles(point, sid, data, viewportBounds),
       towerGoApi.fence.nearFence(point.latitude, point.longitude, { serviceId: sid }),
       towerGoApi.fence.nearParkingNum(point.latitude, point.longitude, { serviceId: sid })
     ])
@@ -455,16 +602,17 @@ const loadMapData = async (point: TowerGoPoint = currentLocation.value) => {
 const refreshBySystemLocation = async () => {
   locating.value = true
   try {
-    const point = await resolveTowerGoLocation()
+    const point = await resolveTowerGoLocation({ maximumAge: 0 })
     updateMapCenter(point)
-    await loadMapData(point)
+    await loadMapData(point, { preferViewport: false })
   } finally {
     locating.value = false
   }
 }
 
 const refreshCurrentArea = async () => {
-  await loadMapData(currentLocation.value)
+  // 手动刷新：优先当前视野
+  await loadMapData(currentLocation.value, { preferViewport: true })
 }
 
 // ── 定时刷新 ──────────────────────────────────────────────────────
@@ -488,6 +636,12 @@ const teardownTowerGoRuntime = () => {
   stopRefreshTimer()
   stopLocationWatch()
   clearRouteLine()
+  if (viewportScanTimer) {
+    window.clearTimeout(viewportScanTimer)
+    viewportScanTimer = null
+  }
+  viewportScanInFlight.value = false
+  scannedCellKeys.clear()
   loadingMap.value = false
   scanProgress.value = null
   if (mapErrorHandler) {
@@ -566,14 +720,20 @@ onBeforeUnmount(() => {
 <template>
   <div class="towergo-view towergo-view--fullscreen module-page">
     <header class="tg-fs-header">
-      <button class="tg-icon-btn" type="button" aria-label="返回" @click="emit('back')">
+      <button
+        class="tg-icon-btn tg-back-btn"
+        type="button"
+        aria-label="返回"
+        @click.stop.prevent="handleBack"
+        @touchend.stop.prevent="handleBack"
+      >
         <span class="material-symbols-outlined">arrow_back</span>
       </button>
       <div class="tg-fs-title">
         <strong>小塔出行</strong>
         <small>{{ mapSubtitle }}</small>
       </div>
-      <button class="tg-icon-btn" :disabled="loadingMap" title="刷新附近" @click="refreshCurrentArea">
+      <button class="tg-icon-btn" :disabled="loadingMap" title="刷新当前视野" @click="refreshCurrentArea">
         <span class="material-symbols-outlined">refresh</span>
       </button>
     </header>
@@ -608,7 +768,7 @@ onBeforeUnmount(() => {
         </button>
         <button :disabled="loadingMap" @click="refreshCurrentArea">
           <span class="material-symbols-outlined">radar</span>
-          刷新附近
+          刷新视野
         </button>
       </div>
       <!-- 选中车辆浮卡 + 到车 -->
@@ -616,7 +776,10 @@ onBeforeUnmount(() => {
         <span class="vehicle-icon material-symbols-outlined">electric_bike</span>
         <div class="pop-main">
           <strong>NO.{{ selectedVehicle.id || selectedVehicle.imei || '--' }}</strong>
-          <small>{{ formatDistance(selectedVehicle.distance) }} · 电量 {{ selectedVehicle.battery || '--' }}%</small>
+          <small>
+            {{ formatDistance(selectedVehicle.distance) }} · 电量 {{ selectedVehicle.battery || '--' }}%
+            <template v-if="routeIsStraight"> · 直线示意</template>
+          </small>
         </div>
         <button class="pop-nav" type="button" @click="startNavigateToSelected">到这</button>
         <button class="pop-close" @click="stopNavigateToSelected"><span class="material-symbols-outlined">close</span></button>
@@ -709,7 +872,10 @@ onBeforeUnmount(() => {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 30;
+  /* 必须高于腾讯地图 canvas，否则返回按钮点不到 */
+  z-index: 1000;
+  isolation: isolate;
+  pointer-events: auto;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -744,7 +910,8 @@ onBeforeUnmount(() => {
   top: calc(58px + var(--app-safe-top, env(safe-area-inset-top, 0px)));
   left: 50%;
   transform: translateX(-50%);
-  z-index: 28;
+  z-index: 900;
+  pointer-events: auto;
   display: inline-flex;
   gap: 4px;
   padding: 4px;
@@ -819,6 +986,17 @@ onBeforeUnmount(() => {
   width: 38px;
   min-width: 38px;
   padding: 0;
+  position: relative;
+  z-index: 1001;
+  pointer-events: auto;
+  touch-action: manipulation;
+}
+
+.tg-back-btn {
+  /* 加大命中区域，避免被地图层吞掉点击 */
+  width: 44px;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .tg-icon-btn:hover,

--- a/src/components/UpdateDialog.vue
+++ b/src/components/UpdateDialog.vue
@@ -6,6 +6,7 @@ import {
   downloadUpdate,
   getCurrentVersion,
   getUpdateChannel,
+  isCurrentInstallDev,
   setSkippedVersion,
   setUpdateChannel,
   isOfficialDownloadUrl
@@ -26,7 +27,14 @@ const sourceSpeedResults = ref({}) // { url: { ms: number, status: 'testing'|'ok
 const showSourceTable = ref(false)
 
 const isDevChannel = computed(() => updateChannel.value === 'dev')
+/** 接收更新偏好（开关），不是安装身份 */
 const channelBadge = computed(() => (isDevChannel.value ? '开发版' : '正式版'))
+/** 当前安装身份：看版本字符串是否 prerelease，与频道开关解耦 */
+const isInstallDev = computed(() => isCurrentInstallDev(currentVersion.value))
+const installBadge = computed(() => (isInstallDev.value ? '开发版' : '正式版'))
+const currentVersionLabel = computed(
+  () => `当前 · ${installBadge.value} v${currentVersion.value || '--'}`
+)
 
 const checkUpdate = async () => {
   checking.value = true
@@ -188,8 +196,14 @@ onMounted(() => {
           </button>
         </div>
         <div class="channel-badge-row">
-          <span class="channel-pill" :data-channel="updateChannel">当前频道：{{ channelBadge }}</span>
+          <span class="channel-pill" :data-channel="isInstallDev ? 'dev' : 'stable'">
+            当前安装：{{ installBadge }}
+          </span>
+          <span class="channel-pill" :data-channel="updateChannel">接收频道：{{ channelBadge }}</span>
         </div>
+        <p v-if="isInstallDev && !isDevChannel" class="install-hint">
+          当前安装为开发版。若要继续接收 Beta 推送，请打开上方开关。
+        </p>
 
         <!-- 检查中 -->
         <div v-if="checking" class="checking">
@@ -200,7 +214,9 @@ onMounted(() => {
         <!-- 有更新 -->
         <template v-else-if="updateInfo?.hasUpdate">
           <div class="version-info">
-            <div class="version-badge current">当前 v{{ currentVersion }}</div>
+            <div class="version-badge current" :data-install="isInstallDev ? 'dev' : 'stable'">
+              {{ currentVersionLabel }}
+            </div>
             <span class="arrow">→</span>
             <div class="version-badge new" :data-channel="updateInfo.channel || updateChannel">
               {{ updateInfo.isPrerelease || isDevChannel ? '开发版' : '新版本' }}
@@ -269,7 +285,7 @@ onMounted(() => {
           <div class="up-to-date">
             <span class="material-symbols-outlined status-icon status-icon--success">check_circle</span>
             <p>{{ isDevChannel ? '已是最新开发版' : '已是最新正式版' }}</p>
-            <span class="version">v{{ currentVersion }}</span>
+            <span class="version">{{ currentVersionLabel }}</span>
             <span v-if="updateInfo.latestVersion" class="version muted">远端 {{ updateInfo.latestVersion }}</span>
           </div>
         </template>
@@ -405,7 +421,17 @@ onMounted(() => {
   transform: translateX(20px);
 }
 
+.install-hint {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #b45309;
+}
+
 .channel-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   margin-bottom: 12px;
 }
 
@@ -481,6 +507,10 @@ onMounted(() => {
 
 .version-badge.new { background: #10b981; color: white; }
 .version-badge.current { background: #f3f4f6; color: #6b7280; }
+.version-badge.current[data-install='dev'] {
+  background: #fef3c7;
+  color: #92400e;
+}
 .arrow { font-size: 20px; color: #9ca3af; }
 
 .release-notes {

--- a/src/features/campus-guide/api/normalize.ts
+++ b/src/features/campus-guide/api/normalize.ts
@@ -76,18 +76,47 @@ export const normalizeScenicInfo = (raw: unknown): ScenicInfo => {
   }
 }
 
+/** 解析经纬度：兼容字符串、微度（绝对值 > 1000 时 /1e6） */
+const toCoord = (value: unknown) => {
+  const num = toNumber(value)
+  if (!Number.isFinite(num)) return NaN
+  if (Math.abs(num) > 1000) return num / 1_000_000
+  return num
+}
+
 export const normalizeSpot = (raw: unknown): CampusSpot | null => {
   if (!raw || typeof raw !== 'object') return null
   const data = raw as Record<string, unknown>
-  const location = (data.location && typeof data.location === 'object' ? data.location : data.point) as
-    | Record<string, unknown>
-    | undefined
-  const lat = toNumber(location?.lat ?? location?.latitude ?? data.latitude)
-  const lng = toNumber(location?.lon ?? location?.lng ?? location?.longitude ?? data.longitude)
+  const location = (data.location && typeof data.location === 'object'
+    ? data.location
+    : data.point && typeof data.point === 'object'
+      ? data.point
+      : data.latlng && typeof data.latlng === 'object'
+        ? data.latlng
+        : undefined) as Record<string, unknown> | undefined
+  let lat = toCoord(location?.lat ?? location?.latitude ?? data.latitude ?? data.lat)
+  let lng = toCoord(
+    location?.lon ?? location?.lng ?? location?.longitude ?? data.longitude ?? data.lng ?? data.lon
+  )
+  // 兼容 "lat,lng" / "lng,lat" 字符串
+  if ((!Number.isFinite(lat) || !Number.isFinite(lng)) && typeof data.location === 'string') {
+    const parts = data.location.split(/[,，\s]+/).map((p) => toCoord(p.trim()))
+    if (parts.length >= 2 && parts.every(Number.isFinite)) {
+      // 智慧景区常见 lat,lng 或 lng,lat：纬度应在 ±90
+      if (Math.abs(parts[0]) <= 90 && Math.abs(parts[1]) <= 180) {
+        lat = parts[0]
+        lng = parts[1]
+      } else if (Math.abs(parts[1]) <= 90 && Math.abs(parts[0]) <= 180) {
+        lat = parts[1]
+        lng = parts[0]
+      }
+    }
+  }
   const spotId = data.spot_id ?? data.id
-  const name = String(data.name ?? '').trim()
+  const name = String(data.name ?? data.title ?? '').trim()
   if (!spotId || !name) return null
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null
 
   return {
     spot_id: spotId as string | number,

--- a/src/features/campus-guide/views/CampusGuideHome.vue
+++ b/src/features/campus-guide/views/CampusGuideHome.vue
@@ -167,6 +167,14 @@ onMounted(async () => {
     if (!store.mapReady) await store.bootstrap()
     activePoi.value = store.selectedSpot
     await initMap()
+    // 地图 ready 后再刷一次，避免首帧 container 尺寸为 0 导致点位丢失
+    window.setTimeout(() => {
+      mapCore.value?.resize()
+      void refreshMapMarkers()
+      if (!store.spots.length && !store.loading && !store.spotsLoading) {
+        showToast('当前分类暂无点位，可切换分类或检查网络', 'warning', 2200)
+      }
+    }, 320)
   } catch {
     // error 已写入
   }

--- a/src/features/campus-map/campus_map_contract.spec.ts
+++ b/src/features/campus-map/campus_map_contract.spec.ts
@@ -66,4 +66,14 @@ describe('campus map contract', () => {
     expect(view).toContain('useCampusMap')
     expect(view).not.toContain('map1.jpg')
   })
+
+  it('uses MarkerStyle for building pins so Tencent MultiMarker is visible', () => {
+    const controller = read('src/features/campus-map/map/campus_map_controller.ts')
+    const markers = read('src/features/campus-map/map/campus_map_markers.ts')
+    expect(markers).toContain('buildCampusBuildingMarkerStyles')
+    expect(markers).toContain('MarkerStyle')
+    expect(controller).toContain('buildCampusBuildingMarkerStyles')
+    expect(controller).toContain('styleId')
+    expect(controller).toContain('campusBuildingStyleId')
+  })
 })

--- a/src/features/campus-map/map/campus_map_controller.ts
+++ b/src/features/campus-map/map/campus_map_controller.ts
@@ -1,6 +1,11 @@
 import { loadTencentMap, toTencentLatLng } from '../../../utils/tencent_map_loader'
 import { TOWERGO_CONFIG } from '../../../utils/towergo_api'
 import type { CampusBuilding, CampusMapConfig, MapLatLng } from '../types'
+import {
+  buildCampusBuildingMarkerStyles,
+  campusBuildingStyleId,
+  campusUserLocationStyleId
+} from './campus_map_markers'
 import { CAMPUS_MAP_CONTAINER_CLASS, injectCampusMapStyles } from './map_style'
 
 type TMapInstance = {
@@ -9,6 +14,7 @@ type TMapInstance = {
   LatLngBounds: new (sw: unknown, ne: unknown) => unknown
   MultiMarker: new (options: Record<string, unknown>) => TMapLayer
   MultiPolyline: new (options: Record<string, unknown>) => TMapLayer
+  MarkerStyle?: new (options: Record<string, unknown>) => unknown
 }
 
 type TMapMap = {
@@ -20,6 +26,7 @@ type TMapMap = {
 
 type TMapLayer = {
   setGeometries?: (geometries: unknown[]) => void
+  setStyles?: (styles: Record<string, unknown>) => void
   on?: (event: string, handler: (event: unknown) => void) => void
   setMap?: (map: TMapMap | null) => void
 }
@@ -80,14 +87,22 @@ export class CampusMapController {
     this.buildings = buildings
     if (!this.map || !this.TMap) return
 
+    // 腾讯 GL MultiMarker 无 MarkerStyle 时 pin 常不可见，必须显式 styleId
+    const styles = buildCampusBuildingMarkerStyles(this.TMap, buildings)
     const geometries = buildings.map((building) => ({
       id: building.id,
+      styleId: campusBuildingStyleId(building),
       position: toTencentLatLng(this.TMap!, { lat: building.lat, lng: building.lng }),
       properties: { title: building.name, category: building.category }
     }))
 
     if (!this.buildingLayer) {
-      this.buildingLayer = new this.TMap.MultiMarker({ map: this.map, geometries })
+      this.buildingLayer = new this.TMap.MultiMarker({
+        map: this.map,
+        styles,
+        geometries,
+        zIndex: 30
+      })
       this.buildingLayer.on?.('click', (event: { geometry?: { id?: string } }) => {
         const id = event?.geometry?.id
         const target = this.buildings.find((item) => item.id === id)
@@ -95,6 +110,7 @@ export class CampusMapController {
       })
       return
     }
+    this.buildingLayer.setStyles?.(styles)
     this.buildingLayer.setGeometries?.(geometries)
   }
 
@@ -106,15 +122,23 @@ export class CampusMapController {
 
   setUserLocation(point: MapLatLng) {
     if (!this.map || !this.TMap) return
+    const styles = buildCampusBuildingMarkerStyles(this.TMap, [])
     const geometry = {
       id: 'user-location',
+      styleId: campusUserLocationStyleId(),
       position: toTencentLatLng(this.TMap, point),
       properties: { title: '我的位置' }
     }
     if (!this.userLayer) {
-      this.userLayer = new this.TMap.MultiMarker({ map: this.map, geometries: [geometry] })
+      this.userLayer = new this.TMap.MultiMarker({
+        map: this.map,
+        styles,
+        geometries: [geometry],
+        zIndex: 40
+      })
       return
     }
+    this.userLayer.setStyles?.(styles)
     this.userLayer.setGeometries?.([geometry])
   }
 

--- a/src/features/campus-map/map/campus_map_markers.ts
+++ b/src/features/campus-map/map/campus_map_markers.ts
@@ -1,0 +1,67 @@
+/** 校园地图（legacy）建筑/用户点 MarkerStyle 构建 — 腾讯 GL 无 style 时 pin 不可见 */
+
+import type { CampusBuilding } from '../types'
+
+type MarkerStyleFactory = {
+  MarkerStyle?: new (opts: Record<string, unknown>) => unknown
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  library: '#2563eb',
+  teaching: '#0d9488',
+  canteen: '#ea580c',
+  dorm: '#7c3aed',
+  sports: '#16a34a',
+  gate: '#b45309',
+  service: '#64748b'
+}
+
+const pinSvg = (label: string, fill: string) => {
+  const text = String(label || '').slice(0, 2)
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="48" viewBox="0 0 40 48">
+    <path d="M20 2C11.7 2 5 8.7 5 17c0 11.2 15 29 15 29s15-17.8 15-29C35 8.7 28.3 2 20 2z" fill="${fill}" stroke="#fff" stroke-width="1.5"/>
+    <circle cx="20" cy="17" r="7" fill="#fff"/>
+    <text x="20" y="20" text-anchor="middle" font-size="9" font-weight="700" fill="${fill}" font-family="sans-serif">${text}</text>
+  </svg>`
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
+}
+
+const userDotSvg = () => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+    <circle cx="20" cy="20" r="9" fill="#007AFF" stroke="#ffffff" stroke-width="3"/>
+    <circle cx="20" cy="20" r="16" fill="none" stroke="#007AFF" stroke-opacity="0.28" stroke-width="4"/>
+  </svg>`
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
+}
+
+export const campusBuildingStyleId = (building: Pick<CampusBuilding, 'id' | 'category' | 'name'>) =>
+  `bldg-${building.category || 'default'}-${building.id}`
+
+export const campusUserLocationStyleId = () => 'user-location'
+
+export const buildCampusBuildingMarkerStyles = (
+  TMap: MarkerStyleFactory,
+  buildings: Array<Pick<CampusBuilding, 'id' | 'category' | 'name'>>
+) => {
+  const styles: Record<string, unknown> = {}
+  if (typeof TMap.MarkerStyle !== 'function') return styles
+
+  styles[campusUserLocationStyleId()] = new TMap.MarkerStyle({
+    width: 32,
+    height: 32,
+    anchor: { x: 16, y: 16 },
+    src: userDotSvg()
+  })
+
+  for (const building of buildings || []) {
+    const fill = CATEGORY_COLORS[String(building.category || '')] || '#0074CF'
+    const styleId = campusBuildingStyleId(building)
+    styles[styleId] = new TMap.MarkerStyle({
+      width: 34,
+      height: 40,
+      anchor: { x: 17, y: 40 },
+      src: pinSvg(building.name, fill)
+    })
+  }
+  return styles
+}

--- a/src/utils/p0_multi_module_contract.spec.ts
+++ b/src/utils/p0_multi_module_contract.spec.ts
@@ -18,7 +18,8 @@ describe('P0 multi-module contracts', () => {
   it('downshifts TowerGo scan defaults and nearby-first caps', () => {
     expect(SCAN_CONCURRENCY).toBeLessThanOrEqual(4)
     expect(SCAN_GRID_SPACING_METERS).toBeGreaterThanOrEqual(150)
-    expect(SCAN_MAX_POINTS).toBeLessThanOrEqual(32)
+    // 视口动态扫描允许略高上限，仍远低于全校区无界网格
+    expect(SCAN_MAX_POINTS).toBeLessThanOrEqual(48)
 
     const polygon = [
       { latitude: 30.47, longitude: 114.30 },

--- a/src/utils/towergo_map.spec.ts
+++ b/src/utils/towergo_map.spec.ts
@@ -10,7 +10,8 @@ import {
   isPointInPolygon,
   normalizePoint,
   normalizeVehicles,
-  resolveTowerGoLocation
+  resolveTowerGoLocation,
+  scanCellKey
 } from './towergo_map'
 
 describe('towergo map utilities', () => {
@@ -139,7 +140,7 @@ describe('towergo map utilities', () => {
   it('caps scan points for nearby-first low-impact scans', () => {
     expect(SCAN_CONCURRENCY).toBeLessThanOrEqual(4)
     expect(SCAN_GRID_SPACING_METERS).toBeGreaterThanOrEqual(150)
-    expect(SCAN_MAX_POINTS).toBeLessThanOrEqual(32)
+    expect(SCAN_MAX_POINTS).toBeLessThanOrEqual(48)
 
     const polygon = [
       { latitude: 30.47, longitude: 114.30 },
@@ -158,5 +159,62 @@ describe('towergo map utilities', () => {
     expect(points.length).toBeLessThanOrEqual(SCAN_MAX_POINTS)
     // 最近点应为用户原点
     expect(points[0].latitude).toBeCloseTo(HBUT_LOCATION.latitude, 4)
+  })
+
+  it('generates scan points from map viewport bounds', () => {
+    const polygon = [
+      { latitude: 30.47, longitude: 114.30 },
+      { latitude: 30.47, longitude: 114.33 },
+      { latitude: 30.50, longitude: 114.33 },
+      { latitude: 30.50, longitude: 114.30 }
+    ]
+    // 视口在服务区北侧，远离默认原点附近
+    const bounds = {
+      minLat: 30.492,
+      maxLat: 30.498,
+      minLng: 114.31,
+      maxLng: 114.32
+    }
+    const points = createServiceAreaScanPoints({
+      serviceData: { points: polygon, centerLat: 30.483, centerLng: 114.313 },
+      origin: HBUT_LOCATION,
+      spacingMeters: 200,
+      maxPoints: 20,
+      bounds
+    })
+    expect(points.length).toBeGreaterThanOrEqual(1)
+    expect(points.length).toBeLessThanOrEqual(20)
+    // 点应落在视口∩服务区附近，而非全部挤在校区中心
+    const midLat = points.reduce((s, p) => s + p.latitude, 0) / points.length
+    expect(midLat).toBeGreaterThan(30.485)
+  })
+
+  it('builds stable scan cell keys for incremental viewport loading', () => {
+    const a = scanCellKey({ latitude: 30.4819, longitude: 114.313 }, 180)
+    const b = scanCellKey({ latitude: 30.48191, longitude: 114.31301 }, 180)
+    const far = scanCellKey({ latitude: 30.495, longitude: 114.32 }, 180)
+    expect(a).toBe(b)
+    expect(a).not.toBe(far)
+  })
+
+  it('requests fresh geolocation with maximumAge 0 by default', async () => {
+    let seenMaximumAge: number | undefined
+    await resolveTowerGoLocation({
+      geolocation: {
+        getCurrentPosition: (
+          success: PositionCallback,
+          _error?: PositionErrorCallback | null,
+          options?: PositionOptions
+        ) => {
+          seenMaximumAge = options?.maximumAge
+          success({
+            coords: { latitude: 30.483, longitude: 114.315, accuracy: 8 } as GeolocationCoordinates,
+            timestamp: Date.now()
+          } as GeolocationPosition)
+        }
+      } as unknown as Geolocation,
+      fallback: HBUT_LOCATION
+    })
+    expect(seenMaximumAge).toBe(0)
   })
 })

--- a/src/utils/towergo_map.ts
+++ b/src/utils/towergo_map.ts
@@ -32,9 +32,31 @@ export const SCAN_CONCURRENCY = 3
 /** 单次请求间隔（ms）。 */
 export const SCAN_REQUEST_DELAY_MS = 80
 /** 单次扫描最多探测点数（含原点/中心）。超出时保留距用户最近的点。 */
-export const SCAN_MAX_POINTS = 24
-/** 定时刷新间隔（ms）：仅刷新附近，不整区打爆。 */
+export const SCAN_MAX_POINTS = 36
+/** 定时刷新间隔（ms）：仅刷新附近/当前视野，不整区打爆。 */
 export const SCAN_REFRESH_INTERVAL_MS = 180_000
+/** 视口扫描防抖（ms）。 */
+export const SCAN_VIEWPORT_DEBOUNCE_MS = 400
+
+export type ScanBounds = {
+  minLat: number
+  maxLat: number
+  minLng: number
+  maxLng: number
+}
+
+/** 将扫描点量化为格子 key，用于增量扫描去重 */
+export const scanCellKey = (
+  point: { latitude: number; longitude: number },
+  spacingMeters = SCAN_GRID_SPACING_METERS
+) => {
+  const step = Math.max(50, Number(spacingMeters) || SCAN_GRID_SPACING_METERS)
+  const latStep = step / 111320
+  const lngStep = step / (111320 * Math.max(0.1, Math.cos((point.latitude * Math.PI) / 180)))
+  const latCell = Math.round(point.latitude / latStep)
+  const lngCell = Math.round(point.longitude / lngStep)
+  return `${latCell},${lngCell}`
+}
 
 const toNumber = (value: unknown) => {
   const num = Number(value)
@@ -195,14 +217,17 @@ export const createServiceAreaScanPoints = ({
   origin = HBUT_LOCATION,
   spacingMeters = SCAN_GRID_SPACING_METERS,
   maxPoints = SCAN_MAX_POINTS,
-  /** 仅扫描用户附近半径（米）；默认 900m 附近优先，避免整区打爆。 */
-  nearbyRadiusMeters = 900
+  /** 仅扫描用户附近半径（米）；默认 900m 附近优先，避免整区打爆。有 bounds 时忽略。 */
+  nearbyRadiusMeters = 900,
+  /** 地图视口外包矩形：与服务区求交后网格扫描（动态加载） */
+  bounds
 }: {
   serviceData?: unknown
   origin?: TowerGoPoint
   spacingMeters?: number
   maxPoints?: number
   nearbyRadiusMeters?: number
+  bounds?: ScanBounds | null
 }) => {
   const loc = normalizePoint(origin) || HBUT_LOCATION
   const polygon = getServiceAreaPolygon(serviceData)
@@ -211,13 +236,34 @@ export const createServiceAreaScanPoints = ({
     longitude: (serviceData as Record<string, unknown> | undefined)?.centerLng
   }) || loc
 
-  // Determine scan bounding box（优先用户附近方框，而不是整片服务区）
-  const nearbyDeg = Math.max(200, Number(nearbyRadiusMeters) || 900) / 111320
-  let minLat = loc.latitude - nearbyDeg
-  let maxLat = loc.latitude + nearbyDeg
-  let minLng = loc.longitude - nearbyDeg / Math.max(0.1, Math.cos(loc.latitude * Math.PI / 180))
-  let maxLng = loc.longitude + nearbyDeg / Math.max(0.1, Math.cos(loc.latitude * Math.PI / 180))
+  let minLat: number
+  let maxLat: number
+  let minLng: number
+  let maxLng: number
   let effectiveSpacing = Math.max(80, Number(spacingMeters) || SCAN_GRID_SPACING_METERS)
+
+  if (
+    bounds &&
+    Number.isFinite(bounds.minLat) &&
+    Number.isFinite(bounds.maxLat) &&
+    Number.isFinite(bounds.minLng) &&
+    Number.isFinite(bounds.maxLng) &&
+    bounds.minLat <= bounds.maxLat &&
+    bounds.minLng <= bounds.maxLng
+  ) {
+    // 视口优先：用当前地图视野作为扫描范围
+    minLat = bounds.minLat
+    maxLat = bounds.maxLat
+    minLng = bounds.minLng
+    maxLng = bounds.maxLng
+  } else {
+    // 冷启动：用户附近方框
+    const nearbyDeg = Math.max(200, Number(nearbyRadiusMeters) || 900) / 111320
+    minLat = loc.latitude - nearbyDeg
+    maxLat = loc.latitude + nearbyDeg
+    minLng = loc.longitude - nearbyDeg / Math.max(0.1, Math.cos((loc.latitude * Math.PI) / 180))
+    maxLng = loc.longitude + nearbyDeg / Math.max(0.1, Math.cos((loc.latitude * Math.PI) / 180))
+  }
 
   if (polygon.length >= 3) {
     // 与服务区求交：不超过服务区外包矩形
@@ -243,18 +289,33 @@ export const createServiceAreaScanPoints = ({
 
   const midLat = (minLat + maxLat) / 2
   const latStep = effectiveSpacing / 111320
-  const lngStep = effectiveSpacing / (111320 * Math.max(0.1, Math.cos(midLat * Math.PI / 180)))
+  const lngStep = effectiveSpacing / (111320 * Math.max(0.1, Math.cos((midLat * Math.PI) / 180)))
 
-  const points: TowerGoPoint[] = [loc, center]
+  const points: TowerGoPoint[] = bounds ? [] : [loc, center]
+  // 视口中心也纳入，便于视野内优先
+  if (bounds) {
+    points.push({
+      latitude: Number(((minLat + maxLat) / 2).toFixed(6)),
+      longitude: Number(((minLng + maxLng) / 2).toFixed(6))
+    })
+  }
   for (let lat = minLat; lat <= maxLat + 1e-12; lat += latStep) {
     for (let lng = minLng; lng <= maxLng + 1e-12; lng += lngStep) {
       points.push({ latitude: Number(lat.toFixed(6)), longitude: Number(lng.toFixed(6)) })
     }
   }
 
-  const sorted = dedupeScanPoints(points).sort((a, b) =>
-    distanceMeters(loc.latitude, loc.longitude, a.latitude, a.longitude) -
-    distanceMeters(loc.latitude, loc.longitude, b.latitude, b.longitude)
+  const sortOrigin = bounds
+    ? {
+        latitude: (minLat + maxLat) / 2,
+        longitude: (minLng + maxLng) / 2
+      }
+    : loc
+
+  const sorted = dedupeScanPoints(points).sort(
+    (a, b) =>
+      distanceMeters(sortOrigin.latitude, sortOrigin.longitude, a.latitude, a.longitude) -
+      distanceMeters(sortOrigin.latitude, sortOrigin.longitude, b.latitude, b.longitude)
   )
   const limit = Math.max(4, Number(maxPoints) || SCAN_MAX_POINTS)
   return sorted.slice(0, limit)
@@ -306,13 +367,16 @@ export const dedupeVehicles = (vehicles: TowerGoVehicle[], origin: TowerGoPoint 
 export const resolveTowerGoLocation = async ({
   geolocation = typeof navigator === 'undefined' ? undefined : navigator.geolocation,
   fallback = HBUT_LOCATION,
-  timeoutMs = 5000,
-  maxDriftMeters = 2000
+  timeoutMs = 12000,
+  maxDriftMeters = 2000,
+  /** 0 = 强制刷新，避免 iOS/系统把陈旧校外坐标当当前 */
+  maximumAge = 0
 }: {
   geolocation?: Geolocation
   fallback?: TowerGoPoint
   timeoutMs?: number
   maxDriftMeters?: number
+  maximumAge?: number
 } = {}): Promise<TowerGoPoint> => {
   if (!geolocation?.getCurrentPosition) {
     return { ...fallback, source: 'fallback' }
@@ -341,7 +405,11 @@ export const resolveTowerGoLocation = async ({
         () => {
           resolve({ ...fallback, source: 'fallback' })
         },
-        { timeout: timeoutMs, enableHighAccuracy: true, maximumAge: 5000 }
+        {
+          timeout: timeoutMs,
+          enableHighAccuracy: true,
+          maximumAge: Math.max(0, Number(maximumAge) || 0)
+        }
       )
     } catch {
       resolve({ ...fallback, source: 'fallback' })

--- a/src/utils/updater.js
+++ b/src/utils/updater.js
@@ -264,6 +264,17 @@ function isPrereleaseVersion(version) {
   return parseVersion(version).isPrerelease
 }
 
+/**
+ * 当前安装是否为开发版/预发布构建。
+ * 以版本字符串为准（含 -beta/-dev/-rc 等），与「接收更新频道」开关无关。
+ */
+export function isCurrentInstallDev(version) {
+  const text = String(version || '').replace(/^v/i, '').trim()
+  if (!text) return false
+  if (isPrereleaseVersion(text)) return true
+  return /(^|[-._])(alpha|beta|rc|dev|nightly)([-._]|$)/i.test(text)
+}
+
 /** 归一化用户更新频道：stable | dev */
 export const normalizeUpdateChannel = (value) => {
   const text = String(value || '').trim().toLowerCase()
@@ -737,14 +748,23 @@ export async function downloadUpdate(downloadUrls, filename, onProgress) {
   throw new Error('无法打开浏览器下载链接')
 }
 
+/**
+ * 读取当前安装版本：
+ * 1. 原生包版本（Tauri/Capacitor）— 开发版 APK 可能带 -beta，优先于构建期注入
+ * 2. Vite 注入 VITE_APP_VERSION
+ * 3. 兜底 1.0.0
+ */
 export async function getCurrentVersion() {
-  if (import.meta.env.VITE_APP_VERSION) return import.meta.env.VITE_APP_VERSION
   try {
-    const version = await getNativeAppVersion()
-    return version || '1.0.0'
+    const native = await getNativeAppVersion()
+    const nativeText = String(native || '').trim()
+    if (nativeText) return nativeText.replace(/^v/i, '')
   } catch {
-    return '1.0.0'
+    // fall through
   }
+  const viteVersion = String(import.meta.env.VITE_APP_VERSION || '').trim()
+  if (viteVersion) return viteVersion.replace(/^v/i, '')
+  return '1.0.0'
 }
 
 export default {
@@ -759,5 +779,6 @@ export default {
   getSkippedVersion,
   setSkippedVersion,
   shouldOfferRelease,
-  isDevRelease
+  isDevRelease,
+  isCurrentInstallDev
 }

--- a/src/utils/updater_channel.spec.ts
+++ b/src/utils/updater_channel.spec.ts
@@ -5,6 +5,7 @@ import {
   buildUpdateDownloadUrls,
   getSkippedVersionKey,
   getUpdateChannel,
+  isCurrentInstallDev,
   isDevRelease,
   normalizeCdnManifestAsRelease,
   normalizeUpdateChannel,
@@ -112,6 +113,24 @@ describe('update channel (stable / dev)', () => {
     )
   })
 
+  it('detects current install identity from version string', () => {
+    expect(isCurrentInstallDev('1.4.3')).toBe(false)
+    expect(isCurrentInstallDev('1.4.3-beta.1')).toBe(true)
+    expect(isCurrentInstallDev('v1.4.3-dev.2')).toBe(true)
+    expect(isCurrentInstallDev('1.4.3-rc.1')).toBe(true)
+    expect(isCurrentInstallDev('')).toBe(false)
+  })
+
+  it('prefers native package version over Vite inject in getCurrentVersion', () => {
+    const updater = readSource('src/utils/updater.js')
+    expect(updater).toContain('getNativeAppVersion')
+    // 原生优先：先 await native，再 VITE_APP_VERSION
+    const nativeIdx = updater.indexOf('const native = await getNativeAppVersion()')
+    const viteIdx = updater.indexOf('import.meta.env.VITE_APP_VERSION')
+    expect(nativeIdx).toBeGreaterThan(-1)
+    expect(viteIdx).toBeGreaterThan(nativeIdx)
+  })
+
   it('wires UpdateDialog channel toggle and App autoCheck channel options', () => {
     const dialog = readSource('src/components/UpdateDialog.vue')
     const app = readSource('src/App.vue')
@@ -123,6 +142,9 @@ describe('update channel (stable / dev)', () => {
     expect(dialog).toContain('getUpdateChannel')
     expect(dialog).toContain('dev-latest')
     expect(dialog).toContain('handleChannelToggle')
+    expect(dialog).toContain('isCurrentInstallDev')
+    expect(dialog).toContain('当前安装')
+    expect(dialog).toContain('currentVersionLabel')
     expect(app).toContain('checkForUpdates(currentVersion, { channel })')
     expect(app).toContain('getSkippedVersion')
     expect(updater).toContain('DEV_MANIFEST_URL')
@@ -131,5 +153,6 @@ describe('update channel (stable / dev)', () => {
     expect(updater).toContain('fetchDevReleaseInfo')
     expect(updater).toContain('app.zip')
     expect(updater).toContain('preferDevZip')
+    expect(updater).toContain('isCurrentInstallDev')
   })
 })

--- a/src/utils/updater_download_sources.spec.ts
+++ b/src/utils/updater_download_sources.spec.ts
@@ -81,7 +81,9 @@ describe('update download sources', () => {
   it('renders the current version on the left and the target version on the right', () => {
     const source = readSource('src/components/UpdateDialog.vue')
 
-    expect(source).toContain('<div class="version-badge current">当前 v{{ currentVersion }}</div>')
+    expect(source).toContain('currentVersionLabel')
+    expect(source).toContain('当前 ·')
+    expect(source).toContain('isCurrentInstallDev')
     expect(source).toContain('<span class="arrow">→</span>')
     expect(source).toContain('version-badge new')
     expect(source).toContain('updateInfo.latestVersion')


### PR DESCRIPTION
## Summary
- **#308** 版本更新：原生包版本优先，`isCurrentInstallDev` 区分「当前安装」与「接收频道」
- **#309** 校园地图：legacy MultiMarker 增加 MarkerStyle；导览 normalize 坐标兼容；空点位提示
- **#310** 定位 maximumAge=0；小塔「到这」优先步行折线，失败再直线示意
- **#311** 小塔返回按钮 z-index 1000 + stop 事件
- **#312** 视口 bounds 扫描 + 格子缓存增量加载

Closes #307
Closes #308
Closes #309
Closes #310
Closes #311
Closes #312

## Test plan
- [x] vitest: updater_channel, towergo_map, TowerGoView, campus_map_contract
- [ ] 手测：开发版安装徽章、地图 pin、拖图加载车辆、返回可点