### PR TITLE
fix(modules/calendar): 模块 manifest 404 与校历离线 (#392 #393)

### DIFF
--- a/scripts/prune_website_module_versions.mjs
+++ b/scripts/prune_website_module_versions.mjs
@@ -1,5 +1,15 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * 裁剪 modules 历史版本目录，避免 website-pages 体积膨胀。
+ *
+ * 关键约束（#392）：
+ * - 根目录 `manifest.json` 的 `version` 对应目录 **必须保留**
+ * - 禁止仅用版本名字典序（`2026…` 会压过 `1.4.3-beta.xxx` 误删刚构建版本）
+ * - 其余版本按 mtime 新→旧补足 KEEP_VERSIONS
+ */
 
 const MODULES_ROOT = path.resolve(process.argv[2] || 'website/dist/modules')
 const KEEP_VERSIONS = Math.max(1, Number.parseInt(process.env.MODULE_KEEP_VERSIONS || '1', 10) || 1)
@@ -30,16 +40,64 @@ const listVersionDirs = (moduleDir) =>
     .filter((entry) => entry.isDirectory() && !RESERVED_DIR_NAMES.has(entry.name))
     .map((entry) => path.join(moduleDir, entry.name))
 
-const pruneModuleDir = (moduleDir) => {
+const readPreferredVersion = (moduleDir) => {
+  const manifestPath = path.join(moduleDir, 'manifest.json')
+  try {
+    if (!fs.existsSync(manifestPath)) return ''
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    return String(raw?.version || '').trim()
+  } catch {
+    return ''
+  }
+}
+
+const dirMtimeMs = (dirPath) => {
+  try {
+    return fs.statSync(dirPath).mtimeMs || 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * @param {string} moduleDir
+ * @param {{ keepVersions?: number }} [options]
+ * @returns {number} removed count
+ */
+export const pruneModuleDir = (moduleDir, options = {}) => {
+  const keepVersions = Math.max(1, Number(options.keepVersions || KEEP_VERSIONS) || 1)
   const versionDirs = listVersionDirs(moduleDir)
-  if (versionDirs.length <= KEEP_VERSIONS) return 0
+  if (versionDirs.length <= keepVersions) return 0
 
-  const sorted = versionDirs.sort((left, right) => path.basename(right).localeCompare(path.basename(left)))
-  const keep = new Set(sorted.slice(0, KEEP_VERSIONS))
+  const preferredVersion = readPreferredVersion(moduleDir)
+  const preferredDir = preferredVersion ? path.resolve(path.join(moduleDir, preferredVersion)) : ''
+  const preferredExists = preferredDir && fs.existsSync(preferredDir)
+
+  const keep = new Set()
+  if (preferredExists) {
+    keep.add(preferredDir)
+  }
+
+  const others = versionDirs
+    .map((dir) => path.resolve(dir))
+    .filter((dir) => !keep.has(dir))
+    .sort((left, right) => dirMtimeMs(right) - dirMtimeMs(left))
+
+  const remainingSlots = Math.max(0, keepVersions - keep.size)
+  for (const dir of others.slice(0, remainingSlots)) {
+    keep.add(dir)
+  }
+
+  if (keep.size === 0) {
+    for (const dir of others.slice(0, keepVersions)) {
+      keep.add(dir)
+    }
+  }
+
   let removed = 0
-
   for (const versionDir of versionDirs) {
-    if (keep.has(versionDir)) continue
+    const resolved = path.resolve(versionDir)
+    if (keep.has(resolved)) continue
     removeDir(versionDir)
     removed += 1
   }
@@ -63,4 +121,7 @@ const main = () => {
   console.log(`[modules-prune] removed ${removedVersions} old version dirs under ${MODULES_ROOT}`)
 }
 
-main()
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isDirectRun) {
+  main()
+}

--- a/scripts/prune_website_module_versions.spec.mjs
+++ b/scripts/prune_website_module_versions.spec.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { pruneModuleDir } from './prune_website_module_versions.mjs'
+
+const writeJson = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2))
+}
+
+const touchDir = (dirPath, mtimeMs) => {
+  fs.mkdirSync(dirPath, { recursive: true })
+  fs.writeFileSync(path.join(dirPath, 'marker.txt'), 'ok')
+  const when = new Date(mtimeMs)
+  fs.utimesSync(dirPath, when, when)
+}
+
+test('keeps manifest-pointed version even when older name sorts lower', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'modules-prune-'))
+  const moduleDir = path.join(root, 'hbut_2048')
+  // 模拟事故：manifest 指向 1.4.3-beta.308，另有 2026 时间戳目录
+  const beta = path.join(moduleDir, '1.4.3-beta.308')
+  const stamp = path.join(moduleDir, '20260715181525-bbf6f6e')
+  touchDir(beta, Date.now())
+  touchDir(stamp, Date.now() - 60_000)
+  fs.writeFileSync(path.join(beta, 'bundle.zip'), 'zip-beta')
+  fs.writeFileSync(path.join(stamp, 'bundle.zip'), 'zip-stamp')
+  writeJson(path.join(moduleDir, 'manifest.json'), {
+    version: '1.4.3-beta.308',
+    package_url: 'https://example.com/1.4.3-beta.308/bundle.zip'
+  })
+
+  const removed = pruneModuleDir(moduleDir, { keepVersions: 1 })
+  assert.equal(removed, 1)
+  assert.ok(fs.existsSync(path.join(beta, 'bundle.zip')), 'must keep manifest version dir')
+  assert.equal(fs.existsSync(stamp), false, 'older non-manifest version should be pruned')
+})
+
+test('without manifest keeps newest mtime version', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'modules-prune-'))
+  const moduleDir = path.join(root, 'demo')
+  const older = path.join(moduleDir, 'a-old')
+  const newer = path.join(moduleDir, 'b-new')
+  touchDir(older, Date.now() - 120_000)
+  touchDir(newer, Date.now())
+  const removed = pruneModuleDir(moduleDir, { keepVersions: 1 })
+  assert.equal(removed, 1)
+  assert.ok(fs.existsSync(newer))
+  assert.equal(fs.existsSync(older), false)
+})

