### PR TITLE
fix(website): Hero 三栏布局——左文案、中手机、右功能轮播

### DIFF
--- a/docs/app-store/ALLOWED_DOMAINS.md
+++ b/docs/app-store/ALLOWED_DOMAINS.md
@@ -10,6 +10,7 @@ Helper: `src/config/allowed_domains.ts`.
 - `jsdelivr.net` / `unpkg.com`
 - `docs.qq.com` / `qq.com`
 - `map.qq.com` / `apis.map.qq.com`
+- `miit.gov.cn` / `beian.miit.gov.cn`（工信部备案查询）
 
 ## Forbidden
 

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -3,6 +3,8 @@ import { ref, nextTick, watch, computed } from 'vue'
 import { openExternal } from '../utils/external_link'
 import LoginV3 from './LoginV3.vue'
 import {
+  ICP_BEIAN_TEXT,
+  ICP_BEIAN_URL,
   NON_OFFICIAL_DISCLAIMER_EN,
   NON_OFFICIAL_DISCLAIMER_ZH,
   PRIVACY_POLICY_URL,
@@ -129,6 +131,10 @@ const handleOpenSource = () => {
 
 const openGithub = async () => {
     await openExternal('https://github.com/superdaobo/mini-hbut')
+}
+
+const openIcpBeian = async () => {
+  await openExternal(ICP_BEIAN_URL)
 }
 
 const handleShowLegal = async (tab) => {
@@ -337,6 +343,13 @@ const handleShowLegal = async (tab) => {
         <p>继续使用即表示你已阅读并同意本隐私政策。</p>
       </div>
     </section>
+
+    <!-- 工信部 ICP 备案公示（页底） -->
+    <footer class="icp-beian-footer">
+      <button type="button" class="icp-beian-link" @click="openIcpBeian">
+        {{ ICP_BEIAN_TEXT }}
+      </button>
+    </footer>
 
     <!-- 开源说明弹窗 -->
     <div v-if="showOpenSourceModal" class="modal-mask" @click="showOpenSourceModal = false">
@@ -697,6 +710,32 @@ const handleShowLegal = async (tab) => {
 
 .legal-content li {
   margin: 6px 0;
+}
+
+/* ICP 备案号 — 页底次要公示 */
+.icp-beian-footer {
+  display: flex;
+  justify-content: center;
+  padding: 8px 12px 4px;
+  margin-bottom: 8px;
+}
+
+.icp-beian-link {
+  border: none;
+  background: transparent;
+  padding: 6px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 500;
+  color: #9ca3af;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.icp-beian-link:active {
+  color: #6b7280;
 }
 
 /* Modal */

--- a/src/config/allowed_domains.spec.ts
+++ b/src/config/allowed_domains.spec.ts
@@ -6,6 +6,7 @@ describe('allowed_domains', () => {
     expect(isAllowedHttpsUrl('https://hbut.6661111.xyz/privacy')).toBe(true)
     expect(isAllowedHttpsUrl('https://superdaobo.github.io/mini-hbut/privacy')).toBe(true)
     expect(isAllowedHttpsUrl('https://github.com/superdaobo/mini-hbut')).toBe(true)
+    expect(isAllowedHttpsUrl('https://beian.miit.gov.cn/')).toBe(true)
   })
 
   it('rejects http, javascript, and localhost', () => {

--- a/src/config/allowed_domains.ts
+++ b/src/config/allowed_domains.ts
@@ -13,7 +13,10 @@ const DEFAULT_ALLOWED_HOST_SUFFIXES = Object.freeze([
   'docs.qq.com',
   'qq.com',
   'map.qq.com',
-  'apis.map.qq.com'
+  'apis.map.qq.com',
+  // 工信部备案查询（我的页 ICP 链接）
+  'miit.gov.cn',
+  'beian.miit.gov.cn'
 ])
 
 export function isAllowedHttpsUrl(url: unknown, extraSuffixes: string[] = []): boolean {

--- a/src/config/app_store_policy.ts
+++ b/src/config/app_store_policy.ts
@@ -265,6 +265,11 @@ export const PROJECT_HOME_URL = 'https://hbut.6661111.xyz'
 export const GITHUB_URL = 'https://github.com/superdaobo/mini-hbut'
 export const FEEDBACK_URL = 'https://docs.qq.com/sheet/DQkdvWHJxQ3RwWlB4?tab=BB08J2'
 
+/** 工信部 ICP 备案号（我的页底部公示） */
+export const ICP_BEIAN_TEXT = '鲁ICP备2026039385号-1A'
+/** 工信部备案查询官网 */
+export const ICP_BEIAN_URL = 'https://beian.miit.gov.cn/'
+
 export const DEMO_MODE_BANNER_ZH =
   '当前为审核演示模式，页面使用虚构数据，不连接真实校园服务。'
 

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -676,6 +676,14 @@ html.dark .legal-card {
   border: 1px solid rgba(148, 163, 184, 0.15) !important;
 }
 
+html.dark .me-view .icp-beian-link {
+  color: #64748b !important;
+}
+
+html.dark .me-view .icp-beian-link:active {
+  color: #94a3b8 !important;
+}
+
 /* 我的页面 - 功能入口卡片 */
 html.dark .me-view .func-item,
 html.dark .me-view [class*="func-card"],

--- a/website/src/components/CameraRig.tsx
+++ b/website/src/components/CameraRig.tsx
@@ -7,7 +7,8 @@ import { applyParallax, vec3ToThree } from '@/lib/scroll-utils';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
 
 /**
- * 驱动唯一 3D 产品手机的镜头：滚动关键帧 + 首屏 idle 环绕。
+ * 镜头始终看向「居中手机」，做推进 / 环绕 / 仰视运镜。
+ * 左右栏是 2D UI，不参与 3D 偏移。
  */
 export default function CameraRig() {
   const { camera } = useThree();
@@ -20,21 +21,18 @@ export default function CameraRig() {
     const t = Math.min(0.12, delta);
     idlePhase.current += delta;
 
-    const parallaxStrength = reducedMotion ? 0 : 0.1;
+    const parallaxStrength = reducedMotion ? 0 : 0.08;
     let camPos = applyParallax(sample.camera.position, pointer, parallaxStrength);
-    let lookAt = applyParallax(sample.camera.lookAt, pointer, parallaxStrength * 0.4);
+    let lookAt = applyParallax(sample.camera.lookAt, pointer, parallaxStrength * 0.35);
 
-    // 镜头略偏向右侧产品位（与 PhoneModel 0.42 偏移对齐）
-    camPos = { ...camPos, x: camPos.x + 0.35 };
-    lookAt = { ...lookAt, x: lookAt.x + 0.35 };
-
-    if (!reducedMotion && sample.globalProgress < 0.1) {
+    // 首屏 idle：轻微环绕，体现 3D 厚度
+    if (!reducedMotion && sample.globalProgress < 0.12) {
       const idle = idlePhase.current;
-      const amp = 1 - sample.globalProgress / 0.1;
+      const amp = 1 - sample.globalProgress / 0.12;
       camPos = {
-        x: camPos.x + Math.sin(idle * 0.5) * 0.18 * amp,
-        y: camPos.y + Math.sin(idle * 0.38) * 0.05 * amp,
-        z: camPos.z + Math.cos(idle * 0.5) * 0.08 * amp,
+        x: camPos.x + Math.sin(idle * 0.55) * 0.22 * amp,
+        y: camPos.y + Math.sin(idle * 0.4) * 0.05 * amp,
+        z: camPos.z + Math.cos(idle * 0.55) * 0.1 * amp,
       };
     }
 

--- a/website/src/components/FeatureTextOverlay.tsx
+++ b/website/src/components/FeatureTextOverlay.tsx
@@ -41,7 +41,7 @@ export default function FeatureTextOverlay() {
       {opacity > 0.05 && (
         <motion.div
           key={copyKey}
-          className="pointer-events-none fixed inset-x-0 bottom-[22vh] z-20 mx-auto max-w-3xl px-6 text-center"
+          className="pointer-events-none fixed inset-x-0 bottom-[18vh] z-20 mx-auto max-w-3xl px-6 text-center lg:hidden"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity, y: 0 }}
           exit={{ opacity: 0, y: -12 }}

--- a/website/src/components/HeroFeatureOrbits.tsx
+++ b/website/src/components/HeroFeatureOrbits.tsx
@@ -9,41 +9,43 @@ type OrbitCard = {
   id: AppModuleId;
   metric: string;
   screen: AppScreen;
-  /** 仅用右侧/上下安全区，避免侵入左侧 lg:w-[42%] 文案 */
   top: string;
-  right: string;
 };
 
 /**
- * 浮卡全部锚在「手机右侧栏」：
- * 布局用 fixed 右侧轨道，不再用负向 translate 冲进左半屏。
+ * 右侧功能轮询卡：
+ * - 固定右栏，不侵入中间手机与左侧文案
+ * - 随 activeScreen 高亮，形成「功能轮播」感
  */
 const ORBIT_CARDS: OrbitCard[] = [
-  { id: 'grades', metric: 'GPA 3.72', screen: 'grades', top: '18%', right: '4%' },
-  { id: 'classroom', metric: '今 12 间空闲', screen: 'classroom', top: '32%', right: '3%' },
-  { id: 'exams', metric: '倒计时 6 天', screen: 'exams', top: '46%', right: '4.5%' },
-  { id: 'electricity', metric: '余额 ¥28.6', screen: 'electricity', top: '60%', right: '3%' },
-  { id: 'calendar', metric: '第 14 教学周', screen: 'home', top: '74%', right: '5%' },
+  { id: 'grades', metric: 'GPA 3.72', screen: 'grades', top: '18%' },
+  { id: 'classroom', metric: '今 12 间空闲', screen: 'classroom', top: '32%' },
+  { id: 'exams', metric: '倒计时 6 天', screen: 'exams', top: '46%' },
+  { id: 'electricity', metric: '余额 ¥28.6', screen: 'electricity', top: '60%' },
+  { id: 'calendar', metric: '第 14 教学周', screen: 'home', top: '74%' },
 ];
 
 function screenMatches(card: OrbitCard, active: AppScreen) {
   if (card.screen === active) return true;
   if (active === 'all-features') return card.id === 'grades';
   if (active === 'home') return card.id === 'calendar' || card.id === 'grades';
+  if (active === 'schedule') return card.id === 'calendar';
   return false;
 }
 
 export default function HeroFeatureOrbits() {
   const { sample, reducedMotion, isMobile } = useScrollProgress();
-  // 平板以下隐藏；桌面放在右 1/3，绝不进左文案区
   if (isMobile) return null;
 
   return (
     <div
-      className="pointer-events-none fixed inset-y-0 right-0 z-[13] hidden w-[min(280px,28vw)] min-w-[200px] lg:block"
+      className="pointer-events-none fixed inset-y-0 right-0 z-[25] hidden w-[min(260px,24vw)] min-w-[188px] lg:block"
       aria-hidden
     >
-      <div className="relative h-full w-full pr-3 pt-24">
+      <div className="relative h-full w-full pr-4 pt-28">
+        <p className="mb-3 pr-1 text-right text-[10px] font-medium tracking-wide text-white/35">
+          功能速览 · 随界面轮播
+        </p>
         {ORBIT_CARDS.map((card, i) => {
           const mod = APP_MODULES.find((m) => m.id === card.id);
           if (!mod) return null;
@@ -52,28 +54,28 @@ export default function HeroFeatureOrbits() {
           return (
             <motion.div
               key={card.id}
-              className="absolute w-[148px]"
-              style={{ top: card.top, right: card.right }}
-              initial={reducedMotion ? false : { opacity: 0, x: 24 }}
+              className="absolute right-0 w-[156px]"
+              style={{ top: card.top }}
+              initial={reducedMotion ? false : { opacity: 0, x: 28 }}
               animate={{
-                opacity: 0.72 + sample.phone.screenBrightness * 0.28,
+                opacity: active ? 1 : 0.55 + sample.phone.screenBrightness * 0.2,
                 x: 0,
-                scale: active ? 1.05 : 1,
+                scale: active ? 1.06 : 0.98,
               }}
-              transition={{ delay: 0.12 + i * 0.05, duration: 0.4 }}
+              transition={{ delay: 0.1 + i * 0.05, duration: 0.35 }}
             >
               <motion.div
-                className="rounded-2xl border border-white/15 bg-black/50 p-2.5 shadow-[0_16px_40px_rgba(0,0,0,0.45)] backdrop-blur-md"
+                className="rounded-2xl border border-white/15 bg-black/55 p-2.5 shadow-[0_16px_40px_rgba(0,0,0,0.45)] backdrop-blur-md"
                 style={{
                   boxShadow: active
-                    ? `0 0 0 1px ${mod.color}88, 0 16px 40px rgba(0,0,0,0.5), 0 0 24px ${mod.color}40`
+                    ? `0 0 0 1px ${mod.color}99, 0 16px 40px rgba(0,0,0,0.5), 0 0 28px ${mod.color}45`
                     : undefined,
                 }}
-                animate={reducedMotion ? undefined : { y: [0, i % 2 === 0 ? -4 : 4, 0] }}
+                animate={reducedMotion ? undefined : { y: [0, i % 2 === 0 ? -5 : 5, 0] }}
                 transition={
                   reducedMotion
                     ? undefined
-                    : { duration: 3 + i * 0.2, repeat: Infinity, ease: 'easeInOut' }
+                    : { duration: 3.2 + i * 0.25, repeat: Infinity, ease: 'easeInOut' }
                 }
               >
                 <div className="flex items-center gap-2">
@@ -89,12 +91,11 @@ export default function HeroFeatureOrbits() {
                   </div>
                 </div>
                 <div className="mt-2 h-0.5 overflow-hidden rounded-full bg-white/10">
-                  <div
-                    className="h-full rounded-full transition-all"
-                    style={{
-                      width: active ? '85%' : '45%',
-                      background: mod.color,
-                    }}
+                  <motion.div
+                    className="h-full rounded-full"
+                    style={{ background: mod.color }}
+                    animate={{ width: active ? '88%' : '38%' }}
+                    transition={{ duration: 0.45 }}
                   />
                 </div>
               </motion.div>

--- a/website/src/components/HeroText.tsx
+++ b/website/src/components/HeroText.tsx
@@ -15,6 +15,9 @@ const FEATURE_CHIPS = [
   { id: 'classroom', label: '空教室', color: '#fb923c' },
 ] as const;
 
+/**
+ * 左侧营销文案栏：固定占左 ~30%，不与中间手机、右侧功能卡重叠。
+ */
 export default function HeroText() {
   const { sample, reducedMotion } = useScrollProgress();
   const opacity = sample.heroOpacity;
@@ -24,81 +27,79 @@ export default function HeroText() {
 
   return (
     <motion.div
-      className="pointer-events-none fixed inset-0 z-20"
+      className="pointer-events-none fixed inset-0 z-[25]"
       initial={false}
       animate={{ opacity }}
       transition={{ duration: reducedMotion ? 0 : 0.35, ease: 'easeOut' }}
     >
-      <div className="mx-auto flex h-full max-w-7xl flex-col justify-center px-5 pb-16 pt-24 md:px-8 lg:flex-row lg:items-center lg:gap-8 lg:px-8 xl:px-10">
-        {/* 左侧文案 — 限制宽度，右侧留给 3D 手机与浮卡 */}
-        <div className="pointer-events-auto max-w-xl lg:w-[38%] lg:max-w-md xl:w-[40%]">
-          <motion.div
-            initial={reducedMotion ? false : { opacity: 0, y: 18 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
-          >
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1 text-[11px] font-medium tracking-wide text-cyan-200">
-              <Sparkles className="h-3.5 w-3.5" />
-              Mini-HBUT · 校园信息聚合客户端
-            </div>
+      {/* 仅左栏：lg 起固定左侧安全区 */}
+      <div className="pointer-events-auto absolute inset-y-0 left-0 flex w-full max-w-full flex-col justify-center px-5 pb-16 pt-24 md:px-8 lg:w-[min(32vw,380px)] lg:px-8 xl:w-[min(30vw,400px)] xl:px-10">
+        <motion.div
+          initial={reducedMotion ? false : { opacity: 0, y: 18 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1 text-[11px] font-medium tracking-wide text-cyan-200">
+            <Sparkles className="h-3.5 w-3.5" />
+            Mini-HBUT · 校园信息聚合客户端
+          </div>
 
-            <h1 className="bg-gradient-to-br from-white via-cyan-50 to-violet-200 bg-clip-text text-4xl font-semibold leading-[1.12] text-transparent sm:text-5xl md:text-[3.25rem]">
-              一个入口，
-              <br />
-              看清整个校园日程。
-            </h1>
+          <h1 className="bg-gradient-to-br from-white via-cyan-50 to-violet-200 bg-clip-text text-3xl font-semibold leading-[1.14] text-transparent sm:text-4xl lg:text-[2.55rem] xl:text-[2.75rem]">
+            一个入口，
+            <br />
+            看清整个校园日程。
+          </h1>
 
-            <p className="mt-4 max-w-md text-sm leading-7 text-white/65 sm:text-base">
-              课表、成绩、考试、通知、电费与空教室——在真实 App 界面里滚动体验，而不是看一张静态截图。
-            </p>
+          <p className="mt-4 max-w-sm text-sm leading-7 text-white/65">
+            课表、成绩、考试、通知、电费与空教室——在真实 App 界面里滚动体验，而不是看一张静态截图。
+          </p>
 
-            <div className="mt-5 flex flex-wrap gap-2">
-              {FEATURE_CHIPS.map((chip, i) => (
-                <motion.span
-                  key={chip.id}
-                  className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/80 backdrop-blur-sm"
-                  style={{ boxShadow: `inset 0 0 0 1px ${chip.color}33` }}
-                  initial={reducedMotion ? false : { opacity: 0, y: 8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.12 + i * 0.05, duration: 0.4 }}
-                >
-                  <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full" style={{ background: chip.color }} />
-                  {chip.label}
-                </motion.span>
-              ))}
-            </div>
-
-            <div className="mt-7 flex flex-wrap items-center gap-3">
-              <a
-                href="#download"
-                className="group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 to-sky-500 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_0_32px_rgba(34,211,238,0.35)] transition hover:brightness-110"
+          <div className="mt-5 flex flex-wrap gap-2">
+            {FEATURE_CHIPS.map((chip, i) => (
+              <motion.span
+                key={chip.id}
+                className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/80 backdrop-blur-sm"
+                style={{ boxShadow: `inset 0 0 0 1px ${chip.color}33` }}
+                initial={reducedMotion ? false : { opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.12 + i * 0.05, duration: 0.4 }}
               >
-                <Download className="h-4 w-4" />
-                免费下载
-                <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
-              </a>
-              <Link
-                href="/docs"
-                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-medium text-white/85 backdrop-blur-sm transition hover:border-cyan-400/40 hover:text-white"
-              >
-                查看文档
-              </Link>
-            </div>
+                <span
+                  className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full"
+                  style={{ background: chip.color }}
+                />
+                {chip.label}
+              </motion.span>
+            ))}
+          </div>
 
-            <p className="mt-4 text-[11px] text-white/40">
-              向下滚动 · 观看 3D 运镜与界面演示
-            </p>
-          </motion.div>
-        </div>
+          <div className="mt-7 flex flex-wrap items-center gap-3">
+            <a
+              href="#download"
+              className="group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 to-sky-500 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_0_32px_rgba(34,211,238,0.35)] transition hover:brightness-110"
+            >
+              <Download className="h-4 w-4" />
+              免费下载
+              <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+            </a>
+            <Link
+              href="/docs"
+              className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-medium text-white/85 backdrop-blur-sm transition hover:border-cyan-400/40 hover:text-white"
+            >
+              查看文档
+            </Link>
+          </div>
 
-        {/* 右侧字幕贴在文案列底部小条，避免与右栏浮卡争抢 */}
-        <div className="pointer-events-none mt-6 max-w-md lg:absolute lg:bottom-[12vh] lg:left-8 lg:mt-0 lg:w-[min(360px,34vw)] xl:left-10">
+          {/* 当前屏字幕贴在左栏底部，不进中/右区 */}
           <motion.div
             key={sample.activeScreen}
-            className="hidden rounded-2xl border border-white/10 bg-black/45 p-3.5 shadow-[0_16px_48px_rgba(0,0,0,0.4)] backdrop-blur-md lg:block"
-            initial={reducedMotion ? false : { opacity: 0, y: 12 }}
-            animate={{ opacity: Math.min(1, 0.4 + sample.phone.screenBrightness * 0.6), y: 0 }}
-            transition={{ duration: 0.4 }}
+            className="mt-8 hidden max-w-sm rounded-2xl border border-white/10 bg-black/45 p-3.5 shadow-[0_16px_48px_rgba(0,0,0,0.4)] backdrop-blur-md lg:block"
+            initial={reducedMotion ? false : { opacity: 0, y: 10 }}
+            animate={{
+              opacity: Math.min(1, 0.45 + sample.phone.screenBrightness * 0.55),
+              y: 0,
+            }}
+            transition={{ duration: 0.35 }}
           >
             <div className="mb-1.5 flex items-center gap-2">
               <span
@@ -107,12 +108,14 @@ export default function HeroText() {
               >
                 {caption.label}
               </span>
-              <span className="text-[10px] text-white/40">App 界面预览</span>
+              <span className="text-[10px] text-white/40">界面预览</span>
             </div>
-            <h2 className="text-base font-semibold text-white">{caption.title}</h2>
+            <h2 className="text-sm font-semibold text-white">{caption.title}</h2>
             <p className="mt-1 text-xs leading-5 text-white/60">{caption.blurb}</p>
           </motion.div>
-        </div>
+
+          <p className="mt-5 text-[11px] text-white/40 lg:mt-4">向下滚动 · 3D 运镜与功能演示</p>
+        </motion.div>
       </div>
     </motion.div>
   );

--- a/website/src/components/PhoneModel.tsx
+++ b/website/src/components/PhoneModel.tsx
@@ -23,7 +23,7 @@ const SCREEN_DOM_W = 270;
 const SCREEN_DOM_H = 556;
 
 /**
- * 唯一 3D 产品手机：机身 + 屏幕 Html 贴图（真 App UI）。
+ * 唯一 3D 产品手机：居中主视觉 + 屏幕 Html 贴图。
  * 桌面主路径；移动端由 PhoneScreenOverlay DOM 降级。
  */
 export default function PhoneModel() {
@@ -61,46 +61,46 @@ export default function PhoneModel() {
     if (!groupRef.current || isMobile) return;
     const t = state.clock.elapsedTime;
     const floatY = Math.sin(t * 1.1) * sample.phone.float * 0.1;
-    const parallaxX = reducedMotion ? 0 : pointer.x * 0.08;
-    const parallaxY = reducedMotion ? 0 : pointer.y * 0.05;
+    const parallaxX = reducedMotion ? 0 : pointer.x * 0.06;
+    const parallaxY = reducedMotion ? 0 : pointer.y * 0.04;
 
-    // 产品位：略偏右，给左侧文案留空（世界坐标）
+    // 居中主视觉；关键帧只做轻微位移动效，不把机身推到左右栏
     groupRef.current.position.set(
-      0.42 + sample.phone.position.x * 0.35 + parallaxX,
-      sample.phone.position.y * 0.5 + floatY + parallaxY,
-      sample.phone.position.z * 0.4,
+      sample.phone.position.x * 0.12 + parallaxX,
+      sample.phone.position.y * 0.35 + floatY + parallaxY,
+      sample.phone.position.z * 0.2,
     );
     groupRef.current.rotation.set(
       sample.phone.rotation.x * 0.9,
-      sample.phone.rotation.y * 0.95 + parallaxX * 0.12,
+      sample.phone.rotation.y * 0.95 + parallaxX * 0.1,
       sample.phone.rotation.z,
     );
-    groupRef.current.scale.setScalar(sample.phone.scale * 0.98);
+    groupRef.current.scale.setScalar(sample.phone.scale);
   });
 
   if (isMobile) return null;
 
   const zFront = PHONE_DEPTH / 2;
-  // 经验标定：屏世界高度 ≈1.15，DOM 556px
-  const htmlDistanceFactor = 1.58;
+  /**
+   * drei Html(transform) 缩放系数 ≈ distanceFactor/400（越大越大）。
+   * 1.58 会整屏贴脸；0.48 又过小。居中机身 + 中距离镜头下约 1.12 贴合屏平面。
+   */
+  const htmlDistanceFactor = 0.98;
 
   return (
     <group ref={groupRef}>
       <mesh geometry={frameGeometry} material={frameMaterial} castShadow receiveShadow />
 
-      {/* 屏幕黑边 */}
       <mesh position={[0, 0, zFront + 0.001]}>
         <planeGeometry args={[SCREEN_WIDTH + 0.02, SCREEN_HEIGHT + 0.02]} />
         <meshStandardMaterial color="#05080f" metalness={0.5} roughness={0.4} />
       </mesh>
 
-      {/* 动态岛 */}
       <mesh position={[0, PHONE_HEIGHT / 2 - 0.095, zFront + 0.004]}>
         <capsuleGeometry args={[0.028, 0.1, 4, 12]} />
         <meshStandardMaterial color="#030508" metalness={0.9} roughness={0.2} />
       </mesh>
 
-      {/* 侧键 */}
       <mesh position={[PHONE_WIDTH / 2 + 0.003, 0.12, 0]} rotation={[0, 0, Math.PI / 2]}>
         <boxGeometry args={[0.09, 0.01, 0.018]} />
         <primitive object={buttonMaterial} attach="material" />
@@ -110,7 +110,6 @@ export default function PhoneModel() {
         <primitive object={buttonMaterial} attach="material" />
       </mesh>
 
-      {/* App UI 贴屏 — 唯一屏幕内容源（桌面） */}
       <Html
         transform
         occlude={false}
@@ -125,7 +124,7 @@ export default function PhoneModel() {
           userSelect: 'none',
           background: '#f0f4f8',
         }}
-        zIndexRange={[20, 0]}
+        zIndexRange={[12, 0]}
       >
         <div
           style={{
@@ -144,7 +143,6 @@ export default function PhoneModel() {
         </div>
       </Html>
 
-      {/* 玻璃反光（在 Html 之上用半透明 mesh 会挡住点击，此处仅边缘高光 mesh 在屏后即可） */}
       <mesh position={[0.08, 0.22, zFront + 0.007]} rotation={[0, 0, 0.25]}>
         <planeGeometry args={[0.12, 0.38]} />
         <meshBasicMaterial color="#ffffff" transparent opacity={0.05} depthWrite={false} />

--- a/website/src/components/SceneCanvas.tsx
+++ b/website/src/components/SceneCanvas.tsx
@@ -96,7 +96,7 @@ export default function SceneCanvas() {
       <SceneErrorBoundary fallback={<CanvasFallback />}>
         <Canvas
           dpr={dpr}
-          camera={{ position: [0.55, 0.35, 2.65], fov: 36, near: 0.05, far: 40 }}
+          camera={{ position: [0.55, 0.32, 3.35], fov: 34, near: 0.05, far: 40 }}
           gl={{ antialias: true, alpha: false, powerPreference: 'high-performance' }}
           shadows
           onCreated={({ gl }) => {

--- a/website/src/hooks/use-idle-hero-demo.ts
+++ b/website/src/hooks/use-idle-hero-demo.ts
@@ -29,11 +29,12 @@ export function useIdleHeroDemo(enabled: boolean) {
       if (userTouched.current) return;
       if (startRef.current == null) startRef.current = now;
       const elapsed = (now - startRef.current) / 1000;
-      // 前 1s 静止展示入场，之后循环演示
-      if (elapsed >= 1) {
-        const cycle = ((elapsed - 1) % 18) / 18;
+      // 前 1.6s 定妆，之后在 0.04→0.58 循环：驱动 3D 运镜 + 多屏 UI + 右侧功能卡高亮
+      // 左侧文案靠 heroOpacity 缓淡，不抢中/右区
+      if (elapsed >= 1.6) {
+        const cycle = ((elapsed - 1.6) % 20) / 20;
         const tri = cycle < 0.72 ? cycle / 0.72 : 1 - (cycle - 0.72) / 0.28;
-        const target = 0.03 + tri * 0.54;
+        const target = 0.04 + tri * 0.54;
         setProgress(target);
       }
       raf = requestAnimationFrame(loop);

--- a/website/src/lib/scroll-utils.ts
+++ b/website/src/lib/scroll-utils.ts
@@ -96,44 +96,44 @@ const PHASE_RANGES: Array<{ phase: ScrollPhase; start: number; end: number }> = 
 ];
 
 /**
- * 产品展示镜头轨：首屏即见手机 → 推进点亮 → 侧向环绕 → 正视 UI → 拉远 CTA
- * （旧轨 y≈11/z≈14 过远，机身几乎不可见，像扁平截图）
+ * 三栏构图：左文案 / 中手机 / 右功能卡。
+ * 镜头始终看向原点附近的居中手机，做推进与左右环绕。
  */
 const CAMERA_KEYFRAMES: CameraKeyframe[] = [
-  // intro：3/4 侧前，手机占据主视觉
-  { position: { x: 1.15, y: 0.55, z: 2.85 }, lookAt: { x: 0.05, y: 0.05, z: 0 }, fov: 38 },
-  // ignite：略推进 + 点亮
-  { position: { x: 0.85, y: 0.42, z: 2.45 }, lookAt: { x: 0.02, y: 0.06, z: 0 }, fov: 36 },
-  // lift：抬到更正视
-  { position: { x: 0.45, y: 0.28, z: 2.15 }, lookAt: { x: 0, y: 0.08, z: 0 }, fov: 34 },
-  // dive：贴近屏幕，看清 App UI
-  { position: { x: 0.12, y: 0.12, z: 1.72 }, lookAt: { x: 0, y: 0.1, z: 0 }, fov: 32 },
-  // schedule：微侧，露出机身厚度
-  { position: { x: -0.55, y: 0.18, z: 1.95 }, lookAt: { x: 0.02, y: 0.08, z: 0 }, fov: 33 },
-  // grades：另一侧环绕
-  { position: { x: 0.7, y: 0.22, z: 1.88 }, lookAt: { x: -0.02, y: 0.06, z: 0 }, fov: 33 },
-  // tunnel：更戏剧的仰视
-  { position: { x: 0.25, y: -0.05, z: 2.05 }, lookAt: { x: 0, y: 0.12, z: 0 }, fov: 35 },
-  // return：回正
-  { position: { x: 0.35, y: 0.25, z: 2.25 }, lookAt: { x: 0, y: 0.05, z: 0 }, fov: 36 },
+  // intro：正前略侧，完整见整机
+  { position: { x: 0.55, y: 0.32, z: 3.35 }, lookAt: { x: 0, y: 0.05, z: 0 }, fov: 34 },
+  // ignite：推进
+  { position: { x: 0.35, y: 0.26, z: 3.0 }, lookAt: { x: 0, y: 0.06, z: 0 }, fov: 33 },
+  // lift：更正视
+  { position: { x: 0.15, y: 0.2, z: 2.75 }, lookAt: { x: 0, y: 0.07, z: 0 }, fov: 32 },
+  // dive：看清 App UI（仍保持整机可见）
+  { position: { x: 0.05, y: 0.12, z: 2.55 }, lookAt: { x: 0, y: 0.08, z: 0 }, fov: 31 },
+  // schedule：左侧环绕，露机身厚度
+  { position: { x: -0.75, y: 0.18, z: 2.85 }, lookAt: { x: 0.02, y: 0.07, z: 0 }, fov: 33 },
+  // grades：右侧环绕
+  { position: { x: 0.85, y: 0.2, z: 2.8 }, lookAt: { x: -0.02, y: 0.06, z: 0 }, fov: 33 },
+  // tunnel：轻微仰视
+  { position: { x: 0.2, y: -0.08, z: 2.9 }, lookAt: { x: 0, y: 0.12, z: 0 }, fov: 34 },
+  // return
+  { position: { x: 0.25, y: 0.22, z: 3.0 }, lookAt: { x: 0, y: 0.05, z: 0 }, fov: 33 },
   // pre-cta
-  { position: { x: 0.9, y: 0.4, z: 2.55 }, lookAt: { x: 0, y: 0, z: 0 }, fov: 37 },
-  // cta：稍远产品定妆
-  { position: { x: 1.05, y: 0.48, z: 2.75 }, lookAt: { x: 0, y: 0.02, z: 0 }, fov: 38 },
+  { position: { x: 0.45, y: 0.3, z: 3.2 }, lookAt: { x: 0, y: 0.04, z: 0 }, fov: 34 },
+  // cta：产品定妆
+  { position: { x: 0.55, y: 0.34, z: 3.4 }, lookAt: { x: 0, y: 0.03, z: 0 }, fov: 34 },
 ];
 
-/** 手机始终大致立起、足够大；亮度从首帧就点亮 */
+/** 手机居中立起；旋转做 3D 展示，位移保持小幅度 */
 const PHONE_KEYFRAMES: PhoneKeyframe[] = [
-  { position: { x: 0.08, y: 0.02, z: 0 }, rotation: { x: -0.12, y: 0.42, z: 0.04 }, scale: 1.05, screenBrightness: 0.95, float: 0.02 },
-  { position: { x: 0.06, y: 0.04, z: 0.02 }, rotation: { x: -0.08, y: 0.28, z: 0.02 }, scale: 1.08, screenBrightness: 1, float: 0.024 },
-  { position: { x: 0.02, y: 0.06, z: 0.03 }, rotation: { x: -0.04, y: 0.12, z: 0 }, scale: 1.12, screenBrightness: 1, float: 0.028 },
-  { position: { x: 0, y: 0.05, z: 0.04 }, rotation: { x: -0.02, y: 0.02, z: 0 }, scale: 1.18, screenBrightness: 1, float: 0.03 },
-  { position: { x: 0.04, y: 0.04, z: 0.03 }, rotation: { x: -0.03, y: -0.28, z: -0.02 }, scale: 1.12, screenBrightness: 1, float: 0.028 },
-  { position: { x: -0.02, y: 0.05, z: 0.03 }, rotation: { x: -0.02, y: 0.32, z: 0.02 }, scale: 1.1, screenBrightness: 1, float: 0.026 },
-  { position: { x: 0, y: 0.08, z: 0.02 }, rotation: { x: 0.06, y: 0.08, z: 0 }, scale: 1.08, screenBrightness: 1, float: 0.024 },
-  { position: { x: 0.03, y: 0.04, z: 0.02 }, rotation: { x: -0.04, y: 0.15, z: 0.01 }, scale: 1.06, screenBrightness: 1, float: 0.022 },
-  { position: { x: 0.06, y: 0.03, z: 0.01 }, rotation: { x: -0.08, y: 0.28, z: 0.02 }, scale: 1.04, screenBrightness: 1, float: 0.02 },
-  { position: { x: 0.08, y: 0.02, z: 0 }, rotation: { x: -0.1, y: 0.36, z: 0.03 }, scale: 1.02, screenBrightness: 0.98, float: 0.018 },
+  { position: { x: 0, y: 0.02, z: 0 }, rotation: { x: -0.1, y: 0.42, z: 0.03 }, scale: 0.94, screenBrightness: 0.95, float: 0.02 },
+  { position: { x: 0, y: 0.03, z: 0.01 }, rotation: { x: -0.07, y: 0.28, z: 0.02 }, scale: 0.96, screenBrightness: 1, float: 0.024 },
+  { position: { x: 0, y: 0.04, z: 0.02 }, rotation: { x: -0.04, y: 0.1, z: 0 }, scale: 0.98, screenBrightness: 1, float: 0.028 },
+  { position: { x: 0, y: 0.04, z: 0.03 }, rotation: { x: -0.02, y: 0.02, z: 0 }, scale: 1.0, screenBrightness: 1, float: 0.03 },
+  { position: { x: 0.02, y: 0.03, z: 0.02 }, rotation: { x: -0.03, y: -0.32, z: -0.02 }, scale: 0.98, screenBrightness: 1, float: 0.028 },
+  { position: { x: -0.02, y: 0.04, z: 0.02 }, rotation: { x: -0.02, y: 0.34, z: 0.02 }, scale: 0.97, screenBrightness: 1, float: 0.026 },
+  { position: { x: 0, y: 0.05, z: 0.01 }, rotation: { x: 0.05, y: 0.08, z: 0 }, scale: 0.96, screenBrightness: 1, float: 0.024 },
+  { position: { x: 0, y: 0.03, z: 0.01 }, rotation: { x: -0.04, y: 0.16, z: 0.01 }, scale: 0.95, screenBrightness: 1, float: 0.022 },
+  { position: { x: 0, y: 0.02, z: 0 }, rotation: { x: -0.08, y: 0.28, z: 0.02 }, scale: 0.94, screenBrightness: 1, float: 0.02 },
+  { position: { x: 0, y: 0.02, z: 0 }, rotation: { x: -0.1, y: 0.36, z: 0.03 }, scale: 0.92, screenBrightness: 0.98, float: 0.018 },
 ];
 
 export function clamp01(value: number): number {
@@ -256,7 +256,8 @@ export function sampleScroll(progress: number): ScrollSample {
   const ribbonIntensity = smoothstep(0.38, 0.58, globalProgress) * (1 - smoothstep(0.72, 0.86, globalProgress));
   const cardSpread = smoothstep(0.30, 0.44, globalProgress) * (1 - smoothstep(0.68, 0.82, globalProgress));
 
-  const heroOpacity = 1 - smoothstep(0.1, 0.24, globalProgress);
+  // 左栏文案：运镜前半段保持可见，后半段再淡出
+  const heroOpacity = 1 - smoothstep(0.22, 0.42, globalProgress);
   const featureOpacity = smoothstep(0.22, 0.32, globalProgress) * (1 - smoothstep(0.74, 0.86, globalProgress));
   const ctaOpacity = smoothstep(0.84, 0.94, globalProgress);
   const screenTransition = resolveScreenTransition(globalProgress);


### PR DESCRIPTION
## Summary

官网 Hero 按产品页三栏重排，并修复 3D 手机「贴脸放大」与文案重叠。

### 布局
1. **左**：营销文案 + 下载 CTA + 当前界面字幕
2. **中**：3D 手机居中主视觉（Html 贴屏比例校准）
3. **右**：功能卡纵向轨道，随 `activeScreen` 高亮轮播

### 技术修复
- `distanceFactor` 从错误标定改回贴屏合理值（drei transform 缩放 ∝ factor）
- 镜头绕原点手机运镜；idle 循环驱动 3D + 多屏切换
- 桌面隐藏居中 FeatureTextOverlay，避免压手机

### 附带
- 我的页底部 ICP：`鲁ICP备2026039385号-1A` → `beian.miit.gov.cn`

## Test plan
- [x] 本地 1440×900：左文案 / 中手机 mid≈center / 右功能卡；gap>0
- [ ] 滚动与 idle：镜头环绕、界面切换、右卡高亮
- [ ] 移动端：右卡隐藏、DOM 手机降级
