### PR TITLE
fix(map): #369 校园导览手绘/POI + #370 小塔坐标GPS调试日志

### DIFF
--- a/src/components/TowerGoView.vue
+++ b/src/components/TowerGoView.vue
@@ -21,6 +21,7 @@ import {
   type TowerGoPoint,
   type TowerGoVehicle
 } from '../utils/towergo_map'
+import { pushDebugLog } from '../utils/debug_logger'
 import { loadTencentMap, toTencentLatLng } from '../utils/tencent_map_loader'
 
 defineProps({
@@ -170,13 +171,26 @@ const toTMapLatLng = (point: TowerGoPoint) => {
   return toTencentLatLng(TMap, { latitude: point.latitude, longitude: point.longitude })
 }
 
-/** Apple Maps 风格：用户蓝点 + 车辆青绿 pin（SVG data URL → MarkerStyle） */
+/** 用户蓝点 / 车辆 pin：iOS WKWebView 对 charset=UTF-8 的 SVG data URL 常不渲染，改用 base64 */
+const svgToDataUrl = (svg: string) => {
+  try {
+    const encoded =
+      typeof btoa === 'function'
+        ? btoa(unescape(encodeURIComponent(svg)))
+        : ''
+    if (encoded) return `data:image/svg+xml;base64,${encoded}`
+  } catch {
+    // fall through
+  }
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
+}
+
 const appleUserDotSvg = () => {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewBox="0 0 44 44">
     <circle cx="22" cy="22" r="10" fill="#007AFF" stroke="#ffffff" stroke-width="3"/>
     <circle cx="22" cy="22" r="18" fill="none" stroke="#007AFF" stroke-opacity="0.28" stroke-width="4"/>
   </svg>`
-  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
+  return svgToDataUrl(svg)
 }
 
 const appleVehiclePinSvg = (active = false) => {
@@ -186,7 +200,7 @@ const appleVehiclePinSvg = (active = false) => {
     <circle cx="20" cy="17" r="7" fill="#fff"/>
     <path d="M14 18h12l-1.2-4.2a3 3 0 0 0-2.9-2.3h-3.8a3 3 0 0 0-2.9 2.3L14 18zm1.5 1.5h9v2.2a1.2 1.2 0 0 1-1.2 1.2h-6.6a1.2 1.2 0 0 1-1.2-1.2v-2.2z" fill="${fill}"/>
   </svg>`
-  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`
+  return svgToDataUrl(svg)
 }
 
 const buildTowerGoMarkerStyles = (TMap: any) => {
@@ -196,9 +210,9 @@ const buildTowerGoMarkerStyles = (TMap: any) => {
       ? (opts: Record<string, unknown>) => new TMap.MarkerStyle(opts)
       : (opts: Record<string, unknown>) => ({ ...opts })
   styles.user = makeStyle({
-    width: 36,
-    height: 36,
-    anchor: { x: 18, y: 18 },
+    width: 40,
+    height: 40,
+    anchor: { x: 20, y: 20 },
     src: appleUserDotSvg()
   })
   styles.vehicle = makeStyle({
@@ -216,31 +230,62 @@ const buildTowerGoMarkerStyles = (TMap: any) => {
   return styles
 }
 
-const initMap = async () => {
+const ensureUserLocationMarker = (point: TowerGoPoint) => {
+  if (!mapInstance.value || !(window as any).TMap) return
+  const TMap = (window as any).TMap
+  const styles = buildTowerGoMarkerStyles(TMap)
+  const center = toTMapLatLng(point)
+  const geometry = {
+    id: 'center',
+    styleId: 'user',
+    position: center,
+    properties: { title: point.name || '当前位置' }
+  }
+  if (!centerMarkerLayer.value) {
+    centerMarkerLayer.value = new TMap.MultiMarker({
+      map: mapInstance.value,
+      styles,
+      geometries: [geometry],
+      zIndex: 200
+    })
+    return
+  }
+  centerMarkerLayer.value.setStyles?.(styles)
+  centerMarkerLayer.value.setGeometries?.([geometry])
+}
+
+const initMap = async (retry = 0): Promise<void> => {
   const container = mapContainerRef.value
   if (!container || mapInstance.value) return
   if (!container.offsetWidth || !container.offsetHeight) {
+    // iOS 首帧容器常为 0：重试而非直接 fallback
+    if (retry < 8) {
+      mapScriptState.value = 'loading'
+      await new Promise((r) => window.setTimeout(r, 120 + retry * 80))
+      return initMap(retry + 1)
+    }
     mapScriptState.value = 'fallback'
+    mapErrors.value = ['地图容器尺寸为 0，请返回后重试']
+    pushDebugLog('TowerGo', '地图初始化失败：容器尺寸为 0', 'error')
     return
   }
   try {
     mapScriptState.value = 'loading'
     const TMap = await loadTencentMap(TOWERGO_CONFIG.qqMapKey)
     const center = toTMapLatLng(currentLocation.value)
-    mapInstance.value = new TMap.Map(container, { center, zoom: 16, viewMode: '2D' })
-    const styles = buildTowerGoMarkerStyles(TMap)
-    centerMarkerLayer.value = new TMap.MultiMarker({
-      map: mapInstance.value,
-      styles,
-      geometries: [{
-        id: 'center',
-        styleId: 'user',
-        position: center,
-        properties: { title: currentLocation.value.name || '当前位置' }
-      }]
-    })
+    mapInstance.value = new TMap.Map(container, { center, zoom: 16, viewMode: '2D', showControl: false })
+    ensureUserLocationMarker(currentLocation.value)
     bindMapViewportScan()
     mapScriptState.value = 'ready'
+    pushDebugLog(
+      'TowerGo',
+      `地图就绪 size=${container.offsetWidth}x${container.offsetHeight}`,
+      'info',
+      {
+        lat: currentLocation.value.latitude,
+        lng: currentLocation.value.longitude
+      }
+    )
     // 地图就绪后主动扫一次当前视野（不依赖 idle 是否触发）
     window.setTimeout(() => {
       void scanViewportVehicles()
@@ -248,6 +293,7 @@ const initMap = async () => {
   } catch (error) {
     mapScriptState.value = 'fallback'
     mapErrors.value = [(error as Error)?.message || '地图加载失败']
+    pushDebugLog('TowerGo', `地图加载失败: ${(error as Error)?.message || error}`, 'error')
   }
 }
 
@@ -256,15 +302,13 @@ const updateMapCenter = (point: TowerGoPoint) => {
   if (!mapInstance.value || !(window as any).TMap) return
   const center = toTMapLatLng(point)
   mapInstance.value.setCenter(center)
-  const TMap = (window as any).TMap
-  const styles = buildTowerGoMarkerStyles(TMap)
-  centerMarkerLayer.value?.setStyles?.(styles)
-  centerMarkerLayer.value?.setGeometries?.([{
-    id: 'center',
-    styleId: 'user',
-    position: center,
-    properties: { title: point.name || '当前位置' }
-  }])
+  ensureUserLocationMarker(point)
+  pushDebugLog(
+    'TowerGo',
+    `地图已更新自身位置 lat=${point.latitude.toFixed(6)} lng=${point.longitude.toFixed(6)} source=${point.source || 'unknown'}`,
+    'info',
+    point
+  )
 }
 
 const renderVehicleMarkers = () => {
@@ -288,13 +332,15 @@ const renderVehicleMarkers = () => {
       map: mapInstance.value,
       styles,
       geometries,
-      zIndex: 80
+      zIndex: 120
     })
     vehicleMarkerLayer.value.on?.('click', (event: any) => {
       const id = event?.geometry?.id
       const item = vehicles.value.find((vehicle) => vehicle.id === id || vehicle.imei === id)
       if (item) selectVehicle(item)
     })
+    // 保证用户蓝点在车辆之上
+    ensureUserLocationMarker(currentLocation.value)
     return
   }
   vehicleMarkerLayer.value.setStyles?.(styles)
@@ -618,11 +664,25 @@ const loadMapData = async (
       .map((item) => item.msg)
     lastScanAt.value = Date.now()
     mapDataReady.value = true
+    const sample = vehicles.value.slice(0, 3).map((v) => ({
+      id: v.id || v.imei,
+      lat: v.latitude,
+      lng: v.longitude,
+      dist: v.distance
+    }))
+    pushDebugLog(
+      'TowerGo',
+      `车辆扫描完成 count=${vehicles.value.length} serviceId=${sid}`,
+      'info',
+      { count: vehicles.value.length, serviceId: sid, sample, origin: point }
+    )
     renderVehicleMarkers()
+    ensureUserLocationMarker(point)
     renderFenceLayers()
   } catch (error) {
     vehicles.value = []
     mapErrors.value = [(error as Error)?.message || '地图数据加载失败']
+    pushDebugLog('TowerGo', `地图数据加载失败: ${(error as Error)?.message || error}`, 'error')
   } finally {
     scanProgress.value = null
     loadingMap.value = false
@@ -785,12 +845,19 @@ onBeforeUnmount(() => {
 
     <!-- 地图全屏 -->
     <section v-show="activeTab === 'map'" class="tg-map-panel tg-map-panel--fs">
-      <div ref="mapContainerRef" class="tg-map tg-map--fs">
-        <div v-if="mapScriptState === 'fallback' || !mapDataReady" class="map-fallback">
-          <span class="material-symbols-outlined">electric_bike</span>
-          <strong>{{ currentLocation.name || '湖北工业大学' }}</strong>
-          <p>{{ mapErrors[0] || '地图加载中，车辆数据会继续刷新。' }}</p>
-        </div>
+      <!-- 地图容器必须独占 DOM，fallback 不可塞进 map 节点内（#370） -->
+      <div ref="mapContainerRef" class="tg-map tg-map--fs" />
+      <div
+        v-if="mapScriptState === 'fallback' || (mapScriptState !== 'ready' && !mapDataReady)"
+        class="map-fallback map-fallback--overlay"
+      >
+        <span class="material-symbols-outlined">electric_bike</span>
+        <strong>{{ currentLocation.name || '湖北工业大学' }}</strong>
+        <p>{{ mapErrors[0] || '地图加载中，车辆数据会继续刷新。' }}</p>
+        <small v-if="currentLocation.latitude">
+          定位 {{ currentLocation.latitude.toFixed(5) }}, {{ currentLocation.longitude.toFixed(5) }}
+          <template v-if="currentLocation.source"> · {{ currentLocation.source }}</template>
+        </small>
       </div>
       <div class="map-toolbar map-toolbar--fs">
         <button :disabled="locating || loadingMap" @click="refreshBySystemLocation">
@@ -1176,14 +1243,27 @@ onBeforeUnmount(() => {
   padding: 24px;
 }
 
+.map-fallback--overlay {
+  z-index: 8;
+  pointer-events: none;
+  background: color-mix(in srgb, var(--ui-surface, #f8fafc) 72%, transparent);
+  backdrop-filter: blur(2px);
+}
+
 .map-fallback .material-symbols-outlined {
   font-size: 52px;
   color: var(--ui-primary, #2563eb);
 }
 
-.map-fallback p {
+.map-fallback p,
+.map-fallback small {
   margin: 0;
   color: var(--ui-muted, #475569);
+}
+
+.map-fallback small {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
 }
 
 .map-toolbar {

--- a/src/composables/useGeolocation.ts
+++ b/src/composables/useGeolocation.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { pushDebugLog } from '../utils/debug_logger'
 
 export interface GeoPosition {
   latitude: number
@@ -24,11 +25,16 @@ export function useGeolocation() {
   async function getCurrentPosition(timeout = 10000, maximumAge = 5000): Promise<GeoPosition> {
     if (!available.value) {
       lastError.value = '当前设备不支持定位'
+      pushDebugLog('Geo', lastError.value, 'warn', { available: false })
       throw new Error(lastError.value)
     }
 
     loading.value = true
     lastError.value = ''
+    pushDebugLog('Geo', `定位请求开始 timeout=${timeout}ms maximumAge=${maximumAge}`, 'debug', {
+      timeout,
+      maximumAge
+    })
 
     return new Promise<GeoPosition>((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(
@@ -40,6 +46,18 @@ export function useGeolocation() {
           }
           lastPosition.value = result
           loading.value = false
+          // #370：写入设置调试信息
+          pushDebugLog(
+            'Geo',
+            `定位成功 lat=${result.latitude.toFixed(6)} lng=${result.longitude.toFixed(6)} ±${Math.round(result.accuracy || 0)}m`,
+            'info',
+            {
+              latitude: result.latitude,
+              longitude: result.longitude,
+              accuracy: result.accuracy,
+              source: 'system'
+            }
+          )
           resolve(result)
         },
         (err) => {
@@ -57,6 +75,10 @@ export function useGeolocation() {
             default:
               lastError.value = '定位失败'
           }
+          pushDebugLog('Geo', `定位失败: ${lastError.value}`, 'error', {
+            code: err.code,
+            message: err.message
+          })
           reject(new Error(lastError.value))
         },
         {

--- a/src/features/campus-guide/map/campus-map-core.ts
+++ b/src/features/campus-guide/map/campus-map-core.ts
@@ -1,3 +1,4 @@
+import { pushDebugLog } from '../../../utils/debug_logger'
 import { CAMPUS_GUIDE_CONFIG } from '../config'
 import type { CampusSpot, GeoPoint } from '../types'
 import { applyMarkerDodge, visibleDodgedSpots } from './marker-dodge'
@@ -28,11 +29,14 @@ export class CampusMapCore {
   private locationLayer: TencentLayer | null = null
   private polylineLayer: TencentLayer | null = null
   private customLayer: TencentLayer | null = null
+  private customLayerReady = false
+  private customLayerRetries = 0
   private spotMap = new Map<string, CampusSpot>()
   private lastSpots: CampusSpot[] = []
   private lastSelectedSpotId?: string | number
   private lastSpotSignature = ''
   private zoomRefreshTimer: ReturnType<typeof setTimeout> | null = null
+  private customLayerRetryTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(container: HTMLElement, options: CampusMapCoreOptions) {
     this.container = container
@@ -54,13 +58,16 @@ export class CampusMapCore {
       draggable: true,
       scrollable: true,
       doubleClickZoom: true,
+      // 手绘层优先：减少 2D 楼块/兴趣点遮挡自定义瓦片（#369 iOS）
       baseMap: {
         type: 'vector',
-        features: ['base', 'building2d', 'point']
+        features: ['base']
       }
     })
 
+    // 首帧 container 在 iOS 上常为 0 尺寸，延后 + 重试挂载手绘层
     await this.mountCustomLayer()
+    this.scheduleCustomLayerRetry()
     this.renderAoi()
     this.bindZoomRefresh()
     return this.map
@@ -113,20 +120,86 @@ export class CampusMapCore {
     })
   }
 
+  private scheduleCustomLayerRetry() {
+    if (this.customLayerReady || this.customLayerRetries >= 4) return
+    if (this.customLayerRetryTimer) clearTimeout(this.customLayerRetryTimer)
+    const delay = 400 + this.customLayerRetries * 500
+    this.customLayerRetryTimer = setTimeout(() => {
+      this.customLayerRetryTimer = null
+      void this.mountCustomLayer()
+      this.scheduleCustomLayerRetry()
+    }, delay)
+  }
+
   private async mountCustomLayer() {
-    if (!this.TMap || !this.map) return
+    if (!this.TMap || !this.map || this.customLayerReady) return
+    const layerId = CAMPUS_GUIDE_CONFIG.customLayerId
+    const w = this.container?.clientWidth || 0
+    const h = this.container?.clientHeight || 0
     try {
-      const layer = await this.TMap.ImageTileLayer.createCustomLayer({
-        layerId: CAMPUS_GUIDE_CONFIG.customLayerId,
+      // 尺寸为 0 时创建的自定义层在 iOS WKWebView 上常不可见（不计入失败次数）
+      if (w < 8 || h < 8) {
+        pushDebugLog(
+          'CampusGuide',
+          `手绘层延后挂载（容器未就绪） size=${w}x${h}`,
+          'warn',
+          { layerId, size: `${w}x${h}` }
+        )
+        return
+      }
+      this.customLayerRetries += 1
+      const attempt = this.customLayerRetries
+      // 仅触发 SDK resize，避免递归 schedule
+      const map = this.map as { resize?: () => void } | null
+      map?.resize?.()
+      const create = this.TMap.ImageTileLayer?.createCustomLayer
+      if (typeof create !== 'function') {
+        pushDebugLog('CampusGuide', 'ImageTileLayer.createCustomLayer 不可用', 'error', { layerId })
+        return
+      }
+      // 销毁半成品层再挂，避免 iOS 重复创建失败
+      if (this.customLayer) {
+        try {
+          this.customLayer.setMap?.(null)
+          this.customLayer.destroy?.()
+        } catch {
+          // ignore
+        }
+        this.customLayer = null
+      }
+      const layer = await create({
+        layerId,
         map: this.map,
         minZoom: CAMPUS_GUIDE_CONFIG.minZoom,
         maxZoom: CAMPUS_GUIDE_CONFIG.maxZoom,
-        zIndex: 1,
+        zIndex: 2,
         opacity: 1
       })
-      if (layer) this.customLayer = layer
-    } catch {
-      // 手绘图层鉴权失败时保留标准底图
+      if (layer) {
+        this.customLayer = layer
+        this.customLayerReady = true
+        pushDebugLog(
+          'CampusGuide',
+          `手绘层挂载成功 attempt=${attempt} layerId=${layerId}`,
+          'info',
+          { layerId, attempt, size: `${w}x${h}` }
+        )
+        return
+      }
+      pushDebugLog(
+        'CampusGuide',
+        `手绘层返回空 attempt=${attempt} layerId=${layerId}`,
+        'warn',
+        { layerId, attempt }
+      )
+    } catch (err) {
+      pushDebugLog(
+        'CampusGuide',
+        `手绘层挂载失败 attempt=${attempt}: ${(err as Error)?.message || err}`,
+        'error',
+        { layerId, attempt, err }
+      )
+      // 手绘图层鉴权/瓦片失败时保留标准底图
     }
   }
 
@@ -275,6 +348,8 @@ export class CampusMapCore {
   resize() {
     const map = this.map as { resize?: () => void } | null
     map?.resize?.()
+    // iOS 首屏旋转/壳层高度变化后补挂手绘层
+    if (!this.customLayerReady) this.scheduleCustomLayerRetry()
   }
 
   fitPoints(points: GeoPoint[]) {
@@ -293,6 +368,10 @@ export class CampusMapCore {
       clearTimeout(this.zoomRefreshTimer)
       this.zoomRefreshTimer = null
     }
+    if (this.customLayerRetryTimer) {
+      clearTimeout(this.customLayerRetryTimer)
+      this.customLayerRetryTimer = null
+    }
     this.markerLayer?.destroy?.()
     this.aoiLayer?.destroy?.()
     this.locationLayer?.destroy?.()
@@ -304,6 +383,8 @@ export class CampusMapCore {
     this.locationLayer = null
     this.polylineLayer = null
     this.customLayer = null
+    this.customLayerReady = false
+    this.customLayerRetries = 0
     this.map = null
     this.TMap = null
     this.spotMap.clear()

--- a/src/features/campus-guide/map/campus-map-core.ts
+++ b/src/features/campus-guide/map/campus-map-core.ts
@@ -31,6 +31,8 @@ export class CampusMapCore {
   private customLayer: TencentLayer | null = null
   private customLayerReady = false
   private customLayerRetries = 0
+  /** 含尺寸未就绪的调度次数上限，避免容器长期 0 尺寸时无限 timer */
+  private customLayerScheduleCount = 0
   private spotMap = new Map<string, CampusSpot>()
   private lastSpots: CampusSpot[] = []
   private lastSelectedSpotId?: string | number
@@ -121,9 +123,11 @@ export class CampusMapCore {
   }
 
   private scheduleCustomLayerRetry() {
-    if (this.customLayerReady || this.customLayerRetries >= 4) return
+    if (this.customLayerReady) return
+    if (this.customLayerRetries >= 4 || this.customLayerScheduleCount >= 10) return
     if (this.customLayerRetryTimer) clearTimeout(this.customLayerRetryTimer)
-    const delay = 400 + this.customLayerRetries * 500
+    this.customLayerScheduleCount += 1
+    const delay = 400 + Math.min(this.customLayerScheduleCount, 6) * 350
     this.customLayerRetryTimer = setTimeout(() => {
       this.customLayerRetryTimer = null
       void this.mountCustomLayer()
@@ -136,6 +140,7 @@ export class CampusMapCore {
     const layerId = CAMPUS_GUIDE_CONFIG.customLayerId
     const w = this.container?.clientWidth || 0
     const h = this.container?.clientHeight || 0
+    let attempt = this.customLayerRetries
     try {
       // 尺寸为 0 时创建的自定义层在 iOS WKWebView 上常不可见（不计入失败次数）
       if (w < 8 || h < 8) {
@@ -148,7 +153,7 @@ export class CampusMapCore {
         return
       }
       this.customLayerRetries += 1
-      const attempt = this.customLayerRetries
+      attempt = this.customLayerRetries
       // 仅触发 SDK resize，避免递归 schedule
       const map = this.map as { resize?: () => void } | null
       map?.resize?.()
@@ -385,6 +390,7 @@ export class CampusMapCore {
     this.customLayer = null
     this.customLayerReady = false
     this.customLayerRetries = 0
+    this.customLayerScheduleCount = 0
     this.map = null
     this.TMap = null
     this.spotMap.clear()

--- a/src/features/campus-guide/map/map-theme.css
+++ b/src/features/campus-guide/map/map-theme.css
@@ -248,25 +248,40 @@
 .campus-guide-entrance-floating {
   position: absolute;
   right: 14px;
-  bottom: 180px;
+  /* 高于 POI 详情层，避免与底部卡片重叠 */
+  bottom: calc(200px + var(--app-safe-bottom, env(safe-area-inset-bottom, 0px)));
   width: 220px;
 }
 
+/* #369：抬高详情层，避开 iOS Home 指示条 / 壳层底栏 */
 .campus-guide-poi-layer {
   position: absolute;
   left: 12px;
   right: 12px;
-  bottom: 12px;
+  bottom: calc(16px + var(--app-safe-bottom, env(safe-area-inset-bottom, 0px)) + 52px);
   z-index: 40;
+  max-height: min(44vh, 340px);
+  display: flex;
+  flex-direction: column;
+  pointer-events: none;
+}
+
+.campus-guide-poi-layer > * {
+  pointer-events: auto;
 }
 
 .campus-poi-card {
   position: relative;
   padding: 14px 14px 12px;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.98);
+  background: var(--ui-surface, rgba(255, 255, 255, 0.98));
+  color: var(--ui-text, #0f172a);
+  border: 1px solid var(--ui-surface-border, rgba(15, 23, 42, 0.08));
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.22);
   backdrop-filter: blur(8px);
+  max-height: inherit;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .campus-poi-close {
@@ -276,7 +291,7 @@
   border: none;
   background: transparent;
   font-size: 22px;
-  color: #94a3b8;
+  color: var(--ui-muted, #94a3b8);
   cursor: pointer;
 }
 
@@ -285,23 +300,25 @@
   justify-content: space-between;
   gap: 12px;
   align-items: baseline;
+  padding-right: 28px;
 }
 
 .campus-poi-head h3 {
   margin: 0;
   font-size: 18px;
-  color: #0f172a;
+  color: var(--ui-text, #0f172a);
 }
 
 .campus-poi-head span {
-  color: #0074cf;
+  color: var(--ui-primary, #0074cf);
   font-size: 13px;
   font-weight: 600;
+  flex-shrink: 0;
 }
 
 .campus-poi-desc {
   margin: 8px 0 0;
-  color: #64748b;
+  color: var(--ui-muted, #64748b);
   font-size: 13px;
   line-height: 1.5;
   display: -webkit-box;
@@ -318,19 +335,19 @@
 }
 
 .campus-poi-actions button {
-  border: 1px solid rgba(0, 116, 207, 0.18);
+  border: 1px solid color-mix(in oklab, var(--ui-primary, #0074cf) 22%, transparent);
   border-radius: 12px;
   padding: 8px 6px;
-  background: #fff;
-  color: #0074cf;
+  background: var(--ui-surface, #fff);
+  color: var(--ui-primary, #0074cf);
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
 }
 
 .campus-poi-actions button.primary {
-  background: #0074cf;
-  border-color: #0074cf;
+  background: var(--ui-primary, #0074cf);
+  border-color: var(--ui-primary, #0074cf);
   color: #fff;
 }
 
@@ -619,19 +636,86 @@
   border: 1px solid var(--ui-surface-border, rgba(15, 23, 42, 0.08));
 }
 
+/* #369：系统暗色 + 应用 graphite_night / html.dark 统一可读对比度 */
 @media (prefers-color-scheme: dark) {
   .campus-guide-fab,
   .campus-guide-search,
   .campus-notice-bar,
   .campus-guide-tabs button,
   .campus-entrance-menu button,
-  .campus-guide-entrance-floating button,
-  .campus-poi-card {
+  .campus-guide-entrance-floating button {
     background: rgba(15, 23, 42, 0.9);
     color: #e2e8f0;
   }
 
-  .campus-poi-actions button {
-    background: rgba(15, 23, 42, 0.7);
+  .campus-poi-card {
+    background: rgba(30, 41, 59, 0.96);
+    color: #f1f5f9;
+    border-color: rgba(148, 163, 184, 0.22);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
   }
+
+  .campus-poi-head h3 {
+    color: #f8fafc;
+  }
+
+  .campus-poi-head span {
+    color: #7dd3fc;
+  }
+
+  .campus-poi-desc {
+    color: #cbd5e1;
+  }
+
+  .campus-poi-close {
+    color: #94a3b8;
+  }
+
+  .campus-poi-actions button {
+    background: rgba(15, 23, 42, 0.85);
+    color: #e0f2fe;
+    border-color: rgba(125, 211, 252, 0.35);
+  }
+
+  .campus-poi-actions button.primary {
+    background: #0284c7;
+    border-color: #0284c7;
+    color: #fff;
+  }
+}
+
+html.dark .campus-poi-card,
+html[data-theme='graphite_night'] .campus-poi-card {
+  background: rgba(30, 41, 59, 0.96);
+  color: #f1f5f9;
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+html.dark .campus-poi-head h3,
+html[data-theme='graphite_night'] .campus-poi-head h3 {
+  color: #f8fafc;
+}
+
+html.dark .campus-poi-head span,
+html[data-theme='graphite_night'] .campus-poi-head span {
+  color: #7dd3fc;
+}
+
+html.dark .campus-poi-desc,
+html[data-theme='graphite_night'] .campus-poi-desc {
+  color: #cbd5e1;
+}
+
+html.dark .campus-poi-actions button,
+html[data-theme='graphite_night'] .campus-poi-actions button {
+  background: rgba(15, 23, 42, 0.85);
+  color: #e0f2fe;
+  border-color: rgba(125, 211, 252, 0.35);
+}
+
+html.dark .campus-poi-actions button.primary,
+html[data-theme='graphite_night'] .campus-poi-actions button.primary {
+  background: #0284c7;
+  border-color: #0284c7;
+  color: #fff;
 }

--- a/src/features/campus-guide/services/location-service.ts
+++ b/src/features/campus-guide/services/location-service.ts
@@ -1,4 +1,5 @@
 import { useGeolocation } from '../../../composables/useGeolocation'
+import { pushDebugLog } from '../../../utils/debug_logger'
 import { HBUT_LOCATION, normalizePoint } from '../../../utils/towergo_map'
 import type { GeoPoint } from '../types'
 import { isPointInAoi } from '../utils/geo'
@@ -25,20 +26,43 @@ export const writeMockLocation = (point: GeoPoint | null) => {
 
 export const resolveCampusLocation = async (): Promise<GeoPoint> => {
   const mock = readMockLocation()
-  if (mock) return { ...mock, name: mock.name || '模拟定位' }
+  if (mock) {
+    const point = { ...mock, name: mock.name || '模拟定位' }
+    pushDebugLog(
+      'CampusGuide',
+      `定位结果 source=mock lat=${point.latitude} lng=${point.longitude}`,
+      'info',
+      point
+    )
+    return point
+  }
 
   const geo = useGeolocation()
   try {
     // 缩短 maximumAge：避免 iOS 把缓存的旧坐标（校外）当成当前
     const position = await geo.getCurrentPosition(12000, 0)
-    return {
+    const point = {
       latitude: position.latitude,
       longitude: position.longitude,
       accuracy: position.accuracy,
       name: '当前位置'
     }
-  } catch {
-    return { ...HBUT_LOCATION, name: HBUT_LOCATION.name || '湖北工业大学' }
+    pushDebugLog(
+      'CampusGuide',
+      `定位结果 source=system lat=${point.latitude.toFixed(6)} lng=${point.longitude.toFixed(6)} ±${Math.round(point.accuracy || 0)}m`,
+      'info',
+      { ...point, source: 'system' }
+    )
+    return point
+  } catch (err) {
+    const fallback = { ...HBUT_LOCATION, name: HBUT_LOCATION.name || '湖北工业大学' }
+    pushDebugLog(
+      'CampusGuide',
+      `定位回退校区中心: ${(err as Error)?.message || err}`,
+      'warn',
+      { ...fallback, source: 'fallback' }
+    )
+    return fallback
   }
 }
 

--- a/src/utils/campus_guide_bridge_contract.spec.ts
+++ b/src/utils/campus_guide_bridge_contract.spec.ts
@@ -50,6 +50,16 @@ describe('campus guide bridge contract', () => {
     expect(home).toContain('NoticeBar')
     expect(home).toContain('openYunyou')
     expect(home).toContain('openPunch')
+    // #369：手绘层重试 + POI 暗色/安全区
+    const core = read('src/features/campus-guide/map/campus-map-core.ts')
+    expect(core).toContain('mountCustomLayer')
+    expect(core).toContain('scheduleCustomLayerRetry')
+    expect(core).toContain('pushDebugLog')
+    expect(core).toContain("features: ['base']")
+    const theme = read('src/features/campus-guide/map/map-theme.css')
+    expect(theme).toContain('--app-safe-bottom')
+    expect(theme).toContain("html[data-theme='graphite_night'] .campus-poi-card")
+    expect(theme).toContain('html.dark .campus-poi-head h3')
   })
 
   it('resolves campus-guide API base: iOS/desktop loopback, Android without 127.0.0.1', () => {

--- a/src/utils/debug_logger.ts
+++ b/src/utils/debug_logger.ts
@@ -80,7 +80,14 @@ const notifyListeners = () => {
       // ignore
     }
   })
-  window.dispatchEvent(new CustomEvent(LOG_EVENT))
+  // Node/Vitest 无 window（#370 定位日志在单测中调用）
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    try {
+      window.dispatchEvent(new CustomEvent(LOG_EVENT))
+    } catch {
+      // ignore
+    }
+  }
 }
 
 const pushRecord = (level: DebugLevel, args: unknown[]) => {

--- a/src/utils/towergo_bridge_contract.spec.ts
+++ b/src/utils/towergo_bridge_contract.spec.ts
@@ -5,6 +5,24 @@ import { describe, expect, it } from 'vitest'
 const read = (relativePath: string) => readFileSync(path.join(process.cwd(), relativePath), 'utf8')
 
 describe('towergo bridge and location permission contract', () => {
+  it('#370 writes location to debug log and keeps map container exclusive', () => {
+    const mapUtil = read('src/utils/towergo_map.ts')
+    const view = read('src/components/TowerGoView.vue')
+    const geo = read('src/composables/useGeolocation.ts')
+    const guideLoc = read('src/features/campus-guide/services/location-service.ts')
+    expect(mapUtil).toContain('pushDebugLog')
+    expect(mapUtil).toContain('coerceChinaLatLng')
+    expect(mapUtil).toContain('carLat')
+    expect(view).toContain('ensureUserLocationMarker')
+    expect(view).toContain('map-fallback--overlay')
+    expect(view).toContain('svgToDataUrl')
+    // 地图节点必须自闭合独占，fallback 作为兄弟节点
+    expect(view).toMatch(/ref="mapContainerRef" class="tg-map tg-map--fs"\s*\/>/)
+    expect(geo).toContain("pushDebugLog('Geo'")
+    expect(guideLoc).toContain("pushDebugLog(")
+    expect(guideLoc).toContain('CampusGuide')
+  })
+
   it('keeps the TowerGo proxy isolated from the main Mini-HBUT /api bridge', () => {
     const vite = read('vite.config.ts')
     const bridge = read('src-tauri/src/http_server.rs')

--- a/src/utils/towergo_map.spec.ts
+++ b/src/utils/towergo_map.spec.ts
@@ -53,7 +53,9 @@ describe('towergo map utilities', () => {
       maxDriftMeters: 2000
     })
 
-    expect(drifted).toEqual({ ...HBUT_LOCATION, source: 'fallback' })
+    expect(drifted.source).toBe('fallback')
+    expect(drifted.latitude).toBe(HBUT_LOCATION.latitude)
+    expect(drifted.longitude).toBe(HBUT_LOCATION.longitude)
   })
 
   it('keeps system location when within the campus threshold', async () => {
@@ -111,6 +113,38 @@ describe('towergo map utilities', () => {
     expect(deduped.map((item) => item.id)).toEqual(['A', 'B'])
     expect(deduped[0].battery).toBe(80)
     expect(deduped[0].distance).toBeLessThan(deduped[1].distance)
+  })
+
+  it('#370 swaps inverted lat/lng and reads nested/alias vehicle fields', () => {
+    // 常见写反：lat=114.x lng=30.x
+    expect(normalizePoint({ lat: 114.313, lng: 30.482 })).toEqual({
+      latitude: 30.482,
+      longitude: 114.313
+    })
+    const nested = normalizeVehicles(
+      {
+        data: {
+          deviceList: [
+            {
+              car_id: 'C1',
+              location: { carLat: 30.483, carLng: 114.314 },
+              restBattery: 66
+            },
+            {
+              imei: 'IMEI2',
+              lat: 114.32,
+              lng: 30.485,
+              battery: 40
+            }
+          ]
+        }
+      },
+      HBUT_LOCATION
+    )
+    expect(nested.length).toBe(2)
+    expect(nested[0].latitude).toBeCloseTo(30.483, 3)
+    expect(nested[0].longitude).toBeCloseTo(114.314, 3)
+    expect(nested.some((v) => v.latitude > 70)).toBe(false)
   })
 
   it('reduces scan point count as spacing increases without dropping below minimum coverage', () => {

--- a/src/utils/towergo_map.ts
+++ b/src/utils/towergo_map.ts
@@ -1,3 +1,5 @@
+import { pushDebugLog } from './debug_logger'
+
 export interface TowerGoPoint {
   name?: string
   latitude: number
@@ -25,18 +27,20 @@ export const HBUT_LOCATION: TowerGoPoint = {
   longitude: 114.313
 }
 
-/** 默认网格间距（米）。越大请求越少；附近优先策略下再配合 maxScanPoints。 */
-export const SCAN_GRID_SPACING_METERS = 180
+/** 默认网格间距（米）。#370 略加密以减少漏扫，仍远低于全校无界网格。 */
+export const SCAN_GRID_SPACING_METERS = 150
 /** 并发拉取车辆上限，避免 WebView 主线程与网络打满。 */
-export const SCAN_CONCURRENCY = 3
+export const SCAN_CONCURRENCY = 4
 /** 单次请求间隔（ms）。 */
-export const SCAN_REQUEST_DELAY_MS = 80
+export const SCAN_REQUEST_DELAY_MS = 60
 /** 单次扫描最多探测点数（含原点/中心）。超出时保留距用户最近的点。 */
-export const SCAN_MAX_POINTS = 36
+export const SCAN_MAX_POINTS = 48
 /** 定时刷新间隔（ms）：仅刷新附近/当前视野，不整区打爆。 */
 export const SCAN_REFRESH_INTERVAL_MS = 180_000
 /** 视口扫描防抖（ms）。 */
 export const SCAN_VIEWPORT_DEBOUNCE_MS = 400
+/** 冷启动附近扫描半径（米） */
+export const SCAN_NEARBY_RADIUS_METERS = 1200
 
 export type ScanBounds = {
   minLat: number
@@ -63,29 +67,111 @@ const toNumber = (value: unknown) => {
   return Number.isFinite(num) ? num : NaN
 }
 
+/**
+ * 纠偏：部分接口把 lat/lng 写反（lat≈114、lng≈30）。
+ * 中国大陆大致 lat 18–54、lng 73–135。
+ */
+export const coerceChinaLatLng = (lat: number, lng: number): { latitude: number; longitude: number } | null => {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  let a = lat
+  let b = lng
+  const latLooksLikeLng = a > 70 && a < 140 && b > 15 && b < 55
+  if (latLooksLikeLng) {
+    const tmp = a
+    a = b
+    b = tmp
+  }
+  // 明显不在中国附近的坐标丢弃（避免标到海里/赤道）
+  if (a < 15 || a > 55 || b < 70 || b > 140) return null
+  return { latitude: a, longitude: b }
+}
+
 const firstArray = (data: unknown): unknown[] => {
   if (Array.isArray(data)) return data
   if (!data || typeof data !== 'object') return []
   const obj = data as Record<string, unknown>
-  for (const key of ['list', 'records', 'rows', 'data', 'items']) {
+  for (const key of [
+    'list',
+    'records',
+    'rows',
+    'data',
+    'items',
+    'deviceList',
+    'device_list',
+    'carList',
+    'car_list',
+    'ebikeList',
+    'eBikeList',
+    'nearList',
+    'bikeList',
+    'vehicles'
+  ]) {
     if (Array.isArray(obj[key])) return obj[key] as unknown[]
   }
+  // 再下钻一层常见包装
+  for (const key of ['data', 'result', 'payload']) {
+    const nested = obj[key]
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      const inner = firstArray(nested)
+      if (inner.length) return inner
+    }
+  }
   return []
+}
+
+const readLatLngFromObject = (obj: Record<string, unknown>): { latitude: number; longitude: number } | null => {
+  // 嵌套 location / pos / coordinate
+  for (const nestKey of ['location', 'pos', 'position', 'coordinate', 'coord', 'gps', 'point']) {
+    const nested = obj[nestKey]
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      const fromNested = readLatLngFromObject(nested as Record<string, unknown>)
+      if (fromNested) return fromNested
+    }
+    if (Array.isArray(nested) && nested.length >= 2) {
+      const coerced = coerceChinaLatLng(toNumber(nested[1]), toNumber(nested[0]))
+      // 数组默认 [lng, lat]
+      if (coerced) return coerced
+      const swapped = coerceChinaLatLng(toNumber(nested[0]), toNumber(nested[1]))
+      if (swapped) return swapped
+    }
+  }
+
+  const lat = toNumber(
+    obj.lat ??
+      obj.latitude ??
+      obj.carLat ??
+      obj.car_lat ??
+      obj.posLat ??
+      obj.pos_lat ??
+      obj.centerLat ??
+      obj.latY ??
+      obj.y
+  )
+  const lng = toNumber(
+    obj.lng ??
+      obj.lon ??
+      obj.longitude ??
+      obj.carLng ??
+      obj.car_lng ??
+      obj.posLng ??
+      obj.pos_lng ??
+      obj.centerLng ??
+      obj.lngX ??
+      obj.x
+  )
+  return coerceChinaLatLng(lat, lng)
 }
 
 export const normalizePoint = (point: unknown): TowerGoPoint | null => {
   if (!point) return null
   if (Array.isArray(point)) {
-    const lng = toNumber(point[0])
-    const lat = toNumber(point[1])
-    return Number.isFinite(lat) && Number.isFinite(lng) ? { latitude: lat, longitude: lng } : null
+    // GeoJSON / 业务侧常见 [lng, lat]
+    const asLngLat = coerceChinaLatLng(toNumber(point[1]), toNumber(point[0]))
+    if (asLngLat) return asLngLat
+    return coerceChinaLatLng(toNumber(point[0]), toNumber(point[1]))
   }
   if (typeof point !== 'object') return null
-  const obj = point as Record<string, unknown>
-  const lat = toNumber(obj.lat ?? obj.latitude ?? obj.centerLat ?? obj.y)
-  const lng = toNumber(obj.lng ?? obj.longitude ?? obj.centerLng ?? obj.x)
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
-  return { latitude: lat, longitude: lng }
+  return readLatLngFromObject(point as Record<string, unknown>)
 }
 
 const parsePolygonText = (raw: string): TowerGoPoint[] => {
@@ -217,8 +303,8 @@ export const createServiceAreaScanPoints = ({
   origin = HBUT_LOCATION,
   spacingMeters = SCAN_GRID_SPACING_METERS,
   maxPoints = SCAN_MAX_POINTS,
-  /** 仅扫描用户附近半径（米）；默认 900m 附近优先，避免整区打爆。有 bounds 时忽略。 */
-  nearbyRadiusMeters = 900,
+  /** 仅扫描用户附近半径（米）；默认 1200m 附近优先，避免整区打爆。有 bounds 时忽略。 */
+  nearbyRadiusMeters = SCAN_NEARBY_RADIUS_METERS,
   /** 地图视口外包矩形：与服务区求交后网格扫描（动态加载） */
   bounds
 }: {
@@ -326,24 +412,37 @@ export const normalizeVehicles = (data: unknown, origin: TowerGoPoint = HBUT_LOC
   return firstArray(data)
     .map((item) => {
       const obj = (item || {}) as Record<string, unknown>
-      const lat = toNumber(obj.lat ?? obj.latitude)
-      const lng = toNumber(obj.lng ?? obj.longitude)
-      const rawDistance = toNumber(obj.distance)
+      const coords = readLatLngFromObject(obj)
+      if (!coords) return null
+      const { latitude: lat, longitude: lng } = coords
+      const rawDistance = toNumber(obj.distance ?? obj.dist ?? obj.meters)
+      // 部分接口 distance 为 km
+      let distance = Number.isFinite(rawDistance) ? rawDistance : distanceMeters(loc.latitude, loc.longitude, lat, lng)
+      if (Number.isFinite(rawDistance) && rawDistance > 0 && rawDistance < 30 && distanceMeters(loc.latitude, loc.longitude, lat, lng) > 200) {
+        // 像 km 又像 m：若原始值很小但直线距离很大，按 km→m
+        if (rawDistance * 1000 > 50) distance = rawDistance * 1000
+      }
       return {
-        id: String(obj.carId || obj.id || obj.imei || ''),
-        imei: String(obj.imei || ''),
+        id: String(obj.carId || obj.car_id || obj.id || obj.imei || obj.deviceId || ''),
+        imei: String(obj.imei || obj.deviceId || ''),
         latitude: lat,
         longitude: lng,
-        battery: obj.restBattery as number | string ?? obj.battery as number | string ?? obj.power as number | string ?? 0,
-        distance: Number.isFinite(rawDistance) ? rawDistance : distanceMeters(loc.latitude, loc.longitude, lat, lng),
-        mileage: obj.restMileage as string | number ?? obj.mileage as string | number ?? '',
-        lastUsedTime: String(obj.lastUsedTime || ''),
+        battery:
+          (obj.restBattery as number | string) ??
+          (obj.battery as number | string) ??
+          (obj.power as number | string) ??
+          (obj.soc as number | string) ??
+          0,
+        distance,
+        mileage: (obj.restMileage as string | number) ?? (obj.mileage as string | number) ?? '',
+        lastUsedTime: String(obj.lastUsedTime || obj.last_used_time || ''),
         hasReward: obj.hasReward,
         raw: item
-      }
+      } as TowerGoVehicle
     })
-    .filter((item) => Number.isFinite(item.latitude) && Number.isFinite(item.longitude))
-    .sort((a, b) => Number(a.distance || 0) - Number(b.distance || 0))
+    .filter(Boolean)
+    .filter((item) => Number.isFinite(item!.latitude) && Number.isFinite(item!.longitude))
+    .sort((a, b) => Number(a!.distance || 0) - Number(b!.distance || 0)) as TowerGoVehicle[]
 }
 
 export const dedupeVehicles = (vehicles: TowerGoVehicle[], origin: TowerGoPoint = HBUT_LOCATION) => {
@@ -379,31 +478,62 @@ export const resolveTowerGoLocation = async ({
   maximumAge?: number
 } = {}): Promise<TowerGoPoint> => {
   if (!geolocation?.getCurrentPosition) {
-    return { ...fallback, source: 'fallback' }
+    const point = { ...fallback, source: 'fallback' as const }
+    pushDebugLog(
+      'TowerGo',
+      `定位不可用，回退校区 lat=${point.latitude} lng=${point.longitude}`,
+      'warn',
+      point
+    )
+    return point
   }
+  pushDebugLog('TowerGo', `定位请求开始 timeout=${timeoutMs}ms maximumAge=${maximumAge}`, 'debug', {
+    timeoutMs,
+    maximumAge
+  })
   return new Promise((resolve) => {
     try {
       geolocation.getCurrentPosition(
         (position) => {
           const lat = position.coords.latitude
           const lng = position.coords.longitude
+          const accuracy = position.coords.accuracy || 0
           // 系统定位可能偏移到校外几公里（桌面端/室内/VPN），超阈值则回退到校区坐标，
           // 避免用偏移坐标查服务区识别成别的校区
           const drift = distanceMeters(fallback.latitude, fallback.longitude, lat, lng)
           if (Number.isFinite(drift) && drift > maxDriftMeters) {
-            resolve({ ...fallback, source: 'fallback' })
+            const point = { ...fallback, source: 'fallback' as const, accuracy }
+            pushDebugLog(
+              'TowerGo',
+              `定位漂移 ${Math.round(drift)}m > ${maxDriftMeters}m，回退校区 lat=${point.latitude} lng=${point.longitude}`,
+              'warn',
+              { lat, lng, accuracy, drift, ...point }
+            )
+            resolve(point)
             return
           }
-          resolve({
+          const point = {
             name: '当前位置',
             latitude: lat,
             longitude: lng,
-            accuracy: position.coords.accuracy || 0,
-            source: 'system'
-          })
+            accuracy,
+            source: 'system' as const
+          }
+          pushDebugLog(
+            'TowerGo',
+            `定位成功 lat=${lat.toFixed(6)} lng=${lng.toFixed(6)} ±${Math.round(accuracy)}m`,
+            'info',
+            point
+          )
+          resolve(point)
         },
-        () => {
-          resolve({ ...fallback, source: 'fallback' })
+        (err) => {
+          const point = { ...fallback, source: 'fallback' as const }
+          pushDebugLog('TowerGo', `定位失败，回退校区: ${err?.message || err}`, 'error', {
+            ...point,
+            code: err?.code
+          })
+          resolve(point)
         },
         {
           timeout: timeoutMs,
@@ -411,8 +541,15 @@ export const resolveTowerGoLocation = async ({
           maximumAge: Math.max(0, Number(maximumAge) || 0)
         }
       )
-    } catch {
-      resolve({ ...fallback, source: 'fallback' })
+    } catch (err) {
+      const point = { ...fallback, source: 'fallback' as const }
+      pushDebugLog(
+        'TowerGo',
+        `定位异常，回退校区: ${(err as Error)?.message || err}`,
+        'error',
+        point
+      )
+      resolve(point)
     }
   })
 }


### PR DESCRIPTION
## Summary

Fixes #369 and #370.

### #369 校园导览
- iOS 手绘层：容器尺寸就绪后重试 `createCustomLayer`，减少底图楼块遮挡，失败写入调试日志
- 桌面暗色 / graphite_night：POI 卡片标题、描述、按钮使用可读浅色字
- 手机详情：抬高底部安全区 + 壳层预留，避免被 Home 指示条遮挡

### #370 小塔出行
- 车辆坐标：支持 carLat/嵌套 location、lat/lng 写反纠偏、更多列表字段
- GPS 自身位置：base64 标记、重试初始化、map 容器独占、确保用户蓝点图层
- 定位结果：`useGeolocation` / 校园导览 / 小塔 均 `pushDebugLog` 到设置调试信息

## Test plan

- [x] vitest: towergo_map / bridge contracts / campus_guide / p0 / TowerGoView
- [ ] iOS：校园导览手绘层可见；POI 暗色可读；详情不被底栏裁切
- [ ] iOS：小塔授权定位后显示蓝点；车辆位置更接近官方 App
- [ ] 设置 → 调试信息：可见 Geo / CampusGuide / TowerGo 定位日志
