### PR TITLE
fix(ci): PRO/dev-latest 包内写入 beta 版本身份

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -241,6 +241,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
 
+      - name: Stamp beta app version into package sources
+        env:
+          BETA_VERSION: ${{ needs.meta.outputs.beta_version }}
+        run: node scripts/ci/stamp_app_version.mjs "$BETA_VERSION"
+
       - name: Initialize Android project
         run: npm run tauri android init
 
@@ -368,6 +373,12 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
 
+      - name: Stamp beta app version into package sources
+        shell: bash
+        env:
+          BETA_VERSION: ${{ needs.meta.outputs.beta_version }}
+        run: node scripts/ci/stamp_app_version.mjs "$BETA_VERSION"
+
       - name: Regenerate and verify official desktop icons
         shell: powershell
         run: |
@@ -443,6 +454,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Stamp beta app version into package sources
+        env:
+          BETA_VERSION: ${{ needs.meta.outputs.beta_version }}
+        run: node scripts/ci/stamp_app_version.mjs "$BETA_VERSION"
 
       - name: Regenerate and verify official desktop icons
         run: |
@@ -546,23 +562,40 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
 
+      - name: Stamp beta app version into package sources
+        env:
+          BETA_VERSION: ${{ needs.meta.outputs.beta_version }}
+        run: node scripts/ci/stamp_app_version.mjs "$BETA_VERSION"
+
       - name: Install Tauri CLI
         run: npm exec -- tauri --version
 
       - name: Build iOS app bundle
+        env:
+          BETA_VERSION: ${{ needs.meta.outputs.beta_version }}
         run: |
           set -euo pipefail
           node --input-type=module - <<'NODE'
           import fs from 'node:fs';
           const p = 'src-tauri/tauri.conf.json';
           const conf = JSON.parse(fs.readFileSync(p, 'utf8'));
+          const betaVersion = String(process.env.BETA_VERSION || '').trim();
           conf.build = conf.build || {};
           delete conf.build.devUrl;
           delete conf.build.beforeDevCommand;
           conf.build.beforeBuildCommand = 'npm run build && node scripts/check_dist_boundary.mjs';
           conf.build.frontendDist = conf.build.frontendDist || '../dist';
+          if (betaVersion) {
+            conf.version = betaVersion;
+            conf.bundle = conf.bundle || {};
+            conf.bundle.iOS = conf.bundle.iOS || {};
+            conf.bundle.iOS.bundleVersion = betaVersion.replace(/[^0-9]/g, '') || String(Date.now());
+          }
           fs.writeFileSync(p, JSON.stringify(conf, null, 2) + '\n');
-          console.log('Patched tauri.conf.json for iOS CI.');
+          console.log('Patched tauri.conf.json for iOS CI.', {
+            version: conf.version,
+            bundleVersion: conf.bundle?.iOS?.bundleVersion,
+          });
           NODE
 
           PYTHON_BIN=python source scripts/ci/setup_python_venv.sh
@@ -640,6 +673,8 @@ jobs:
             -sdk iphoneos \
             -destination "generic/platform=iOS" \
             -derivedDataPath build-ios \
+            MARKETING_VERSION="${BETA_VERSION}" \
+            CURRENT_PROJECT_VERSION="${BETA_VERSION//[^0-9]/}" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_IDENTITY="" \
@@ -666,6 +701,18 @@ jobs:
             echo "No iPhoneOS .app found under build-ios/Build/Products"
             find build-ios/Build/Products -maxdepth 6 -type d -print || true
             exit 1
+          fi
+
+          # Defense-in-depth: ensure installed app identity carries prerelease version.
+          PLIST="$APP_PATH/Info.plist"
+          if [ -f "$PLIST" ]; then
+            /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${BETA_VERSION}" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string ${BETA_VERSION}" "$PLIST"
+            BUILD_NUM="${BETA_VERSION//[^0-9]/}"
+            /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${BUILD_NUM}" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string ${BUILD_NUM}" "$PLIST"
+            echo "CFBundleShortVersionString=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$PLIST")"
+            echo "CFBundleVersion=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$PLIST")"
           fi
 
           APP_BIN="$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$APP_PATH/Info.plist" 2>/dev/null || basename "$APP_PATH" .app)"
@@ -734,6 +781,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Stamp beta app version into package sources
+        env:
+          BETA_VERSION: ${{ needs.meta.outputs.beta_version }}
+        run: node scripts/ci/stamp_app_version.mjs "$BETA_VERSION"
 
       - name: Regenerate and verify official desktop icons
         run: |

