### PR TITLE
feat(website): Hero v3 课表成绩对齐、右栏浮卡与 R3F 贴屏

### DIFF
--- a/website/src/components/CameraRig.tsx
+++ b/website/src/components/CameraRig.tsx
@@ -3,38 +3,53 @@
 import { useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
+import { applyParallax, vec3ToThree } from '@/lib/scroll-utils';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
 
 /**
- * 氛围镜头：缓慢漂移，服务粒子/光带背景。
- * 产品手机已改为 DOM 层，不再绑定 PhoneModel 关键帧。
+ * 驱动唯一 3D 产品手机的镜头：滚动关键帧 + 首屏 idle 环绕。
  */
 export default function CameraRig() {
   const { camera } = useThree();
-  const { pointer, reducedMotion, progress } = useScrollProgress();
-  const tRef = useRef(0);
-  const look = useRef(new THREE.Vector3(0, 0, 0));
+  const { sample, pointer, reducedMotion, isMobile } = useScrollProgress();
+  const lookAtRef = useRef(new THREE.Vector3());
+  const idlePhase = useRef(0);
 
   useFrame((_, delta) => {
-    tRef.current += delta;
-    const t = tRef.current;
-    const idle = reducedMotion ? 0 : 1;
+    if (isMobile) return;
+    const t = Math.min(0.12, delta);
+    idlePhase.current += delta;
 
-    const baseX = 0.15 + progress * 0.25 + pointer.x * 0.15 * idle;
-    const baseY = 1.15 + Math.sin(t * 0.35) * 0.08 * idle + pointer.y * 0.08 * idle;
-    const baseZ = 4.1 - progress * 0.35;
+    const parallaxStrength = reducedMotion ? 0 : 0.1;
+    let camPos = applyParallax(sample.camera.position, pointer, parallaxStrength);
+    let lookAt = applyParallax(sample.camera.lookAt, pointer, parallaxStrength * 0.4);
 
-    const target = new THREE.Vector3(baseX, baseY, baseZ);
-    const ease = 1 - Math.pow(0.001, Math.min(0.12, delta));
-    camera.position.lerp(target, ease);
+    // 镜头略偏向右侧产品位（与 PhoneModel 0.42 偏移对齐）
+    camPos = { ...camPos, x: camPos.x + 0.35 };
+    lookAt = { ...lookAt, x: lookAt.x + 0.35 };
 
-    look.current.lerp(new THREE.Vector3(pointer.x * 0.2 * idle, 0.1, 0), ease);
-    camera.lookAt(look.current);
+    if (!reducedMotion && sample.globalProgress < 0.1) {
+      const idle = idlePhase.current;
+      const amp = 1 - sample.globalProgress / 0.1;
+      camPos = {
+        x: camPos.x + Math.sin(idle * 0.5) * 0.18 * amp,
+        y: camPos.y + Math.sin(idle * 0.38) * 0.05 * amp,
+        z: camPos.z + Math.cos(idle * 0.5) * 0.08 * amp,
+      };
+    }
+
+    const targetPos = vec3ToThree(camPos);
+    const targetLook = vec3ToThree(lookAt);
+    const ease = 1 - Math.pow(0.0008, t);
+
+    camera.position.lerp(targetPos, ease);
+    lookAtRef.current.lerp(targetLook, ease);
+    camera.lookAt(lookAtRef.current);
 
     if ('fov' in camera) {
-      const p = camera as THREE.PerspectiveCamera;
-      p.fov = THREE.MathUtils.lerp(p.fov, 42 - progress * 2, ease);
-      p.updateProjectionMatrix();
+      const perspective = camera as THREE.PerspectiveCamera;
+      perspective.fov = THREE.MathUtils.lerp(perspective.fov, sample.camera.fov, ease);
+      perspective.updateProjectionMatrix();
     }
   });
 

--- a/website/src/components/HeroFeatureOrbits.tsx
+++ b/website/src/components/HeroFeatureOrbits.tsx
@@ -9,48 +9,41 @@ type OrbitCard = {
   id: AppModuleId;
   metric: string;
   screen: AppScreen;
-  /** 相对手机中心的百分比偏移 */
-  x: string;
-  y: string;
+  /** 仅用右侧/上下安全区，避免侵入左侧 lg:w-[42%] 文案 */
+  top: string;
+  right: string;
 };
 
-/** 与 Dashboard 快捷入口/功能网格同源的模块迷你卡 */
+/**
+ * 浮卡全部锚在「手机右侧栏」：
+ * 布局用 fixed 右侧轨道，不再用负向 translate 冲进左半屏。
+ */
 const ORBIT_CARDS: OrbitCard[] = [
-  { id: 'grades', metric: 'GPA 3.72', screen: 'grades', x: '-118%', y: '8%' },
-  { id: 'classroom', metric: '今 12 间空闲', screen: 'classroom', x: '108%', y: '0%' },
-  { id: 'exams', metric: '倒计时 6 天', screen: 'exams', x: '-102%', y: '58%' },
-  { id: 'electricity', metric: '余额 ¥28.6', screen: 'electricity', x: '96%', y: '52%' },
-  { id: 'calendar', metric: '第 14 教学周', screen: 'home', x: '-40%', y: '-18%' },
+  { id: 'grades', metric: 'GPA 3.72', screen: 'grades', top: '18%', right: '4%' },
+  { id: 'classroom', metric: '今 12 间空闲', screen: 'classroom', top: '32%', right: '3%' },
+  { id: 'exams', metric: '倒计时 6 天', screen: 'exams', top: '46%', right: '4.5%' },
+  { id: 'electricity', metric: '余额 ¥28.6', screen: 'electricity', top: '60%', right: '3%' },
+  { id: 'calendar', metric: '第 14 教学周', screen: 'home', top: '74%', right: '5%' },
 ];
 
 function screenMatches(card: OrbitCard, active: AppScreen) {
   if (card.screen === active) return true;
-  if (active === 'all-features' || active === 'home') return card.id === 'calendar' || card.id === 'grades';
+  if (active === 'all-features') return card.id === 'grades';
+  if (active === 'home') return card.id === 'calendar' || card.id === 'grades';
   return false;
 }
 
 export default function HeroFeatureOrbits() {
   const { sample, reducedMotion, isMobile } = useScrollProgress();
+  // 平板以下隐藏；桌面放在右 1/3，绝不进左文案区
   if (isMobile) return null;
 
-  const progress = sample.globalProgress;
-  // 随滚动略微散开
-  const spread = 1 + progress * 0.12;
-
   return (
-    <div className="pointer-events-none fixed inset-0 z-[13] hidden lg:block" aria-hidden>
-      <div
-        className="absolute left-1/2 top-0"
-        style={{
-          // 与 PhoneScreenOverlay 手机锚点大致对齐（偏右）
-          transform: `translate(calc(-50% + 18% + ${sample.phone.position.x * 40}%), ${
-            typeof window !== 'undefined' ? window.innerHeight * 0.14 + sample.phone.position.y * 70 : 120
-          }px) scale(${spread})`,
-          width: 292,
-          height: 600,
-          transformOrigin: 'center center',
-        }}
-      >
+    <div
+      className="pointer-events-none fixed inset-y-0 right-0 z-[13] hidden w-[min(280px,28vw)] min-w-[200px] lg:block"
+      aria-hidden
+    >
+      <div className="relative h-full w-full pr-3 pt-24">
         {ORBIT_CARDS.map((card, i) => {
           const mod = APP_MODULES.find((m) => m.id === card.id);
           if (!mod) return null;
@@ -59,35 +52,28 @@ export default function HeroFeatureOrbits() {
           return (
             <motion.div
               key={card.id}
-              className="absolute w-[132px]"
-              style={{
-                left: '50%',
-                top: '50%',
-                transform: `translate(${card.x}, ${card.y})`,
-              }}
-              initial={reducedMotion ? false : { opacity: 0, scale: 0.9 }}
+              className="absolute w-[148px]"
+              style={{ top: card.top, right: card.right }}
+              initial={reducedMotion ? false : { opacity: 0, x: 24 }}
               animate={{
-                opacity: 0.55 + sample.phone.screenBrightness * 0.45,
-                scale: active ? 1.06 : 1,
+                opacity: 0.72 + sample.phone.screenBrightness * 0.28,
+                x: 0,
+                scale: active ? 1.05 : 1,
               }}
-              transition={{ delay: 0.15 + i * 0.06, duration: 0.45 }}
+              transition={{ delay: 0.12 + i * 0.05, duration: 0.4 }}
             >
               <motion.div
-                className="rounded-2xl border border-white/15 bg-black/45 p-2.5 shadow-[0_16px_40px_rgba(0,0,0,0.45)] backdrop-blur-md"
+                className="rounded-2xl border border-white/15 bg-black/50 p-2.5 shadow-[0_16px_40px_rgba(0,0,0,0.45)] backdrop-blur-md"
                 style={{
                   boxShadow: active
-                    ? `0 0 0 1px ${mod.color}66, 0 16px 40px rgba(0,0,0,0.5), 0 0 28px ${mod.color}33`
+                    ? `0 0 0 1px ${mod.color}88, 0 16px 40px rgba(0,0,0,0.5), 0 0 24px ${mod.color}40`
                     : undefined,
                 }}
-                animate={
-                  reducedMotion
-                    ? undefined
-                    : { y: [0, i % 2 === 0 ? -5 : 5, 0] }
-                }
+                animate={reducedMotion ? undefined : { y: [0, i % 2 === 0 ? -4 : 4, 0] }}
                 transition={
                   reducedMotion
                     ? undefined
-                    : { duration: 3.2 + i * 0.25, repeat: Infinity, ease: 'easeInOut' }
+                    : { duration: 3 + i * 0.2, repeat: Infinity, ease: 'easeInOut' }
                 }
               >
                 <div className="flex items-center gap-2">
@@ -102,11 +88,14 @@ export default function HeroFeatureOrbits() {
                     <p className="truncate text-[9px] text-white/55">{card.metric}</p>
                   </div>
                 </div>
-                <div
-                  className="mt-2 h-0.5 overflow-hidden rounded-full bg-white/10"
-                  style={{ opacity: active ? 1 : 0.35 }}
-                >
-                  <div className="h-full w-2/3 rounded-full" style={{ background: mod.color }} />
+                <div className="mt-2 h-0.5 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{
+                      width: active ? '85%' : '45%',
+                      background: mod.color,
+                    }}
+                  />
                 </div>
               </motion.div>
             </motion.div>

--- a/website/src/components/HeroText.tsx
+++ b/website/src/components/HeroText.tsx
@@ -29,9 +29,9 @@ export default function HeroText() {
       animate={{ opacity }}
       transition={{ duration: reducedMotion ? 0 : 0.35, ease: 'easeOut' }}
     >
-      <div className="mx-auto flex h-full max-w-7xl flex-col justify-center px-5 pb-16 pt-24 md:px-8 lg:flex-row lg:items-center lg:gap-10 lg:px-10">
-        {/* 左侧文案 — 桌面；移动端置顶 */}
-        <div className="pointer-events-auto max-w-xl lg:w-[42%]">
+      <div className="mx-auto flex h-full max-w-7xl flex-col justify-center px-5 pb-16 pt-24 md:px-8 lg:flex-row lg:items-center lg:gap-8 lg:px-8 xl:px-10">
+        {/* 左侧文案 — 限制宽度，右侧留给 3D 手机与浮卡 */}
+        <div className="pointer-events-auto max-w-xl lg:w-[38%] lg:max-w-md xl:w-[40%]">
           <motion.div
             initial={reducedMotion ? false : { opacity: 0, y: 18 }}
             animate={{ opacity: 1, y: 0 }}
@@ -91,35 +91,26 @@ export default function HeroText() {
           </motion.div>
         </div>
 
-        {/* 右侧：当前屏幕字幕（对齐 3D 手机叙事） */}
-        <div className="pointer-events-none mt-8 hidden flex-1 justify-end lg:mt-0 lg:flex">
+        {/* 右侧字幕贴在文案列底部小条，避免与右栏浮卡争抢 */}
+        <div className="pointer-events-none mt-6 max-w-md lg:absolute lg:bottom-[12vh] lg:left-8 lg:mt-0 lg:w-[min(360px,34vw)] xl:left-10">
           <motion.div
             key={sample.activeScreen}
-            className="w-full max-w-sm rounded-2xl border border-white/10 bg-black/40 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.45)] backdrop-blur-md"
-            initial={reducedMotion ? false : { opacity: 0, x: 24 }}
-            animate={{ opacity: Math.min(1, 0.35 + sample.phone.screenBrightness * 0.65), x: 0 }}
-            transition={{ duration: 0.45 }}
+            className="hidden rounded-2xl border border-white/10 bg-black/45 p-3.5 shadow-[0_16px_48px_rgba(0,0,0,0.4)] backdrop-blur-md lg:block"
+            initial={reducedMotion ? false : { opacity: 0, y: 12 }}
+            animate={{ opacity: Math.min(1, 0.4 + sample.phone.screenBrightness * 0.6), y: 0 }}
+            transition={{ duration: 0.4 }}
           >
-            <div className="mb-2 flex items-center gap-2">
+            <div className="mb-1.5 flex items-center gap-2">
               <span
-                className="rounded-full px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-950"
+                className="rounded-full px-2 py-0.5 text-[10px] font-semibold text-slate-950"
                 style={{ background: caption.accent }}
               >
                 {caption.label}
               </span>
               <span className="text-[10px] text-white/40">App 界面预览</span>
             </div>
-            <h2 className="text-lg font-semibold text-white">{caption.title}</h2>
-            <p className="mt-1.5 text-sm leading-6 text-white/60">{caption.blurb}</p>
-            <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/10">
-              <motion.div
-                className="h-full rounded-full"
-                style={{ background: caption.accent }}
-                initial={{ width: '0%' }}
-                animate={{ width: `${12 + sample.globalProgress * 88}%` }}
-                transition={{ duration: 0.3 }}
-              />
-            </div>
+            <h2 className="text-base font-semibold text-white">{caption.title}</h2>
+            <p className="mt-1 text-xs leading-5 text-white/60">{caption.blurb}</p>
           </motion.div>
         </div>
       </div>

--- a/website/src/components/PhoneModel.tsx
+++ b/website/src/components/PhoneModel.tsx
@@ -2,8 +2,11 @@
 
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import PhoneAppScreen from './phone-app/PhoneAppScreen';
+import './phone-app/phone-app.css';
 import {
   BEVEL_RADIUS,
   PHONE_DEPTH,
@@ -15,9 +18,17 @@ import {
   phoneExtrudeSettings,
 } from './phone-app/phone-geometry';
 
+/** 屏幕 DOM 像素，配合 distanceFactor 贴合 3D 屏 */
+const SCREEN_DOM_W = 270;
+const SCREEN_DOM_H = 556;
+
+/**
+ * 唯一 3D 产品手机：机身 + 屏幕 Html 贴图（真 App UI）。
+ * 桌面主路径；移动端由 PhoneScreenOverlay DOM 降级。
+ */
 export default function PhoneModel() {
   const groupRef = useRef<THREE.Group>(null);
-  const { sample, pointer, reducedMotion } = useScrollProgress();
+  const { sample, pointer, reducedMotion, isMobile } = useScrollProgress();
 
   const frameGeometry = useMemo(() => {
     const shape = createPhoneProfile(PHONE_WIDTH, PHONE_HEIGHT, BEVEL_RADIUS);
@@ -29,33 +40,9 @@ export default function PhoneModel() {
   const frameMaterial = useMemo(
     () =>
       new THREE.MeshStandardMaterial({
-        color: '#141a28',
-        metalness: 0.94,
-        roughness: 0.18,
-      }),
-    [],
-  );
-
-  const bezelMaterial = useMemo(
-    () =>
-      new THREE.MeshStandardMaterial({
-        color: '#05080f',
-        metalness: 0.6,
-        roughness: 0.35,
-      }),
-    [],
-  );
-
-  const glassMaterial = useMemo(
-    () =>
-      new THREE.MeshPhysicalMaterial({
-        color: '#0a1628',
-        metalness: 0,
-        roughness: 0.05,
-        transmission: 0.15,
-        thickness: 0.05,
-        transparent: true,
-        opacity: 0.92,
+        color: '#1c2436',
+        metalness: 0.92,
+        roughness: 0.22,
       }),
     [],
   );
@@ -70,131 +57,97 @@ export default function PhoneModel() {
     [],
   );
 
-  const deskMaterial = useMemo(
-    () =>
-      new THREE.MeshPhysicalMaterial({
-        color: '#0d1118',
-        metalness: 0.1,
-        roughness: 0.15,
-        transmission: 0.65,
-        thickness: 0.8,
-        transparent: true,
-        opacity: 0.55,
-      }),
-    [],
-  );
-
   useFrame((state) => {
-    if (!groupRef.current) return;
+    if (!groupRef.current || isMobile) return;
     const t = state.clock.elapsedTime;
-    const floatY = Math.sin(t * 1.15) * sample.phone.float * 0.12;
-    const parallaxX = reducedMotion ? 0 : pointer.x * 0.1;
-    const parallaxY = reducedMotion ? 0 : pointer.y * 0.06;
-    // 与 DOM 产品框错位：3D 机身略偏左后，作景深与光影，UI 由前景 chrome 呈现
-    const stageOffsetX = -0.55;
-    const stageOffsetZ = -0.35;
+    const floatY = Math.sin(t * 1.1) * sample.phone.float * 0.1;
+    const parallaxX = reducedMotion ? 0 : pointer.x * 0.08;
+    const parallaxY = reducedMotion ? 0 : pointer.y * 0.05;
 
+    // 产品位：略偏右，给左侧文案留空（世界坐标）
     groupRef.current.position.set(
-      sample.phone.position.x + parallaxX + stageOffsetX,
-      sample.phone.position.y + floatY + parallaxY,
-      sample.phone.position.z + stageOffsetZ,
+      0.42 + sample.phone.position.x * 0.35 + parallaxX,
+      sample.phone.position.y * 0.5 + floatY + parallaxY,
+      sample.phone.position.z * 0.4,
     );
     groupRef.current.rotation.set(
-      sample.phone.rotation.x * 0.85,
-      sample.phone.rotation.y + 0.55 + parallaxX * 0.2,
+      sample.phone.rotation.x * 0.9,
+      sample.phone.rotation.y * 0.95 + parallaxX * 0.12,
       sample.phone.rotation.z,
     );
-    groupRef.current.scale.setScalar(sample.phone.scale * 0.92);
+    groupRef.current.scale.setScalar(sample.phone.scale * 0.98);
   });
 
-  const deskOpacity = 1 - Math.min(1, sample.globalProgress * 4);
+  if (isMobile) return null;
+
   const zFront = PHONE_DEPTH / 2;
+  // 经验标定：屏世界高度 ≈1.15，DOM 556px
+  const htmlDistanceFactor = 1.58;
 
   return (
     <group ref={groupRef}>
-      {/* 磨砂玻璃桌面 */}
-      <mesh position={[0, -0.42, 0]} rotation={[-Math.PI / 2, 0, 0]} material={deskMaterial}>
-        <planeGeometry args={[4.5, 3.2]} />
-      </mesh>
-      <mesh position={[0, -0.415, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-        <planeGeometry args={[4.2, 2.9]} />
-        <meshStandardMaterial
-          color="#0ff0fc"
-          transparent
-          opacity={0.04 * deskOpacity}
-          emissive="#0ff0fc"
-          emissiveIntensity={0.15}
-        />
-      </mesh>
-
-      {/* 机身 — 挤出圆角矩形 */}
-      <mesh geometry={frameGeometry} material={frameMaterial} castShadow />
+      <mesh geometry={frameGeometry} material={frameMaterial} castShadow receiveShadow />
 
       {/* 屏幕黑边 */}
       <mesh position={[0, 0, zFront + 0.001]}>
         <planeGeometry args={[SCREEN_WIDTH + 0.02, SCREEN_HEIGHT + 0.02]} />
-        <primitive object={bezelMaterial} attach="material" />
-      </mesh>
-
-      {/* 屏幕玻璃 */}
-      <mesh position={[0, 0, zFront + 0.0025]}>
-        <planeGeometry args={[SCREEN_WIDTH, SCREEN_HEIGHT]} />
-        <primitive object={glassMaterial} attach="material" />
-      </mesh>
-
-      {/* 屏幕反光 */}
-      <mesh position={[0.06, 0.2, zFront + 0.004]} rotation={[0, 0, 0.3]}>
-        <planeGeometry args={[0.14, 0.42]} />
-        <meshBasicMaterial color="#ffffff" transparent opacity={0.06 + sample.phone.screenBrightness * 0.05} />
+        <meshStandardMaterial color="#05080f" metalness={0.5} roughness={0.4} />
       </mesh>
 
       {/* 动态岛 */}
-      <mesh position={[0, PHONE_HEIGHT / 2 - 0.095, zFront + 0.003]}>
+      <mesh position={[0, PHONE_HEIGHT / 2 - 0.095, zFront + 0.004]}>
         <capsuleGeometry args={[0.028, 0.1, 4, 12]} />
         <meshStandardMaterial color="#030508" metalness={0.9} roughness={0.2} />
       </mesh>
-      <mesh position={[-0.022, PHONE_HEIGHT / 2 - 0.095, zFront + 0.004]}>
-        <circleGeometry args={[0.006, 16]} />
-        <meshStandardMaterial color="#111827" metalness={1} roughness={0.1} />
-      </mesh>
 
-      {/* 侧边电源键 */}
+      {/* 侧键 */}
       <mesh position={[PHONE_WIDTH / 2 + 0.003, 0.12, 0]} rotation={[0, 0, Math.PI / 2]}>
         <boxGeometry args={[0.09, 0.01, 0.018]} />
         <primitive object={buttonMaterial} attach="material" />
       </mesh>
-      {/* 音量键 */}
       <mesh position={[-PHONE_WIDTH / 2 - 0.003, 0.2, 0]} rotation={[0, 0, Math.PI / 2]}>
         <boxGeometry args={[0.05, 0.01, 0.018]} />
         <primitive object={buttonMaterial} attach="material" />
       </mesh>
-      <mesh position={[-PHONE_WIDTH / 2 - 0.003, 0.1, 0]} rotation={[0, 0, Math.PI / 2]}>
-        <boxGeometry args={[0.05, 0.01, 0.018]} />
-        <primitive object={buttonMaterial} attach="material" />
-      </mesh>
 
-      {/* 底部扬声器开孔 */}
-      {[-0.06, -0.03, 0, 0.03, 0.06].map((x) => (
-        <mesh key={x} position={[x, -PHONE_HEIGHT / 2 + 0.04, zFront + 0.002]}>
-          <circleGeometry args={[0.004, 8]} />
-          <meshStandardMaterial color="#1a2030" />
-        </mesh>
-      ))}
+      {/* App UI 贴屏 — 唯一屏幕内容源（桌面） */}
+      <Html
+        transform
+        occlude={false}
+        position={[0, 0, zFront + 0.006]}
+        distanceFactor={htmlDistanceFactor}
+        style={{
+          width: SCREEN_DOM_W,
+          height: SCREEN_DOM_H,
+          borderRadius: 22,
+          overflow: 'hidden',
+          pointerEvents: 'none',
+          userSelect: 'none',
+          background: '#f0f4f8',
+        }}
+        zIndexRange={[20, 0]}
+      >
+        <div
+          style={{
+            width: SCREEN_DOM_W,
+            height: SCREEN_DOM_H,
+            overflow: 'hidden',
+            borderRadius: 22,
+            background: '#f0f4f8',
+          }}
+        >
+          <PhoneAppScreen
+            screenFrom={sample.screenFrom}
+            screenTo={sample.screenTo}
+            screenBlend={sample.screenBlend}
+          />
+        </div>
+      </Html>
 
-      {/* 发光屏幕（具体 App UI 由前景产品框 PhoneScreenOverlay 呈现） */}
-      <mesh position={[0, 0, zFront + 0.003]}>
-        <planeGeometry args={[SCREEN_WIDTH, SCREEN_HEIGHT]} />
-        <meshStandardMaterial
-          color="#0c1a2e"
-          emissive="#38bdf8"
-          emissiveIntensity={0.25 + sample.phone.screenBrightness * 0.85}
-          metalness={0.1}
-          roughness={0.2}
-        />
-      </mesh>
-      <mesh position={[0, 0, zFront + 0.004]}>
-        <planeGeometry args={[SCREEN_WIDTH * 0.92, SCREEN_HEIGHT * 0.55]} />
-        <meshBasicMaterial color="#67e8f9" transparent opacity={0.06 + sample.phone.screenBrightness * 0.08} />
+      {/* 玻璃反光（在 Html 之上用半透明 mesh 会挡住点击，此处仅边缘高光 mesh 在屏后即可） */}
+      <mesh position={[0.08, 0.22, zFront + 0.007]} rotation={[0, 0, 0.25]}>
+        <planeGeometry args={[0.12, 0.38]} />
+        <meshBasicMaterial color="#ffffff" transparent opacity={0.05} depthWrite={false} />
       </mesh>
     </group>
   );

--- a/website/src/components/SceneCanvas.tsx
+++ b/website/src/components/SceneCanvas.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { ContactShadows, Grid } from '@react-three/drei';
+import { ContactShadows, Float, Grid } from '@react-three/drei';
 import CameraRig from './CameraRig';
+import PhoneModel from './PhoneModel';
 import ParticleField from './ParticleField';
 import LightRibbons from './LightRibbons';
 import SceneErrorBoundary from './SceneErrorBoundary';
@@ -18,41 +19,47 @@ function supportsWebGL() {
   }
 }
 
-/** 仅氛围 3D：粒子 / 光带 / 地面阴影。产品手机由 DOM 层唯一呈现，不再挂空壳机身。 */
+/** 唯一 3D 产品手机（Html 贴屏）+ 氛围 */
 function SceneContent() {
   return (
     <>
       <color attach="background" args={['#03060d']} />
-      <fog attach="fog" args={['#03060d', 6, 16]} />
+      <fog attach="fog" args={['#03060d', 5.5, 14]} />
 
-      <ambientLight intensity={0.4} />
-      <hemisphereLight args={['#b8e7ff', '#0a1020', 0.55]} />
-      <directionalLight position={[3, 4, 2]} intensity={0.9} color="#d7f3ff" />
-      <directionalLight position={[-3, 2, -1]} intensity={0.4} color="#a78bfa" />
-      <pointLight position={[0.5, 1.2, 1.5]} intensity={0.7} color="#38bdf8" distance={10} />
+      <ambientLight intensity={0.42} />
+      <hemisphereLight args={['#c8ecff', '#0a1020', 0.6]} />
+      <directionalLight position={[2.8, 4.2, 2.4]} intensity={1.15} color="#e8f7ff" castShadow />
+      <directionalLight position={[-3.2, 1.6, -1.2]} intensity={0.5} color="#a78bfa" />
+      <pointLight position={[0.6, 1.1, 1.6]} intensity={0.9} color="#38bdf8" distance={9} />
+      <spotLight position={[1.2, 2.8, 2.2]} angle={0.4} penumbra={0.55} intensity={0.85} color="#7dd3fc" />
 
       <CameraRig />
+
+      <Float speed={1.05} rotationIntensity={0.06} floatIntensity={0.12}>
+        <PhoneModel />
+      </Float>
+
       <ParticleField />
       <LightRibbons />
 
       <ContactShadows
-        position={[0, -1.1, 0]}
-        opacity={0.4}
-        scale={10}
-        blur={2.8}
-        far={5}
+        position={[0, -0.95, 0]}
+        opacity={0.48}
+        scale={9}
+        blur={2.5}
+        far={4.5}
         color="#000000"
       />
 
       <Grid
-        position={[0, -1.12, 0]}
+        position={[0, -0.97, 0]}
         args={[14, 14]}
-        cellSize={0.32}
+        cellSize={0.3}
         cellThickness={0.35}
-        sectionSize={1.4}
-        sectionThickness={0.7}
-        fadeDistance={11}
-        fadeStrength={1.5}
+        sectionSize={1.3}
+        sectionThickness={0.75}
+        fadeDistance={10}
+        fadeStrength={1.45}
         cellColor="#12263d"
         sectionColor="#0e7490"
         infiniteGrid
@@ -89,8 +96,9 @@ export default function SceneCanvas() {
       <SceneErrorBoundary fallback={<CanvasFallback />}>
         <Canvas
           dpr={dpr}
-          camera={{ position: [0.2, 1.2, 4.2], fov: 42, near: 0.1, far: 40 }}
+          camera={{ position: [0.55, 0.35, 2.65], fov: 36, near: 0.05, far: 40 }}
           gl={{ antialias: true, alpha: false, powerPreference: 'high-performance' }}
+          shadows
           onCreated={({ gl }) => {
             gl.setClearColor('#03060d');
           }}

--- a/website/src/components/home/HomeExperience.tsx
+++ b/website/src/components/home/HomeExperience.tsx
@@ -10,7 +10,7 @@ import HomeClassicSections from '@/components/home/HomeClassicSections';
 import PhoneScreenOverlay from '@/components/phone-app/PhoneScreenOverlay';
 import HeroFeatureOrbits from '@/components/HeroFeatureOrbits';
 import SceneErrorBoundary from '@/components/SceneErrorBoundary';
-import { ScrollProgressProvider } from '@/hooks/use-scroll-progress';
+import { ScrollProgressProvider, useScrollProgress } from '@/hooks/use-scroll-progress';
 import { useHeroScrollPhase } from '@/hooks/use-hero-scroll-phase';
 import { useIdleHeroDemo } from '@/hooks/use-idle-hero-demo';
 
@@ -21,6 +21,7 @@ const SceneCanvas = dynamic(() => import('@/components/SceneCanvas'), {
 
 function HomeExperienceInner() {
   const pastHero = useHeroScrollPhase();
+  const { isMobile } = useScrollProgress();
   useIdleHeroDemo(!pastHero);
 
   return (
@@ -31,17 +32,17 @@ function HomeExperienceInner() {
         <div id="download" className="sr-only" aria-hidden />
         <div id="about" className="sr-only" aria-hidden />
 
-        {/* 背景氛围 3D（无手机空壳） */}
+        {/* 桌面：R3F 唯一手机贴屏；移动端场景仅氛围 */}
         <SmoothScrollProvider hideScene={pastHero}>
           <SceneErrorBoundary>
             <SceneCanvas />
           </SceneErrorBoundary>
         </SmoothScrollProvider>
 
-        {/* 唯一产品手机 + 迷你功能卡 */}
         {!pastHero && (
           <>
-            <PhoneScreenOverlay />
+            {/* 移动端 DOM 降级手机；桌面不叠第二台 */}
+            {isMobile && <PhoneScreenOverlay />}
             <HeroFeatureOrbits />
             <HeroText />
             <FeatureTextOverlay />

--- a/website/src/components/phone-app/PhoneAppScreen.tsx
+++ b/website/src/components/phone-app/PhoneAppScreen.tsx
@@ -197,8 +197,11 @@ function HomeScreen() {
 }
 
 function ScheduleScreen() {
+  // 对齐 ScheduleView：月栏 + 7 日 + 节次轴 + 彩色课程块
   const days = ['一', '二', '三', '四', '五', '六', '日'];
-  const periods = [1, 2, 3, 4, 5, 6, 7, 8];
+  const dayNums = [14, 15, 16, 17, 18, 19, 20];
+  const periods = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const todayIdx = 2;
 
   return (
     <AppShell screen="schedule">
@@ -211,10 +214,11 @@ function ScheduleScreen() {
           </div>
           <div className="phone-schedule-topbar-center">
             <div className="phone-schedule-topbar-title">我的课表</div>
-            <div className="phone-schedule-topbar-sub">2025-2026 第 1 学期</div>
+            <div className="phone-schedule-topbar-sub">2025-2026 · 第 1 学期</div>
           </div>
-          <div className="phone-schedule-week-pill">第 14 周</div>
+          <div className="phone-schedule-week-pill">第 14 周 ▾</div>
         </div>
+
         <div className="phone-schedule-date-header">
           <div className="phone-schedule-month">
             <span className="phone-schedule-month-num">7</span>
@@ -222,24 +226,32 @@ function ScheduleScreen() {
           </div>
           <div className="phone-schedule-days-row">
             {days.map((d, i) => (
-              <div key={d} className={`phone-schedule-day-col ${i === 2 ? 'is-today' : ''}`}>
-                <div className="phone-schedule-day-num">{14 + i}</div>
+              <div key={d} className={`phone-schedule-day-col ${i === todayIdx ? 'is-today' : ''}`}>
+                <div className="phone-schedule-day-num">{dayNums[i]}</div>
                 <div className="phone-schedule-day-label">周{d}</div>
               </div>
             ))}
           </div>
         </div>
+
         <div className="phone-schedule-grid-body">
           <div className="phone-schedule-time-axis">
             {periods.map((p) => (
-              <div key={p} className="phone-schedule-time-slot">
+              <div key={p} className="phone-schedule-time-slot" style={{ height: 22 }}>
                 <span className="period-num">{p}</span>
               </div>
             ))}
           </div>
-          <div className="phone-schedule-courses-grid" style={{ height: 160 }}>
-            {[0, 1, 2, 3, 4].map((dayIdx) => (
-              <div key={dayIdx} className={`phone-schedule-day-column ${dayIdx === 2 ? 'is-today' : ''}`}>
+          <div
+            className="phone-schedule-courses-grid"
+            style={{ height: periods.length * 22, gridTemplateColumns: 'repeat(7, 1fr)' }}
+          >
+            {days.map((_, dayIdx) => (
+              <div
+                key={dayIdx}
+                className={`phone-schedule-day-column ${dayIdx === todayIdx ? 'is-today' : ''}`}
+                style={{ gridTemplateRows: `repeat(${periods.length}, 22px)` }}
+              >
                 {DEMO_SCHEDULE_BLOCKS.filter((b) => b.day === dayIdx + 1).map((block) => (
                   <div
                     key={`${block.day}-${block.period}-${block.name}`}
@@ -263,29 +275,61 @@ function ScheduleScreen() {
 }
 
 function GradesScreen() {
+  // 对齐成绩模块：学期 chip + 绩点横幅 + 课程列表卡
+  const terms = ['全部', '2025-2026-1', '2024-2025-2'];
+  const activeTerm = '2025-2026-1';
+  // Hero 演示固定本学期；chip「全部」仅视觉，列表仍按 activeTerm 过滤
+  const list = DEMO_GRADES.filter((g) => g.term === activeTerm);
+
   return (
     <AppShell screen="grades" showNav={false}>
       <PageHeader title="成绩查询" icon={<GraduationCap className="h-4 w-4 text-indigo-500" />} />
       <div className="phone-feature-body">
-        <div className="phone-gradient-banner phone-gradient-indigo">
-          <p className="phone-banner-label">本学期绩点</p>
-          <p className="phone-banner-value">{DEMO_STUDENT.gpa}</p>
-          <p className="phone-banner-sub">已修学分 {DEMO_STUDENT.credits}</p>
+        <div className="phone-grade-term-row">
+          {terms.map((t) => (
+            <span
+              key={t}
+              className={`phone-grade-term-chip ${t === activeTerm ? 'is-active' : ''}`}
+            >
+              {t === '全部' ? t : t.replace('2025-2026-1', '本学期').replace('2024-2025-2', '上学期')}
+            </span>
+          ))}
         </div>
-        {DEMO_GRADES.map((g) => (
-          <div key={g.name} className="phone-list-item">
+
+        <div className="phone-gradient-banner phone-gradient-indigo">
+          <div className="flex items-end justify-between">
             <div>
-              <p className="phone-list-item-title">{g.name}</p>
-              <p className="phone-list-item-sub">
-                {g.teacher} · {g.term}
-              </p>
+              <p className="phone-banner-label">本学期绩点</p>
+              <p className="phone-banner-value">{DEMO_STUDENT.gpa}</p>
+              <p className="phone-banner-sub">已修学分 {DEMO_STUDENT.credits}</p>
             </div>
-            <div className="phone-list-item-right">
-              <p className="phone-list-item-value">{g.score}</p>
-              <p className="phone-list-item-meta">绩点 {g.point}</p>
+            <div className="text-right text-[9px] opacity-90">
+              <p>专业排名</p>
+              <p className="text-lg font-bold">{DEMO_RANKING.rank}</p>
             </div>
           </div>
-        ))}
+        </div>
+
+        {list.map((g) => {
+          const scoreNum = Number(g.score);
+          const scoreColor = scoreNum >= 90 ? '#16a34a' : scoreNum >= 80 ? '#2563eb' : '#d97706';
+          return (
+            <div key={`${g.name}-${g.term}`} className="phone-grade-course-card">
+              <div className="min-w-0 flex-1">
+                <p className="phone-list-item-title">{g.name}</p>
+                <p className="phone-list-item-sub">
+                  {g.teacher} · {g.term}
+                </p>
+              </div>
+              <div className="phone-grade-score-block">
+                <p className="phone-grade-score" style={{ color: scoreColor }}>
+                  {g.score}
+                </p>
+                <p className="phone-list-item-meta">绩点 {g.point}</p>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </AppShell>
   );

--- a/website/src/components/phone-app/PhoneScreenOverlay.tsx
+++ b/website/src/components/phone-app/PhoneScreenOverlay.tsx
@@ -7,8 +7,8 @@ import PhoneAppScreen from './PhoneAppScreen';
 import './phone-app.css';
 
 /**
- * 唯一产品手机：CSS 3D 机框 + 屏幕内 Dashboard 同源 UI。
- * 不再依赖场景中的空壳 PhoneModel。
+ * 移动端产品手机降级：CSS 机框 + 与桌面同源的 PhoneAppScreen。
+ * 桌面由 R3F PhoneModel（drei Html 贴屏）承担，本组件仅 isMobile 挂载。
  */
 export default function PhoneScreenOverlay() {
   const { sample, reducedMotion, isMobile } = useScrollProgress();

--- a/website/src/components/phone-app/phone-app.css
+++ b/website/src/components/phone-app/phone-app.css
@@ -890,6 +890,50 @@
   height: 16px;
 }
 
+/* 成绩页 — 对齐 App 列表层次 */
+.phone-grade-term-row {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+  margin-bottom: 2px;
+}
+.phone-grade-term-chip {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: #fff;
+  color: #6b7280;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+}
+.phone-grade-term-chip.is-active {
+  background: #eef2ff;
+  color: #4f46e5;
+  border-color: #c7d2fe;
+}
+.phone-grade-course-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: #fff;
+  border-radius: 14px;
+  padding: 11px 12px;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+}
+.phone-grade-score-block {
+  text-align: right;
+  flex-shrink: 0;
+}
+.phone-grade-score {
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
 /* Dashboard 今日安排底部统计（对齐 Tauri） */
 .phone-today-stats {
   display: flex;


### PR DESCRIPTION
## Summary

官网 Hero 第三轮（关闭 #400 #401 #402）：

1. **#400 课表/成绩屏对齐真 App**
   - 课表：周次顶栏、7 日日期行、节次轴 + 彩色课程块（ScheduleView 语义）
   - 成绩：学期 chip、绩点横幅、分数着色课程列表卡

2. **#401 迷你功能卡避让左侧文案**
   - `HeroFeatureOrbits` 改为固定右侧轨道（`right-0` / `w-[min(280px,28vw)]`）
   - 去掉负向 translate，不再侵入 `lg:w-[38%]` 文案列
   - `HeroText` 左侧列收窄，字幕贴左下安全区

3. **#402 单台 R3F 手机贴屏**
   - `SceneCanvas` 重新挂载唯一 `PhoneModel`
   - 屏幕用 `@react-three/drei` `Html` 渲染同源 `PhoneAppScreen`
   - 桌面不再叠第二台 DOM 手机；移动端保留 `PhoneScreenOverlay` 降级
   - `CameraRig` 镜头对齐产品位（+0.35 x）

## Test plan

- [x] `npm run build --prefix website` 通过（Next 15 export）
- [ ] 桌面首屏：仅一台 3D 手机，可见机身厚度/阴影，屏幕为 Dashboard 风格 UI
- [ ] 滚动切到课表/成绩：结构可认作 Mini-HBUT 对应模块
- [ ] 1440px：右侧浮卡与左侧文案不重叠；浮卡随 activeScreen 高亮
- [ ] 窄屏/移动：DOM 手机降级可见，浮卡隐藏
- [ ] 控制台无业务 error（允许 WebGL 降级）

## Deploy notes

合并后触发 EdgeOne / GitHub Pages 同步即可预览线上。
