### PR TITLE
fix(chaoxing): #351 热会话进页不阻塞 + keep-alive 学习通补票

### DIFF
--- a/docs/portal-session.md
+++ b/docs/portal-session.md
@@ -110,7 +110,8 @@ auth.hbut.edu.cn (CASTGC / TGT)
 |------|------|
 | 学习通 7 天票 | `ensure_chaoxing_sso`：jar 有 UID+token 则 `cookie_reuse`；进程内 7 天 SSO 缓存；30 分钟内跳过网络探针 |
 | 教务 jw_uf 2h | `ensure_chaoxing_academic_session`：90 分钟 soft TTL；过期先 `getMenuList` 探针，失败再 xxtlogin 续期 |
-| keep-alive | `refresh_session` 成功后顺带补 jw 短票并 `persist_session_cookies` |
+| keep-alive | 前端约 20 分钟 `refresh_session`：门户信息刷新 + jw 短票 + **后台 `ensure_chaoxing_sso` 补票**（#351，失败不阻断） |
+| 进页 | 有 last-class 时先进壳并行拉资料；登录后 `spawn_chaoxing_sso_warmup` 预热（#351） |
 
 关键 cookie 名：
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4078,8 +4078,32 @@ async fn get_cookies(state: State<'_, AppState>) -> Result<String, String> {
 
 #[tauri::command]
 async fn refresh_session(state: State<'_, AppState>) -> Result<UserInfo, String> {
-    let mut client = state.client.write().await;
-    client.refresh_session().await.map_err(|e| e.to_string())
+    let info = {
+        let mut client = state.client.write().await;
+        client.refresh_session().await.map_err(|e| e.to_string())?
+    };
+    // #351：keep-alive（约 20min）顺带后台轻量学习通补票；不阻塞本次返回
+    let client_arc = state.client.clone();
+    let sid = info.student_id.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut client = client_arc.write().await;
+        match modules::chaoxing_sso::ensure_chaoxing_sso(
+            &mut client,
+            Some(&sid),
+            modules::chaoxing_sso::EnsureSsoOptions {
+                force: false,
+                allow_silent_relogin: true,
+                preheated: false,
+                portal_password: None,
+            },
+        )
+        .await
+        {
+            Ok(v) => println!("[session] keep-alive 学习通补票: {}", v),
+            Err(e) => println!("[session] keep-alive 学习通补票失败（不阻断）: {}", e),
+        }
+    });
+    Ok(info)
 }
 
 #[tauri::command]

--- a/src/components/ChaoxingClassView.vue
+++ b/src/components/ChaoxingClassView.vue
@@ -1173,11 +1173,10 @@ const metaLine = (item) => {
 }
 
 /**
- * 进入路径：
+ * 进入路径（#351）：
  * 1) 远程/缓存邀请码
- * 2) SSO
- * 3) 有 last-class → 拉资料；not_joined 才「重新加入」
- * 4) 无 last-class：preview 后教师/已在班直进资料，否则欢迎入班
+ * 2) 有 last-class → 立刻出壳 + 并行拉资料（list_resources 内 ensure）；SSO hint 不阻塞首屏
+ * 3) 无 last-class → SSO → preview → 资料；冷路径展示明确 loading 文案
  */
 const boot = async () => {
   loadingBoot.value = true
@@ -1192,22 +1191,15 @@ const boot = async () => {
   loadDeclined()
   const saved = loadLastClass()
 
-  bootPhase.value = 'sso'
-  ssoHint.value = '正在连接学习通会话…'
+  // 热路径：本地已有班级缓存 → 秒开壳层，资料与 SSO 并行
   if (saved) {
     activeClass.value = saved
     bootPhase.value = 'ready'
     loadingBoot.value = false
-  }
-
-  const ssoOk = await ensureSso()
-  if (!ssoOk) {
-    bootPhase.value = 'error'
-    loadingBoot.value = false
-    return
-  }
-
-  if (saved) {
+    ssoHint.value = '正在连接学习通会话…'
+    statusMsg.value = '正在加载资料…'
+    // list_resources 后端已 ensure_chaoxing_sso；前端 ensure 只更新顶栏 hint
+    const ssoPromise = ensureSso()
     try {
       await loadResources({ rejoinOnNotJoined: true })
     } catch (e) {
@@ -1222,6 +1214,24 @@ const boot = async () => {
         error.value = msg
       }
     }
+    const ssoOk = await ssoPromise
+    // 列表与 SSO 均失败：升级错误态（有资料则仍可浏览缓存结果）
+    if (!ssoOk && resources.value.length === 0) {
+      bootPhase.value = 'error'
+      if (!error.value && ssoHint.value) {
+        error.value = ssoHint.value
+      }
+    }
+    return
+  }
+
+  // 冷路径：无 last-class，需先 SSO 再解析邀请码
+  bootPhase.value = 'sso'
+  ssoHint.value = '正在连接学习通会话…'
+  const ssoOk = await ensureSso()
+  if (!ssoOk) {
+    bootPhase.value = 'error'
+    loadingBoot.value = false
     return
   }
 
@@ -1284,16 +1294,16 @@ onMounted(() => {
       </template>
     </TPageHeader>
 
-    <!-- 启动中 -->
+    <!-- 启动中（冷路径全屏；热路径有 last-class 时直接出列表壳，不挡在此） -->
     <div v-if="loadingBoot" class="cx-boot">
       <div class="cx-spinner" />
       <p class="cx-boot-text">
         {{
           bootPhase === 'sso'
-            ? '正在连接学习通…'
+            ? '正在连接学习通会话…'
             : bootPhase === 'preview'
               ? '正在获取班级信息…'
-              : '加载中…'
+              : '首次进入需完成门户 SSO，请稍候…'
         }}
       </p>
       <p class="cx-boot-sub">通过校园门户 SSO 接入，无需学习通密码</p>

--- a/src/utils/chaoxing_class_home_contract.spec.ts
+++ b/src/utils/chaoxing_class_home_contract.spec.ts
@@ -75,6 +75,12 @@ describe('chaoxing_class home integration contract', () => {
     expect(classRs).toContain('resolve_membership')
     expect(view).toContain('loadSeq')
     expect(view).toContain('重试加载')
+    // #351：热路径 last-class 秒开壳 + 并行 SSO；冷路径明确 loading；keep-alive 补票
+    expect(view).toContain('ssoPromise')
+    expect(view).toContain('正在加载资料')
+    expect(view).toContain('首次进入需完成门户 SSO')
+    expect(rustLib).toContain('keep-alive 学习通补票')
+    expect(rustLib).toContain('spawn_chaoxing_sso_warmup')
     const remote = read('src/utils/remote_config.js')
     expect(remote).toContain('chaoxing_class')
     expect(remote).toContain('getChaoxingClassConfig')


### PR DESCRIPTION
## Summary
- 有 `last-class` 缓存时先进学习通壳层，资料列表与 SSO 并行，不再串行阻塞首屏
- 前端 ~20min `refresh_session` keep-alive 后台 `ensure_chaoxing_sso` 轻量补票
- 冷路径全屏 loading 文案更明确；文档与契约测试同步

## Test plan
- [x] `vitest`：`chaoxing_class_home_contract` + `chaoxing_sso_session_contract` 通过
- [ ] 有 last-class 冷启动：先进列表壳再出资料
- [ ] keep-alive 日志可见「学习通补票」

Closes #351