--- a/scripts/ci/stamp_app_version.mjs
+++ b/scripts/ci/stamp_app_version.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Stamp package / Tauri / Cargo marketing version for CI builds.
+ *
+ * Dev / PRO builds must write prerelease versions (e.g. 1.4.3-beta.123)
+ * into the sources that end up in the installed app identity:
+ * - package.json → Vite VITE_APP_VERSION
+ * - src-tauri/tauri.conf.json → Tauri getVersion / native marketing version
+ * - src-tauri/Cargo.toml → crate package.version (keep in sync)
+ *
+ * Usage:
+ *   node scripts/ci/stamp_app_version.mjs 1.4.3-beta.29143832544
+ *   APP_VERSION=1.4.3-beta.1 node scripts/ci/stamp_app_version.mjs
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '../..')
+
+const VERSION_RE = /^[0-9]+(?:\.[0-9]+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/
+
+export function normalizeAppVersion(raw) {
+  const text = String(raw || '')
+    .trim()
+    .replace(/^v/i, '')
+  if (!text) {
+    throw new Error('version is required (arg or APP_VERSION / BETA_VERSION env)')
+  }
+  if (!VERSION_RE.test(text)) {
+    throw new Error(`invalid app version: ${text}`)
+  }
+  return text
+}
+
+export function stampPackageJson(content, version) {
+  const data = JSON.parse(content)
+  data.version = version
+  return `${JSON.stringify(data, null, 2)}\n`
+}
+
+export function stampTauriConf(content, version) {
+  const data = JSON.parse(content)
+  data.version = version
+  return `${JSON.stringify(data, null, 2)}\n`
+}
+
+export function stampCargoToml(content, version) {
+  const text = String(content)
+  // Only rewrite the root package version in [package], not dependency versions.
+  const packageHeader = text.match(/^\[package\]\s*$/m)
+  if (!packageHeader || packageHeader.index == null) {
+    throw new Error('Cargo.toml missing [package] section')
+  }
+  const start = packageHeader.index
+  const rest = text.slice(start + packageHeader[0].length)
+  const nextHeader = rest.search(/\n\[/)
+  const packageBody = nextHeader === -1 ? rest : rest.slice(0, nextHeader)
+  const after = nextHeader === -1 ? '' : rest.slice(nextHeader)
+
+  if (!/^\s*version\s*=\s*"[^"]*"/m.test(packageBody)) {
+    throw new Error('Cargo.toml [package] missing version field')
+  }
+
+  const stampedBody = packageBody.replace(
+    /^(\s*version\s*=\s*")[^"]*(")/m,
+    `$1${version}$2`
+  )
+  return `${text.slice(0, start)}${packageHeader[0]}${stampedBody}${after}`
+}
+
+export function stampWorkspaceFiles(rootDir, version) {
+  const v = normalizeAppVersion(version)
+  const targets = [
+    {
+      rel: 'package.json',
+      stamp: stampPackageJson
+    },
+    {
+      rel: path.join('src-tauri', 'tauri.conf.json'),
+      stamp: stampTauriConf
+    },
+    {
+      rel: path.join('src-tauri', 'Cargo.toml'),
+      stamp: stampCargoToml
+    }
+  ]
+
+  const written = []
+  for (const target of targets) {
+    const full = path.join(rootDir, target.rel)
+    if (!fs.existsSync(full)) {
+      throw new Error(`missing file: ${target.rel}`)
+    }
+    const before = fs.readFileSync(full, 'utf8')
+    const after = target.stamp(before, v)
+    if (before !== after) {
+      fs.writeFileSync(full, after, 'utf8')
+    }
+    written.push(target.rel)
+  }
+  return { version: v, files: written }
+}
+
+function resolveCliVersion(argv = process.argv.slice(2), env = process.env) {
+  const fromArg = argv.find((item) => item && !item.startsWith('-'))
+  return fromArg || env.APP_VERSION || env.BETA_VERSION || env.VERSION || ''
+}
+
+function main() {
+  const version = resolveCliVersion()
+  const result = stampWorkspaceFiles(ROOT, version)
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        version: result.version,
+        files: result.files
+      },
+      null,
+      2
+    )
+  )
+}
+
+const isDirectRun =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isDirectRun) {
+  try {
+    main()
+  } catch (error) {
+    console.error(`[stamp_app_version] ${error instanceof Error ? error.message : error}`)
+    process.exit(1)
+  }
+}