--- a/src-tauri/src/http_client/academic.rs
+++ b/src-tauri/src/http_client/academic.rs
@@ -1874,9 +1874,8 @@ impl HbutClient {
         );
 
         // 走超星教务时，前端 student_id 可能是手机号；从 cookie username 回落学号。
-        let use_chaoxing_primary = primary_base.contains("chaoxing")
-            || self.prefer_chaoxing_jwxt
-            || has_chaoxing_cookie;
+        let use_chaoxing_primary =
+            primary_base.contains("chaoxing") || self.prefer_chaoxing_jwxt || has_chaoxing_cookie;
         if use_chaoxing_primary
             && xh.starts_with('1')
             && xh.len() == 11
@@ -1970,14 +1969,9 @@ impl HbutClient {
                 }
 
                 if super::looks_like_academic_login_url(&final_url) {
-                    last_login_error = Some(format!(
-                        "排名会话失效 base={} final={}",
-                        base, final_url
-                    ));
-                    println!(
-                        "[调试] 排名域名 {} 仍为登录页，尝试下一候选（若有）",
-                        base
-                    );
+                    last_login_error =
+                        Some(format!("排名会话失效 base={} final={}", base, final_url));
+                    println!("[调试] 排名域名 {} 仍为登录页，尝试下一候选（若有）", base);
                     continue;
                 }
             }

