### PR TITLE
fix(website): 消除 Hero 滚动闪烁并适配移动端

### DIFF
--- a/website/src/components/CTASection.tsx
+++ b/website/src/components/CTASection.tsx
@@ -16,8 +16,10 @@ interface MagneticButtonProps {
 function MagneticButton({ href, children, variant = 'ghost', external }: MagneticButtonProps) {
   const ref = useRef<HTMLAnchorElement>(null);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const { isMobile } = useScrollProgress();
 
   const handleMove = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (isMobile) return;
     const el = ref.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
@@ -63,18 +65,22 @@ function MagneticButton({ href, children, variant = 'ghost', external }: Magneti
 }
 
 export default function CTASection() {
-  const { sample } = useScrollProgress();
+  const { sample, isMobile } = useScrollProgress();
   const opacity = sample.ctaOpacity;
 
-  if (opacity <= 0.02) return null;
-
+  // 保持挂载，避免 opacity 阈值附近闪灭
   return (
-    <motion.section
+    <section
       id="download"
-      className="pointer-events-auto fixed inset-x-0 bottom-[8vh] z-30 mx-auto flex max-w-3xl flex-col items-center gap-4 px-6"
-      initial={false}
-      animate={{ opacity, y: (1 - opacity) * 30 }}
-      transition={{ duration: 0.45 }}
+      className={`pointer-events-auto fixed inset-x-0 z-30 mx-auto flex max-w-3xl flex-col items-center gap-4 px-6 ${
+        isMobile ? 'bottom-[6vh]' : 'bottom-[8vh]'
+      }`}
+      style={{
+        opacity: opacity <= 0.02 ? 0 : opacity,
+        visibility: opacity <= 0.02 ? 'hidden' : 'visible',
+        transform: `translateY(${(1 - Math.max(opacity, 0)) * 24}px)`,
+        transition: 'opacity 0.35s ease, transform 0.35s ease',
+      }}
     >
       <div className="flex flex-wrap items-center justify-center gap-3">
         <MagneticButton href="/releases" variant="primary">
@@ -84,13 +90,11 @@ export default function CTASection() {
           <Github size={16} />
           GitHub
         </MagneticButton>
-        <MagneticButton href="/docs">
-          了解功能
-        </MagneticButton>
+        <MagneticButton href="/docs">了解功能</MagneticButton>
       </div>
       <p className="text-center text-xs text-white/45">
         下载 Windows / macOS / Linux / Android / iOS 全平台版本
       </p>
-    </motion.section>
+    </section>
   );
 }

--- a/website/src/components/CameraRig.tsx
+++ b/website/src/components/CameraRig.tsx
@@ -8,16 +8,18 @@ import { useScrollProgress } from '@/hooks/use-scroll-progress';
 
 /**
  * 镜头始终看向「居中手机」，做推进 / 环绕 / 仰视运镜。
- * 左右栏是 2D UI，不参与 3D 偏移。
+ * 从 sampleRef 读进度，避免 progress 每帧 React 更新导致抖动。
  */
 export default function CameraRig() {
   const { camera } = useThree();
-  const { sample, pointer, reducedMotion, isMobile } = useScrollProgress();
+  const { sampleRef, pointerRef, reducedMotion, isMobile } = useScrollProgress();
   const lookAtRef = useRef(new THREE.Vector3());
   const idlePhase = useRef(0);
 
   useFrame((_, delta) => {
     if (isMobile) return;
+    const sample = sampleRef.current;
+    const pointer = pointerRef.current;
     const t = Math.min(0.12, delta);
     idlePhase.current += delta;
 
@@ -25,14 +27,14 @@ export default function CameraRig() {
     let camPos = applyParallax(sample.camera.position, pointer, parallaxStrength);
     let lookAt = applyParallax(sample.camera.lookAt, pointer, parallaxStrength * 0.35);
 
-    // 首屏 idle：轻微环绕，体现 3D 厚度
-    if (!reducedMotion && sample.globalProgress < 0.12) {
+    // 首屏 idle：极轻环绕（不改 progress）
+    if (!reducedMotion && sample.globalProgress < 0.1) {
       const idle = idlePhase.current;
-      const amp = 1 - sample.globalProgress / 0.12;
+      const amp = 1 - sample.globalProgress / 0.1;
       camPos = {
-        x: camPos.x + Math.sin(idle * 0.55) * 0.22 * amp,
-        y: camPos.y + Math.sin(idle * 0.4) * 0.05 * amp,
-        z: camPos.z + Math.cos(idle * 0.55) * 0.1 * amp,
+        x: camPos.x + Math.sin(idle * 0.45) * 0.12 * amp,
+        y: camPos.y + Math.sin(idle * 0.32) * 0.03 * amp,
+        z: camPos.z + Math.cos(idle * 0.45) * 0.06 * amp,
       };
     }
 

--- a/website/src/components/FeatureTextOverlay.tsx
+++ b/website/src/components/FeatureTextOverlay.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { motion, AnimatePresence } from 'framer-motion';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
 
 const FEATURE_COPY: Record<string, { title: string; body: string }> = {
@@ -30,27 +29,28 @@ function getCopyKey(phase: string): keyof typeof FEATURE_COPY {
   return 'schedule';
 }
 
+/**
+ * 中段功能文案。
+ * 不用 AnimatePresence mode=wait（进出场叠 progress 抖动会整段闪）。
+ * 移动端文案改由 Hero 顶部 + 手机字幕承担，这里隐藏以免叠层跳动。
+ */
 export default function FeatureTextOverlay() {
-  const { sample } = useScrollProgress();
+  const { sample, isMobile } = useScrollProgress();
+  if (isMobile) return null;
+
   const opacity = sample.featureOpacity;
+  if (opacity <= 0.05) return null;
+
   const copyKey = getCopyKey(sample.phase);
   const copy = FEATURE_COPY[copyKey];
 
   return (
-    <AnimatePresence mode="wait">
-      {opacity > 0.05 && (
-        <motion.div
-          key={copyKey}
-          className="pointer-events-none fixed inset-x-0 bottom-[18vh] z-20 mx-auto max-w-3xl px-6 text-center lg:hidden"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity, y: 0 }}
-          exit={{ opacity: 0, y: -12 }}
-          transition={{ duration: 0.4 }}
-        >
-          <h2 className="text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h2>
-          <p className="mt-3 text-base text-white/65 sm:text-lg">{copy.body}</p>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-[18vh] z-20 mx-auto max-w-3xl px-6 text-center lg:hidden"
+      style={{ opacity, transition: 'opacity 0.3s ease' }}
+    >
+      <h2 className="text-2xl font-semibold text-white sm:text-3xl">{copy.title}</h2>
+      <p className="mt-3 text-base text-white/65 sm:text-lg">{copy.body}</p>
+    </div>
   );
 }

--- a/website/src/components/HeroFeatureOrbits.tsx
+++ b/website/src/components/HeroFeatureOrbits.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import { useDisplayScreen } from '@/hooks/use-display-screen';
 import { APP_MODULES, type AppModuleId } from '@/components/phone-app/app-modules';
 import type { AppScreen } from '@/lib/scroll-utils';
 
@@ -35,6 +36,7 @@ function screenMatches(card: OrbitCard, active: AppScreen) {
 
 export default function HeroFeatureOrbits() {
   const { sample, reducedMotion, isMobile } = useScrollProgress();
+  const display = useDisplayScreen();
   if (isMobile) return null;
 
   return (
@@ -50,7 +52,7 @@ export default function HeroFeatureOrbits() {
           const mod = APP_MODULES.find((m) => m.id === card.id);
           if (!mod) return null;
           const Icon = mod.icon;
-          const active = screenMatches(card, sample.activeScreen);
+          const active = screenMatches(card, display.activeScreen);
           return (
             <motion.div
               key={card.id}
@@ -60,23 +62,17 @@ export default function HeroFeatureOrbits() {
               animate={{
                 opacity: active ? 1 : 0.55 + sample.phone.screenBrightness * 0.2,
                 x: 0,
-                scale: active ? 1.06 : 0.98,
+                scale: active ? 1.04 : 0.98,
               }}
               transition={{ delay: 0.1 + i * 0.05, duration: 0.35 }}
             >
-              <motion.div
+              <div
                 className="rounded-2xl border border-white/15 bg-black/55 p-2.5 shadow-[0_16px_40px_rgba(0,0,0,0.45)] backdrop-blur-md"
                 style={{
                   boxShadow: active
                     ? `0 0 0 1px ${mod.color}99, 0 16px 40px rgba(0,0,0,0.5), 0 0 28px ${mod.color}45`
                     : undefined,
                 }}
-                animate={reducedMotion ? undefined : { y: [0, i % 2 === 0 ? -5 : 5, 0] }}
-                transition={
-                  reducedMotion
-                    ? undefined
-                    : { duration: 3.2 + i * 0.25, repeat: Infinity, ease: 'easeInOut' }
-                }
               >
                 <div className="flex items-center gap-2">
                   <div
@@ -91,14 +87,15 @@ export default function HeroFeatureOrbits() {
                   </div>
                 </div>
                 <div className="mt-2 h-0.5 overflow-hidden rounded-full bg-white/10">
-                  <motion.div
-                    className="h-full rounded-full"
-                    style={{ background: mod.color }}
-                    animate={{ width: active ? '88%' : '38%' }}
-                    transition={{ duration: 0.45 }}
+                  <div
+                    className="h-full rounded-full transition-[width] duration-400"
+                    style={{
+                      background: mod.color,
+                      width: active ? '88%' : '38%',
+                    }}
                   />
                 </div>
-              </motion.div>
+              </div>
             </motion.div>
           );
         })}

--- a/website/src/components/HeroText.tsx
+++ b/website/src/components/HeroText.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { ArrowRight, Download, Sparkles } from 'lucide-react';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import { useDisplayScreen } from '@/hooks/use-display-screen';
 import { SCREEN_CAPTIONS } from '@/lib/screen-captions';
 
 const FEATURE_CHIPS = [
@@ -16,107 +17,135 @@ const FEATURE_CHIPS = [
 ] as const;
 
 /**
- * 左侧营销文案栏：固定占左 ~30%，不与中间手机、右侧功能卡重叠。
+ * 左栏营销文案：
+ * - 桌面：固定左栏，不与中/右重叠
+ * - 移动：顶部紧凑文案，手机在中部独立展示
  */
 export default function HeroText() {
-  const { sample, reducedMotion } = useScrollProgress();
-  const opacity = sample.heroOpacity;
-  const caption = SCREEN_CAPTIONS[sample.activeScreen] ?? SCREEN_CAPTIONS.home;
+  const { sample, reducedMotion, isMobile } = useScrollProgress();
+  const display = useDisplayScreen();
+  const opacity = isMobile ? Math.max(0.75, sample.heroOpacity) : sample.heroOpacity;
+  const caption = SCREEN_CAPTIONS[display.activeScreen] ?? SCREEN_CAPTIONS.home;
 
-  if (opacity <= 0.02) return null;
+  // 不用 return null：卸载/挂载会造成整层闪一下
+  const hidden = opacity <= 0.02;
 
   return (
-    <motion.div
+    <div
       className="pointer-events-none fixed inset-0 z-[25]"
-      initial={false}
-      animate={{ opacity }}
-      transition={{ duration: reducedMotion ? 0 : 0.35, ease: 'easeOut' }}
+      style={{
+        opacity: hidden ? 0 : opacity,
+        visibility: hidden ? 'hidden' : 'visible',
+        transition: reducedMotion ? undefined : 'opacity 0.35s ease-out',
+      }}
     >
-      {/* 仅左栏：lg 起固定左侧安全区 */}
-      <div className="pointer-events-auto absolute inset-y-0 left-0 flex w-full max-w-full flex-col justify-center px-5 pb-16 pt-24 md:px-8 lg:w-[min(32vw,380px)] lg:px-8 xl:w-[min(30vw,400px)] xl:px-10">
+      <div
+        className={
+          isMobile
+            ? 'pointer-events-auto absolute inset-x-0 top-0 flex flex-col px-4 pb-2 pt-[4.75rem]'
+            : 'pointer-events-auto absolute inset-y-0 left-0 flex w-full max-w-full flex-col justify-center px-5 pb-16 pt-24 md:px-8 lg:w-[min(32vw,380px)] lg:px-8 xl:w-[min(30vw,400px)] xl:px-10'
+        }
+      >
         <motion.div
-          initial={reducedMotion ? false : { opacity: 0, y: 18 }}
+          initial={reducedMotion ? false : { opacity: 0, y: 14 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+          transition={{ duration: 0.65, ease: [0.22, 1, 0.36, 1] }}
         >
-          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1 text-[11px] font-medium tracking-wide text-cyan-200">
-            <Sparkles className="h-3.5 w-3.5" />
+          <div className="mb-2.5 inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-2.5 py-1 text-[10px] font-medium tracking-wide text-cyan-200 sm:mb-4 sm:px-3 sm:text-[11px]">
+            <Sparkles className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
             Mini-HBUT · 校园信息聚合客户端
           </div>
 
-          <h1 className="bg-gradient-to-br from-white via-cyan-50 to-violet-200 bg-clip-text text-3xl font-semibold leading-[1.14] text-transparent sm:text-4xl lg:text-[2.55rem] xl:text-[2.75rem]">
+          <h1
+            className={
+              isMobile
+                ? 'bg-gradient-to-br from-white via-cyan-50 to-violet-200 bg-clip-text text-[1.65rem] font-semibold leading-[1.18] text-transparent'
+                : 'bg-gradient-to-br from-white via-cyan-50 to-violet-200 bg-clip-text text-3xl font-semibold leading-[1.14] text-transparent sm:text-4xl lg:text-[2.55rem] xl:text-[2.75rem]'
+            }
+          >
             一个入口，
-            <br />
+            {isMobile ? ' ' : <br />}
             看清整个校园日程。
           </h1>
 
-          <p className="mt-4 max-w-sm text-sm leading-7 text-white/65">
-            课表、成绩、考试、通知、电费与空教室——在真实 App 界面里滚动体验，而不是看一张静态截图。
+          <p
+            className={
+              isMobile
+                ? 'mt-2 max-w-md text-[12px] leading-5 text-white/65'
+                : 'mt-4 max-w-sm text-sm leading-7 text-white/65'
+            }
+          >
+            {isMobile
+              ? '课表、成绩、考试、电费——下滑体验真实 App 界面。'
+              : '课表、成绩、考试、通知、电费与空教室——在真实 App 界面里滚动体验，而不是看一张静态截图。'}
           </p>
 
-          <div className="mt-5 flex flex-wrap gap-2">
-            {FEATURE_CHIPS.map((chip, i) => (
-              <motion.span
-                key={chip.id}
-                className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/80 backdrop-blur-sm"
-                style={{ boxShadow: `inset 0 0 0 1px ${chip.color}33` }}
-                initial={reducedMotion ? false : { opacity: 0, y: 8 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.12 + i * 0.05, duration: 0.4 }}
-              >
-                <span
-                  className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full"
-                  style={{ background: chip.color }}
-                />
-                {chip.label}
-              </motion.span>
-            ))}
-          </div>
+          {!isMobile && (
+            <div className="mt-5 flex flex-wrap gap-2">
+              {FEATURE_CHIPS.map((chip, i) => (
+                <motion.span
+                  key={chip.id}
+                  className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-medium text-white/80 backdrop-blur-sm"
+                  style={{ boxShadow: `inset 0 0 0 1px ${chip.color}33` }}
+                  initial={reducedMotion ? false : { opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.12 + i * 0.05, duration: 0.4 }}
+                >
+                  <span
+                    className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full"
+                    style={{ background: chip.color }}
+                  />
+                  {chip.label}
+                </motion.span>
+              ))}
+            </div>
+          )}
 
-          <div className="mt-7 flex flex-wrap items-center gap-3">
+          <div className={`flex flex-wrap items-center gap-2.5 ${isMobile ? 'mt-3' : 'mt-7 gap-3'}`}>
             <a
               href="#download"
-              className="group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 to-sky-500 px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-[0_0_32px_rgba(34,211,238,0.35)] transition hover:brightness-110"
+              className={`group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 to-sky-500 font-semibold text-slate-950 shadow-[0_0_32px_rgba(34,211,238,0.35)] transition hover:brightness-110 ${
+                isMobile ? 'px-4 py-2 text-xs' : 'px-5 py-2.5 text-sm'
+              }`}
             >
-              <Download className="h-4 w-4" />
+              <Download className={isMobile ? 'h-3.5 w-3.5' : 'h-4 w-4'} />
               免费下载
-              <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+              <ArrowRight className={`transition group-hover:translate-x-0.5 ${isMobile ? 'h-3.5 w-3.5' : 'h-4 w-4'}`} />
             </a>
             <Link
               href="/docs"
-              className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-medium text-white/85 backdrop-blur-sm transition hover:border-cyan-400/40 hover:text-white"
+              className={`inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 font-medium text-white/85 backdrop-blur-sm transition hover:border-cyan-400/40 hover:text-white ${
+                isMobile ? 'px-4 py-2 text-xs' : 'px-5 py-2.5 text-sm'
+              }`}
             >
               查看文档
             </Link>
           </div>
 
-          {/* 当前屏字幕贴在左栏底部，不进中/右区 */}
-          <motion.div
-            key={sample.activeScreen}
-            className="mt-8 hidden max-w-sm rounded-2xl border border-white/10 bg-black/45 p-3.5 shadow-[0_16px_48px_rgba(0,0,0,0.4)] backdrop-blur-md lg:block"
-            initial={reducedMotion ? false : { opacity: 0, y: 10 }}
-            animate={{
-              opacity: Math.min(1, 0.45 + sample.phone.screenBrightness * 0.55),
-              y: 0,
-            }}
-            transition={{ duration: 0.35 }}
-          >
-            <div className="mb-1.5 flex items-center gap-2">
-              <span
-                className="rounded-full px-2 py-0.5 text-[10px] font-semibold text-slate-950"
-                style={{ background: caption.accent }}
-              >
-                {caption.label}
-              </span>
-              <span className="text-[10px] text-white/40">界面预览</span>
+          {!isMobile && (
+            <div
+              key={display.activeScreen}
+              className="mt-8 hidden max-w-sm rounded-2xl border border-white/10 bg-black/45 p-3.5 shadow-[0_16px_48px_rgba(0,0,0,0.4)] backdrop-blur-md lg:block"
+            >
+              <div className="mb-1.5 flex items-center gap-2">
+                <span
+                  className="rounded-full px-2 py-0.5 text-[10px] font-semibold text-slate-950"
+                  style={{ background: caption.accent }}
+                >
+                  {caption.label}
+                </span>
+                <span className="text-[10px] text-white/40">界面预览</span>
+              </div>
+              <h2 className="text-sm font-semibold text-white">{caption.title}</h2>
+              <p className="mt-1 text-xs leading-5 text-white/60">{caption.blurb}</p>
             </div>
-            <h2 className="text-sm font-semibold text-white">{caption.title}</h2>
-            <p className="mt-1 text-xs leading-5 text-white/60">{caption.blurb}</p>
-          </motion.div>
+          )}
 
-          <p className="mt-5 text-[11px] text-white/40 lg:mt-4">向下滚动 · 3D 运镜与功能演示</p>
+          <p className={`text-[11px] text-white/40 ${isMobile ? 'mt-2' : 'mt-5 lg:mt-4'}`}>
+            {isMobile ? '向下滑动 · 查看功能演示' : '向下滚动 · 3D 运镜与功能演示'}
+          </p>
         </motion.div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/website/src/components/LightRibbons.tsx
+++ b/website/src/components/LightRibbons.tsx
@@ -9,7 +9,7 @@ const RIBBON_COUNT = 5;
 
 export default function LightRibbons() {
   const groupRef = useRef<THREE.Group>(null);
-  const { sample, isMobile } = useScrollProgress();
+  const { sampleRef, isMobile } = useScrollProgress();
 
   const ribbons = useMemo(() => {
     return Array.from({ length: isMobile ? 3 : RIBBON_COUNT }, (_, i) => {
@@ -35,7 +35,7 @@ export default function LightRibbons() {
   useFrame((state) => {
     if (!groupRef.current) return;
     const t = state.clock.elapsedTime;
-    const intensity = sample.ribbonIntensity;
+    const intensity = sampleRef.current.ribbonIntensity;
     groupRef.current.visible = intensity > 0.02;
     groupRef.current.children.forEach((child, i) => {
       child.position.z = -2.5 - i * 0.4 + Math.sin(t * 0.5 + ribbons[i].offset) * 0.15 * intensity;

--- a/website/src/components/ParticleField.tsx
+++ b/website/src/components/ParticleField.tsx
@@ -11,8 +11,8 @@ interface ParticleFieldProps {
 
 export default function ParticleField({ count }: ParticleFieldProps) {
   const pointsRef = useRef<THREE.Points>(null);
-  const { sample, isMobile } = useScrollProgress();
-  const particleCount = count ?? (isMobile ? 280 : 720);
+  const { sampleRef, isMobile } = useScrollProgress();
+  const particleCount = count ?? (isMobile ? 160 : 720);
 
   const { positions, speeds } = useMemo(() => {
     const pos = new Float32Array(particleCount * 3);
@@ -31,7 +31,8 @@ export default function ParticleField({ count }: ParticleFieldProps) {
     const geo = pointsRef.current.geometry;
     const attr = geo.getAttribute('position') as THREE.BufferAttribute;
     const t = state.clock.elapsedTime;
-    const intensity = sample.particleIntensity;
+    const intensity = sampleRef.current.particleIntensity;
+    const mat = pointsRef.current.material as THREE.PointsMaterial;
 
     for (let i = 0; i < particleCount; i += 1) {
       const yIndex = i * 3 + 1;
@@ -41,6 +42,7 @@ export default function ParticleField({ count }: ParticleFieldProps) {
     }
     attr.needsUpdate = true;
     pointsRef.current.rotation.y = t * 0.02 * intensity;
+    mat.opacity = 0.35 + intensity * 0.45;
   });
 
   return (
@@ -49,10 +51,10 @@ export default function ParticleField({ count }: ParticleFieldProps) {
         <bufferAttribute attach="attributes-position" args={[positions, 3]} />
       </bufferGeometry>
       <pointsMaterial
-        size={0.025}
+        size={isMobile ? 0.02 : 0.025}
         color="#7dd3fc"
         transparent
-        opacity={0.35 + sample.particleIntensity * 0.45}
+        opacity={0.45}
         depthWrite={false}
         blending={THREE.AdditiveBlending}
       />

--- a/website/src/components/PhoneModel.tsx
+++ b/website/src/components/PhoneModel.tsx
@@ -5,6 +5,7 @@ import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import { useDisplayScreen } from '@/hooks/use-display-screen';
 import PhoneAppScreen from './phone-app/PhoneAppScreen';
 import './phone-app/phone-app.css';
 import {
@@ -28,7 +29,8 @@ const SCREEN_DOM_H = 556;
  */
 export default function PhoneModel() {
   const groupRef = useRef<THREE.Group>(null);
-  const { sample, pointer, reducedMotion, isMobile } = useScrollProgress();
+  const { sampleRef, pointerRef, reducedMotion, isMobile } = useScrollProgress();
+  const display = useDisplayScreen();
 
   const frameGeometry = useMemo(() => {
     const shape = createPhoneProfile(PHONE_WIDTH, PHONE_HEIGHT, BEVEL_RADIUS);
@@ -59,32 +61,29 @@ export default function PhoneModel() {
 
   useFrame((state) => {
     if (!groupRef.current || isMobile) return;
+    const phone = sampleRef.current.phone;
+    const pointer = pointerRef.current;
     const t = state.clock.elapsedTime;
-    const floatY = Math.sin(t * 1.1) * sample.phone.float * 0.1;
+    const floatY = Math.sin(t * 1.1) * phone.float * 0.1;
     const parallaxX = reducedMotion ? 0 : pointer.x * 0.06;
     const parallaxY = reducedMotion ? 0 : pointer.y * 0.04;
 
-    // 居中主视觉；关键帧只做轻微位移动效，不把机身推到左右栏
     groupRef.current.position.set(
-      sample.phone.position.x * 0.12 + parallaxX,
-      sample.phone.position.y * 0.35 + floatY + parallaxY,
-      sample.phone.position.z * 0.2,
+      phone.position.x * 0.12 + parallaxX,
+      phone.position.y * 0.35 + floatY + parallaxY,
+      phone.position.z * 0.2,
     );
     groupRef.current.rotation.set(
-      sample.phone.rotation.x * 0.9,
-      sample.phone.rotation.y * 0.95 + parallaxX * 0.1,
-      sample.phone.rotation.z,
+      phone.rotation.x * 0.9,
+      phone.rotation.y * 0.95 + parallaxX * 0.1,
+      phone.rotation.z,
     );
-    groupRef.current.scale.setScalar(sample.phone.scale);
+    groupRef.current.scale.setScalar(phone.scale);
   });
 
   if (isMobile) return null;
 
   const zFront = PHONE_DEPTH / 2;
-  /**
-   * drei Html(transform) 缩放系数 ≈ distanceFactor/400（越大越大）。
-   * 1.58 会整屏贴脸；0.48 又过小。居中机身 + 中距离镜头下约 1.12 贴合屏平面。
-   */
   const htmlDistanceFactor = 0.98;
 
   return (
@@ -136,9 +135,9 @@ export default function PhoneModel() {
           }}
         >
           <PhoneAppScreen
-            screenFrom={sample.screenFrom}
-            screenTo={sample.screenTo}
-            screenBlend={sample.screenBlend}
+            screenFrom={display.screenFrom}
+            screenTo={display.screenTo}
+            screenBlend={display.screenBlend}
           />
         </div>
       </Html>

--- a/website/src/components/SceneCanvas.tsx
+++ b/website/src/components/SceneCanvas.tsx
@@ -35,7 +35,8 @@ function SceneContent() {
 
       <CameraRig />
 
-      <Float speed={1.05} rotationIntensity={0.06} floatIntensity={0.12}>
+      {/* Float 幅度保持极小，避免与 scroll 插值叠出“乱跳”感 */}
+      <Float speed={0.8} rotationIntensity={0.03} floatIntensity={0.06}>
         <PhoneModel />
       </Float>
 

--- a/website/src/components/SmoothScrollProvider.tsx
+++ b/website/src/components/SmoothScrollProvider.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, type ReactNode } from 'react';
 import Lenis from 'lenis';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
-import { SCROLL_DRIVER_VH } from '@/lib/scroll-utils';
+import { SCROLL_DRIVER_VH, SCROLL_DRIVER_VH_MOBILE } from '@/lib/scroll-utils';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
 
 gsap.registerPlugin(ScrollTrigger);
@@ -16,7 +16,7 @@ interface SmoothScrollProviderProps {
 
 export default function SmoothScrollProvider({ children, hideScene = false }: SmoothScrollProviderProps) {
   const driverRef = useRef<HTMLDivElement>(null);
-  const { setProgress, reducedMotion } = useScrollProgress();
+  const { setProgress, reducedMotion, isMobile } = useScrollProgress();
   const lenisRef = useRef<Lenis | null>(null);
   const rafRef = useRef<((time: number) => void) | null>(null);
 
@@ -24,11 +24,14 @@ export default function SmoothScrollProvider({ children, hideScene = false }: Sm
     const driver = driverRef.current;
     if (!driver) return undefined;
 
-    if (!reducedMotion) {
+    // 移动端用原生滚动：Lenis + 地址栏伸缩更容易造成 progress 抖动
+    const useLenis = !reducedMotion && !isMobile;
+
+    if (useLenis) {
       const lenis = new Lenis({
-        duration: 1.15,
+        duration: 1.05,
         smoothWheel: true,
-        touchMultiplier: 1.4,
+        touchMultiplier: 1.2,
       });
       lenisRef.current = lenis;
 
@@ -46,17 +49,28 @@ export default function SmoothScrollProvider({ children, hideScene = false }: Sm
       trigger: driver,
       start: 'top top',
       end: 'bottom bottom',
-      scrub: true,
+      // 轻微 scrub 平滑，避免 onUpdate 硬切
+      scrub: isMobile ? 0.35 : 0.55,
       onUpdate: (self) => {
         setProgress(self.progress);
       },
     });
 
-    const refresh = () => ScrollTrigger.refresh();
+    // 初始化一次，避免首帧 progress 与 scroll 脱节
+    setProgress(trigger.progress);
+
+    let resizeTimer = 0;
+    const refresh = () => {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(() => {
+        ScrollTrigger.refresh();
+      }, 120);
+    };
     window.addEventListener('resize', refresh);
 
     return () => {
       window.removeEventListener('resize', refresh);
+      window.clearTimeout(resizeTimer);
       trigger.kill();
       if (rafRef.current) {
         gsap.ticker.remove(rafRef.current);
@@ -64,7 +78,9 @@ export default function SmoothScrollProvider({ children, hideScene = false }: Sm
       lenisRef.current?.destroy();
       lenisRef.current = null;
     };
-  }, [setProgress, reducedMotion]);
+  }, [setProgress, reducedMotion, isMobile]);
+
+  const driverVh = isMobile ? SCROLL_DRIVER_VH_MOBILE : SCROLL_DRIVER_VH;
 
   return (
     <>
@@ -72,7 +88,7 @@ export default function SmoothScrollProvider({ children, hideScene = false }: Sm
         ref={driverRef}
         data-hero-scroll-driver
         className="relative"
-        style={{ height: `${SCROLL_DRIVER_VH}vh` }}
+        style={{ height: `${driverVh}vh` }}
         aria-hidden
       />
       <div

--- a/website/src/components/home/HomeExperience.tsx
+++ b/website/src/components/home/HomeExperience.tsx
@@ -21,8 +21,9 @@ const SceneCanvas = dynamic(() => import('@/components/SceneCanvas'), {
 
 function HomeExperienceInner() {
   const pastHero = useHeroScrollPhase();
-  const { isMobile } = useScrollProgress();
-  useIdleHeroDemo(!pastHero);
+  const { isMobile, reducedMotion } = useScrollProgress();
+  // 仅在 Hero 区内做 UI 轮播；绝不改写 scroll progress
+  useIdleHeroDemo(!pastHero, reducedMotion);
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-[#03060d] text-white">
@@ -32,36 +33,42 @@ function HomeExperienceInner() {
         <div id="download" className="sr-only" aria-hidden />
         <div id="about" className="sr-only" aria-hidden />
 
-        {/* 桌面：R3F 唯一手机贴屏；移动端场景仅氛围 */}
         <SmoothScrollProvider hideScene={pastHero}>
           <SceneErrorBoundary>
+            {/* 移动端仍挂轻量场景作氛围；手机主体走 DOM 降级 */}
             <SceneCanvas />
           </SceneErrorBoundary>
         </SmoothScrollProvider>
 
-        {!pastHero && (
-          <>
-            {/* 移动端 DOM 降级手机；桌面不叠第二台 */}
-            {isMobile && <PhoneScreenOverlay />}
-            <HeroFeatureOrbits />
-            <HeroText />
-            <FeatureTextOverlay />
-            <CTASection />
-          </>
-        )}
+        {/* 固定层用 opacity 隐藏，避免 pastHero 切换时整树卸载闪一下（勿用 display:contents） */}
+        <div
+          className="pointer-events-none fixed inset-0 z-[20]"
+          style={{
+            opacity: pastHero ? 0 : 1,
+            visibility: pastHero ? 'hidden' : 'visible',
+            transition: 'opacity 0.4s ease',
+          }}
+          aria-hidden={pastHero}
+        >
+          {isMobile && <PhoneScreenOverlay />}
+          <HeroFeatureOrbits />
+          <HeroText />
+          <FeatureTextOverlay />
+          <CTASection />
+        </div>
 
         <HomeClassicSections />
       </main>
 
-      {!pastHero && (
-        <div
-          className="pointer-events-none fixed inset-0 z-[1] opacity-45"
-          style={{
-            background:
-              'radial-gradient(ellipse 65% 50% at 70% 40%, rgba(56,189,248,0.16), transparent 55%), radial-gradient(ellipse 45% 35% at 15% 28%, rgba(167,139,250,0.12), transparent 50%)',
-          }}
-        />
-      )}
+      <div
+        className="pointer-events-none fixed inset-0 z-[1]"
+        style={{
+          opacity: pastHero ? 0 : 0.45,
+          transition: 'opacity 0.45s ease',
+          background:
+            'radial-gradient(ellipse 65% 50% at 70% 40%, rgba(56,189,248,0.16), transparent 55%), radial-gradient(ellipse 45% 35% at 15% 28%, rgba(167,139,250,0.12), transparent 50%)',
+        }}
+      />
     </div>
   );
 }

--- a/website/src/components/phone-app/PhoneScreenOverlay.tsx
+++ b/website/src/components/phone-app/PhoneScreenOverlay.tsx
@@ -1,103 +1,76 @@
 'use client';
 
-import { motion } from 'framer-motion';
 import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import { useDisplayScreen } from '@/hooks/use-display-screen';
 import { SCREEN_CAPTIONS } from '@/lib/screen-captions';
 import PhoneAppScreen from './PhoneAppScreen';
 import './phone-app.css';
 
 /**
- * 移动端产品手机降级：CSS 机框 + 与桌面同源的 PhoneAppScreen。
- * 桌面由 R3F PhoneModel（drei Html 贴屏）承担，本组件仅 isMobile 挂载。
+ * 移动端产品手机降级：CSS 机框 + 同源 PhoneAppScreen。
+ * 位置固定、无 spring，避免 progress 连续更新时整机弹跳闪烁。
  */
 export default function PhoneScreenOverlay() {
-  const { sample, reducedMotion, isMobile } = useScrollProgress();
-  const brightness = Math.max(0.85, sample.phone.screenBrightness);
-  const caption = SCREEN_CAPTIONS[sample.activeScreen] ?? SCREEN_CAPTIONS.home;
+  const { sample, isMobile } = useScrollProgress();
+  const display = useDisplayScreen();
+  const caption = SCREEN_CAPTIONS[display.activeScreen] ?? SCREEN_CAPTIONS.home;
 
-  const progress = sample.globalProgress;
-  const phoneScale = sample.phone.scale;
-  const rotY = sample.phone.rotation.y;
-  const rotX = sample.phone.rotation.x;
-
-  const baseScale = isMobile ? 0.82 : 0.96;
-  const scale = baseScale * (0.94 + (phoneScale - 1) * 0.28);
-  const rotateY = rotY * 26;
-  const rotateX = -rotX * 16 + 5;
-  const translateX = isMobile ? 0 : 16 + progress * 3 + sample.phone.position.x * 36;
-  const translateY =
-    (typeof window !== 'undefined' ? window.innerHeight * (isMobile ? 0.18 : 0.12) : 110) +
-    sample.phone.position.y * 64;
+  if (!isMobile) return null;
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-[12] overflow-hidden" aria-hidden>
-      <motion.div
-        className="absolute left-1/2 top-0"
-        style={{ transformStyle: 'preserve-3d', perspective: 1400 }}
-        initial={false}
-        animate={{
-          opacity: brightness,
-          x: `calc(-50% + ${translateX}%)`,
-          y: translateY,
+    <div
+      className="pointer-events-none fixed inset-x-0 z-[12] flex flex-col items-center"
+      style={{
+        top: 'max(9.5rem, 22vh)',
+        paddingBottom: '1rem',
+      }}
+      aria-hidden
+    >
+      <div
+        className="relative"
+        style={{
+          width: 'min(68vw, 260px)',
+          height: 'min(140vw, 534px)',
+          maxHeight: '52vh',
+          opacity: Math.max(0.9, sample.phone.screenBrightness),
+          transition: 'opacity 0.3s ease',
         }}
-        transition={{ type: 'spring', stiffness: 100, damping: 24, mass: 0.75 }}
       >
         <div
-          className="relative"
+          className="absolute inset-0 rounded-[36px]"
           style={{
-            width: 300,
-            height: 618,
-            transform: `rotateY(${rotateY}deg) rotateX(${rotateX}deg) scale(${scale})`,
-            transformStyle: 'preserve-3d',
-            transition: reducedMotion ? undefined : 'transform 0.5s cubic-bezier(0.22,1,0.36,1)',
+            background:
+              'linear-gradient(155deg, #3d4a63 0%, #1a2233 35%, #0c1018 65%, #243044 100%)',
+            boxShadow:
+              '0 24px 50px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.1), inset 0 1px 0 rgba(255,255,255,0.12)',
           }}
-        >
-          {/* 机身边框 */}
-          <div
-            className="absolute inset-0 rounded-[44px]"
-            style={{
-              background:
-                'linear-gradient(155deg, #3d4a63 0%, #1a2233 35%, #0c1018 65%, #243044 100%)',
-              boxShadow:
-                '0 40px 90px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.1), inset 0 1px 0 rgba(255,255,255,0.12)',
-              transform: 'translateZ(-10px)',
-            }}
-          />
-          <div
-            className="absolute inset-y-10 -left-[1px] w-[3px] rounded-full opacity-60"
-            style={{
-              background: 'linear-gradient(180deg, transparent, #67e8f9aa, transparent)',
-            }}
-          />
+        />
 
-          {/* 屏幕 */}
-          <div className="absolute inset-[10px] overflow-hidden rounded-[36px] bg-[#f0f4f8] ring-1 ring-black/40">
-            <div className="absolute left-1/2 top-2.5 z-20 h-[22px] w-[92px] -translate-x-1/2 rounded-full bg-black" />
-            <div className="absolute inset-0">
-              <PhoneAppScreen
-                screenFrom={sample.screenFrom}
-                screenTo={sample.screenTo}
-                screenBlend={sample.screenBlend}
-              />
-            </div>
-            <div
-              className="pointer-events-none absolute inset-0 z-10"
-              style={{
-                background:
-                  'linear-gradient(118deg, rgba(255,255,255,0.16) 0%, transparent 28%, transparent 70%, rgba(56,189,248,0.06) 100%)',
-              }}
+        <div className="absolute inset-[8px] overflow-hidden rounded-[28px] bg-[#f0f4f8] ring-1 ring-black/40">
+          <div className="absolute left-1/2 top-1.5 z-20 h-[16px] w-[72px] -translate-x-1/2 rounded-full bg-black" />
+          <div className="absolute inset-0">
+            <PhoneAppScreen
+              screenFrom={display.screenFrom}
+              screenTo={display.screenTo}
+              screenBlend={display.screenBlend}
             />
           </div>
-
-          {/* 移动端字幕 */}
-          <div className="absolute -bottom-14 left-1/2 w-[min(280px,85vw)] -translate-x-1/2 rounded-xl border border-white/10 bg-black/55 px-3 py-2 text-center backdrop-blur-md lg:hidden">
-            <p className="text-[10px] font-semibold" style={{ color: caption.accent }}>
-              {caption.label}
-            </p>
-            <p className="text-xs text-white/85">{caption.title}</p>
-          </div>
+          <div
+            className="pointer-events-none absolute inset-0 z-10"
+            style={{
+              background:
+                'linear-gradient(118deg, rgba(255,255,255,0.14) 0%, transparent 28%, transparent 70%, rgba(56,189,248,0.05) 100%)',
+            }}
+          />
         </div>
-      </motion.div>
+      </div>
+
+      <div className="mt-3 w-[min(280px,88vw)] rounded-xl border border-white/10 bg-black/60 px-3 py-2 text-center backdrop-blur-md">
+        <p className="text-[10px] font-semibold" style={{ color: caption.accent }}>
+          {caption.label}
+        </p>
+        <p className="text-xs text-white/85">{caption.title}</p>
+      </div>
     </div>
   );
 }

--- a/website/src/hooks/use-display-screen.ts
+++ b/website/src/hooks/use-display-screen.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { AppScreen } from '@/lib/scroll-utils';
+import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import { subscribeIdleDemoScreen } from '@/hooks/use-idle-hero-demo';
+
+/**
+ * 手机预览屏选择：
+ * - 滚动进度较低且 idle 轮播激活时 → idle 演示屏
+ * - 用户已滚动 → 严格跟随 sample 的 screen 序列
+ */
+export function useDisplayScreen() {
+  const { sample, progress } = useScrollProgress();
+  const [idleScreen, setIdleScreen] = useState<AppScreen | null>(null);
+
+  useEffect(() => subscribeIdleDemoScreen(setIdleScreen), []);
+
+  const useIdle = progress < 0.06 && idleScreen != null;
+
+  if (useIdle) {
+    return {
+      screenFrom: idleScreen,
+      screenTo: idleScreen,
+      screenBlend: 0,
+      activeScreen: idleScreen,
+      isIdleDemo: true,
+    };
+  }
+
+  return {
+    screenFrom: sample.screenFrom,
+    screenTo: sample.screenTo,
+    screenBlend: sample.screenBlend,
+    activeScreen: sample.activeScreen,
+    isIdleDemo: false,
+  };
+}

--- a/website/src/hooks/use-hero-scroll-phase.ts
+++ b/website/src/hooks/use-hero-scroll-phase.ts
@@ -2,11 +2,17 @@
 
 import { useEffect, useState } from 'react';
 
-/** 是否已滚过 3D Hero 滚动驱动区，进入下方经典官网内容 */
+/**
+ * 是否已滚过 3D Hero 滚动驱动区。
+ * 使用 hysteresis，避免边界附近 pastHero 来回翻转导致整页闪一下。
+ */
 export function useHeroScrollPhase() {
   const [pastHero, setPastHero] = useState(false);
 
   useEffect(() => {
+    const ENTER_PAST = -24; // bottom 越过视口上方再切
+    const EXIT_PAST = 48; // 重新进入时留缓冲
+
     const update = () => {
       const driver = document.querySelector('[data-hero-scroll-driver]');
       if (!driver) {
@@ -14,7 +20,13 @@ export function useHeroScrollPhase() {
         return;
       }
       const bottom = driver.getBoundingClientRect().bottom;
-      setPastHero(bottom <= 0);
+      setPastHero((prev) => {
+        if (prev) {
+          // 已 past：只有明显回到驱动区才退出 past
+          return bottom <= EXIT_PAST;
+        }
+        return bottom <= ENTER_PAST;
+      });
     };
 
     update();

--- a/website/src/hooks/use-idle-hero-demo.ts
+++ b/website/src/hooks/use-idle-hero-demo.ts
@@ -1,52 +1,100 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useScrollProgress } from '@/hooks/use-scroll-progress';
+import type { AppScreen } from '@/lib/scroll-utils';
+import { PHONE_SCREEN_SEQUENCE_FOR_DEMO } from '@/lib/scroll-utils';
+
+export type IdleDemoListener = (screen: AppScreen | null) => void;
 
 /**
- * 用户未主动滚动时，缓慢推进 hero 进度 0→~0.55→回弹，
- * 以展示镜头运镜与多屏 App UI。一旦用户滚动则停止接管。
+ * 模块级 idle 演示：只切换手机「界面预览」屏，**绝不**改写 scroll progress。
+ * 旧实现每帧 setProgress 与 ScrollTrigger 互抢，导致主页闪烁/乱跳。
  */
-export function useIdleHeroDemo(enabled: boolean) {
-  const { setProgress, reducedMotion } = useScrollProgress();
+const listeners = new Set<IdleDemoListener>();
+let currentDemoScreen: AppScreen | null = null;
+
+export function subscribeIdleDemoScreen(listener: IdleDemoListener) {
+  listeners.add(listener);
+  listener(currentDemoScreen);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getIdleDemoScreen() {
+  return currentDemoScreen;
+}
+
+function publish(screen: AppScreen | null) {
+  currentDemoScreen = screen;
+  listeners.forEach((fn) => fn(screen));
+}
+
+/**
+ * 用户未滚动时，缓慢轮播手机内 UI 预览屏。
+ * - 不调用 setProgress / 不驱动镜头关键帧
+ * - 用户一滚动即停止，之后完全跟随真实滚动进度
+ */
+export function useIdleHeroDemo(enabled: boolean, reducedMotion: boolean) {
   const userTouched = useRef(false);
-  const startRef = useRef<number | null>(null);
+  const started = useRef(false);
 
   useEffect(() => {
-    if (!enabled || reducedMotion) return undefined;
+    if (!enabled || reducedMotion) {
+      publish(null);
+      return undefined;
+    }
+
+    userTouched.current = false;
+    started.current = false;
 
     const markTouched = () => {
+      if (userTouched.current) return;
       userTouched.current = true;
+      publish(null);
+    };
+
+    // 真实滚动即停；忽略 1px 级噪声用 scrollY 阈值
+    let lastY = window.scrollY;
+    const onScroll = () => {
+      if (Math.abs(window.scrollY - lastY) > 4) {
+        markTouched();
+      }
+      lastY = window.scrollY;
     };
 
     window.addEventListener('wheel', markTouched, { passive: true });
-    window.addEventListener('touchstart', markTouched, { passive: true });
+    window.addEventListener('touchmove', markTouched, { passive: true });
     window.addEventListener('keydown', markTouched);
-    window.addEventListener('pointerdown', markTouched);
+    window.addEventListener('scroll', onScroll, { passive: true });
 
-    let raf = 0;
-    const loop = (now: number) => {
+    const sequence = PHONE_SCREEN_SEQUENCE_FOR_DEMO;
+    const HOLD_MS = 2800;
+    const START_DELAY_MS = 2200;
+    let index = 0;
+    let timer = 0;
+
+    const tick = () => {
       if (userTouched.current) return;
-      if (startRef.current == null) startRef.current = now;
-      const elapsed = (now - startRef.current) / 1000;
-      // 前 1.6s 定妆，之后在 0.04→0.58 循环：驱动 3D 运镜 + 多屏 UI + 右侧功能卡高亮
-      // 左侧文案靠 heroOpacity 缓淡，不抢中/右区
-      if (elapsed >= 1.6) {
-        const cycle = ((elapsed - 1.6) % 20) / 20;
-        const tri = cycle < 0.72 ? cycle / 0.72 : 1 - (cycle - 0.72) / 0.28;
-        const target = 0.04 + tri * 0.54;
-        setProgress(target);
-      }
-      raf = requestAnimationFrame(loop);
+      publish(sequence[index % sequence.length]);
+      index += 1;
+      timer = window.setTimeout(tick, HOLD_MS);
     };
-    raf = requestAnimationFrame(loop);
+
+    const startTimer = window.setTimeout(() => {
+      if (userTouched.current) return;
+      started.current = true;
+      tick();
+    }, START_DELAY_MS);
 
     return () => {
-      cancelAnimationFrame(raf);
+      window.clearTimeout(startTimer);
+      window.clearTimeout(timer);
       window.removeEventListener('wheel', markTouched);
-      window.removeEventListener('touchstart', markTouched);
+      window.removeEventListener('touchmove', markTouched);
       window.removeEventListener('keydown', markTouched);
-      window.removeEventListener('pointerdown', markTouched);
+      window.removeEventListener('scroll', onScroll);
+      publish(null);
     };
-  }, [enabled, reducedMotion, setProgress]);
+  }, [enabled, reducedMotion]);
 }

--- a/website/src/hooks/use-scroll-progress.tsx
+++ b/website/src/hooks/use-scroll-progress.tsx
@@ -6,7 +6,9 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  type MutableRefObject,
   type ReactNode,
 } from 'react';
 import { sampleScroll, type ScrollSample } from '@/lib/scroll-utils';
@@ -15,27 +17,47 @@ interface ScrollProgressContextValue {
   progress: number;
   sample: ScrollSample;
   pointer: { x: number; y: number };
+  /** 高频读取（R3F useFrame），避免依赖每帧 React 重渲染 */
+  progressRef: MutableRefObject<number>;
+  sampleRef: MutableRefObject<ScrollSample>;
+  pointerRef: MutableRefObject<{ x: number; y: number }>;
   reducedMotion: boolean;
   isMobile: boolean;
+  /**
+   * 仅应由 ScrollTrigger / 真实滚动写入。
+   * 禁止 idle 演示改写 progress（会与滚动驱动互抢导致闪烁）。
+   */
   setProgress: (value: number) => void;
 }
 
 const defaultSample = sampleScroll(0);
 
-const ScrollProgressContext = createContext<ScrollProgressContextValue>({
-  progress: 0,
-  sample: defaultSample,
-  pointer: { x: 0, y: 0 },
-  reducedMotion: false,
-  isMobile: false,
-  setProgress: () => undefined,
-});
+const ScrollProgressContext = createContext<ScrollProgressContextValue | null>(null);
+
+/** 低于此变化不触发 React 状态更新 */
+const REACT_PROGRESS_EPS = 0.0035;
+/** 与当前 ref 几乎相同则完全忽略 */
+const HARD_PROGRESS_EPS = 0.0004;
 
 export function ScrollProgressProvider({ children }: { children: ReactNode }) {
   const [progress, setProgressState] = useState(0);
   const [pointer, setPointer] = useState({ x: 0, y: 0 });
-  const [reducedMotion, setReducedMotion] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  // 客户端首帧即按视口判断，避免 isMobile 从 false→true 时驱动区高度突变导致跳动
+  const [reducedMotion, setReducedMotion] = useState(() =>
+    typeof window !== 'undefined'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false,
+  );
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(max-width: 768px)').matches : false,
+  );
+
+  const progressRef = useRef(0);
+  const sampleRef = useRef<ScrollSample>(defaultSample);
+  const pointerRef = useRef({ x: 0, y: 0 });
+  const reactRafRef = useRef(0);
+  const lastReactProgress = useRef(0);
+  const lastPointerReactAt = useRef(0);
 
   useEffect(() => {
     const media = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -56,20 +78,58 @@ export function ScrollProgressProvider({ children }: { children: ReactNode }) {
     const handleMove = (event: PointerEvent) => {
       const x = (event.clientX / window.innerWidth) * 2 - 1;
       const y = (event.clientY / window.innerHeight) * 2 - 1;
-      setPointer({ x, y });
+      pointerRef.current = { x, y };
+
+      // 指针仅低频同步到 React（3D 走 ref）
+      const now = performance.now();
+      if (now - lastPointerReactAt.current > 100) {
+        lastPointerReactAt.current = now;
+        setPointer({ x, y });
+      }
     };
     window.addEventListener('pointermove', handleMove, { passive: true });
     return () => window.removeEventListener('pointermove', handleMove);
   }, []);
 
+  useEffect(
+    () => () => {
+      if (reactRafRef.current) cancelAnimationFrame(reactRafRef.current);
+    },
+    [],
+  );
+
   const setProgress = useCallback((value: number) => {
-    setProgressState(Math.min(1, Math.max(0, value)));
+    const next = Math.min(1, Math.max(0, value));
+    if (Math.abs(next - progressRef.current) < HARD_PROGRESS_EPS) return;
+
+    progressRef.current = next;
+    sampleRef.current = sampleScroll(next);
+
+    // 合并到每帧最多一次 React 更新
+    if (reactRafRef.current) return;
+    reactRafRef.current = requestAnimationFrame(() => {
+      reactRafRef.current = 0;
+      const latest = progressRef.current;
+      if (Math.abs(latest - lastReactProgress.current) < REACT_PROGRESS_EPS) return;
+      lastReactProgress.current = latest;
+      setProgressState(latest);
+    });
   }, []);
 
   const sample = useMemo(() => sampleScroll(progress), [progress]);
 
   const value = useMemo(
-    () => ({ progress, sample, pointer, reducedMotion, isMobile, setProgress }),
+    () => ({
+      progress,
+      sample,
+      pointer,
+      progressRef,
+      sampleRef,
+      pointerRef,
+      reducedMotion,
+      isMobile,
+      setProgress,
+    }),
     [progress, sample, pointer, reducedMotion, isMobile, setProgress],
   );
 
@@ -81,5 +141,22 @@ export function ScrollProgressProvider({ children }: { children: ReactNode }) {
 }
 
 export function useScrollProgress() {
-  return useContext(ScrollProgressContext);
+  const ctx = useContext(ScrollProgressContext);
+  if (!ctx) {
+    const progressRef = { current: 0 };
+    const sampleRef = { current: defaultSample };
+    const pointerRef = { current: { x: 0, y: 0 } };
+    return {
+      progress: 0,
+      sample: defaultSample,
+      pointer: { x: 0, y: 0 },
+      progressRef,
+      sampleRef,
+      pointerRef,
+      reducedMotion: false,
+      isMobile: false,
+      setProgress: () => undefined,
+    } satisfies ScrollProgressContextValue;
+  }
+  return ctx;
 }

--- a/website/src/lib/scroll-utils.ts
+++ b/website/src/lib/scroll-utils.ts
@@ -79,6 +79,20 @@ const PHONE_SCREEN_SEQUENCE: AppScreen[] = [
   'all-features',
 ];
 
+/** 首屏 idle 轮播用（与滚动关键帧解耦，仅切换 UI 预览） */
+export const PHONE_SCREEN_SEQUENCE_FOR_DEMO: AppScreen[] = [
+  'home',
+  'schedule',
+  'grades',
+  'exams',
+  'notifications',
+  'electricity',
+  'classroom',
+];
+
+/** 移动端缩短滚动驱动高度，减少长距离刷屏与误触闪烁 */
+export const SCROLL_DRIVER_VH_MOBILE = 420;
+
 const PHONE_DEMO_START = 0.22;
 const PHONE_DEMO_END = 0.88;
 const SCREEN_FADE_PORTION = 0.28;


### PR DESCRIPTION
## Summary
- 修复主页静止/滚动时整页闪烁、乱跳：idle 演示不再改写 scroll progress，避免与 ScrollTrigger 互抢
- progress 合并 rAF 更新，3D 相机/粒子走 ref，去掉手机 spring 与无意义 remount
- 移动端：DOM 手机 + 顶部紧凑文案、禁用 Lenis、缩短滚动驱动高度、pastHero 滞回

## Test plan
- [x] website next build 通过
- [x] 本地静止约 3s scrollY/高度稳定
- [x] 分段滚动后无回弹乱跳
- [x] 390x844 移动端首屏文案+手机+字幕正常
- [ ] 合并后 Sync Website 成功，主站/GH Pages 硬刷新验证