### PR TITLE
feat(website): /privacy + GitHub Pages 备用源与 CSS 修复

### DIFF
--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -4,13 +4,10 @@ on:
   push:
     branches:
       - main
+    # 文档-only 变更可跳过；网站源码 / 发布脚本 / 本 workflow 变更必须触发双部署
     paths-ignore:
       - "**.md"
-      - "website/**"
-      - "scripts/build_website_modules.mjs"
-      - "scripts/build_release_manifests.mjs"
-      - ".github/workflows/website-modules.yml"
-      - ".github/workflows/sync-website.yml"
+      - "docs/**"
   workflow_dispatch:
 
 permissions:

--- a/scripts/ci/deploy_github_pages.sh
+++ b/scripts/ci/deploy_github_pages.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # 将 GITHUB_PAGES=true 构建的 website/dist 推送到 gh-pages 分支根目录。
 # GitHub Pages 项目站地址：https://superdaobo.github.io/mini-hbut/（需要 basePath=/mini-hbut）
+#
+# 体积策略：GH Pages 作官网 + 更新清单备用源，不镜像 modules 游戏包与大体量安装包
+#（安装包仍走 GitHub Releases / 代理；EdgeOne website-pages 承载完整 CDN）。
 set -euo pipefail
 
 DEPLOY_MESSAGE="${DEPLOY_MESSAGE:?DEPLOY_MESSAGE is required}"
@@ -14,13 +17,30 @@ if [ ! -d "$DEPLOY_SOURCE_DIR" ]; then
   exit 1
 fi
 
-if [ -d "$DEPLOY_SOURCE_DIR/modules" ]; then
-  node scripts/prune_website_module_versions.mjs "$DEPLOY_SOURCE_DIR/modules"
+DEPLOY="$(mktemp -d)"
+# 仅同步站点静态页 + _next + 清单类资源，排除 modules 与大安装包
+rsync -a \
+  --exclude 'modules/' \
+  --exclude 'modules-src/' \
+  --exclude '*.exe' \
+  --exclude '*.msi' \
+  --exclude '*.dmg' \
+  --exclude '*.apk' \
+  --exclude '*.ipa' \
+  --exclude '*.AppImage' \
+  --exclude '*.zip' \
+  --exclude '*.tar.gz' \
+  "$DEPLOY_SOURCE_DIR/" "$DEPLOY/"
+
+# 发布清单 JSON 保留（更新探测备用）；清理空 releases 子目录中的大文件后若无 json 再删
+if [ -d "$DEPLOY/releases" ]; then
+  find "$DEPLOY/releases" -type f \
+    ! -name '*.json' ! -name '*.html' ! -name '*.txt' ! -name '*.md' \
+    -delete 2>/dev/null || true
 fi
 
-DEPLOY="$(mktemp -d)"
-cp -r "$DEPLOY_SOURCE_DIR/." "$DEPLOY/"
 touch "$DEPLOY/.nojekyll"
+# 确保 .nojekyll 优先被识别（避免 Jekyll 吃掉 _next）
 cd "$DEPLOY"
 git init -q
 git config user.name "github-actions[bot]"
@@ -28,4 +48,4 @@ git config user.email "github-actions[bot]@users.noreply.github.com"
 git add -A
 git commit -q -m "$DEPLOY_MESSAGE"
 git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:"$DEPLOY_BRANCH"
-echo "Deployed $DEPLOY_BRANCH from $DEPLOY_SOURCE_DIR: $DEPLOY_MESSAGE"
+echo "Deployed $DEPLOY_BRANCH (slim site + release JSON) from $DEPLOY_SOURCE_DIR: $DEPLOY_MESSAGE"

