### PR TITLE
fix(website): GitHub Pages 导航保留 /mini-hbut basePath

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -11,6 +11,10 @@ const basePath = isGitHubPages ? '/mini-hbut' : '';
 const nextConfig: NextConfig = {
   basePath,
   assetPrefix: basePath || undefined,
+  // 客户端 Navbar 等需要读到 basePath，修复 GH Pages 上 `/#xxx` 丢仓库前缀
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
   output: 'export',
   distDir: 'dist',
   images: { unoptimized: true },

--- a/website/scripts/check-gh-basepath.mjs
+++ b/website/scripts/check-gh-basepath.mjs
@@ -1,0 +1,40 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = join(process.cwd(), 'dist');
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (/\.(html|js)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(root);
+const bareHash = [];
+const goodHash = [];
+const bareRootHome = [];
+
+for (const file of files) {
+  const t = readFileSync(file, 'utf8');
+  if (t.includes('/mini-hbut/#')) goodHash.push(file);
+  // bare absolute hash that drops basePath
+  if (/(?:href|=)["'`]\/#(features|download|about)/.test(t)) bareHash.push(file);
+  // client code that builds `/${hash}` without base
+  if (t.includes('`/${') && t.includes('startsWith("#")')) bareHash.push(file);
+  if (t.includes('/${href}') || t.includes('/${e}') ) {
+    // old pattern: `/${href}` when href is #xxx
+    if (t.includes('startsWith("#")') || t.includes(".startsWith('#')")) bareHash.push(file);
+  }
+}
+
+console.log(JSON.stringify({
+  fileCount: files.length,
+  goodHashFiles: goodHash.length,
+  bareHashFiles: [...new Set(bareHash)].map((f) => f.replace(root, 'dist')),
+}, null, 2));
+
+if (bareHash.length) process.exitCode = 1;

--- a/website/scripts/inspect-navbar-bundle.mjs
+++ b/website/scripts/inspect-navbar-bundle.mjs
@@ -1,0 +1,27 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = join(process.cwd(), 'dist/_next/static/chunks');
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith('.js')) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(root);
+for (const file of files) {
+  const t = readFileSync(file, 'utf8');
+  if (!t.includes('#features') || !t.includes('获取应用')) continue;
+  console.log('file', file);
+  console.log('has /mini-hbut', t.includes('/mini-hbut'));
+  console.log('has bare /#features string', t.includes('/#features') || t.includes('/#download'));
+  // find function near startsWith("#")
+  const re = /startsWith\(["']#["']\)[\s\S]{0,250}/g;
+  let m;
+  while ((m = re.exec(t))) {
+    console.log('snippet:', m[0].replace(/\s+/g, ' ').slice(0, 240));
+  }
+}

--- a/website/src/components/Navbar.tsx
+++ b/website/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { gsap } from 'gsap';
 import { Menu, X, Download } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { homeWithHash } from '@/lib/base-path';
 
 type NavLink = { name: string; href: string; external?: boolean };
 
@@ -89,20 +90,27 @@ export default function Navbar({ variant = 'default', pastHero = false }: Navbar
     e.currentTarget.textContent = e.currentTarget.dataset.text || '';
   };
 
+  /**
+   * 首页内：锚点平滑滚动。
+   * 非首页：走带 basePath 的首页锚点（如 /mini-hbut/#download），禁止写成 `/#download` 丢掉仓库前缀。
+   */
   const scrollToSection = (e: React.MouseEvent<HTMLAnchorElement>, href: string) => {
-    if (!isHome && href.startsWith('#')) {
-      setIsMobileMenuOpen(false);
-      return;
-    }
+    if (!href.startsWith('#')) return;
 
-    if (href.startsWith('#')) {
+    if (isHome) {
       e.preventDefault();
       document.querySelector(href)?.scrollIntoView({ behavior: 'smooth' });
-      setIsMobileMenuOpen(false);
     }
+    // 非首页：不 preventDefault，使用 getLinkHref 生成的 /mini-hbut/#xxx 导航
+    setIsMobileMenuOpen(false);
   };
 
-  const getLinkHref = (href: string) => (href.startsWith('#') && !isHome ? `/${href}` : href);
+  /** 锚点链接：首页用 #id；其它页用 /{basePath}/#id */
+  const getLinkHref = (href: string) => {
+    if (!href.startsWith('#')) return href;
+    if (isHome) return href;
+    return homeWithHash(href);
+  };
 
   const renderNavLink = (link: NavLink, index?: number, mobile = false) => {
     const underline = (

--- a/website/src/lib/base-path.spec.ts
+++ b/website/src/lib/base-path.spec.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('base-path helpers', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('with empty basePath keeps root-relative paths', async () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_PATH', '');
+    const { withBasePath, homeWithHash, BASE_PATH } = await import('./base-path');
+    expect(BASE_PATH).toBe('');
+    expect(withBasePath('/')).toBe('/');
+    expect(withBasePath('/docs')).toBe('/docs');
+    expect(homeWithHash('#features')).toBe('/#features');
+  });
+
+  it('with GitHub Pages basePath prefixes paths and home hashes', async () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_PATH', '/mini-hbut');
+    const { withBasePath, homeWithHash, BASE_PATH } = await import('./base-path');
+    expect(BASE_PATH).toBe('/mini-hbut');
+    expect(withBasePath('/')).toBe('/mini-hbut');
+    expect(withBasePath('/docs')).toBe('/mini-hbut/docs');
+    expect(withBasePath('/mini-hbut/docs')).toBe('/mini-hbut/docs');
+    expect(homeWithHash('#download')).toBe('/mini-hbut/#download');
+    expect(homeWithHash('about')).toBe('/mini-hbut/#about');
+    // never emit bare /# which drops the repo path on github.io
+    expect(homeWithHash('#features')).not.toBe('/#features');
+  });
+});

--- a/website/src/lib/base-path.ts
+++ b/website/src/lib/base-path.ts
@@ -1,0 +1,40 @@
+/**
+ * 与 next.config.ts 的 basePath 对齐。
+ * GitHub Pages 项目站：/mini-hbut ；自定义域名 / EdgeOne：空。
+ *
+ * 注意：客户端可读到 NEXT_PUBLIC_BASE_PATH（由 next.config env 注入）。
+ */
+export const BASE_PATH =
+  typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH
+    ? process.env.NEXT_PUBLIC_BASE_PATH
+    : '';
+
+/** 站内路径加 basePath（已是 http(s) 则原样返回） */
+export function withBasePath(path: string): string {
+  const raw = String(path || '').trim();
+  if (!raw) return BASE_PATH || '/';
+  if (/^(https?:)?\/\//i.test(raw) || raw.startsWith('mailto:') || raw.startsWith('tel:')) {
+    return raw;
+  }
+  // 仅 hash：留给调用方决定（首页内滚动 vs 回首页再跳锚点）
+  if (raw.startsWith('#')) {
+    return homeWithHash(raw);
+  }
+  const normalized = raw.startsWith('/') ? raw : `/${raw}`;
+  if (!BASE_PATH) return normalized;
+  if (normalized === '/') return BASE_PATH;
+  // 避免重复前缀
+  if (normalized === BASE_PATH || normalized.startsWith(`${BASE_PATH}/`)) return normalized;
+  return `${BASE_PATH}${normalized}`;
+}
+
+/**
+ * 首页 + 锚点，始终保留 basePath。
+ * - basePath=/mini-hbut, hash=#features → /mini-hbut/#features
+ * - basePath='', hash=#features → /#features
+ */
+export function homeWithHash(hash: string): string {
+  const h = hash.startsWith('#') ? hash : `#${hash}`;
+  if (!BASE_PATH) return `/${h}`;
+  return `${BASE_PATH}/${h}`;
+}


### PR DESCRIPTION
## 问题

在 GitHub Pages 备用站 `https://superdaobo.github.io/mini-hbut/` 上，从子页（如 `/privacy`、`/docs`）点击导航「功能/下载/关于/获取应用」时，会跳到 **`https://superdaobo.github.io/#...`**，仓库前缀 `/mini-hbut` 被丢掉。

## 根因（MCP 实测）

`Navbar.tsx` 原先：

```ts
const getLinkHref = (href) => (href.startsWith('#') && !isHome ? `/${href}` : href);
// #download → /#download  → 解析为 github.io 根路径
```

非首页点击这些链接时，浏览器按绝对路径 `/#download` 导航，丢失项目站 basePath。

## 修复

- 新增 `lib/base-path.ts`：`homeWithHash('#x')` → `/mini-hbut/#x`（有 basePath 时）
- `next.config.ts` 注入 `NEXT_PUBLIC_BASE_PATH`
- Navbar 非首页锚点改为 `homeWithHash`，首页仍用 `#id` 平滑滚动
- 构建产物检查：client bundle 含 `/mini-hbut` 且生成 `base + '/' + '#hash'`

## 验证

- [x] MCP 打开 privacy：`返回首页` href=`/mini-hbut`（正确）
- [x] 线上问题链接形态为 `/#features`（错误，本次修复）
- [x] `GITHUB_PAGES=true npm run build` 通过
- [ ] 合并后 Sync Website，在 GH Pages 从 `/privacy` 点「功能/下载」应落在 `/mini-hbut/#...`