--- a/scripts/ci/stamp_app_version.spec.mjs
+++ b/scripts/ci/stamp_app_version.spec.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  normalizeAppVersion,
+  stampCargoToml,
+  stampPackageJson,
+  stampTauriConf,
+  stampWorkspaceFiles
+} from './stamp_app_version.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function testNormalize() {
+  assert.equal(normalizeAppVersion('v1.4.3-beta.1'), '1.4.3-beta.1')
+  assert.equal(normalizeAppVersion('1.4.3'), '1.4.3')
+  assert.throws(() => normalizeAppVersion(''), /required/)
+  assert.throws(() => normalizeAppVersion('not-a-version'), /invalid/)
+}
+
+function testStampHelpers() {
+  const pkg = stampPackageJson('{"name":"x","version":"1.0.0"}\n', '1.4.3-beta.9')
+  assert.match(pkg, /"version": "1\.4\.3-beta\.9"/)
+
+  const conf = stampTauriConf('{"productName":"Mini","version":"1.0.0"}\n', '1.4.3-beta.9')
+  assert.match(conf, /"version": "1\.4\.3-beta\.9"/)
+
+  const cargo = stampCargoToml(
+    `[package]\nname = "hbut-helper"\nversion = "1.4.3"\nedition = "2021"\n\n[dependencies]\nserde = { version = "1.0" }\n`,
+    '1.4.3-beta.9'
+  )
+  assert.match(cargo, /\[package\][\s\S]*version = "1\.4\.3-beta\.9"/)
+  assert.match(cargo, /serde = \{ version = "1\.0" \}/)
+  assert.doesNotMatch(
+    cargo.replace(/\[package\][\s\S]*?(?=\n\[|$)/, ''),
+    /version = "1\.4\.3-beta\.9"/
+  )
+}
+
+function testWorkspaceStamp() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'stamp-app-version-'))
+  try {
+    fs.mkdirSync(path.join(tmp, 'src-tauri'), { recursive: true })
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'mini-hbut', version: '1.4.3' }, null, 2) + '\n',
+      'utf8'
+    )
+    fs.writeFileSync(
+      path.join(tmp, 'src-tauri', 'tauri.conf.json'),
+      JSON.stringify({ productName: 'Mini-HBUT', version: '1.4.3' }, null, 2) + '\n',
+      'utf8'
+    )
+    fs.writeFileSync(
+      path.join(tmp, 'src-tauri', 'Cargo.toml'),
+      `[package]\nname = "hbut-helper"\nversion = "1.4.3"\nedition = "2021"\n\n[dependencies]\nfoo = { version = "2.0" }\n`,
+      'utf8'
+    )
+
+    const result = stampWorkspaceFiles(tmp, '1.4.3-beta.29143832544')
+    assert.equal(result.version, '1.4.3-beta.29143832544')
+    assert.deepEqual(result.files, [
+      'package.json',
+      path.join('src-tauri', 'tauri.conf.json'),
+      path.join('src-tauri', 'Cargo.toml')
+    ])
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'package.json'), 'utf8'))
+    const conf = JSON.parse(
+      fs.readFileSync(path.join(tmp, 'src-tauri', 'tauri.conf.json'), 'utf8')
+    )
+    const cargo = fs.readFileSync(path.join(tmp, 'src-tauri', 'Cargo.toml'), 'utf8')
+    assert.equal(pkg.version, '1.4.3-beta.29143832544')
+    assert.equal(conf.version, '1.4.3-beta.29143832544')
+    assert.match(cargo, /^version = "1\.4\.3-beta\.29143832544"$/m)
+    assert.match(cargo, /foo = \{ version = "2\.0" \}/)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function testCliHelpPathExists() {
+  const script = path.join(__dirname, 'stamp_app_version.mjs')
+  assert.ok(fs.existsSync(script))
+  // Ensure module stays importable as ESM from CI.
+  assert.ok(pathToFileURL(script).href.startsWith('file:'))
+}
+
+testNormalize()
+testStampHelpers()
+testWorkspaceStamp()
+testCliHelpPathExists()
+console.log('stamp_app_version.spec.mjs: ok')

--- a/src/utils/updater_channel.spec.ts
+++ b/src/utils/updater_channel.spec.ts
@@ -131,6 +131,20 @@ describe('update channel (stable / dev)', () => {
     expect(viteIdx).toBeGreaterThan(nativeIdx)
   })
 
+  it('dev-build stamps beta marketing version before platform builds', () => {
+    const workflow = readSource('.github/workflows/dev-build.yml')
+    const stampScript = readSource('scripts/ci/stamp_app_version.mjs')
+    expect(stampScript).toContain('stampWorkspaceFiles')
+    expect(stampScript).toContain('package.json')
+    expect(stampScript).toContain('tauri.conf.json')
+    expect(stampScript).toContain('Cargo.toml')
+    // 每个平台构建 job 都应 stamp，避免仅改文件名
+    const stampMatches = workflow.match(/stamp_app_version\.mjs/g) || []
+    expect(stampMatches.length).toBeGreaterThanOrEqual(5)
+    expect(workflow).toContain('MARKETING_VERSION="${BETA_VERSION}"')
+    expect(workflow).toContain('CFBundleShortVersionString')
+  })
+
   it('wires UpdateDialog channel toggle and App autoCheck channel options', () => {
     const dialog = readSource('src/components/UpdateDialog.vue')
     const app = readSource('src/App.vue')


### PR DESCRIPTION
## Summary
- 根因：dev-build 只把 1.4.3-beta.<run_id> 用在产物文件名，包内 package.json / tauri.conf.json / Cargo.toml 与 iOS marketing version 仍是裸 1.4.3，所以 #308/#313 修好识别逻辑后，从 PRO/dev-latest 下载的测试包仍显示「当前安装正式版」。
- 新增 scripts/ci/stamp_app_version.mjs，在 Android / Windows / macOS / iOS / Linux 构建前 stamp beta 版本。
- iOS 额外设置 MARKETING_VERSION，打包时强制写入 CFBundleShortVersionString。
- 契约测试覆盖 workflow stamp 与 isCurrentInstallDev。

Closes #314

## Test plan
- [x] node scripts/ci/stamp_app_version.spec.mjs
- [x] npx vitest run src/utils/updater_channel.spec.ts
- [ ] 合并后跑一次 Dev Build，安装新 IPA/APK，检查更新应显示「当前 · 开发版 v1.4.3-beta.*」