--- a/src/config/allowed_domains.spec.ts
+++ b/src/config/allowed_domains.spec.ts
@@ -4,6 +4,7 @@ import { isAllowedHttpsUrl, isDangerousUrlScheme } from './allowed_domains'
 describe('allowed_domains', () => {
   it('accepts project https hosts', () => {
     expect(isAllowedHttpsUrl('https://hbut.6661111.xyz/privacy')).toBe(true)
+    expect(isAllowedHttpsUrl('https://superdaobo.github.io/mini-hbut/privacy')).toBe(true)
     expect(isAllowedHttpsUrl('https://github.com/superdaobo/mini-hbut')).toBe(true)
   })
 

--- a/src/config/allowed_domains.ts
+++ b/src/config/allowed_domains.ts
@@ -5,6 +5,7 @@
 const DEFAULT_ALLOWED_HOST_SUFFIXES = Object.freeze([
   'hbut.6661111.xyz',
   'github.com',
+  'github.io',
   'githubusercontent.com',
   'gitcode.com',
   'jsdelivr.net',

--- a/src/utils/more_modules.js
+++ b/src/utils/more_modules.js
@@ -9,11 +9,13 @@ const assertRemoteModulesAllowed = () => {
 }
 
 const DEFAULT_MODULE_CDN_BASE = 'https://hbut.6661111.xyz/modules'
+/** GitHub Pages 备用模块 CDN（与 EdgeOne 同构 /modules 路径） */
+const GITHUB_PAGES_MODULE_CDN_BASE = 'https://superdaobo.github.io/mini-hbut/modules'
 const GITHUB_REPO = 'superdaobo/mini-hbut'
 const GITHUB_RAW_BASE = `https://raw.githubusercontent.com/${GITHUB_REPO}`
 const GITHUB_WEBSITE_BRANCH = 'website-pages'
 const GITHUB_PROXY_PREFIXES = Object.freeze(['https://hk.gh-proxy.org/', 'https://gh-proxy.com/', ''])
-const MODULE_PUBLIC_REPO_PATH = 'dist/modules'
+const MODULE_PUBLIC_REPO_PATH = 'modules'
 const MODULE_CDN_OVERRIDE_STORAGE_KEY = 'hbu_debug_module_cdn_base'
 const MODULE_STATE_STORAGE_KEY = 'hbu_more_module_state_v1'
 const MODULE_CATALOG_CACHE_STORAGE_KEY = 'hbu_more_module_catalog_cache_v1'
@@ -429,7 +431,14 @@ const extractModuleRelativePath = (inputUrl) => {
 const buildGithubRawUrl = (relativePath) => {
   const safePath = safeText(relativePath).replace(/^\/+/, '')
   if (!safePath) return ''
+  // website-pages 分支根目录即静态站（modules/ 在根下，兼容历史 dist/modules）
   return `${GITHUB_RAW_BASE}/${GITHUB_WEBSITE_BRANCH}/${MODULE_PUBLIC_REPO_PATH}/${safePath}`
+}
+
+const buildGithubPagesModuleUrl = (relativePath) => {
+  const safePath = safeText(relativePath).replace(/^\/+/, '')
+  if (!safePath) return ''
+  return `${GITHUB_PAGES_MODULE_CDN_BASE.replace(/\/+$/, '')}/${safePath}`
 }
 
 const buildCurrentBaseUrl = (relativePath) => {
@@ -503,13 +512,15 @@ const buildRemoteUrlCandidates = (inputUrl, preferredChannel = '', purpose = 're
       ? relativePath.replace(new RegExp(`^${channelHint}/`), `${normalizeChannel(preferredChannel)}/`)
       : relativePath
   const currentBaseUrl = buildCurrentBaseUrl(normalizedRelativePath)
+  const githubPagesUrl = buildGithubPagesModuleUrl(normalizedRelativePath)
   const rawUrl = buildGithubRawUrl(normalizedRelativePath)
+  // raw.githubusercontent 可走代理；GitHub Pages 备用站可直接嵌入（无 X-Frame 代理问题）
   const githubCandidates = buildMirrorCandidateUrls(rawUrl)
   const primaryCandidates = isModuleCdnOverrideActive()
     ? [currentBaseUrl]
-    : [currentBaseUrl, absolute]
+    : [currentBaseUrl, githubPagesUrl, absolute]
   return finalizeRemoteCandidates(
-    toUniqueTextList([...primaryCandidates, ...githubCandidates]),
+    toUniqueTextList([...primaryCandidates, githubPagesUrl, ...githubCandidates]),
     purpose,
     normalizedRelativePath
   )

--- a/src/utils/updater.js
+++ b/src/utils/updater.js
@@ -6,10 +6,18 @@ const GITHUB_RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`
 const GH_API_PROXY_PREFIX = 'https://gh-proxy.com/'
 const GH_DOWNLOAD_PROXY_PREFIX = 'https://gh-proxy.org/'
 
-// 腾讯云 EdgeOne Pages CDN 域名（部署后填写实际域名，留空则跳过 CDN 优先逻辑）
+// 主 CDN：腾讯云 EdgeOne Pages；备用：GitHub Pages 项目站（/mini-hbut）
 const EDGEONE_CDN_BASE = 'https://hbut.6661111.xyz'
-const STABLE_MANIFEST_URL = EDGEONE_CDN_BASE ? `${EDGEONE_CDN_BASE}/releases/stable-latest.json` : ''
-const DEV_MANIFEST_URL = EDGEONE_CDN_BASE ? `${EDGEONE_CDN_BASE}/releases/dev-latest.json` : ''
+const GITHUB_PAGES_CDN_BASE = 'https://superdaobo.github.io/mini-hbut'
+/** 更新清单 / 安装包 CDN 顺序：EdgeOne 优先，GitHub Pages 备用 */
+const CDN_BASES = Object.freeze(
+  [EDGEONE_CDN_BASE, GITHUB_PAGES_CDN_BASE].filter((base) => String(base || '').trim())
+)
+const STABLE_MANIFEST_URLS = CDN_BASES.map((base) => `${base}/releases/stable-latest.json`)
+const DEV_MANIFEST_URLS = CDN_BASES.map((base) => `${base}/releases/dev-latest.json`)
+// 兼容旧引用
+const STABLE_MANIFEST_URL = STABLE_MANIFEST_URLS[0] || ''
+const DEV_MANIFEST_URL = DEV_MANIFEST_URLS[0] || ''
 const UPDATE_CHANNEL_KEY = 'hbu_update_channel'
 const SKIPPED_VERSION_STABLE_KEY = 'hbu_skipped_version'
 const SKIPPED_VERSION_DEV_KEY = 'hbu_skipped_version_dev'
@@ -72,11 +80,17 @@ const DOWNLOAD_PROXIES = [
 export const isOfficialDownloadUrl = (url) => {
   const value = String(url || '').trim()
   if (!value) return false
-  return Boolean(EDGEONE_CDN_BASE && value.startsWith(`${EDGEONE_CDN_BASE}/releases/`))
+  return CDN_BASES.some((base) => value.startsWith(`${base}/releases/`))
 }
 
 export const describeUpdateDownloadSource = (url, index = 0) => {
   const value = String(url || '').trim()
+  if (EDGEONE_CDN_BASE && value.startsWith(`${EDGEONE_CDN_BASE}/`)) {
+    return { label: 'EdgeOne 主站', tag: 'edgeone' }
+  }
+  if (GITHUB_PAGES_CDN_BASE && value.startsWith(`${GITHUB_PAGES_CDN_BASE}/`)) {
+    return { label: 'GitHub Pages 备用', tag: 'ghpages' }
+  }
   if (value.includes('ghfast.top')) {
     return { label: '代理下载 1', tag: 'proxy1' }
   }
@@ -98,10 +112,21 @@ export const describeUpdateDownloadSource = (url, index = 0) => {
   return { label: `线路 ${index + 1}`, tag: `line${index}` }
 }
 
+/** CDN 安装包直链（EdgeOne 主 + GitHub Pages 备用），用于清单归一化与探测 */
+export const buildCdnReleaseAssetUrls = (downloadDir, filename) => {
+  const dir = String(downloadDir || '').trim().replace(/^\/+|\/+$/g, '')
+  const name = String(filename || '').trim().replace(/^\/+/, '')
+  if (!dir || !name) return []
+  return CDN_BASES.map((base) => `${base}/releases/${dir}/${name}`)
+}
+
 export const buildUpdateDownloadUrls = (tag, filename, primaryUrl = '') => {
+  // 下载列表：GitHub 代理链 + 源站；CDN 官方直链由 isOfficialDownloadUrl 过滤（UI 不重复展示）
+  // 清单阶段已用 EdgeOne → GitHub Pages 双 CDN 探测版本
   const candidates = [
     ...DOWNLOAD_PROXIES.map((fn) => fn(tag, filename)),
-    primaryUrl
+    primaryUrl,
+    ...buildCdnReleaseAssetUrls(tag, filename)
   ]
   return uniqueUrls(candidates).filter((url) => !isOfficialDownloadUrl(url))
 }
@@ -449,18 +474,22 @@ const normalizeReleaseNotesForVersion = (notes, version) => {
   return body
 }
 
-export const normalizeCdnManifestAsRelease = (manifest) => {
+export const normalizeCdnManifestAsRelease = (manifest, cdnBase = EDGEONE_CDN_BASE) => {
   if (!manifest?.tag || !manifest?.assets) return null
   const tag = String(manifest.tag || '').trim()
   const downloadDir = String(manifest.downloadDir || tag).trim() || tag
   const version = String(manifest.version || tag).replace(/^v/, '')
   const rawBody = String(manifest.release_notes || manifest.body || '').trim()
   const body = normalizeReleaseNotesForVersion(rawBody, version || tag)
+  const assetBase = String(cdnBase || EDGEONE_CDN_BASE || GITHUB_PAGES_CDN_BASE || '').replace(/\/+$/, '')
   const assets = Object.values(manifest.assets || {})
     .filter(Boolean)
     .map((filename) => ({
       name: filename,
-      browser_download_url: `${EDGEONE_CDN_BASE}/releases/${downloadDir}/${filename}`
+      // 资产 URL 绑定实际命中的 CDN；下载时还会追加 GitHub 代理与另一 CDN 候选
+      browser_download_url: assetBase
+        ? `${assetBase}/releases/${downloadDir}/${filename}`
+        : ''
     }))
 
   return {
@@ -475,8 +504,26 @@ export const normalizeCdnManifestAsRelease = (manifest) => {
     channel: String(manifest.channel || '').trim(),
     downloadDir,
     __fromCdnManifest: true,
+    __cdnBase: assetBase,
     __staleReleaseNotes: Boolean(rawBody && !body)
   }
+}
+
+/** 按 CDN 顺序拉取 manifest；返回 { manifest, base } 或 null */
+const fetchFirstCdnManifest = async (urls, timeoutMs = 6000) => {
+  for (const url of urls || []) {
+    const text = String(url || '').trim()
+    if (!text) continue
+    try {
+      const manifest = await fetchJson(text, timeoutMs)
+      if (!manifest?.tag || !manifest?.assets) continue
+      const base = CDN_BASES.find((b) => text.startsWith(`${b}/`)) || EDGEONE_CDN_BASE
+      return { manifest, base }
+    } catch (_) {
+      // try next CDN
+    }
+  }
+  return null
 }
 
 export const mergeCdnReleaseWithApiNotes = (cdnRelease, apiRelease) => {
@@ -498,23 +545,19 @@ export const mergeCdnReleaseWithApiNotes = (cdnRelease, apiRelease) => {
 
 async function fetchStableReleaseInfo(currentVersion) {
   let cdnCandidate = null
-  if (STABLE_MANIFEST_URL) {
-    try {
-      // 稳定频道只读 stable-latest，避免误用 dev alias。
-      const manifest = await fetchJson(STABLE_MANIFEST_URL, 6000)
-      const release = normalizeCdnManifestAsRelease(manifest)
-      if (release && shouldOfferRelease(release, currentVersion, 'stable')) {
-        if (release.__staleReleaseNotes) {
-          cdnCandidate = release
-        } else {
-          return release
-        }
-      } else if (release) {
-        // 即使无需升级也保留 candidate，供 UI 展示 latestVersion
+  // EdgeOne 主站 → GitHub Pages 备用 → GitHub API
+  const hit = await fetchFirstCdnManifest(STABLE_MANIFEST_URLS, 6000)
+  if (hit) {
+    const release = normalizeCdnManifestAsRelease(hit.manifest, hit.base)
+    if (release && shouldOfferRelease(release, currentVersion, 'stable')) {
+      if (release.__staleReleaseNotes) {
         cdnCandidate = release
+      } else {
+        return release
       }
-    } catch (_) {
-      // stable manifest 不可用，继续 fallback
+    } else if (release) {
+      // 即使无需升级也保留 candidate，供 UI 展示 latestVersion
+      cdnCandidate = release
     }
   }
 
@@ -540,22 +583,18 @@ async function fetchStableReleaseInfo(currentVersion) {
 
 async function fetchDevReleaseInfo(currentVersion) {
   let cdnCandidate = null
-  if (DEV_MANIFEST_URL) {
-    try {
-      const manifest = await fetchJson(DEV_MANIFEST_URL, 6000)
-      const release = normalizeCdnManifestAsRelease(manifest)
-      if (release) {
-        // 强制标记为 dev，避免旧 manifest 缺 channel
-        release.channel = release.channel || 'dev'
-        release.prerelease = true
-        if (!release.tag_name) release.tag_name = DEV_RELEASE_TAG
-        cdnCandidate = release
-        if (shouldOfferRelease(release, currentVersion, 'dev') && !release.__staleReleaseNotes) {
-          return release
-        }
+  const hit = await fetchFirstCdnManifest(DEV_MANIFEST_URLS, 6000)
+  if (hit) {
+    const release = normalizeCdnManifestAsRelease(hit.manifest, hit.base)
+    if (release) {
+      // 强制标记为 dev，避免旧 manifest 缺 channel
+      release.channel = release.channel || 'dev'
+      release.prerelease = true
+      if (!release.tag_name) release.tag_name = DEV_RELEASE_TAG
+      cdnCandidate = release
+      if (shouldOfferRelease(release, currentVersion, 'dev') && !release.__staleReleaseNotes) {
+        return release
       }
-    } catch (_) {
-      // dev CDN 不可用，走 GH tag
     }
   }
 

--- a/src/utils/updater_download_sources.spec.ts
+++ b/src/utils/updater_download_sources.spec.ts
@@ -24,7 +24,12 @@ describe('update download sources', () => {
       `https://hbut.6661111.xyz/releases/${tag}/${filename}`
     )
 
+    // EdgeOne / GitHub Pages 官方 CDN 直链不出现在代理列表（UI 用 isOfficialDownloadUrl 过滤）
     expect(urls.some((url) => isOfficialDownloadUrl(url))).toBe(false)
+    expect(isOfficialDownloadUrl(`https://hbut.6661111.xyz/releases/${tag}/${filename}`)).toBe(true)
+    expect(
+      isOfficialDownloadUrl(`https://superdaobo.github.io/mini-hbut/releases/${tag}/${filename}`)
+    ).toBe(true)
     expect(urls).toEqual([
       `https://ghfast.top/https://github.com/superdaobo/mini-hbut/releases/download/${tag}/${filename}`,
       `https://v4.gh-proxy.org/https://github.com/superdaobo/mini-hbut/releases/download/${tag}/${filename}`,
@@ -32,6 +37,17 @@ describe('update download sources', () => {
       `https://cdn.gh-proxy.org/https://github.com/superdaobo/mini-hbut/releases/download/${tag}/${filename}`,
       `https://github.com/superdaobo/mini-hbut/releases/download/${tag}/${filename}`
     ])
+  })
+
+  it('labels EdgeOne and GitHub Pages CDN sources', () => {
+    expect(
+      describeUpdateDownloadSource(`https://hbut.6661111.xyz/releases/${tag}/${filename}`)
+    ).toEqual({ label: 'EdgeOne 主站', tag: 'edgeone' })
+    expect(
+      describeUpdateDownloadSource(
+        `https://superdaobo.github.io/mini-hbut/releases/${tag}/${filename}`
+      )
+    ).toEqual({ label: 'GitHub Pages 备用', tag: 'ghpages' })
   })
 
   it('labels proxy URLs as proxies even though they contain github.com in the target URL', () => {
@@ -132,7 +148,10 @@ describe('update download sources', () => {
       assets: []
     })
 
-    expect(merged.assets[0].browser_download_url).toContain('hbut.6661111.xyz/releases/v1.4.0/')
+    expect(merged.assets[0].browser_download_url).toMatch(
+      /hbut\.6661111\.xyz|superdaobo\.github\.io\/mini-hbut/
+    )
+    expect(merged.assets[0].browser_download_url).toContain('/releases/v1.4.0/')
     expect(merged.body).toContain('v1.4.0')
     expect(merged.body).not.toContain('v1.3.6')
   })

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -8,9 +8,25 @@ export const metadata: Metadata = {
   description: '聚合课表、成绩、考试、通知与日程，把复杂的校园信息变成清晰、高效、好用的移动体验。',
 };
 
+// 与 next.config basePath 一致：GitHub Pages 项目站在 /mini-hbut 下
+const basePath = process.env.GITHUB_PAGES === 'true' ? '/mini-hbut' : '';
+const fontFaceCss = `
+@font-face {
+  font-family: 'SmileySans';
+  src: url('${basePath}/fonts/SmileySans-Oblique.woff2') format('woff2'),
+       url('${basePath}/fonts/SmileySans-Oblique.ttf') format('truetype');
+  font-weight: normal;
+  font-style: italic;
+  font-display: swap;
+}
+`.trim();
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="zh-CN">
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: fontFaceCss }} />
+      </head>
       <body className="bg-[#03060d] text-white antialiased" style={{ margin: 0, backgroundColor: '#03060d', color: '#ffffff' }}>
         <Suspense fallback={null}>
           <RouteScrollManager />

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import Privacy from '@/views/Privacy';
+
+export const metadata: Metadata = {
+  title: '隐私政策 — Mini-HBUT',
+  description:
+    'Mini-HBUT 隐私政策：说明本地会话、学业缓存、可选云同步与第三方端点如何处理你的数据。',
+};
+
+export default function PrivacyPage() {
+  return <Privacy />;
+}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -5,14 +5,7 @@
 @tailwind utilities;
 
 @layer base {
-  @font-face {
-    font-family: 'SmileySans';
-    src: url('/fonts/SmileySans-Oblique.woff2') format('woff2'),
-      url('/fonts/SmileySans-Oblique.ttf') format('truetype');
-    font-weight: normal;
-    font-style: italic;
-    font-display: swap;
-  }
+  /* @font-face 在 layout.tsx 注入（带 basePath），避免 GitHub Pages 子路径下 /fonts 404 */
 
   :root {
     --background: 0 0% 0%;

--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -1,23 +1,37 @@
 import { useEffect, useRef } from 'react';
+import Link from 'next/link';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
-import { Github, Heart, ExternalLink, Code2, Terminal } from 'lucide-react';
+import { Github, Heart, ExternalLink, Code2, Terminal, Shield } from 'lucide-react';
 
 gsap.registerPlugin(ScrollTrigger);
 
-const footerLinks = [
+type FooterLink = {
+  name: string;
+  href: string;
+  icon: typeof Github;
+  external?: boolean;
+};
+
+const footerLinks: { title: string; links: FooterLink[] }[] = [
   {
     title: '项目',
     links: [
-      { name: 'GitHub', href: 'https://github.com/superdaobo/mini-hbut', icon: Github },
-      { name: 'Releases', href: 'https://github.com/superdaobo/mini-hbut/releases', icon: ExternalLink },
+      { name: 'GitHub', href: 'https://github.com/superdaobo/mini-hbut', icon: Github, external: true },
+      {
+        name: 'Releases',
+        href: 'https://github.com/superdaobo/mini-hbut/releases',
+        icon: ExternalLink,
+        external: true,
+      },
     ],
   },
   {
     title: '文档',
     links: [
-      { name: 'README', href: 'https://github.com/superdaobo/mini-hbut#readme', icon: Code2 },
-      { name: 'Issues', href: 'https://github.com/superdaobo/mini-hbut/issues', icon: Terminal },
+      { name: 'README', href: 'https://github.com/superdaobo/mini-hbut#readme', icon: Code2, external: true },
+      { name: 'Issues', href: 'https://github.com/superdaobo/mini-hbut/issues', icon: Terminal, external: true },
+      { name: '隐私政策', href: '/privacy', icon: Shield, external: false },
     ],
   },
 ];
@@ -96,17 +110,26 @@ export default function Footer() {
               <ul className="space-y-3">
                 {group.links.map((link) => {
                   const Icon = link.icon;
+                  const className =
+                    'text-gray-400 text-sm font-mono hover:text-cyan transition-colors flex items-center gap-2 group';
                   return (
                     <li key={link.name}>
-                      <a
-                        href={link.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-gray-400 text-sm font-mono hover:text-cyan transition-colors flex items-center gap-2 group"
-                      >
-                        <Icon className="w-4 h-4 group-hover:scale-110 transition-transform" />
-                        {link.name}
-                      </a>
+                      {link.external === false ? (
+                        <Link href={link.href} className={className}>
+                          <Icon className="w-4 h-4 group-hover:scale-110 transition-transform" />
+                          {link.name}
+                        </Link>
+                      ) : (
+                        <a
+                          href={link.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={className}
+                        >
+                          <Icon className="w-4 h-4 group-hover:scale-110 transition-transform" />
+                          {link.name}
+                        </a>
+                      )}
                     </li>
                   );
                 })}
@@ -135,7 +158,21 @@ export default function Footer() {
             >
               GNU General Public License v3.0 (GPL v3) © 2026 Mini-HBUT
             </a>
-            <div>
+            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
+              <Link
+                href="/privacy"
+                className="text-gray-600 hover:text-cyan text-xs font-mono transition-colors"
+              >
+                隐私政策
+              </Link>
+              <a
+                href="https://superdaobo.github.io/mini-hbut/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-600 hover:text-cyan text-xs font-mono transition-colors"
+              >
+                GitHub Pages 备用站
+              </a>
               <a
                 href="https://icp.gov.moe/?keyword=20266111"
                 target="_blank"

--- a/website/src/views/Privacy.tsx
+++ b/website/src/views/Privacy.tsx
@@ -1,0 +1,212 @@
+import Link from 'next/link';
+import Navbar from '@/components/Navbar';
+
+const lastUpdated = '2026-07-17';
+
+const sections = [
+  {
+    id: 'overview',
+    title: '1. 概述',
+    paragraphs: [
+      'Mini-HBUT（以下简称「本应用」）是由个人开发者提供的校园信息聚合工具，用于在用户主动登录后查询课表、成绩、考试、通知、校园生活等相关信息。',
+      '本隐私政策说明我们收集哪些信息、如何使用、是否离开设备，以及你如何控制与删除数据。使用本应用即表示你已阅读并理解本政策；若不同意，请停止使用并卸载。',
+    ],
+  },
+  {
+    id: 'controller',
+    title: '2. 开发者与联系方式',
+    paragraphs: [
+      '本应用由个人开发者 superdaobo 维护，开源仓库见 GitHub：superdaobo/mini-hbut。',
+      '问题反馈请通过 GitHub Issues 或应用内公告/文档指引的渠道联系。官网：https://hbut.6661111.xyz ；备用站点：https://superdaobo.github.io/mini-hbut/ 。',
+    ],
+  },
+  {
+    id: 'data-we-process',
+    title: '3. 我们处理的数据',
+    paragraphs: [
+      '以下数据仅在你使用对应功能时处理，且多数保存在你的设备本地：',
+    ],
+    bullets: [
+      '账号标识：学号/用户名（用于登录与会话恢复）。',
+      '校园认证凭据：密码仅在你选择「记住密码」时可能存入系统密钥环；App Store 构建不会把密码备份到 localStorage。',
+      '会话 Cookie：统一身份认证、教务、学习通等相关 Cookie，用于维持已登录状态。',
+      '学业与校园数据缓存：课表、成绩、考试、排名、个人信息、电费、通知等接口返回的内容，用于离线查看与加速。',
+      '应用设置：主题、布局、字体、更新频道等偏好。',
+      '可选云同步标识：若你启用云同步，会生成设备标识并上传你选择同步的设置/学业缓存（不含密码与 Cookie）。',
+      '可选功能数据：验证码图片（OCR）、论坛资料、模块中心远程模块、AI 对话内容等，仅在你主动使用时产生。',
+      '演示账号 reviewer：仅使用本地演示数据，不向校园系统发送真实凭据。',
+    ],
+  },
+  {
+    id: 'not-collected',
+    title: '4. 我们不主动收集的数据',
+    bullets: [
+      '不出售你的个人数据。',
+      '不把密码或 Cookie 上传到第三方广告平台。',
+      'App Store / 合规构建下：默认关闭远程云同步开关与用量上送，且不请求不必要的定位权限。',
+      '不把调试日志、校园码、二维码默认发送到开发者服务器；仅在你主动反馈时可能由你自行提供。',
+    ],
+  },
+  {
+    id: 'purposes',
+    title: '5. 使用目的',
+    bullets: [
+      '完成校园统一身份认证并代你访问已授权的教务/学习通等接口。',
+      '在本地展示课表、成绩、考试、通知与校园生活相关信息。',
+      '在你启用时提供云同步、远程模块、论坛、OCR、AI 等可选能力。',
+      '检查应用更新、加载远程配置（公告、功能开关等）。',
+      '改进稳定性（仅限你主动开启的诊断/调试能力）。',
+    ],
+  },
+  {
+    id: 'third-parties',
+    title: '6. 第三方与数据离开设备的情况',
+    paragraphs: [
+      '本应用会在你操作时连接以下类型的服务（具体端点以远程配置与校园官方域名为准）：',
+    ],
+    bullets: [
+      '校园官方系统：统一身份认证、教务、学习通、图书馆、电费等（登录与业务查询所必需）。',
+      '更新与静态资源：腾讯云 EdgeOne Pages（主站 hbut.6661111.xyz）以及 GitHub Pages 备用站（superdaobo.github.io/mini-hbut）。',
+      '可选 OCR / 论坛 / 资料分享 / 云同步代理：仅在对应功能启用且你使用时访问。',
+      '字体或脚本 CDN（如 jsDelivr / unpkg）：仅在你选择远程字体等外观能力时。',
+      '开源托管：GitHub（源码、Release 安装包下载）。',
+    ],
+    paragraphsAfter: [
+      '第三方服务各自适用其隐私政策。校园系统由学校或官方平台运营，本应用无法控制其数据处理规则。',
+    ],
+  },
+  {
+    id: 'storage',
+    title: '7. 存储位置与期限',
+    bullets: [
+      '本地：应用数据目录、SQLite 会话库、localStorage/缓存、系统密钥环（若可用）。',
+      '会话 Cookie：随登录态存在，退出登录会清理运行态会话；彻底清除仍需删除应用数据。',
+      '缓存数据：用于离线体验，可在设置中清理，或卸载应用删除。',
+      '云端（仅你启用云同步时）：保留期限取决于云同步服务配置；关闭同步不保证远端历史立即删除。',
+    ],
+  },
+  {
+    id: 'security',
+    title: '8. 安全说明（如实披露）',
+    paragraphs: [
+      '我们采取合理技术措施保护本地会话，但请理解：',
+    ],
+    bullets: [
+      '本地 SQLite 与部分字段并非军用级加密；历史版本中可能存在 Base64 编码字段，不等于强加密。',
+      '请勿将 Cookie 快照、数据库文件、调试截图、校园码、验证码图片发给不可信对象。',
+      '公共 Wi‑Fi、代理或 HTTP 回退链路会改变传输风险；请优先使用可信网络。',
+      '远程模块与自定义脚本应按不可信内容对待；仅从官方渠道安装应用与模块。',
+    ],
+  },
+  {
+    id: 'your-rights',
+    title: '9. 你的控制权',
+    bullets: [
+      '退出登录：清除运行态会话与部分登录状态。',
+      '清除缓存 / 清除本地数据：删除学业缓存、部分设置与同步状态（以设置页实际能力为准）。',
+      '关闭可选功能：云同步、远程模块、OCR、论坛、AI、用量统计等。',
+      '卸载应用：删除应用沙箱内数据（系统级行为）。',
+      '查阅技术细节：见文档「安全与隐私」页（面向开发者的完整数据映射）。',
+    ],
+  },
+  {
+    id: 'children',
+    title: '10. 未成年人',
+    paragraphs: [
+      '本应用面向高校学生与教职工场景。若你是未成年人，请在监护人指导下使用，并确认是否允许使用校园账号相关功能。',
+    ],
+  },
+  {
+    id: 'changes',
+    title: '11. 政策更新',
+    paragraphs: [
+      '我们可能随功能迭代更新本政策，并在本页更新日期处标明。重大变更时会尽量通过官网公告或应用内通知提示。请定期查阅最新版本。',
+    ],
+  },
+  {
+    id: 'related',
+    title: '12. 相关链接',
+    bullets: [
+      '用户文档总览：/docs',
+      '安全与隐私（技术说明）：/docs/security-privacy',
+      '下载与版本：/releases',
+      '主站：https://hbut.6661111.xyz',
+      'GitHub Pages 备用：https://superdaobo.github.io/mini-hbut/',
+    ],
+  },
+];
+
+export default function Privacy() {
+  return (
+    <div className="relative min-h-screen overflow-x-hidden bg-[#03060d] text-white">
+      <Navbar />
+      <main className="relative z-10 mx-auto max-w-3xl px-4 pb-24 pt-28 sm:px-6 lg:px-8">
+        <header className="mb-10 space-y-4 border-b border-white/10 pb-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.25em] text-cyan/80">Legal</p>
+          <h1 className="bg-gradient-to-r from-cyan to-purple bg-clip-text text-4xl font-bold text-transparent">
+            隐私政策
+          </h1>
+          <p className="text-sm text-gray-400">
+            Mini-HBUT Privacy Policy · 最近更新：{lastUpdated}
+          </p>
+          <p className="leading-7 text-gray-300">
+            本页面向终端用户。若你需要更细的源码级数据映射与安全边界说明，请阅读{' '}
+            <Link href="/docs/security-privacy" className="text-cyan underline-offset-4 hover:underline">
+              安全与隐私文档
+            </Link>
+            。
+          </p>
+        </header>
+
+        <nav className="mb-10 rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+          <h2 className="mb-3 text-sm font-semibold text-white">目录</h2>
+          <ol className="grid gap-2 text-sm text-gray-400 sm:grid-cols-2">
+            {sections.map((section) => (
+              <li key={section.id}>
+                <a href={`#${section.id}`} className="hover:text-cyan">
+                  {section.title}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </nav>
+
+        <div className="space-y-10">
+          {sections.map((section) => (
+            <section key={section.id} id={section.id} className="scroll-mt-28 space-y-4">
+              <h2 className="text-2xl font-bold text-white">{section.title}</h2>
+              {section.paragraphs?.map((p) => (
+                <p key={p} className="leading-7 text-gray-300">
+                  {p}
+                </p>
+              ))}
+              {section.bullets?.length ? (
+                <ul className="list-disc space-y-2 pl-5 text-gray-300">
+                  {section.bullets.map((item) => (
+                    <li key={item} className="leading-7">
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {section.paragraphsAfter?.map((p) => (
+                <p key={p} className="leading-7 text-gray-300">
+                  {p}
+                </p>
+              ))}
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-16 border-t border-white/10 pt-8 text-sm text-gray-500">
+          <p>
+            开源协议 GPL-3.0 · © {new Date().getFullYear()} Mini-HBUT ·{' '}
+            <Link href="/" className="text-cyan hover:underline">
+              返回首页
+            </Link>
+          </p>
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/website/src/views/Search.tsx
+++ b/website/src/views/Search.tsx
@@ -123,6 +123,12 @@ const SEARCH_INDEX: SearchItem[] = [
     keywords: ['安全', '隐私', 'Cookie', 'token', '权限', '调试桥'],
   },
   {
+    title: '隐私政策',
+    description: '面向终端用户的隐私政策：本地数据、可选云同步与第三方端点说明。',
+    url: '/privacy',
+    keywords: ['隐私政策', 'Privacy', 'GDPR', '数据', '合规', 'App Store'],
+  },
+  {
     title: '参考资料',
     description: 'Tauri API、开发规范、外部集成和实现札记。',
     url: '/docs/reference',


### PR DESCRIPTION
## Summary
- 官网新增完整 `/privacy` 隐私政策页（App Store 要求）
- 客户端更新探测：EdgeOne → GitHub Pages → GitHub API 多源回退
- 模块下载增加 GitHub Pages 备用 CDN
- 修复 GitHub Pages CSS 未加载：Pages 源切到 `gh-pages`（`GITHUB_PAGES=true` / basePath=`/mini-hbut`），字体路径随 basePath 注入

## Test plan
- [x] vitest：updater / allowed_domains
- [x] website `GITHUB_PAGES=true` 构建含 `/privacy`
- [x] Playwright：`superdaobo.github.io/mini-hbut/` 样式恢复；`/privacy` 200
- [ ] EdgeOne 主站 `/privacy` 随 website-pages 同步后验证