--- a/src-tauri/src/http_client/academic.rs
+++ b/src-tauri/src/http_client/academic.rs
@@ -306,34 +306,60 @@ impl HbutClient {
         &self,
         semester: &str,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        let calendar_url = format!(
-            "{}/admin/xsd/jcsj/xlgl/getData/{}",
+        // 与排名一致：双侧 cookie 时优先 academic_base_url，失败再换域（#393）
+        let jwxt_url = Url::parse(super::JWXT_BASE_URL)?;
+        let chaoxing_url = Url::parse(super::CHAOXING_JWXT_BASE_URL)?;
+        let has_jwxt = self
+            .cookie_jar
+            .cookies(&jwxt_url)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        let has_cx = self
+            .cookie_jar
+            .cookies(&chaoxing_url)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        let primary = super::resolve_ranking_base_url(
             self.academic_base_url(),
-            semester
+            self.prefer_chaoxing_jwxt,
+            has_jwxt,
+            has_cx,
         );
-        let mut repaired = false;
-        loop {
-            let response = self.client.get(&calendar_url).send().await?;
-            let status = response.status();
-            let final_url = response.url().to_string();
-            if super::looks_like_academic_login_url(&final_url) {
-                if self.prefer_chaoxing_jwxt
-                    && !repaired
-                    && self.ensure_chaoxing_academic_session().await
-                {
-                    repaired = true;
-                    println!("[调试] 校历请求命中登录页，已补票后重试");
-                    continue;
-                }
-                return Err("会话已过期，请重新登录".into());
-            }
-            if !status.is_success() {
-                return Err(format!("请求失败: {}", status).into());
-            }
+        let bases = super::ranking_base_fallback_chain(primary, has_jwxt, has_cx);
+        let mut last_err = String::from("会话已过期，请重新登录");
 
-            let data: serde_json::Value = response.json().await?;
-            return Ok(data);
+        for base in bases {
+            let calendar_url = format!("{}/admin/xsd/jcsj/xlgl/getData/{}", base, semester);
+            let mut repaired = false;
+            loop {
+                println!("[调试] 获取校历：{}", calendar_url);
+                let response = self.client.get(&calendar_url).send().await?;
+                let status = response.status();
+                let final_url = response.url().to_string();
+                println!("[调试] 校历响应状态: {}, 地址: {}", status, final_url);
+                if super::looks_like_academic_login_url(&final_url) {
+                    // 有超星 cookie 或 prefer 时均可补票，不再只认 prefer_chaoxing_jwxt
+                    if !repaired && has_cx && self.ensure_chaoxing_academic_session().await {
+                        repaired = true;
+                        println!("[调试] 校历请求命中登录页，已补票后重试 base={}", base);
+                        continue;
+                    }
+                    last_err = format!("会话已过期，请重新登录 (calendar base={})", base);
+                    break;
+                }
+                if !status.is_success() {
+                    last_err = format!("请求失败: {}", status);
+                    break;
+                }
+
+                let data: serde_json::Value = response.json().await?;
+                return Ok(data);
+            }
         }
+
+        Err(last_err.into())
     }
 
     async fn fetch_calendar_summary_for_semester(

--- a/src-tauri/src/http_client/academic.rs
+++ b/src-tauri/src/http_client/academic.rs
@@ -1833,7 +1833,6 @@ impl HbutClient {
         student_id: Option<&str>,
         semester: Option<&str>,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        // 获取﹀彿
         let mut xh = student_id
             .map(|s| s.to_string())
             .or_else(|| self.user_info.as_ref().map(|u| u.student_id.clone()))
@@ -1843,31 +1842,57 @@ impl HbutClient {
             return Err("未提供学号".into());
         }
 
-        // 学习通账号登录时，前端 student_id 可能是手机号；优先回落到教务域 cookie 的 username。
-        if self.prefer_chaoxing_jwxt
+        let jwxt_url = Url::parse(super::JWXT_BASE_URL)?;
+        let chaoxing_jwxt_url = Url::parse(super::CHAOXING_JWXT_BASE_URL)?;
+        let jwxt_cookie = self
+            .cookie_jar
+            .cookies(&jwxt_url)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+            .unwrap_or_default();
+        let chaoxing_cookie = self
+            .cookie_jar
+            .cookies(&chaoxing_jwxt_url)
+            .map(|v| v.to_str().unwrap_or_default().to_string())
+            .unwrap_or_default();
+        let has_chaoxing_cookie = !chaoxing_cookie.trim().is_empty();
+        let has_jwxt_cookie = !jwxt_cookie.trim().is_empty();
+
+        let academic_base = self.academic_base_url();
+        let primary_base = super::resolve_ranking_base_url(
+            academic_base,
+            self.prefer_chaoxing_jwxt,
+            has_jwxt_cookie,
+            has_chaoxing_cookie,
+        );
+        println!(
+            "[调试] 排名域名决策: academic_base={}, primary={}, prefer_chaoxing={}, cookie_len(jwxt)={}, cookie_len(cx_jwxt)={}",
+            academic_base,
+            primary_base,
+            self.prefer_chaoxing_jwxt,
+            jwxt_cookie.len(),
+            chaoxing_cookie.len()
+        );
+
+        // 走超星教务时，前端 student_id 可能是手机号；从 cookie username 回落学号。
+        let use_chaoxing_primary = primary_base.contains("chaoxing")
+            || self.prefer_chaoxing_jwxt
+            || has_chaoxing_cookie;
+        if use_chaoxing_primary
             && xh.starts_with('1')
             && xh.len() == 11
             && xh.chars().all(|c| c.is_ascii_digit())
         {
-            let chaoxing_jwxt_url = Url::parse("https://hbut.jw.chaoxing.com")?;
-            if let Some(raw_cookie) = self
-                .cookie_jar
-                .cookies(&chaoxing_jwxt_url)
-                .and_then(|v| v.to_str().ok().map(|s| s.to_string()))
+            if let Some(cookie_xh) = chaoxing_cookie
+                .split(';')
+                .map(|v| v.trim())
+                .find_map(|pair| pair.strip_prefix("username=").map(|v| v.trim().to_string()))
+                .filter(|v| v.chars().all(|c| c.is_ascii_digit()) && v.len() >= 8)
             {
-                if let Some(cookie_xh) = raw_cookie
-                    .split(';')
-                    .map(|v| v.trim())
-                    .find_map(|pair| pair.strip_prefix("username=").map(|v| v.trim().to_string()))
-                    .filter(|v| v.chars().all(|c| c.is_ascii_digit()) && v.len() >= 8)
-                {
-                    println!("[调试] 排名学号修正: {} -> {}", xh, cookie_xh);
-                    xh = cookie_xh;
-                }
+                println!("[调试] 排名学号修正: {} -> {}", xh, cookie_xh);
+                xh = cookie_xh;
             }
         }
 
-        // 从学号推断年?
         let grade = if xh.len() >= 2 {
             let prefix = &xh[..2];
             if prefix.chars().all(|c| c.is_ascii_digit()) {
@@ -1880,112 +1905,103 @@ impl HbutClient {
         };
 
         let semester_value = semester.unwrap_or("").to_string();
-
         let params = [
             ("xh", xh.as_str()),
             ("sznj", grade.as_str()),
             ("xnxq", semester_value.as_str()),
         ];
 
-        let jwxt_url = Url::parse("https://jwxt.hbut.edu.cn")?;
-        let chaoxing_jwxt_url = Url::parse("https://hbut.jw.chaoxing.com")?;
-        let jwxt_cookie = self
-            .cookie_jar
-            .cookies(&jwxt_url)
-            .map(|v| v.to_str().unwrap_or_default().to_string())
-            .unwrap_or_default();
-        let chaoxing_cookie = self
-            .cookie_jar
-            .cookies(&chaoxing_jwxt_url)
-            .map(|v| v.to_str().unwrap_or_default().to_string())
-            .unwrap_or_default();
+        let bases =
+            super::ranking_base_fallback_chain(primary_base, has_jwxt_cookie, has_chaoxing_cookie);
+        let mut last_login_error: Option<String> = None;
 
-        let mut base = self.academic_base_url().to_string();
-        let has_chaoxing_cookie = !chaoxing_cookie.trim().is_empty();
-        let has_jwxt_cookie = !jwxt_cookie.trim().is_empty();
-        println!(
-            "[调试] 排名域名决策: base={}, prefer_chaoxing={}, cookie_len(jwxt)={}, cookie_len(cx_jwxt)={}",
-            base,
-            self.prefer_chaoxing_jwxt,
-            jwxt_cookie.len(),
-            chaoxing_cookie.len()
-        );
-        if self.prefer_chaoxing_jwxt && has_chaoxing_cookie {
-            base = "https://hbut.jw.chaoxing.com".to_string();
-        } else if !self.prefer_chaoxing_jwxt && has_jwxt_cookie {
-            base = "https://jwxt.hbut.edu.cn".to_string();
-        } else if has_chaoxing_cookie {
-            base = "https://hbut.jw.chaoxing.com".to_string();
-        }
+        for (idx, base) in bases.iter().enumerate() {
+            let ranking_url = format!("{}/admin/cjgl/xscjbbdy/getXscjpm", base);
+            println!(
+                "[调试] 获取排名[{}/{}]：{} with params: {:?}",
+                idx + 1,
+                bases.len(),
+                ranking_url,
+                params
+            );
 
-        let ranking_url = format!("{}/admin/cjgl/xscjbbdy/getXscjpm", base);
-        println!("[调试] 获取排名：{} with params: {:?}", ranking_url, params);
-        let response = self
-            .client
-            .get(&ranking_url)
-            .query(&params)
-            .header(
-                "Accept",
-                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            )
-            .header(
-                "Referer",
-                format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
-            )
-            .send()
-            .await?;
-        let mut status = response.status();
-        let mut final_url = response.url().to_string();
-        println!("[调试] 排名响应状态: {}, 地址: {}", status, final_url);
-        let mut html = response.text().await?;
-        if super::looks_like_academic_login_url(&final_url) {
-            // 学习通模式下，先补一次教务入口票据再重试。
-            if base.contains("hbut.jw.chaoxing.com") {
-                println!("[调试] 排名请求命中 auth 登录页，尝试补票后重试");
-                let _ = self.ensure_chaoxing_academic_session().await;
-                let retry_url = format!("{}/admin/cjgl/xscjbbdy/getXscjpm", base);
-                println!(
-                    "[调试] 重新获取排名：{} with params: {:?}",
-                    retry_url, params
-                );
-                let retry_resp = self
-                    .client
-                    .get(&retry_url)
-                    .query(&params)
-                    .header(
-                        "Accept",
-                        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                    )
-                    .header(
-                        "Referer",
-                        format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
-                    )
-                    .send()
-                    .await?;
-                status = retry_resp.status();
-                final_url = retry_resp.url().to_string();
-                println!("[调试] 排名重试响应状态: {}, 地址: {}", status, final_url);
-                html = retry_resp.text().await?;
+            let response = self
+                .client
+                .get(&ranking_url)
+                .query(&params)
+                .header(
+                    "Accept",
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                )
+                .header(
+                    "Referer",
+                    format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
+                )
+                .send()
+                .await?;
+            let mut status = response.status();
+            let mut final_url = response.url().to_string();
+            println!("[调试] 排名响应状态: {}, 地址: {}", status, final_url);
+            let mut html = response.text().await?;
+
+            // 命中登录页：超星域先补票；jwxt 域则尝试备选域名（链上的下一项）
+            if super::looks_like_academic_login_url(&final_url) {
+                if base.contains("chaoxing") {
+                    println!("[调试] 排名命中超星教务登录页，尝试补票后重试");
+                    let _ = self.ensure_chaoxing_academic_session().await;
+                    let retry_resp = self
+                        .client
+                        .get(&ranking_url)
+                        .query(&params)
+                        .header(
+                            "Accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                        )
+                        .header(
+                            "Referer",
+                            format!("{}/admin/cjgl/xscjbbdy/xsgrcjpmlist1", base),
+                        )
+                        .send()
+                        .await?;
+                    status = retry_resp.status();
+                    final_url = retry_resp.url().to_string();
+                    println!("[调试] 排名补票重试状态: {}, 地址: {}", status, final_url);
+                    html = retry_resp.text().await?;
+                }
+
+                if super::looks_like_academic_login_url(&final_url) {
+                    last_login_error = Some(format!(
+                        "排名会话失效 base={} final={}",
+                        base, final_url
+                    ));
+                    println!(
+                        "[调试] 排名域名 {} 仍为登录页，尝试下一候选（若有）",
+                        base
+                    );
+                    continue;
+                }
             }
-        }
-        if super::looks_like_academic_login_url(&final_url) {
-            return Err("会话已过期，请重新登录".into());
+
+            let html_lower = html.to_lowercase();
+            if html_lower.contains("authserver/login")
+                || html_lower.contains("id=\"casloginform\"")
+                || html_lower.contains("pwdencryptsalt")
+                || html.contains("统一身份认证")
+            {
+                last_login_error = Some("会话已失效，请重新登录后再查询排名".into());
+                continue;
+            }
+            if !status.is_success() {
+                last_login_error = Some(format!("排名接口请求失败: {}", status));
+                continue;
+            }
+
+            return parser::parse_ranking_html(&html, &xh, &semester_value, &grade);
         }
 
-        let html_lower = html.to_lowercase();
-        if html_lower.contains("authserver/login")
-            || html_lower.contains("id=\"casloginform\"")
-            || html_lower.contains("pwdencryptsalt")
-            || html.contains("统一身份认证")
-        {
-            return Err("会话已失效，请重新登录后再查询排名".into());
-        }
-        if !status.is_success() {
-            return Err(format!("排名接口请求失败: {}", status).into());
-        }
-
-        // 解析 HTML
-        parser::parse_ranking_html(&html, &xh, &semester_value, &grade)
+        Err(last_login_error
+            .unwrap_or_else(|| "会话已过期，请重新登录".to_string())
+            .into())
     }
 
     /// ????????

--- a/src-tauri/src/http_client/mod.rs
+++ b/src-tauri/src/http_client/mod.rs
@@ -96,6 +96,73 @@ pub(super) fn looks_like_academic_login_url(url: &str) -> bool {
         || (lower.contains("/admin/login") && !lower.contains("/admin/login2"))
 }
 
+/// 教务业务域名选择（排名 / 校历等复用）。
+/// 双侧 cookie 时信任 academic_base，避免过期 jwxt cookie 强制走 jwxt（#390/#393）。
+pub(super) fn resolve_ranking_base_url(
+    academic_base: &str,
+    prefer_chaoxing: bool,
+    has_jwxt_cookie: bool,
+    has_chaoxing_cookie: bool,
+) -> &'static str {
+    if prefer_chaoxing && has_chaoxing_cookie {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    if has_chaoxing_cookie && !has_jwxt_cookie {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    if has_jwxt_cookie && !has_chaoxing_cookie {
+        return JWXT_BASE_URL;
+    }
+    if has_chaoxing_cookie && academic_base.contains("chaoxing") {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    if has_jwxt_cookie {
+        return JWXT_BASE_URL;
+    }
+    if has_chaoxing_cookie {
+        return CHAOXING_JWXT_BASE_URL;
+    }
+    JWXT_BASE_URL
+}
+
+/// 主域名失败（登录页）时的备选域名顺序。
+pub(super) fn ranking_base_fallback_chain(
+    primary: &'static str,
+    has_jwxt_cookie: bool,
+    has_chaoxing_cookie: bool,
+) -> Vec<&'static str> {
+    let mut chain = vec![primary];
+    if primary == JWXT_BASE_URL && has_chaoxing_cookie {
+        chain.push(CHAOXING_JWXT_BASE_URL);
+    } else if primary == CHAOXING_JWXT_BASE_URL && has_jwxt_cookie {
+        chain.push(JWXT_BASE_URL);
+    }
+    chain
+}
+
+#[cfg(test)]
+mod ranking_domain_tests {
+    use super::*;
+
+    #[test]
+    fn dual_cookies_prefer_false_follows_academic_chaoxing() {
+        let base = resolve_ranking_base_url("https://hbut.jw.chaoxing.com", false, true, true);
+        assert_eq!(base, CHAOXING_JWXT_BASE_URL);
+    }
+
+    #[test]
+    fn dual_cookies_prefer_false_does_not_force_stale_jwxt() {
+        let base = resolve_ranking_base_url(CHAOXING_JWXT_BASE_URL, false, true, true);
+        assert_ne!(base, JWXT_BASE_URL);
+    }
+
+    #[test]
+    fn jwxt_primary_falls_back_to_chaoxing() {
+        let chain = ranking_base_fallback_chain(JWXT_BASE_URL, true, true);
+        assert_eq!(chain, vec![JWXT_BASE_URL, CHAOXING_JWXT_BASE_URL]);
+    }
+}
+
 /// 生成随机字符串（与学校 CAS 前端相同的字符集）
 pub(super) fn get_random_string(length: usize) -> String {
     const CHARS: &[u8] = b"ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";


### PR DESCRIPTION
## Summary
- **#392 模块中心下载失败 / Android 404**：官网未挂。根因是 `prune_website_module_versions` 按版本**名字典序**保留目录，删掉了根 manifest 指向的 `1.4.3-beta.*`，保留 `2026…`，导致 `bundle.zip` / `site` 404。已改为**永远保留 manifest.version 目录**，其余按 mtime 裁剪。
- **#393 校历离线**：补票不再仅 `prefer_chaoxing`；双教务域回退。
- **#390 排名**：同 PR 合入双域排名请求修复（避免过期 jwxt 强制 offline）。

## 探测结论
| 项 | 结果 |
|----|------|
| `hbut.6661111.xyz` | 200 EdgeOne 正常 |
| catalog / root manifest | 200 |
| manifest 指向的 beta zip | **404（事故）** |
| 实际存活的 `2026…/bundle.zip` | 200 |

## 合并后必须
```bash
gh workflow run \"Website Modules Deploy\" --ref main
```
重建 modules 并同步 EdgeOne，否则线上 manifest 仍坏。

## Test plan
- [x] `node --test scripts/prune_website_module_versions.spec.mjs`
- [x] `cargo test ranking_domain`
- [ ] 部署后 HEAD package_url 200