### PR TITLE
fix(ranking): 过期 jwxt cookie 不再锁死离线排名 (#390)

### DIFF
--- a/src-tauri/src/http_client/academic.rs
+++ b/src-tauri/src/http_client/academic.rs
@@ -1801,13 +1801,12 @@ impl HbutClient {
         parser::parse_exams(&json)
     }
 
-    /// ????/??????????/???
+    /// 绩点排名：班级 / 专业 / 学院排名与绩点摘要。
     pub async fn fetch_ranking(
         &self,
         student_id: Option<&str>,
         semester: Option<&str>,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        // 获取﹀彿
         let mut xh = student_id
             .map(|s| s.to_string())
             .or_else(|| self.user_info.as_ref().map(|u| u.student_id.clone()))
@@ -1817,31 +1816,57 @@ impl HbutClient {
             return Err("未提供学号".into());
         }
 
-        // 学习通账号登录时，前端 student_id 可能是手机号；优先回落到教务域 cookie 的 username。
-        if self.prefer_chaoxing_jwxt
+        let jwxt_url = Url::parse(super::JWXT_BASE_URL)?;
+        let chaoxing_jwxt_url = Url::parse(super::CHAOXING_JWXT_BASE_URL)?;
+        let jwxt_cookie = self
+            .cookie_jar
+            .cookies(&jwxt_url)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+            .unwrap_or_default();
+        let chaoxing_cookie = self
+            .cookie_jar
+            .cookies(&chaoxing_jwxt_url)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+            .unwrap_or_default();
+        let has_chaoxing_cookie = !chaoxing_cookie.trim().is_empty();
+        let has_jwxt_cookie = !jwxt_cookie.trim().is_empty();
+
+        let academic_base = self.academic_base_url();
+        let primary_base = super::resolve_ranking_base_url(
+            academic_base,
+            self.prefer_chaoxing_jwxt,
+            has_jwxt_cookie,
+            has_chaoxing_cookie,
+        );
+        println!(
+            "[调试] 排名域名决策: academic_base={}, primary={}, prefer_chaoxing={}, cookie_len(jwxt)={}, cookie_len(cx_jwxt)={}",
+            academic_base,
+            primary_base,
+            self.prefer_chaoxing_jwxt,
+            jwxt_cookie.len(),
+            chaoxing_cookie.len()
+        );
+
+        // 走超星教务时，前端 student_id 可能是手机号；从 cookie username 回落学号。
+        let use_chaoxing_primary = primary_base.contains("chaoxing")
+            || self.prefer_chaoxing_jwxt
+            || has_chaoxing_cookie;
+        if use_chaoxing_primary
             && xh.starts_with('1')
             && xh.len() == 11
             && xh.chars().all(|c| c.is_ascii_digit())
         {
-            let chaoxing_jwxt_url = Url::parse("https://hbut.jw.chaoxing.com")?;
-            if let Some(raw_cookie) = self
-                .cookie_jar
-                .cookies(&chaoxing_jwxt_url)
-                .and_then(|v| v.to_str().ok().map(|s| s.to_string()))
+            if let Some(cookie_xh) = chaoxing_cookie
+                .split(';')
+                .map(|v| v.trim())
+                .find_map(|pair| pair.strip_prefix("username=").map(|v| v.trim().to_string()))
+                .filter(|v| v.chars().all(|c| c.is_ascii_digit()) && v.len() >= 8)
             {
-                if let Some(cookie_xh) = raw_cookie
-                    .split(';')
-                    .map(|v| v.trim())
-                    .find_map(|pair| pair.strip_prefix("username=").map(|v| v.trim().to_string()))
-                    .filter(|v| v.chars().all(|c| c.is_ascii_digit()) && v.len() >= 8)
-                {
-                    println!("[调试] 排名学号修正: {} -> {}", xh, cookie_xh);
-                    xh = cookie_xh;
-                }
+                println!("[调试] 排名学号修正: {} -> {}", xh, cookie_xh);
+                xh = cookie_xh;
             }
         }
 
-        // 从学号推断年?
         let grade = if xh.len() >= 2 {
             let prefix = &xh[..2];
             if prefix.chars().all(|c| c.is_ascii_digit()) {
@@ -1854,112 +1879,103 @@ impl HbutClient {
         };
 
         let semester_value = semester.unwrap_or("").to_string();
-
         let params = [
             ("xh", xh.as_str()),
             ("sznj", grade.as_str()),
             ("xnxq", semester_value.as_str()),
         ];
 
-        let jwxt_url = Url::parse("https://jwxt.hbut.edu.cn")?;
-        let chaoxing_jwxt_url = Url::parse("https://hbut.jw.chaoxing.com")?;
-        let jwxt_cookie = self
-            .cookie_jar
-            .cookies(&jwxt_url)
-            .map(|v| v.to_str().unwrap_or_default().to_string())
-            .unwrap_or_default();
-        let chaoxing_cookie = self
-            .cookie_jar
-            .cookies(&chaoxing_jwxt_url)
-            .map(|v| v.to_str().unwrap_or_default().to_string())
-            .unwrap_or_default();
+        let bases =
+            super::ranking_base_fallback_chain(primary_base, has_jwxt_cookie, has_chaoxing_cookie);
+        let mut last_login_error: Option<String> = None;
 
-        let mut base = self.academic_base_url().to_string();
-        let has_chaoxing_cookie = !chaoxing_cookie.trim().is_empty();
-        let has_jwxt_cookie = !jwxt_cookie.trim().is_empty();
-        println!(
-            "[调试] 排名域名决策: base={}, prefer_chaoxing={}, cookie_len(jwxt)={}, cookie_len(cx_jwxt)={}",
-            base,
-            self.prefer_chaoxing_jwxt,
-            jwxt_cookie.len(),
-            chaoxing_cookie.len()
-        );
-        if self.prefer_chaoxing_jwxt && has_chaoxing_cookie {
-            base = "https://hbut.jw.chaoxing.com".to_string();
-        } else if !self.prefer_chaoxing_jwxt && has_jwxt_cookie {
-            base = "https://jwxt.hbut.edu.cn".to_string();
-        } else if has_chaoxing_cookie {
-            base = "https://hbut.jw.chaoxing.com".to_string();
-        }
+        for (idx, base) in bases.iter().enumerate() {
+            let ranking_url = format!("{}/admin/cjgl/xscjbbdy/getXscjpm", base);
+            println!(
+                "[调试] 获取排名[{}/{}]：{} with params: {:?}",
+                idx + 1,
+                bases.len(),
+                ranking_url,
+                params
+            );
 
-        let ranking_url = format!("{}/admin/cjgl/xscjbbdy/getXscjpm", base);
-        println!("[调试] 获取排名：{} with params: {:?}", ranking_url, params);
-        let response = self
-            .client
-            .get(&ranking_url)
-            .query(&params)
-            .header(
-                "Accept",
-                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            )
-            .header(
-                "Referer",
-                format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
-            )
-            .send()
-            .await?;
-        let mut status = response.status();
-        let mut final_url = response.url().to_string();
-        println!("[调试] 排名响应状态: {}, 地址: {}", status, final_url);
-        let mut html = response.text().await?;
-        if super::looks_like_academic_login_url(&final_url) {
-            // 学习通模式下，先补一次教务入口票据再重试。
-            if base.contains("hbut.jw.chaoxing.com") {
-                println!("[调试] 排名请求命中 auth 登录页，尝试补票后重试");
-                let _ = self.ensure_chaoxing_academic_session().await;
-                let retry_url = format!("{}/admin/cjgl/xscjbbdy/getXscjpm", base);
-                println!(
-                    "[调试] 重新获取排名：{} with params: {:?}",
-                    retry_url, params
-                );
-                let retry_resp = self
-                    .client
-                    .get(&retry_url)
-                    .query(&params)
-                    .header(
-                        "Accept",
-                        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                    )
-                    .header(
-                        "Referer",
-                        format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
-                    )
-                    .send()
-                    .await?;
-                status = retry_resp.status();
-                final_url = retry_resp.url().to_string();
-                println!("[调试] 排名重试响应状态: {}, 地址: {}", status, final_url);
-                html = retry_resp.text().await?;
+            let response = self
+                .client
+                .get(&ranking_url)
+                .query(&params)
+                .header(
+                    "Accept",
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                )
+                .header(
+                    "Referer",
+                    format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
+                )
+                .send()
+                .await?;
+            let mut status = response.status();
+            let mut final_url = response.url().to_string();
+            println!("[调试] 排名响应状态: {}, 地址: {}", status, final_url);
+            let mut html = response.text().await?;
+
+            // 命中登录页：超星域先补票；jwxt 域则尝试备选域名（链上的下一项）
+            if super::looks_like_academic_login_url(&final_url) {
+                if base.contains("chaoxing") {
+                    println!("[调试] 排名命中超星教务登录页，尝试补票后重试");
+                    let _ = self.ensure_chaoxing_academic_session().await;
+                    let retry_resp = self
+                        .client
+                        .get(&ranking_url)
+                        .query(&params)
+                        .header(
+                            "Accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                        )
+                        .header(
+                            "Referer",
+                            format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
+                        )
+                        .send()
+                        .await?;
+                    status = retry_resp.status();
+                    final_url = retry_resp.url().to_string();
+                    println!("[调试] 排名补票重试状态: {}, 地址: {}", status, final_url);
+                    html = retry_resp.text().await?;
+                }
+
+                if super::looks_like_academic_login_url(&final_url) {
+                    last_login_error = Some(format!(
+                        "排名会话失效 base={} final={}",
+                        base, final_url
+                    ));
+                    println!(
+                        "[调试] 排名域名 {} 仍为登录页，尝试下一候选（若有）",
+                        base
+                    );
+                    continue;
+                }
             }
-        }
-        if super::looks_like_academic_login_url(&final_url) {
-            return Err("会话已过期，请重新登录".into());
+
+            let html_lower = html.to_lowercase();
+            if html_lower.contains("authserver/login")
+                || html_lower.contains("id=\"casloginform\"")
+                || html_lower.contains("pwdencryptsalt")
+                || html.contains("统一身份认证")
+            {
+                last_login_error = Some("会话已失效，请重新登录后再查询排名".into());
+                continue;
+            }
+            if !status.is_success() {
+                last_login_error = Some(format!("排名接口请求失败: {}", status));
+                continue;
+            }
+
+            return parser::parse_ranking_html(&html, &xh, &semester_value, &grade);
         }
 
-        let html_lower = html.to_lowercase();
-        if html_lower.contains("authserver/login")
-            || html_lower.contains("id=\"casloginform\"")
-            || html_lower.contains("pwdencryptsalt")
-            || html.contains("统一身份认证")
-        {
-            return Err("会话已失效，请重新登录后再查询排名".into());
-        }
-        if !status.is_success() {
-            return Err(format!("排名接口请求失败: {}", status).into());
-        }
-
-        // 解析 HTML
-        parser::parse_ranking_html(&html, &xh, &semester_value, &grade)
+        Err(last_login_error
+            .unwrap_or_else(|| "会话已过期，请重新登录".to_string())
+            .into())
     }
 
     /// ????????

--- a/src-tauri/src/http_client/mod.rs
+++ b/src-tauri/src/http_client/mod.rs
@@ -96,6 +96,110 @@ pub(super) fn looks_like_academic_login_url(url: &str) -> bool {
         || (lower.contains("/admin/login") && !lower.contains("/admin/login2"))
 }
 
+/// 绩点排名接口主域名选择。
+///
+/// 历史 bug：`prefer_chaoxing=false` 且 jar 里仍有**过期** jwxt cookie 时，
+/// 会强制走 `jwxt.hbut.edu.cn`，即使用户实际会话在 `hbut.jw.chaoxing.com`。
+/// 结果 200 跳转到 `/admin/login`，上层回退 offline 缓存。
+///
+/// 规则：
+/// 1. 显式学习通教务优先且有 cx cookie → chaoxing
+/// 2. 仅一侧 cookie → 该侧
+/// 3. 双侧都有 → 信任 `academic_base_url`（通常因 cx cookie 已选 chaoxing）
+pub(super) fn resolve_ranking_base_url(
+    academic_base: &str,
+    prefer_chaoxing: bool,
+    has_jwxt_cookie: bool,
+    has_chaoxing_cookie: bool,
+) -> &'static str {
+    if prefer_chaoxing && has_chaoxing_cookie {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    if has_chaoxing_cookie && !has_jwxt_cookie {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    if has_jwxt_cookie && !has_chaoxing_cookie {
+        return JWXT_BASE_URL;
+    }
+    if has_chaoxing_cookie && academic_base.contains("chaoxing") {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    if has_jwxt_cookie {
+        return JWXT_BASE_URL;
+    }
+    if has_chaoxing_cookie {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    JWXT_BASE_URL
+}
+
+/// 主域名失败（登录页）时的备选域名顺序。
+pub(super) fn ranking_base_fallback_chain(
+    primary: &'static str,
+    has_jwxt_cookie: bool,
+    has_chaoxing_cookie: bool,
+) -> Vec<&'static str> {
+    let mut chain = vec![primary];
+    if primary == JWXT_BASE_URL && has_chaoxing_cookie {
+        chain.push(CHAOXING_JWXT_BASE_URL);
+    } else if primary == CHAOXING_JWXT_BASE_URL && has_jwxt_cookie {
+        chain.push(JWXT_BASE_URL);
+    }
+    chain
+}
+
+#[cfg(test)]
+mod ranking_domain_tests {
+    use super::*;
+
+    #[test]
+    fn dual_cookies_prefer_false_follows_academic_chaoxing() {
+        // 复现用户日志：prefer=false，双侧 cookie，academic 已选 chaoxing
+        let base = resolve_ranking_base_url(
+            "https://hbut.jw.chaoxing.com",
+            false,
+            true,
+            true,
+        );
+        assert_eq!(base, CHAOXING_JWXT_BASE_URL);
+    }
+
+    #[test]
+    fn dual_cookies_prefer_false_does_not_force_stale_jwxt() {
+        // 旧逻辑会选 jwxt；新逻辑不得在 academic=chaoxing 时强制 jwxt
+        let base = resolve_ranking_base_url(CHAOXING_JWXT_BASE_URL, false, true, true);
+        assert_ne!(base, JWXT_BASE_URL);
+    }
+
+    #[test]
+    fn only_jwxt_cookie_uses_jwxt() {
+        let base = resolve_ranking_base_url(JWXT_BASE_URL, false, true, false);
+        assert_eq!(base, JWXT_BASE_URL);
+    }
+
+    #[test]
+    fn prefer_chaoxing_uses_chaoxing() {
+        let base = resolve_ranking_base_url(JWXT_BASE_URL, true, true, true);
+        assert_eq!(base, CHAOXING_JWXT_BASE_URL);
+    }
+
+    #[test]
+    fn jwxt_primary_falls_back_to_chaoxing() {
+        let chain = ranking_base_fallback_chain(JWXT_BASE_URL, true, true);
+        assert_eq!(chain, vec![JWXT_BASE_URL, CHAOXING_JWXT_BASE_URL]);
+    }
+
+    #[test]
+    fn login_url_detection_covers_admin_login() {
+        assert!(looks_like_academic_login_url(
+            "https://jwxt.hbut.edu.cn/admin/login"
+        ));
+        assert!(looks_like_academic_login_url(
+            "https://hbut.jw.chaoxing.com/admin/login?service=x"
+        ));
+    }
+}
+
 /// 生成随机字符串（与学校 CAS 前端相同的字符集）
 pub(super) fn get_random_string(length: usize) -> String {
     const CHARS: &[u8] = b"ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";


### PR DESCRIPTION
## Summary
- Fixes #390: 绩点排名因强制 `jwxt.hbut.edu.cn` + 过期 cookie 跳到 `/admin/login`，刷新仍回退 offline 缓存
- 域名选择与 `academic_base_url` 对齐；双侧 cookie 时不再误选过期 jwxt
- 登录页失败时按链尝试 chaoxing / jwxt 并支持超星补票重试
- 单测覆盖用户日志场景的域名决策

## Test plan
- [x] `cargo test ranking_domain`（6 passed）
- [ ] 真机：有超星教务 cookie、jwxt cookie 过期时进入排名应可在线刷新