### PR TITLE
fix: #372 课表横幅 + #373 官网返回 + #375 学习通邀请码 + Android 体积 S1

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -210,6 +210,16 @@ jobs:
     name: Android beta APK
     needs: [source, meta, smoke-fast-build]
     runs-on: ubuntu-latest
+    # S1：Android 单独走小体积 profile（Windows 仍用全局 dev-fast thin LTO）
+    # 避免 Dev APK 从 ~24MB 膨胀到 ~30MB
+    env:
+      MINI_HBUT_BUILD_PROFILE: android-size
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: z
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+      CARGO_PROFILE_RELEASE_LTO: fat
+      CARGO_PROFILE_RELEASE_DEBUG: 0
+      CARGO_PROFILE_RELEASE_PANIC: abort
+      CARGO_PROFILE_RELEASE_STRIP: symbols
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@v4

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1357,6 +1357,9 @@ pub struct ChaoxingClassSsoRequest {
 pub struct ChaoxingClassInviteRequest {
     pub invite_code: String,
     pub student_id: Option<String>,
+    /// 前端 Web 备份门户密码，邀请码会话失效时静默重桥接（#375）
+    #[serde(default)]
+    pub portal_password: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -6095,10 +6098,13 @@ async fn chaoxing_class_preview_invite(
     req: ChaoxingClassInviteRequest,
 ) -> Result<serde_json::Value, String> {
     let mut client = state.client.write().await;
-    // 模块内已走统一 SSO 缓存，不再额外 force ensure
-    let preview = modules::chaoxing_class::preview_invite(&mut client, &req.invite_code)
-        .await
-        .map_err(|e| e.to_string())?;
+    let preview = modules::chaoxing_class::preview_invite(
+        &mut client,
+        &req.invite_code,
+        req.portal_password.as_deref(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     Ok(serde_json::to_value(preview).unwrap_or_default())
 }
 
@@ -6109,9 +6115,13 @@ async fn chaoxing_class_accept_invite(
     req: ChaoxingClassInviteRequest,
 ) -> Result<serde_json::Value, String> {
     let mut client = state.client.write().await;
-    modules::chaoxing_class::accept_invite(&mut client, &req.invite_code)
-        .await
-        .map_err(|e| e.to_string())
+    modules::chaoxing_class::accept_invite(
+        &mut client,
+        &req.invite_code,
+        req.portal_password.as_deref(),
+    )
+    .await
+    .map_err(|e| e.to_string())
 }
 
 /// 学习通班级：资料列表

--- a/src-tauri/src/modules/chaoxing_class.rs
+++ b/src-tauri/src/modules/chaoxing_class.rs
@@ -175,6 +175,26 @@ fn looks_like_login_html(html: &str) -> bool {
             && !h.contains("courseid"))
 }
 
+/// getInviteCode 等接口应返回 JSON；HTML 文档视为会话失效（#375）
+fn looks_like_html_document(body: &str) -> bool {
+    let t = body.trim_start();
+    let lower = t.to_ascii_lowercase();
+    lower.starts_with("<!doctype")
+        || lower.starts_with("<html")
+        || lower.starts_with("<head")
+        || (lower.starts_with('<') && lower.contains("<html"))
+}
+
+fn is_invite_session_error_message(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("非 json")
+        || m.contains("未登录")
+        || m.contains("会话未就绪")
+        || m.contains("登录页")
+        || m.contains("<!doctype")
+        || m.contains("<html")
+}
+
 fn looks_like_login_url(url: &str) -> bool {
     let u = url.to_ascii_lowercase();
     u.contains("passport2.chaoxing.com")
@@ -560,16 +580,23 @@ fn preview_from_fixed(code: &str) -> Option<InvitePreview> {
 }
 
 /// 解析邀请码 → 课程/班级预览（不入班）
+/// `portal_password`：#375 会话假复用后静默重桥接
 pub async fn preview_invite(
     client: &mut HbutClient,
     invite_code: &str,
+    portal_password: Option<&str>,
 ) -> Result<InvitePreview, DynError> {
     let code = invite_code.trim();
     if code.is_empty() {
         return Err(err_box("请输入邀请码"));
     }
 
-    // 统一会话层：缓存命中则跳过重复 FYSSO
+    let pwd = portal_password
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    // 统一会话层：必须真有学习通会话，不可仅凭教务 jw 假复用
     let _ = crate::modules::chaoxing_sso::ensure_chaoxing_sso(
         client,
         None,
@@ -577,7 +604,7 @@ pub async fn preview_invite(
             force: false,
             allow_silent_relogin: true,
             preheated: false,
-            portal_password: None,
+            portal_password: pwd.clone(),
         },
     )
     .await;
@@ -590,7 +617,37 @@ pub async fn preview_invite(
             "邀请码 {} 已识别但未返回完整课程/班级 ID（course={} clazz={}）",
             code, p.course_id, p.clazz_id
         ))),
-        Err(e) => Err(e),
+        Err(e) => {
+            let msg = e.to_string();
+            if !is_invite_session_error_message(&msg) {
+                return Err(e);
+            }
+            // #375：假「会话已复用」后接口回 HTML → 作废缓存、强制重桥接再试一次
+            println!("[chaoxing] 邀请码会话失效，强制 SSO 后重试: {}", msg);
+            crate::modules::chaoxing_sso::invalidate_sso_cache();
+            let _ = crate::modules::chaoxing_sso::ensure_chaoxing_sso(
+                client,
+                None,
+                crate::modules::chaoxing_sso::EnsureSsoOptions {
+                    force: true,
+                    allow_silent_relogin: true,
+                    preheated: false,
+                    portal_password: pwd,
+                },
+            )
+            .await;
+            match fetch_invite_preview_online(client, code).await {
+                Ok(p) if !p.course_id.is_empty() && !p.clazz_id.is_empty() => Ok(p),
+                Ok(p) => Err(err_box(format!(
+                    "邀请码 {} 重试后仍未返回完整课程/班级 ID（course={} clazz={}）",
+                    code, p.course_id, p.clazz_id
+                ))),
+                Err(e2) => Err(err_box(format!(
+                    "学习通会话失效且重试仍失败：{}（请重新登录融合门户后重试，不是断网）",
+                    e2
+                ))),
+            }
+        }
     }
 }
 
@@ -630,9 +687,9 @@ async fn fetch_invite_preview_online(
         .await
         .map_err(|e| err_box(format!("解析邀请码响应失败: {}", e)))?;
 
-    if looks_like_login_html(&body) {
+    if looks_like_login_html(&body) || looks_like_html_document(&body) {
         return Err(err_box(
-            "学习通会话未就绪（邀请码接口返回登录页）。请重新登录融合门户后再试",
+            "学习通会话未就绪（邀请码接口返回 HTML/登录页）。请重新登录融合门户后再试",
         ));
     }
 
@@ -783,21 +840,13 @@ async fn fetch_invite_preview_online(
 }
 
 /// 接受邀请入班
-pub async fn accept_invite(client: &mut HbutClient, invite_code: &str) -> Result<Value, DynError> {
+pub async fn accept_invite(
+    client: &mut HbutClient,
+    invite_code: &str,
+    portal_password: Option<&str>,
+) -> Result<Value, DynError> {
     let code = invite_code.trim();
-    let _ = crate::modules::chaoxing_sso::ensure_chaoxing_sso(
-        client,
-        None,
-        crate::modules::chaoxing_sso::EnsureSsoOptions {
-            force: false,
-            allow_silent_relogin: true,
-            preheated: false,
-            portal_password: None,
-        },
-    )
-    .await;
-
-    let preview = preview_invite(client, code).await?;
+    let preview = preview_invite(client, code, portal_password).await?;
 
     // 学生已入班 或 教师可访问资料 → 无需再走 participate
     if probe_class_accessible(client, &preview.course_id, &preview.clazz_id).await {

--- a/src-tauri/src/modules/chaoxing_sso.rs
+++ b/src-tauri/src/modules/chaoxing_sso.rs
@@ -509,18 +509,19 @@ async fn try_silent_portal_relogin(
     Ok(false)
 }
 
-/// 轻量探测：UID cookie 或课程 API 任一可用即认为学习通可用
+/// 轻量探测：必须有学习通 UID，且优先探针 API
 async fn probe_chaoxing_ready(client: &mut HbutClient) -> bool {
-    let (has_uid, has_jw) = cookie_flags(client);
-    if has_uid || has_jw {
-        // 再确认课程 API（不 force 全量业务缓存逻辑）
-        if online_learning::chaoxing_session_probe_ready(client).await {
-            return true;
-        }
-        // cookie 有但 API 失败：仍可能是瞬时问题，has_uid 时部分能力可用
-        return has_uid;
+    let (has_uid, _has_jw) = cookie_flags(client);
+    // 仅教务 jw_uf 不算学习通就绪（#375）
+    if !has_uid {
+        return false;
     }
-    false
+    // 再确认课程 API（不 force 全量业务缓存逻辑）
+    if online_learning::chaoxing_session_probe_ready(client).await {
+        return true;
+    }
+    // cookie 有但 API 失败：仍可能是瞬时问题，has_uid 时部分能力可用
+    has_uid
 }
 
 #[derive(Debug, Clone, Default)]
@@ -606,14 +607,15 @@ pub async fn ensure_chaoxing_sso(
 
     if !opts.force {
         if let Some(mut hit) = cache_hit() {
-            // 缓存命中仍做极轻 cookie 校验
+            // #375：仅当有学习通 UID 才允许进程缓存命中。
+            // 仅 jw_uf（教务）会误报「会话已复用」，随后 getInviteCode 返回 HTML。
             let (has_uid, has_jw) = cookie_flags(client);
-            if has_uid || has_jw {
+            if has_uid {
                 hit.has_uid = has_uid;
                 hit.has_jw = has_jw;
                 hit.from_cache = true;
                 // 短票可能已过 2h：缓存命中时后台轻量续 jw_uf（不阻塞返回）
-                if has_uid && !has_jw {
+                if !has_jw {
                     let _ = client.ensure_chaoxing_academic_session().await;
                 }
                 return Ok(json!({
@@ -624,13 +626,18 @@ pub async fn ensure_chaoxing_sso(
                     "hint": "复用学习通 SSO 缓存",
                 }));
             }
+            // 仅有教务 cookie：作废假阳性缓存，继续走桥接
+            if has_jw && !has_uid {
+                println!("[SSO] 缓存命中但缺少学习通 UID，忽略缓存并重桥接");
+                invalidate_sso_cache();
+            }
         }
 
         // 7 天长效票在 jar 中：优先复用，跳过 CAS
         let (has_uid, has_jw) = cookie_flags(client);
         if has_uid {
             let long_lived = has_long_lived_chaoxing_ticket(client);
-            // 近期探针成功 + 长效票 → 零网络秒开
+            // 近期探针成功 + 长效票 → 零网络秒开（必须真有 token，不能仅 UID）
             let trust_without_probe = long_lived && recent_cookie_probe_ok();
             let probe_ok = if trust_without_probe {
                 true
@@ -674,6 +681,9 @@ pub async fn ensure_chaoxing_sso(
                     },
                 }));
             }
+            // UID 在但探针失败：清缓存继续 CAS 桥接
+            println!("[SSO] 有 UID 但学习通探针失败，尝试重新桥接");
+            invalidate_sso_cache();
         }
     }
 

--- a/src-tauri/src/modules/school_website_embed.rs
+++ b/src-tauri/src/modules/school_website_embed.rs
@@ -243,7 +243,10 @@ fn close_embed_if_exists(app: &AppHandle) {
     if closed_any {
         println!("[SchoolWebsite] embed closed label={}", EMBED_LABEL);
     } else {
-        println!("[SchoolWebsite] embed close: no webview found for {}", EMBED_LABEL);
+        println!(
+            "[SchoolWebsite] embed close: no webview found for {}",
+            EMBED_LABEL
+        );
     }
 }
 

--- a/src-tauri/src/modules/school_website_embed.rs
+++ b/src-tauri/src/modules/school_website_embed.rs
@@ -200,8 +200,50 @@ fn open_external(app: &AppHandle, target: &str) {
 
 #[cfg(desktop)]
 fn close_embed_if_exists(app: &AppHandle) {
+    // #373：子 WebView 关闭必须足够狠——仅 get_webview+close 在部分桌面端会静默失败，
+    // 导致返回「我的」后官网仍盖住下方内容。
+    let mut closed_any = false;
+
+    // 1) 按 label 直接取
     if let Some(webview) = app.get_webview(EMBED_LABEL) {
-        let _ = webview.close();
+        // 先藏到屏外，避免 close 异步期间仍遮挡
+        let _ = webview.set_position(LogicalPosition::new(-10_000.0, -10_000.0));
+        let _ = webview.set_size(LogicalSize::new(1.0, 1.0));
+        if webview.close().is_ok() {
+            closed_any = true;
+        }
+    }
+
+    // 2) 遍历 App 全部 webview（防止 label 查找不一致）
+    for (label, webview) in app.webviews() {
+        if label.as_str() != EMBED_LABEL {
+            continue;
+        }
+        let _ = webview.set_position(LogicalPosition::new(-10_000.0, -10_000.0));
+        let _ = webview.set_size(LogicalSize::new(1.0, 1.0));
+        if webview.close().is_ok() {
+            closed_any = true;
+        }
+    }
+
+    // 3) 主窗口子 webview 兜底
+    if let Some(window) = app.get_window("main") {
+        for webview in window.webviews() {
+            if webview.label() != EMBED_LABEL {
+                continue;
+            }
+            let _ = webview.set_position(LogicalPosition::new(-10_000.0, -10_000.0));
+            let _ = webview.set_size(LogicalSize::new(1.0, 1.0));
+            if webview.close().is_ok() {
+                closed_any = true;
+            }
+        }
+    }
+
+    if closed_any {
+        println!("[SchoolWebsite] embed closed label={}", EMBED_LABEL);
+    } else {
+        println!("[SchoolWebsite] embed close: no webview found for {}", EMBED_LABEL);
     }
 }
 
@@ -262,6 +304,14 @@ pub async fn school_website_embed_resize(
     app: AppHandle,
     bounds: EmbedBounds,
 ) -> Result<(), String> {
+    // 宽高过小视为无效（返回卸载期容器已塌缩），拒绝放大遮挡
+    if bounds.width < 8.0 || bounds.height < 8.0 {
+        return Err("invalid embed bounds".to_string());
+    }
+    // 位置异常（屏外）不 resize 回来
+    if bounds.x < -100.0 || bounds.y < -100.0 {
+        return Err("invalid embed position".to_string());
+    }
     let webview = app
         .get_webview(EMBED_LABEL)
         .ok_or_else(|| "学校官网内嵌未打开".to_string())?;

--- a/src/App.vue
+++ b/src/App.vue
@@ -452,8 +452,14 @@ const homeLayoutDebugHidden = ref(
 const homeLayoutDebugExpanded = ref(false)
 const homeLayoutDebugReport = ref('')
 prefetchViewComponent(initialView)
-watch(currentView, (view) => {
+watch(currentView, (view, prev) => {
   prefetchViewComponent(view)
+  // #373：离开学校官网时强制关掉桌面子 WebView，避免盖住「我的」等内容区
+  if (prev === 'school_website' && view !== 'school_website') {
+    void import('./utils/school_website_embed').then((mod) => {
+      void mod.forceCloseSchoolWebsiteEmbed?.()
+    }).catch(() => {})
+  }
 })
 if (skipSplashForFastScheduleBoot && !hasBootMetric('splash_dismissed')) {
   markBootMetric('splash_dismissed', {
@@ -2241,6 +2247,12 @@ const handleOpenOfficial = () => {
 }
 
 const handleBackToMe = () => {
+  // 从学校官网等内嵌页返回时，确保桌面子 WebView 已关
+  if (currentView.value === 'school_website') {
+    void import('./utils/school_website_embed').then((mod) => {
+      void mod.forceCloseSchoolWebsiteEmbed?.()
+    }).catch(() => {})
+  }
   goToView('me')
 }
 

--- a/src/components/ChaoxingClassView.vue
+++ b/src/components/ChaoxingClassView.vue
@@ -305,8 +305,14 @@ const fetchPreview = async () => {
   bootPhase.value = 'preview'
   const code = inviteCode.value
   if (!code) throw new Error('未配置学习通邀请码')
+  // #375：邀请码接口可能因假 SSO 复用失败，附带门户密码供静默重桥接
+  const ssoReq = await ssoPayload()
   const res = await invokeNative('chaoxing_class_preview_invite', {
-    req: { invite_code: code, ...studentPayload() }
+    req: {
+      invite_code: code,
+      student_id: ssoReq.student_id ?? null,
+      portal_password: ssoReq.portal_password ?? null
+    }
   })
   preview.value = {
     invite_code: code,
@@ -398,8 +404,13 @@ const handleJoinConfirm = async () => {
   try {
     const code = inviteCode.value
     if (!code) throw new Error('未配置学习通邀请码')
+    const ssoReq = await ssoPayload()
     const res = await invokeNative('chaoxing_class_accept_invite', {
-      req: { invite_code: code, ...studentPayload() }
+      req: {
+        invite_code: code,
+        student_id: ssoReq.student_id ?? null,
+        portal_password: ssoReq.portal_password ?? null
+      }
     })
     const p = res?.preview || preview.value || {}
     const cls = {

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -685,16 +685,19 @@ const applyMeta = (meta, requestedSemester = '') => {
 const applySchedulePayload = (payload, requestedSemester = '', options = {}) => {
   if (!payload?.success) return false
   const rawData = Array.isArray(payload?.data) ? payload.data : []
-  // 已登录且非强制展示：成功在线结果清除离线条；仅 payload.offline 且无「静默秒开」时提示
+  // #372：SWR/stale 缓存会经 withOfflineMeta 强制 offline=true，不等于教务不可用。
+  // 已登录：成功 payload 默认不亮横幅；仅显式 forceOfflineBanner（真实失败回退）才展示。
   const silentCachePaint = options?.silentCachePaint === true
-  if (payload.offline) {
-    if (!silentCachePaint) {
-      offline.value = true
-      // 已登录：勿误报「登录恢复」；首页绿灯时更常见是缓存命中/教务抖动
-      offlineHint.value = String(props.studentId || '').trim()
-        ? '当前显示为缓存课表，教务暂不可用。'
-        : '当前显示为离线数据，登录恢复后自动刷新。'
-    }
+  const forceOfflineBanner = options?.forceOfflineBanner === true
+  const loggedIn = !!String(props.studentId || '').trim()
+  if (forceOfflineBanner || (payload.offline && !silentCachePaint && !loggedIn)) {
+    offline.value = true
+    offlineHint.value = String(
+      options?.offlineHint ||
+        (loggedIn
+          ? '当前显示为缓存课表，教务暂不可用。'
+          : '当前显示为离线数据，登录恢复后自动刷新。')
+    ).trim()
   } else {
     offline.value = false
     offlineHint.value = ''
@@ -727,6 +730,47 @@ const applyCachedScheduleImmediately = (targetSemester = '', options = {}) => {
     syncTime.value = new Date(snapshot.timestamp).toISOString()
   }
   return applied
+}
+
+/** 后台真源刷新：只在明确失败时亮离线条，避免 SWR offline 标记误导 */
+let onlineRevalidateToken = 0
+const revalidateScheduleOnline = async (targetSemester = '') => {
+  const sid = String(props.studentId || '').trim()
+  const sem = String(targetSemester || semester.value || semesterDraft.value || '').trim()
+  if (!sid) return false
+  const token = ++onlineRevalidateToken
+  const cacheKey = sem ? `schedule:${sid}:${sem}` : `schedule:${sid}`
+  try {
+    const { data } = await fetchWithCache(
+      cacheKey,
+      async () => {
+        const res = await axios.post(`${API_BASE}/v2/schedule/query`, {
+          student_id: sid,
+          semester: sem || undefined
+        })
+        return res.data
+      },
+      undefined,
+      { forceRemote: true, priority: 'background', staleWhileRevalidate: false }
+    )
+    if (token !== onlineRevalidateToken) return false
+    if (data?.success && !data?.offline) {
+      applySchedulePayload(data, sem, { silentCachePaint: false })
+      offline.value = false
+      offlineHint.value = ''
+      persistScheduleRenderSnapshot('online-revalidate')
+      return true
+    }
+    if (data?.need_login && (remoteScheduleData.value.length || customScheduleData.value.length)) {
+      offline.value = true
+      offlineHint.value = '当前为缓存课表，登录恢复后自动刷新。'
+    }
+    return false
+  } catch {
+    if (token !== onlineRevalidateToken) return false
+    // 保持静默：有缓存就不恐吓；用户可手动刷新
+    return false
+  }
 }
 
 const applyStoredScheduleRenderSnapshot = (targetSemester = '', options = {}) => {
@@ -789,7 +833,7 @@ const fetchSchedule = async (targetSemester = '', options = {}) => {
     const cacheKey = requestedSemester
       ? `schedule:${props.studentId}:${requestedSemester}`
       : `schedule:${props.studentId}`
-    const { data } = await fetchWithCache(cacheKey, async () => {
+    const { data, fromCache, stale } = await fetchWithCache(cacheKey, async () => {
       const res = await axios.post(`${API_BASE}/v2/schedule/query`, {
         student_id: props.studentId,
         semester: requestedSemester || undefined
@@ -798,11 +842,18 @@ const fetchSchedule = async (targetSemester = '', options = {}) => {
     }, undefined, DEFAULT_SWR_OPTIONS)
 
     if (data?.success) {
-      applySchedulePayload(data, requestedSemester)
-      await loadCustomCourses(requestedSemester || semester.value)
-      if (offline.value && String(props.studentId || '').trim()) {
-        offlineHint.value = '当前显示为缓存课表，教务暂不可用。'
+      // 登录态 + 缓存/SWR 命中（含 offline 标记）：静默秒开，不误报「教务暂不可用」
+      const treatAsSilentCache =
+        !!String(props.studentId || '').trim() &&
+        (!!fromCache || !!data?.offline || !!stale)
+      applySchedulePayload(data, requestedSemester, {
+        silentCachePaint: treatAsSilentCache
+      })
+      // 若本次是陈旧/离线标记缓存，后台再拉一次真源（不阻塞、失败路径才亮条）
+      if (treatAsSilentCache && data?.offline) {
+        void revalidateScheduleOnline(requestedSemester || semester.value)
       }
+      await loadCustomCourses(requestedSemester || semester.value)
       if (!remoteScheduleData.value.length && customScheduleData.value.length > 0) {
         errorMsg.value = ''
       }

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -150,17 +150,34 @@ const handleRetryEmbed = () => {
 const handleBack = async () => {
   if (leaving.value) return
   leaving.value = true
+  // 同步抑制 + 立即关闭：不把 close 拖到 emit 之后
+  try {
+    await forceCloseSchoolWebsiteEmbed()
+  } catch {
+    // ignore
+  }
   try {
     await cleanupEmbed()
+  } catch {
+    // ignore
+  }
+  try {
     await forceCloseSchoolWebsiteEmbed()
   } catch {
     // ignore
   }
   emit('back')
+  // emit 后再兜底关一次（App 切页后子 WebView 仍可能残留）
+  window.setTimeout(() => {
+    void forceCloseSchoolWebsiteEmbed()
+  }, 0)
+  window.setTimeout(() => {
+    void forceCloseSchoolWebsiteEmbed()
+  }, 120)
 }
 
 const handleVisibilityForEmbed = () => {
-  if (document.hidden) return
+  if (document.hidden || leaving.value) return
   // 仅在已有错误或 proxy 模式时自动恢复，避免无意义重载
   if (loadError.value || embedMode.value === 'proxy-iframe') {
     void remountAfterResume()
@@ -168,8 +185,10 @@ const handleVisibilityForEmbed = () => {
 }
 
 const handleAppEmbedResumeEvent = (event) => {
+  if (leaving.value) return
+  // 必须明确是 school_website：空 detail 时禁止 remount（会把已关闭的子 WebView 又拉起来）
   const view = String(event?.detail?.view || '')
-  if (view && view !== 'school_website') return
+  if (view !== 'school_website') return
   void remountAfterResume()
 }
 

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -3,12 +3,14 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { openExternal } from '../utils/external_link'
 import {
   SCHOOL_WEBSITE_URL,
+  forceCloseSchoolWebsiteEmbed,
   mountSchoolWebsiteEmbed,
   resolveSchoolWebsiteEmbedMode,
   resolveSchoolWebsiteIframeUrl
 } from '../utils/school_website_embed'
 
 const emit = defineEmits(['back'])
+const leaving = ref(false)
 
 const frameShellRef = ref(null)
 const embedMode = ref('direct-iframe')
@@ -144,6 +146,19 @@ const handleRetryEmbed = () => {
   void remountAfterResume()
 }
 
+/** #373：先关子 WebView 再返回，避免卸载竞态把内嵌撑成无返回全屏 */
+const handleBack = async () => {
+  if (leaving.value) return
+  leaving.value = true
+  try {
+    await cleanupEmbed()
+    await forceCloseSchoolWebsiteEmbed()
+  } catch {
+    // ignore
+  }
+  emit('back')
+}
+
 const handleVisibilityForEmbed = () => {
   if (document.hidden) return
   // 仅在已有错误或 proxy 模式时自动恢复，避免无意义重载
@@ -167,7 +182,9 @@ onMounted(() => {
 onBeforeUnmount(() => {
   document.removeEventListener('visibilitychange', handleVisibilityForEmbed)
   window.removeEventListener('hbu-embed-resume', handleAppEmbedResumeEvent)
-  void cleanupEmbed()
+  void cleanupEmbed().finally(() => {
+    void forceCloseSchoolWebsiteEmbed()
+  })
 })
 
 defineExpose({ remountAfterResume })
@@ -176,7 +193,7 @@ defineExpose({ remountAfterResume })
 <template>
   <div class="school-website-view">
     <header class="subpage-header">
-      <button class="back-button" type="button" @click="emit('back')" aria-label="返回">
+      <button class="back-button" type="button" @click="handleBack" aria-label="返回">
         <span class="material-symbols-outlined">arrow_back</span>
       </button>
       <div class="header-copy">

--- a/src/utils/chaoxing_class_home_contract.spec.ts
+++ b/src/utils/chaoxing_class_home_contract.spec.ts
@@ -101,6 +101,12 @@ describe('chaoxing_class home integration contract', () => {
     expect(ssoRs).toContain('portal_password')
     expect(ssoRs).toContain('hydrate_session_cookies_from_store')
     expect(ssoRs).toContain('tgt_expired_no_password')
+    // #375：禁止仅凭教务 jw 假复用；邀请码 HTML 响应重桥接
+    expect(ssoRs).toContain('缺少学习通 UID')
+    expect(classRs).toContain('looks_like_html_document')
+    expect(classRs).toContain('is_invite_session_error_message')
+    expect(classRs).toContain('force: true')
+    expect(view).toContain('portal_password')
     expect(protocol).toContain('getInviteCode')
     expect(protocol).toContain('participateCls')
     expect(protocol).toContain('stu-datalist')

--- a/src/utils/schedule_offline_banner_contract.spec.ts
+++ b/src/utils/schedule_offline_banner_contract.spec.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) => readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+
+describe('schedule offline banner contract (#372)', () => {
+  it('does not treat SWR offline cache as 教务暂不可用 for logged-in users', () => {
+    const view = read('src/components/ScheduleView.vue')
+    const api = read('src/utils/api.js')
+
+    expect(api).toContain('withOfflineMeta')
+    expect(api).toContain('getStaleCachedData')
+    expect(view).toContain('silentCachePaint')
+    expect(view).toContain('forceOfflineBanner')
+    expect(view).toContain('treatAsSilentCache')
+    expect(view).toContain('revalidateScheduleOnline')
+    expect(view).toContain('fromCache')
+    // 登录态成功 payload 不因 offline 标记误报
+    expect(view).toContain('!silentCachePaint && !loggedIn')
+    expect(view).toContain('当前显示为缓存课表，教务暂不可用。')
+  })
+})

--- a/src/utils/school_website_back_contract.spec.ts
+++ b/src/utils/school_website_back_contract.spec.ts
@@ -8,13 +8,26 @@ describe('school website back / embed bounds contract (#373)', () => {
   it('closes native embed before navigating back and avoids full-window resize', () => {
     const view = read('src/components/SchoolWebsiteView.vue')
     const embed = read('src/utils/school_website_embed.ts')
+    const app = read('src/App.vue')
+    const rust = read('src-tauri/src/modules/school_website_embed.rs')
 
     expect(view).toContain('handleBack')
     expect(view).toContain('forceCloseSchoolWebsiteEmbed')
     expect(view).toContain('@click="handleBack"')
     expect(view).not.toContain("@click=\"emit('back')\"")
+    // 空 detail 禁止 remount
+    expect(view).toContain("if (view !== 'school_website') return")
     expect(embed).toContain('forceCloseSchoolWebsiteEmbed')
+    expect(embed).toContain('suppressSchoolWebsiteEmbed')
+    expect(embed).toContain('schoolWebsiteEmbedSuppressed')
     expect(embed).toContain('container.isConnected')
+    // App 层离开 school_website 强制 close
+    expect(app).toContain("prev === 'school_website'")
+    expect(app).toContain('forceCloseSchoolWebsiteEmbed')
+    // Rust 多重关闭 + 无效 bounds 拒绝
+    expect(rust).toContain('close_embed_if_exists')
+    expect(rust).toContain('-10_000.0')
+    expect(rust).toContain('invalid embed bounds')
     // 禁止旧的「小于 45% 窗口就撑满」逻辑
     expect(embed).not.toContain('minExpected')
     expect(embed).not.toContain('height >= minExpected ? height : heightFromWindow')

--- a/src/utils/school_website_back_contract.spec.ts
+++ b/src/utils/school_website_back_contract.spec.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) => readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+
+describe('school website back / embed bounds contract (#373)', () => {
+  it('closes native embed before navigating back and avoids full-window resize', () => {
+    const view = read('src/components/SchoolWebsiteView.vue')
+    const embed = read('src/utils/school_website_embed.ts')
+
+    expect(view).toContain('handleBack')
+    expect(view).toContain('forceCloseSchoolWebsiteEmbed')
+    expect(view).toContain('@click="handleBack"')
+    expect(view).not.toContain("@click=\"emit('back')\"")
+    expect(embed).toContain('forceCloseSchoolWebsiteEmbed')
+    expect(embed).toContain('container.isConnected')
+    // 禁止旧的「小于 45% 窗口就撑满」逻辑
+    expect(embed).not.toContain('minExpected')
+    expect(embed).not.toContain('height >= minExpected ? height : heightFromWindow')
+  })
+})

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -104,9 +104,9 @@ export const measureSchoolWebsiteEmbedBounds = async (
   if (canUseTauriEmbeddedWebview()) {
     try {
       const { getCurrentWindow } = await import('@tauri-apps/api/window')
-      const window = getCurrentWindow()
-      const scaleFactor = await window.scaleFactor()
-      const innerSize = await window.innerSize()
+      const win = getCurrentWindow()
+      const scaleFactor = await win.scaleFactor()
+      const innerSize = await win.innerSize()
       const innerLogical = innerSize.toLogical(scaleFactor)
       const bottomPadding = 12
 
@@ -115,16 +115,30 @@ export const measureSchoolWebsiteEmbedBounds = async (
         top = Math.max(0, Math.round(parentRect.top + (rect.top - parentRect.top)))
       }
 
-      width = Math.max(1, Math.round(rect.width || innerLogical.width - left * 2))
-      const heightFromWindow = Math.max(1, Math.round(innerLogical.height - top - bottomPadding))
-      const minExpected = Math.round(innerLogical.height * 0.45)
-      height = height >= minExpected ? height : heightFromWindow
+      // #373：以 DOM 容器为准。旧逻辑在 height < 45% 窗口时强行撑满，
+      // 返回过渡期会把子 WebView 放大成「无返回键全屏」。
+      if (width < 8) {
+        width = Math.max(1, Math.round(innerLogical.width - left * 2))
+      }
+      if (height < 8) {
+        height = Math.max(1, Math.round(innerLogical.height - top - bottomPadding))
+      }
     } catch {
       // 保留 DOM 测量结果
     }
   }
 
   return { x: left, y: top, width, height }
+}
+
+/** 强制关闭桌面子 WebView（返回/卸载兜底，避免全屏残留） */
+export const forceCloseSchoolWebsiteEmbed = async () => {
+  if (!canUseTauriEmbeddedWebview()) return
+  try {
+    await invokeNative('school_website_embed_close')
+  } catch {
+    // ignore
+  }
 }
 
 type MountOptions = {
@@ -164,11 +178,20 @@ export const mountSchoolWebsiteEmbed = async ({
     }
   }
 
+  let closed = false
   try {
     const bounds = await measureSchoolWebsiteEmbedBounds(container)
+    if (closed) {
+      return { mode, cleanup: async () => {} }
+    }
     await invokeNative('school_website_embed_open', { bounds })
 
     const resizeObserver = new ResizeObserver(() => {
+      if (closed) return
+      // 容器已离开布局树时勿再 resize（返回卸载竞态）
+      if (!container.isConnected) return
+      const r = container.getBoundingClientRect()
+      if (r.width < 8 || r.height < 8) return
       void syncNativeEmbedBounds(container).catch(() => {})
     })
     resizeObserver.observe(container)
@@ -176,15 +199,14 @@ export const mountSchoolWebsiteEmbed = async ({
       resizeObserver.observe(container.parentElement)
     }
 
-    let closed = false
     const handleWindowResize = () => {
-      if (closed) return
+      if (closed || !container.isConnected) return
       void syncNativeEmbedBounds(container).catch(() => {})
     }
     window.addEventListener('resize', handleWindowResize)
 
     const layoutTimer = window.setInterval(() => {
-      if (closed) return
+      if (closed || !container.isConnected) return
       void syncNativeEmbedBounds(container).catch(() => {})
     }, 300)
     window.setTimeout(() => {
@@ -209,6 +231,12 @@ export const mountSchoolWebsiteEmbed = async ({
       }
     }
   } catch (error) {
+    closed = true
+    try {
+      await invokeNative('school_website_embed_close')
+    } catch {
+      // ignore
+    }
     const message = error instanceof Error ? error.message : '创建学校官网内嵌视图失败'
     onError?.(message)
     throw error

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -131,9 +131,38 @@ export const measureSchoolWebsiteEmbedBounds = async (
   return { x: left, y: top, width, height }
 }
 
-/** 强制关闭桌面子 WebView（返回/卸载兜底，避免全屏残留） */
+/** 进程内标记：关闭后禁止任何 resize（防止竞态把子 WebView 又拉回可视区） */
+let schoolWebsiteEmbedSuppressed = false
+
+export const isSchoolWebsiteEmbedSuppressed = () => schoolWebsiteEmbedSuppressed
+
+export const suppressSchoolWebsiteEmbed = () => {
+  schoolWebsiteEmbedSuppressed = true
+}
+
+export const allowSchoolWebsiteEmbed = () => {
+  schoolWebsiteEmbedSuppressed = false
+}
+
+/**
+ * 强制关闭桌面子 WebView（返回/卸载/切页兜底）。
+ * 不依赖 isTauriDesktopRuntime：只要是 Tauri 就 invoke close，避免 UA 误判导致关不掉。
+ */
 export const forceCloseSchoolWebsiteEmbed = async () => {
-  if (!canUseTauriEmbeddedWebview()) return
+  suppressSchoolWebsiteEmbed()
+  if (!isTauriRuntime()) return
+  try {
+    const { pushDebugLog } = await import('./debug_logger')
+    pushDebugLog('SchoolWebsite', 'forceClose school_website_embed_close', 'info')
+  } catch {
+    // ignore
+  }
+  try {
+    await invokeNative('school_website_embed_close')
+  } catch {
+    // ignore — 移动端命令可能 no-op
+  }
+  // 再关一次，覆盖 close 竞态
   try {
     await invokeNative('school_website_embed_close')
   } catch {
@@ -159,7 +188,11 @@ const invokeNative = async <T = unknown>(command: string, args?: Record<string, 
 }
 
 const syncNativeEmbedBounds = async (container: HTMLElement) => {
+  if (schoolWebsiteEmbedSuppressed) return
+  if (!container.isConnected) return
   const bounds = await measureSchoolWebsiteEmbedBounds(container)
+  if (schoolWebsiteEmbedSuppressed) return
+  if (bounds.width < 8 || bounds.height < 8) return
   await invokeNative('school_website_embed_resize', { bounds })
 }
 
@@ -178,13 +211,29 @@ export const mountSchoolWebsiteEmbed = async ({
     }
   }
 
+  // 重新进入模块：允许创建
+  allowSchoolWebsiteEmbed()
   let closed = false
   try {
     const bounds = await measureSchoolWebsiteEmbedBounds(container)
-    if (closed) {
+    if (closed || schoolWebsiteEmbedSuppressed) {
       return { mode, cleanup: async () => {} }
     }
     await invokeNative('school_website_embed_open', { bounds })
+    if (schoolWebsiteEmbedSuppressed) {
+      // 打开过程中用户已返回：立刻关掉
+      try {
+        await invokeNative('school_website_embed_close')
+      } catch {
+        // ignore
+      }
+      return {
+        mode,
+        cleanup: async () => {
+          closed = true
+        }
+      }
+    }
 
     const resizeObserver = new ResizeObserver(() => {
       if (closed) return
@@ -220,6 +269,7 @@ export const mountSchoolWebsiteEmbed = async ({
       cleanup: async () => {
         if (closed) return
         closed = true
+        suppressSchoolWebsiteEmbed()
         window.clearInterval(layoutTimer)
         resizeObserver.disconnect()
         window.removeEventListener('resize', handleWindowResize)
@@ -228,10 +278,16 @@ export const mountSchoolWebsiteEmbed = async ({
         } catch {
           // ignore cleanup failure
         }
+        try {
+          await invokeNative('school_website_embed_close')
+        } catch {
+          // ignore
+        }
       }
     }
   } catch (error) {
     closed = true
+    suppressSchoolWebsiteEmbed()
     try {
       await invokeNative('school_website_embed_close')
     } catch {


### PR DESCRIPTION
## Summary

- Fixes #372 课表误报离线横幅
- Fixes #373 学校官网返回子 WebView 遮挡
- Fixes #375 学习通「会话已复用」后邀请码返回 HTML 非 JSON
- S1：Dev Android 单独 fat LTO + Oz（Windows 仍 thin 快编）

## Test plan
- [x] cargo check / vitest contracts
- [ ] CI
- [ ] 真机：学习通进资料库；课表无误报横幅；官网返回；Android APK 体积回落
