### PR TITLE
feat(website): Kimi 风格 Hero + Tauri 手机演示替换 R3F (#407)

### DIFF
--- a/website/src/components/ParticleBackground.tsx
+++ b/website/src/components/ParticleBackground.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/** 轻量粒子星野 + 连线背景（Canvas，低功耗） */
+export default function ParticleBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let w = 0;
+    let h = 0;
+    let raf = 0;
+    const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+
+    type P = { x: number; y: number; vx: number; vy: number; r: number; tw: number };
+    let pts: P[] = [];
+
+    const resize = () => {
+      w = canvas.clientWidth;
+      h = canvas.clientHeight;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const count = Math.min(90, Math.floor((w * h) / 22000));
+      pts = Array.from({ length: count }, () => ({
+        x: Math.random() * w,
+        y: Math.random() * h,
+        vx: (Math.random() - 0.5) * 0.25,
+        vy: (Math.random() - 0.5) * 0.25,
+        r: Math.random() * 1.4 + 0.4,
+        tw: Math.random() * Math.PI * 2,
+      }));
+    };
+
+    let t = 0;
+    const draw = () => {
+      t += 0.016;
+      ctx.clearRect(0, 0, w, h);
+      for (let i = 0; i < pts.length; i++) {
+        for (let j = i + 1; j < pts.length; j++) {
+          const dx = pts[i].x - pts[j].x;
+          const dy = pts[i].y - pts[j].y;
+          const d2 = dx * dx + dy * dy;
+          if (d2 < 120 * 120) {
+            const a = (1 - Math.sqrt(d2) / 120) * 0.1;
+            ctx.strokeStyle = `rgba(56, 189, 248, ${a})`;
+            ctx.lineWidth = 0.6;
+            ctx.beginPath();
+            ctx.moveTo(pts[i].x, pts[i].y);
+            ctx.lineTo(pts[j].x, pts[j].y);
+            ctx.stroke();
+          }
+        }
+      }
+      for (const p of pts) {
+        const twinkle = 0.35 + 0.3 * Math.sin(t * 1.6 + p.tw);
+        ctx.fillStyle = `rgba(103, 232, 249, ${twinkle})`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x < -10) p.x = w + 10;
+        if (p.x > w + 10) p.x = -10;
+        if (p.y < -10) p.y = h + 10;
+        if (p.y > h + 10) p.y = -10;
+      }
+      if (!reduced) raf = requestAnimationFrame(draw);
+    };
+
+    resize();
+    draw();
+    window.addEventListener('resize', resize);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="pointer-events-none absolute inset-0 h-full w-full opacity-70"
+      aria-hidden="true"
+    />
+  );
+}

--- a/website/src/components/Phone3D.tsx
+++ b/website/src/components/Phone3D.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+import { BellRing, ShieldCheck, Zap } from 'lucide-react';
+import PhoneAppScreen, { type PhoneDemoScreen } from '@/components/phone-app/PhoneAppScreen';
+import {
+  HERO_PHONE_CAPTIONS,
+  HERO_PHONE_SEQUENCE,
+} from '@/data/home-content';
+
+const ROTATE_MS = 3200;
+
+export default function Phone3D() {
+  const reduced = useReducedMotion();
+  const [active, setActive] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const phoneRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef(0);
+  const target = useRef({ rx: 0, ry: 0 });
+  const current = useRef({ rx: 0, ry: 0 });
+
+  const screens = HERO_PHONE_SEQUENCE;
+  const activeScreen = screens[active] as PhoneDemoScreen;
+
+  useEffect(() => {
+    if (paused || reduced) return undefined;
+    const t = setInterval(() => setActive((a) => (a + 1) % screens.length), ROTATE_MS);
+    return () => clearInterval(t);
+  }, [paused, reduced, screens.length]);
+
+  const animate = useCallback(() => {
+    current.current.rx += (target.current.rx - current.current.rx) * 0.09;
+    current.current.ry += (target.current.ry - current.current.ry) * 0.09;
+    if (phoneRef.current) {
+      phoneRef.current.style.transform = `rotateX(${current.current.rx}deg) rotateY(${current.current.ry}deg)`;
+    }
+    rafRef.current = requestAnimationFrame(animate);
+  }, []);
+
+  useEffect(() => {
+    if (reduced) return undefined;
+    rafRef.current = requestAnimationFrame(animate);
+    const el = wrapRef.current;
+    if (!el) return undefined;
+    const onMove = (e: MouseEvent) => {
+      const r = el.getBoundingClientRect();
+      const px = (e.clientX - (r.left + r.width / 2)) / r.width;
+      const py = (e.clientY - (r.top + r.height / 2)) / r.height;
+      target.current.ry = px * 14;
+      target.current.rx = -py * 10;
+    };
+    const onLeave = () => {
+      target.current.rx = 0;
+      target.current.ry = 0;
+    };
+    window.addEventListener('mousemove', onMove);
+    el.addEventListener('mouseleave', onLeave);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('mousemove', onMove);
+      el.removeEventListener('mouseleave', onLeave);
+    };
+  }, [animate, reduced]);
+
+  return (
+    <div ref={wrapRef} className="phone-scene relative mx-auto w-fit select-none">
+      <div className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[560px] w-[560px] -translate-x-1/2 -translate-y-1/2">
+        <div className="animate-spin-slower absolute inset-0 rounded-full border border-dashed border-cyan-400/15" />
+        <div className="animate-spin-slower-rev absolute inset-10 rounded-full border border-violet-400/10" />
+        <div className="absolute inset-24 rounded-full bg-cyan-400/[0.05] blur-2xl" />
+        <div className="absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-400/15 blur-[70px]" />
+      </div>
+
+      <div className="pointer-events-none absolute -bottom-14 left-1/2 h-16 w-[75%] -translate-x-1/2 rounded-[100%] bg-cyan-400/20 blur-2xl" />
+
+      <div ref={phoneRef} className="phone-3d relative">
+        <div
+          className="animate-float-slow relative h-[560px] w-[272px] rounded-[2.75rem] bg-gradient-to-b from-slate-700/80 via-slate-800 to-slate-900 p-[3px] shadow-[0_40px_80px_-20px_rgba(0,0,0,0.8),0_0_60px_-20px_rgba(34,211,238,0.35)]"
+          onMouseEnter={() => setPaused(true)}
+          onMouseLeave={() => setPaused(false)}
+        >
+          <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[2.6rem] bg-[#0f172a]">
+            <div className="absolute left-1/2 top-2.5 z-20 h-[22px] w-[96px] -translate-x-1/2 rounded-full bg-black shadow-inner" />
+            <div className="z-10 flex items-center justify-between bg-[#f0f4f8] px-6 pb-1 pt-3 text-[9px] font-medium text-slate-600">
+              <span className="tabular-nums">09:41</span>
+              <div className="flex items-center gap-1">
+                <span className="inline-block h-1.5 w-3 rounded-[2px] bg-slate-500/70" />
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-slate-500/70" />
+                <span className="inline-block h-2 w-4 rounded-[3px] border border-slate-500/60 p-px">
+                  <span className="block h-full w-3/4 rounded-[1.5px] bg-emerald-500" />
+                </span>
+              </div>
+            </div>
+            <div className="relative min-h-0 flex-1 overflow-hidden bg-[#f0f4f8]">
+              <div key={activeScreen} className="animate-screen-in h-full">
+                <PhoneAppScreen screenFrom={activeScreen} screenTo={activeScreen} blend={1} />
+              </div>
+            </div>
+          </div>
+          <div className="absolute -right-[2px] top-28 h-14 w-[3px] rounded-r-md bg-slate-600" />
+          <div className="absolute -left-[2px] top-24 h-8 w-[3px] rounded-l-md bg-slate-600" />
+          <div className="absolute -left-[2px] top-36 h-8 w-[3px] rounded-l-md bg-slate-600" />
+        </div>
+
+        <div
+          className="animate-float absolute -left-28 top-16 hidden md:block"
+          style={{ transform: 'translateZ(70px)' }}
+        >
+          <div className="kimi-glass flex items-center gap-2 rounded-xl px-3 py-2 shadow-lg shadow-black/40">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-cyan-400/15">
+              <Zap className="h-3.5 w-3.5 text-cyan-300" />
+            </span>
+            <div>
+              <p className="text-[10px] font-medium text-white">电费余额 ¥23.6</p>
+              <p className="text-[8.5px] text-white/40">东苑 12栋 · 312</p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="animate-float-delay absolute -right-24 top-40 hidden md:block"
+          style={{ transform: 'translateZ(50px)' }}
+        >
+          <div className="kimi-glass flex items-center gap-2 rounded-xl px-3 py-2 shadow-lg shadow-black/40">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-violet-400/15">
+              <BellRing className="h-3.5 w-3.5 text-violet-300" />
+            </span>
+            <div>
+              <p className="text-[10px] font-medium text-white">考试安排已更新</p>
+              <p className="text-[8.5px] text-white/40">10 分钟前</p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="animate-float absolute -bottom-4 -left-20 hidden md:block"
+          style={{ transform: 'translateZ(90px)' }}
+        >
+          <div className="kimi-glass flex items-center gap-2 rounded-xl px-3 py-2 shadow-lg shadow-black/40">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-400/15">
+              <ShieldCheck className="h-3.5 w-3.5 text-emerald-300" />
+            </span>
+            <div>
+              <p className="text-[10px] font-medium text-white">数据本地存储</p>
+              <p className="text-[8.5px] text-white/40">隐私安全</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 flex flex-col items-center gap-3">
+        <p key={active} className="animate-screen-in text-sm font-medium text-white/70">
+          {HERO_PHONE_CAPTIONS[activeScreen]}
+        </p>
+        <div className="flex items-center gap-1.5" role="tablist" aria-label="App 界面切换">
+          {screens.map((key, i) => (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={i === active}
+              aria-label={HERO_PHONE_CAPTIONS[key]}
+              onClick={() => setActive(i)}
+              className={`h-1.5 rounded-full transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
+                i === active ? 'w-5 bg-cyan-400' : 'w-1.5 bg-white/20 hover:bg-white/40'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/Phone3D.tsx
+++ b/website/src/components/Phone3D.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useReducedMotion } from 'framer-motion';
 import { BellRing, ShieldCheck, Zap } from 'lucide-react';
 import PhoneAppScreen, { type PhoneDemoScreen } from '@/components/phone-app/PhoneAppScreen';
@@ -17,7 +17,6 @@ export default function Phone3D() {
   const [paused, setPaused] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
   const phoneRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef(0);
   const target = useRef({ rx: 0, ry: 0 });
   const current = useRef({ rx: 0, ry: 0 });
 
@@ -30,20 +29,23 @@ export default function Phone3D() {
     return () => clearInterval(t);
   }, [paused, reduced, screens.length]);
 
-  const animate = useCallback(() => {
-    current.current.rx += (target.current.rx - current.current.rx) * 0.09;
-    current.current.ry += (target.current.ry - current.current.ry) * 0.09;
-    if (phoneRef.current) {
-      phoneRef.current.style.transform = `rotateX(${current.current.rx}deg) rotateY(${current.current.ry}deg)`;
-    }
-    rafRef.current = requestAnimationFrame(animate);
-  }, []);
-
   useEffect(() => {
     if (reduced) return undefined;
-    rafRef.current = requestAnimationFrame(animate);
+    let raf = 0;
+    const tick = () => {
+      current.current.rx += (target.current.rx - current.current.rx) * 0.09;
+      current.current.ry += (target.current.ry - current.current.ry) * 0.09;
+      if (phoneRef.current) {
+        phoneRef.current.style.transform = `rotateX(${current.current.rx}deg) rotateY(${current.current.ry}deg)`;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
     const el = wrapRef.current;
-    if (!el) return undefined;
+    if (!el) {
+      cancelAnimationFrame(raf);
+      return undefined;
+    }
     const onMove = (e: MouseEvent) => {
       const r = el.getBoundingClientRect();
       const px = (e.clientX - (r.left + r.width / 2)) / r.width;
@@ -58,11 +60,11 @@ export default function Phone3D() {
     window.addEventListener('mousemove', onMove);
     el.addEventListener('mouseleave', onLeave);
     return () => {
-      cancelAnimationFrame(rafRef.current);
+      cancelAnimationFrame(raf);
       window.removeEventListener('mousemove', onMove);
       el.removeEventListener('mouseleave', onLeave);
     };
-  }, [animate, reduced]);
+  }, [reduced]);
 
   return (
     <div ref={wrapRef} className="phone-scene relative mx-auto w-fit select-none">

--- a/website/src/components/home/HeroSection.tsx
+++ b/website/src/components/home/HeroSection.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { motion, useReducedMotion, useScroll, useTransform } from 'framer-motion';
+import { BookOpenText, ChevronDown, Download, Github, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import { useRef } from 'react';
+import ParticleBackground from '@/components/ParticleBackground';
+import Phone3D from '@/components/Phone3D';
+import {
+  CHIPS,
+  EYEBROW,
+  GITHUB_URL,
+  H1_A,
+  H1_B,
+  SUB,
+  TRUST_ITEMS,
+} from '@/data/home-content';
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 24 },
+  show: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { delay: 0.12 * i, duration: 0.6, ease: [0.22, 1, 0.36, 1] as const },
+  }),
+};
+
+export default function HeroSection() {
+  const reduced = useReducedMotion();
+  const ref = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end start'] });
+  const yCopy = useTransform(scrollYProgress, [0, 1], [0, reduced ? 0 : -70]);
+  const yPhone = useTransform(scrollYProgress, [0, 1], [0, reduced ? 0 : 60]);
+  const opacity = useTransform(scrollYProgress, [0, 0.75], [1, 0]);
+
+  return (
+    <section ref={ref} id="top" className="relative overflow-hidden pb-20 pt-28 md:pt-32">
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#03060d] via-[#060b16] to-[#0a0f1a]" />
+        <div className="aurora-blob left-[-10%] top-[-15%] h-[480px] w-[480px] bg-cyan-500/[0.13]" />
+        <div
+          className="aurora-blob right-[-8%] top-[10%] h-[420px] w-[420px] bg-sky-600/[0.11]"
+          style={{ animationDelay: '-6s' }}
+        />
+        <div
+          className="aurora-blob bottom-[-20%] left-[30%] h-[420px] w-[420px] bg-violet-500/[0.08]"
+          style={{ animationDelay: '-12s' }}
+        />
+        <div className="bg-grid absolute inset-0" />
+        <ParticleBackground />
+      </div>
+
+      <motion.div style={{ opacity }} className="mx-auto max-w-6xl px-5">
+        <div className="grid items-center gap-14 lg:grid-cols-[1.05fr_0.95fr] lg:gap-6">
+          <motion.div style={{ y: yCopy }} className="text-center lg:text-left">
+            <motion.div variants={fadeUp} initial="hidden" animate="show" custom={0}>
+              <span className="inline-flex items-center gap-2 rounded-full border border-cyan-400/20 bg-cyan-400/[0.07] px-3.5 py-1.5 text-xs text-cyan-200/90">
+                <Sparkles className="h-3.5 w-3.5 text-cyan-300" />
+                {EYEBROW}
+              </span>
+            </motion.div>
+
+            <motion.h1
+              variants={fadeUp}
+              initial="hidden"
+              animate="show"
+              custom={1}
+              className="mt-6 text-4xl font-bold leading-[1.15] tracking-tight text-white sm:text-5xl xl:text-[3.4rem]"
+            >
+              {H1_A}
+              <br />
+              <span className="text-gradient">{H1_B}</span>
+            </motion.h1>
+
+            <motion.p
+              variants={fadeUp}
+              initial="hidden"
+              animate="show"
+              custom={2}
+              className="mx-auto mt-5 max-w-xl text-[15px] leading-relaxed text-white/55 lg:mx-0"
+            >
+              {SUB}
+            </motion.p>
+
+            <motion.div
+              variants={fadeUp}
+              initial="hidden"
+              animate="show"
+              custom={3}
+              className="mt-6 flex flex-wrap justify-center gap-2 lg:justify-start"
+            >
+              {CHIPS.map((c) => (
+                <span
+                  key={c}
+                  className="cursor-default rounded-full border border-white/[0.09] bg-white/[0.04] px-3 py-1.5 text-xs text-white/65 transition-all hover:border-cyan-400/35 hover:bg-cyan-400/10 hover:text-cyan-200"
+                >
+                  {c}
+                </span>
+              ))}
+            </motion.div>
+
+            <motion.div
+              variants={fadeUp}
+              initial="hidden"
+              animate="show"
+              custom={4}
+              className="mt-8 flex flex-wrap items-center justify-center gap-3 lg:justify-start"
+            >
+              <a
+                href="#download"
+                className="btn-shine group flex items-center gap-2 rounded-xl bg-gradient-to-r from-cyan-400 to-sky-400 px-6 py-3 text-[15px] font-semibold text-slate-950 shadow-[0_10px_36px_-8px_rgba(34,211,238,0.55)] transition-all hover:scale-[1.04] hover:shadow-[0_14px_44px_-8px_rgba(34,211,238,0.7)] active:scale-95"
+              >
+                <Download className="h-4 w-4 transition-transform group-hover:translate-y-0.5" />
+                免费下载
+              </a>
+              <Link
+                href="/docs"
+                className="flex items-center gap-2 rounded-xl border border-white/12 bg-white/[0.04] px-6 py-3 text-[15px] font-medium text-white/80 backdrop-blur transition-all hover:border-white/30 hover:bg-white/[0.08] hover:text-white"
+              >
+                <BookOpenText className="h-4 w-4" />
+                查看文档
+              </Link>
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="前往 GitHub"
+                className="flex h-[46px] w-[46px] items-center justify-center rounded-xl border border-white/12 bg-white/[0.04] text-white/70 backdrop-blur transition-all hover:border-white/30 hover:text-white"
+              >
+                <Github className="h-4 w-4" />
+              </a>
+            </motion.div>
+
+            <motion.div
+              variants={fadeUp}
+              initial="hidden"
+              animate="show"
+              custom={5}
+              className="mt-9 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-xs text-white/35 lg:justify-start"
+            >
+              {TRUST_ITEMS.map((t, i) => (
+                <span key={t} className="flex items-center gap-4">
+                  {i > 0 && <span className="hidden h-0.5 w-0.5 rounded-full bg-white/20 sm:block" />}
+                  {t}
+                </span>
+              ))}
+            </motion.div>
+          </motion.div>
+
+          <motion.div
+            style={{ y: yPhone }}
+            initial={{ opacity: 0, y: 40, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ delay: 0.35, duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
+            className="relative"
+          >
+            <Phone3D />
+          </motion.div>
+        </div>
+
+        <div className="mt-16 flex flex-col items-center gap-2 text-white/30">
+          <span className="text-[11px]">向下滚动，体验真实 App 界面</span>
+          <ChevronDown className="animate-scroll-hint h-4 w-4" />
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/website/src/components/home/HomeExperience.tsx
+++ b/website/src/components/home/HomeExperience.tsx
@@ -1,82 +1,33 @@
 'use client';
 
-import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
-import SmoothScrollProvider from '@/components/SmoothScrollProvider';
-import HeroText from '@/components/HeroText';
-import FeatureTextOverlay from '@/components/FeatureTextOverlay';
-import CTASection from '@/components/CTASection';
+import HeroSection from '@/components/home/HeroSection';
+import ScrollShowcase from '@/components/home/ScrollShowcase';
 import HomeClassicSections from '@/components/home/HomeClassicSections';
-import PhoneScreenOverlay from '@/components/phone-app/PhoneScreenOverlay';
-import HeroFeatureOrbits from '@/components/HeroFeatureOrbits';
-import SceneErrorBoundary from '@/components/SceneErrorBoundary';
-import { ScrollProgressProvider, useScrollProgress } from '@/hooks/use-scroll-progress';
-import { useHeroScrollPhase } from '@/hooks/use-hero-scroll-phase';
-import { useIdleHeroDemo } from '@/hooks/use-idle-hero-demo';
 
-const SceneCanvas = dynamic(() => import('@/components/SceneCanvas'), {
-  ssr: false,
-  loading: () => <div className="absolute inset-0 bg-[#03060d]" aria-hidden />,
-});
+/**
+ * 首页：Kimi 风格短 Hero + 滚动 Showcase + 经典区块。
+ * 不再挂载 R3F SceneCanvas / 超长 scroll driver。
+ */
+export default function HomeExperience() {
+  const [scrolled, setScrolled] = useState(false);
 
-function HomeExperienceInner() {
-  const pastHero = useHeroScrollPhase();
-  const { isMobile, reducedMotion } = useScrollProgress();
-  // 仅在 Hero 区内做 UI 轮播；绝不改写 scroll progress
-  useIdleHeroDemo(!pastHero, reducedMotion);
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 48);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-[#03060d] text-white">
-      <Navbar variant="home" pastHero={pastHero} />
+      <Navbar variant="home" pastHero={scrolled} />
       <main className="relative">
-        <div id="features" className="sr-only" aria-hidden />
-        <div id="download" className="sr-only" aria-hidden />
-        <div id="about" className="sr-only" aria-hidden />
-
-        <SmoothScrollProvider hideScene={pastHero}>
-          <SceneErrorBoundary>
-            {/* 移动端仍挂轻量场景作氛围；手机主体走 DOM 降级 */}
-            <SceneCanvas />
-          </SceneErrorBoundary>
-        </SmoothScrollProvider>
-
-        {/* 固定层用 opacity 隐藏，避免 pastHero 切换时整树卸载闪一下（勿用 display:contents） */}
-        <div
-          className="pointer-events-none fixed inset-0 z-[20]"
-          style={{
-            opacity: pastHero ? 0 : 1,
-            visibility: pastHero ? 'hidden' : 'visible',
-            transition: 'opacity 0.4s ease',
-          }}
-          aria-hidden={pastHero}
-        >
-          {isMobile && <PhoneScreenOverlay />}
-          <HeroFeatureOrbits />
-          <HeroText />
-          <FeatureTextOverlay />
-          <CTASection />
-        </div>
-
+        <HeroSection />
+        <ScrollShowcase />
         <HomeClassicSections />
       </main>
-
-      <div
-        className="pointer-events-none fixed inset-0 z-[1]"
-        style={{
-          opacity: pastHero ? 0 : 0.45,
-          transition: 'opacity 0.45s ease',
-          background:
-            'radial-gradient(ellipse 65% 50% at 70% 40%, rgba(56,189,248,0.16), transparent 55%), radial-gradient(ellipse 45% 35% at 15% 28%, rgba(167,139,250,0.12), transparent 50%)',
-        }}
-      />
     </div>
-  );
-}
-
-export default function HomeExperience() {
-  return (
-    <ScrollProgressProvider>
-      <HomeExperienceInner />
-    </ScrollProgressProvider>
   );
 }

--- a/website/src/components/home/ScrollShowcase.tsx
+++ b/website/src/components/home/ScrollShowcase.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  motion,
+  useMotionTemplate,
+  useMotionValueEvent,
+  useReducedMotion,
+  useScroll,
+  useSpring,
+  useTransform,
+  type MotionValue,
+} from 'framer-motion';
+import { ArrowDownToLine, Github, MousePointer2 } from 'lucide-react';
+import ParticleBackground from '@/components/ParticleBackground';
+import PhoneAppScreen, { type PhoneDemoScreen } from '@/components/phone-app/PhoneAppScreen';
+import { GITHUB_URL, SHOWCASE_STAGES } from '@/data/home-content';
+
+const META = SHOWCASE_STAGES;
+const N = META.length;
+
+/** 运镜关键帧：每个舞台的相机位 */
+const CAMS = [
+  { ry: -8, rx: 4, s: 0.88, x: 96, y: 0 },
+  { ry: -27, rx: 5, s: 1.0, x: -116, y: 0 },
+  { ry: 25, rx: -3, s: 1.02, x: 116, y: 8 },
+  { ry: -15, rx: 9, s: 1.1, x: -104, y: -6 },
+  { ry: 27, rx: 3, s: 0.98, x: 116, y: 6 },
+  { ry: -25, rx: 11, s: 1.06, x: -116, y: -10 },
+  { ry: 15, rx: -5, s: 1.0, x: 116, y: 0 },
+  { ry: 0, rx: 0, s: 0.94, x: 0, y: 0 },
+];
+
+function useIsMobile() {
+  const [m, setM] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 1023px)');
+    const fn = () => setM(mq.matches);
+    fn();
+    mq.addEventListener('change', fn);
+    return () => mq.removeEventListener('change', fn);
+  }, []);
+  return m;
+}
+
+function StageScreen({
+  index,
+  master,
+  screen,
+}: {
+  index: number;
+  master: MotionValue<number>;
+  screen: PhoneDemoScreen;
+}) {
+  const seg = 1 / (N - 1);
+  const c = index * seg;
+  const first = index === 0;
+  const last = index === N - 1;
+
+  const opacity = useTransform(
+    master,
+    first
+      ? [0, seg * 0.28, seg * 0.62]
+      : last
+        ? [1 - seg * 0.62, 1 - seg * 0.28, 1]
+        : [c - seg * 0.62, c - seg * 0.28, c + seg * 0.28, c + seg * 0.62],
+    first ? [1, 1, 0] : last ? [0, 1, 1] : [0, 1, 1, 0],
+    { clamp: true },
+  );
+
+  return (
+    <motion.div className="absolute inset-0 overflow-hidden" style={{ opacity }} aria-hidden>
+      <PhoneAppScreen screenFrom={screen} screenTo={screen} blend={1} />
+    </motion.div>
+  );
+}
+
+function StageCaption({
+  index,
+  master,
+  active,
+  isMobile,
+}: {
+  index: number;
+  master: MotionValue<number>;
+  active: number;
+  isMobile: boolean;
+}) {
+  const meta = META[index];
+  const seg = 1 / (N - 1);
+  const c = index * seg;
+  const first = index === 0;
+  const last = index === N - 1;
+
+  const opacity = useTransform(
+    master,
+    first
+      ? [0, seg * 0.3, seg * 0.6]
+      : last
+        ? [1 - seg * 0.6, 1 - seg * 0.26, 1]
+        : [c - seg * 0.6, c - seg * 0.26, c + seg * 0.26, c + seg * 0.6],
+    first ? [1, 1, 0] : last ? [0, 1, 1] : [0, 1, 1, 0],
+    { clamp: true },
+  );
+  const y = useTransform(
+    master,
+    first ? [0, seg * 0.2] : [c - seg * 0.55, c - seg * 0.18],
+    [26, 0],
+    { clamp: true },
+  );
+
+  const pos = isMobile
+    ? 'absolute inset-x-5 bottom-[5.5%] text-center'
+    : meta.side === 'left'
+      ? 'absolute left-[7%] top-1/2 max-w-sm -translate-y-1/2 text-left'
+      : meta.side === 'right'
+        ? 'absolute right-[7%] top-1/2 max-w-sm -translate-y-1/2 text-left'
+        : 'absolute inset-x-0 bottom-[7%] mx-auto max-w-xl px-5 text-center';
+
+  return (
+    <motion.div
+      className={`${pos} z-20`}
+      style={{ opacity, y, pointerEvents: active === index ? 'auto' : 'none' }}
+      aria-hidden={active !== index}
+    >
+      <p
+        className="mb-2 flex items-center gap-2 text-xs font-medium tracking-[0.2em] text-cyan-300/80"
+        style={{
+          justifyContent: isMobile || meta.side === 'center' ? 'center' : 'flex-start',
+        }}
+      >
+        <span className="inline-block h-px w-6 bg-cyan-400/50" />
+        {String(index + 1).padStart(2, '0')} · {meta.tag}
+      </p>
+      <h3 className="text-2xl font-bold tracking-tight text-white md:text-[2rem] md:leading-snug">
+        {meta.title}
+      </h3>
+      <p className="mt-2.5 text-sm leading-relaxed text-white/55">{meta.desc}</p>
+      {meta.side === 'center' && (
+        <div className="mt-5 flex items-center justify-center gap-3">
+          <a
+            href="#download"
+            className="btn-shine flex items-center gap-2 rounded-xl bg-gradient-to-r from-cyan-400 to-sky-400 px-6 py-3 text-sm font-semibold text-slate-950 shadow-[0_10px_36px_-8px_rgba(34,211,238,0.55)] transition-transform hover:scale-[1.04] active:scale-95"
+          >
+            <ArrowDownToLine className="h-4 w-4" /> 免费下载
+          </a>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 rounded-xl border border-white/12 bg-white/[0.04] px-5 py-3 text-sm text-white/80 backdrop-blur transition-all hover:border-white/30 hover:text-white"
+          >
+            <Github className="h-4 w-4" /> GitHub
+          </a>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function ShowcaseScroll() {
+  const ref = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
+  const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end end'] });
+  const smooth = useSpring(scrollYProgress, { stiffness: 58, damping: 17, mass: 0.6 });
+
+  const [active, setActive] = useState(0);
+  useMotionValueEvent(smooth, 'change', (v) => {
+    const i = Math.min(N - 1, Math.max(0, Math.round(v * (N - 1))));
+    setActive((prev) => (prev === i ? prev : i));
+  });
+
+  const cams = isMobile ? CAMS.map((c) => ({ ...c, x: 0, y: -40, s: c.s * 0.78 })) : CAMS;
+  const input = META.map((_, i) => i / (N - 1));
+  const ry = useTransform(smooth, input, cams.map((c) => c.ry));
+  const rx = useTransform(smooth, input, cams.map((c) => c.rx));
+  const sc = useTransform(smooth, input, cams.map((c) => c.s));
+  const tx = useTransform(smooth, input, cams.map((c) => c.x));
+  const ty = useTransform(smooth, input, cams.map((c) => c.y));
+  const transform = useMotionTemplate`scale(${sc}) translate3d(${tx}px, ${ty}px, 0) rotateX(${rx}deg) rotateY(${ry}deg)`;
+  const glowOpacity = useTransform(smooth, [0.82, 1], [0, 1], { clamp: true });
+
+  const scrollToStage = (i: number) => {
+    const el = ref.current;
+    if (!el) return;
+    const total = el.offsetHeight - window.innerHeight;
+    window.scrollTo({ top: el.offsetTop + (i / (N - 1)) * total, behavior: 'smooth' });
+  };
+  const skip = () => document.querySelector('#features')?.scrollIntoView({ behavior: 'smooth' });
+
+  return (
+    <section
+      ref={ref}
+      className="relative"
+      style={{ height: `${N * 100}vh` }}
+      aria-label="App 功能滚动演示"
+    >
+      <div className="sticky top-0 flex h-screen items-center justify-center overflow-hidden">
+        <div className="absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-gradient-to-b from-[#0a0f1a] via-[#050a14] to-[#0a0f1a]" />
+          <div className="aurora-blob left-[-8%] top-[5%] h-[420px] w-[420px] bg-cyan-500/[0.09]" />
+          <div
+            className="aurora-blob right-[-6%] bottom-[0%] h-[380px] w-[380px] bg-violet-500/[0.08]"
+            style={{ animationDelay: '-9s' }}
+          />
+          <div className="bg-grid absolute inset-0 opacity-70" />
+          <ParticleBackground />
+        </div>
+
+        <div className="absolute left-1/2 top-[4.5%] z-20 -translate-x-1/2 text-center">
+          <p className="text-[11px] font-medium tracking-[0.3em] text-white/30">APP TOUR</p>
+          <p className="mt-1 text-sm text-white/50">滚动，体验真实 App 界面</p>
+        </div>
+
+        <div className="phone-scene z-10">
+          <motion.div style={{ transform }} className="phone-3d relative">
+            <div className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[540px] w-[540px] -translate-x-1/2 -translate-y-1/2">
+              <div className="animate-spin-slower absolute inset-0 rounded-full border border-dashed border-cyan-400/15" />
+              <div className="animate-spin-slower-rev absolute inset-12 rounded-full border border-violet-400/10" />
+              <div className="absolute left-1/2 top-1/2 h-44 w-44 -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-400/12 blur-[70px]" />
+            </div>
+            <motion.div
+              style={{ opacity: glowOpacity }}
+              className="pointer-events-none absolute left-1/2 top-1/2 -z-10 h-[420px] w-[420px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-400/[0.13] blur-[80px]"
+            />
+
+            <div className="relative h-[560px] w-[272px] rounded-[2.75rem] bg-gradient-to-b from-slate-700/80 via-slate-800 to-slate-900 p-[3px] shadow-[0_40px_80px_-20px_rgba(0,0,0,0.8),0_0_60px_-20px_rgba(34,211,238,0.3)]">
+              <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[2.6rem] bg-[#0f172a]">
+                <div className="absolute left-1/2 top-2.5 z-20 h-[22px] w-[96px] -translate-x-1/2 rounded-full bg-black shadow-inner" />
+                <div className="z-10 flex items-center justify-between bg-[#f0f4f8] px-6 pb-1 pt-3 text-[9px] font-medium text-slate-600">
+                  <span className="tabular-nums">09:41</span>
+                  <div className="flex items-center gap-1">
+                    <span className="inline-block h-1.5 w-3 rounded-[2px] bg-slate-500/70" />
+                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-slate-500/70" />
+                    <span className="inline-block h-2 w-4 rounded-[3px] border border-slate-500/60 p-px">
+                      <span className="block h-full w-3/4 rounded-[1.5px] bg-emerald-500" />
+                    </span>
+                  </div>
+                </div>
+                <div className="relative min-h-0 flex-1 overflow-hidden bg-[#f0f4f8]">
+                  {META.map((m, i) => (
+                    <StageScreen
+                      key={m.tag}
+                      index={i}
+                      master={smooth}
+                      screen={m.screen as PhoneDemoScreen}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div className="absolute -right-[2px] top-28 h-14 w-[3px] rounded-r-md bg-slate-600" />
+              <div className="absolute -left-[2px] top-24 h-8 w-[3px] rounded-l-md bg-slate-600" />
+              <div className="absolute -left-[2px] top-36 h-8 w-[3px] rounded-l-md bg-slate-600" />
+            </div>
+          </motion.div>
+        </div>
+
+        {META.map((_, i) => (
+          <StageCaption key={i} index={i} master={smooth} active={active} isMobile={isMobile} />
+        ))}
+
+        <div className="absolute left-6 top-1/2 z-20 hidden -translate-y-1/2 flex-col gap-2.5 lg:flex">
+          {META.map((m, i) => (
+            <button
+              key={m.tag}
+              type="button"
+              onClick={() => scrollToStage(i)}
+              className="group flex items-center gap-2.5 text-left focus-visible:outline-none"
+              aria-label={`跳到 ${m.tag}`}
+            >
+              <span
+                className={`h-1.5 rounded-full transition-all duration-300 ${
+                  i === active ? 'w-6 bg-cyan-400' : 'w-1.5 bg-white/20 group-hover:bg-white/45'
+                }`}
+              />
+              <span
+                className={`text-[11px] transition-all duration-300 ${
+                  i === active ? 'text-white/90' : 'text-white/30 group-hover:text-white/60'
+                }`}
+              >
+                {m.tag}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="absolute right-6 top-[4.5%] z-20 text-right">
+          <p className="text-2xl font-bold tabular-nums text-white/85">
+            {String(active + 1).padStart(2, '0')}
+            <span className="text-sm font-normal text-white/30">
+              {' '}
+              / {String(N).padStart(2, '0')}
+            </span>
+          </p>
+          <button
+            type="button"
+            onClick={skip}
+            className="mt-1 text-[11px] text-white/35 underline-offset-4 transition-colors hover:text-cyan-300 hover:underline"
+          >
+            跳过演示 ↓
+          </button>
+        </div>
+
+        <div className="absolute bottom-0 left-1/2 z-20 h-[3px] w-full -translate-x-1/2 bg-white/[0.06]">
+          <motion.div
+            className="h-full origin-left bg-gradient-to-r from-cyan-400 to-sky-400"
+            style={{ scaleX: smooth }}
+          />
+        </div>
+        <div
+          className={`absolute bottom-[4%] left-1/2 z-20 -translate-x-1/2 items-center gap-2 text-white/35 transition-opacity duration-500 ${
+            active === 0 ? 'flex' : 'hidden'
+          } ${isMobile ? 'hidden' : ''}`}
+        >
+          <MousePointer2 className="h-3.5 w-3.5" />
+          <span className="text-[11px]">继续滚动</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ShowcaseFallback() {
+  return (
+    <section className="relative py-24" aria-label="App 功能展示">
+      <div className="mx-auto max-w-6xl px-5">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="text-sm font-medium tracking-widest text-cyan-300/80">App 界面</p>
+          <h2 className="mt-3 text-3xl font-bold text-white">每一个界面，都为校园而生</h2>
+        </div>
+        <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          {META.map((m) => (
+            <div key={m.tag} className="rounded-2xl border border-white/[0.07] bg-white/[0.03] p-4">
+              <div className="mx-auto h-[300px] w-[204px] overflow-hidden rounded-[1.5rem] border border-slate-700/50 bg-[#f0f4f8]">
+                <PhoneAppScreen
+                  screenFrom={m.screen as PhoneDemoScreen}
+                  screenTo={m.screen as PhoneDemoScreen}
+                  blend={1}
+                />
+              </div>
+              <p className="mt-3 text-center text-sm font-semibold text-white">{m.title}</p>
+              <p className="mt-1 text-center text-xs leading-relaxed text-white/45">{m.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function ScrollShowcase() {
+  const reduced = useReducedMotion();
+  if (reduced) return <ShowcaseFallback />;
+  return <ShowcaseScroll />;
+}

--- a/website/src/components/phone-app/PhoneAppScreen.tsx
+++ b/website/src/components/phone-app/PhoneAppScreen.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentType } from 'react';
 import type { AppScreen } from '@/lib/scroll-utils';
-import AppShell, { AppCard, PageHeader } from './AppShell';
+import AppShell, { PageHeader } from './AppShell';
 import './phone-app.css';
 import { APP_MODULES, MODULE_CATEGORIES, QUICK_ENTRY_IDS, modulesByCategory } from './app-modules';
 import {
@@ -441,7 +441,7 @@ function ElectricityScreen() {
 function CampusCodeScreen() {
   const c = DEMO_CAMPUS_CODE;
   return (
-    <AppShell screen="home" showNav={false}>
+    <AppShell screen="campus-code" showNav={false}>
       <PageHeader title="校园码" icon={<QrCode className="h-4 w-4 text-teal-600" />} />
       <div className="phone-feature-body">
         <div className="phone-card phone-card-shadow text-center">
@@ -470,7 +470,7 @@ function CampusCodeScreen() {
 
 function TransactionsScreen() {
   return (
-    <AppShell screen="home" showNav={false}>
+    <AppShell screen="transactions" showNav={false}>
       <PageHeader title="交易记录" icon={<Wallet className="h-4 w-4 text-rose-500" />} />
       <div className="phone-feature-body">
         {DEMO_TRANSACTIONS.map((t) => (
@@ -495,7 +495,7 @@ function TransactionsScreen() {
 
 function LibraryScreen() {
   return (
-    <AppShell screen="home" showNav={false}>
+    <AppShell screen="library" showNav={false}>
       <PageHeader title="图书查询" icon={<BookOpen className="h-4 w-4 text-teal-700" />} />
       <div className="phone-feature-body">
         <div className="phone-dashboard-search mx-0 mb-1 max-w-none">
@@ -522,7 +522,7 @@ function LibraryScreen() {
 
 function CalendarScreen() {
   return (
-    <AppShell screen="home" showNav={false}>
+    <AppShell screen="calendar" showNav={false}>
       <PageHeader title="校历" icon={<Calendar className="h-4 w-4 text-blue-500" />} />
       <div className="phone-feature-body">
         <div className="phone-gradient-banner phone-gradient-indigo">
@@ -700,6 +700,10 @@ const SCREEN_MAP: Record<AppScreen, ComponentType> = {
   ranking: RankingScreen,
   'all-features': AllFeaturesScreen,
   me: MeScreen,
+  'campus-code': CampusCodeScreen,
+  transactions: TransactionsScreen,
+  library: LibraryScreen,
+  calendar: CalendarScreen,
 };
 
 function ScreenLayer({

--- a/website/src/components/phone-app/PhoneAppScreen.tsx
+++ b/website/src/components/phone-app/PhoneAppScreen.tsx
@@ -6,17 +6,34 @@ import AppShell, { AppCard, PageHeader } from './AppShell';
 import './phone-app.css';
 import { APP_MODULES, MODULE_CATEGORIES, QUICK_ENTRY_IDS, modulesByCategory } from './app-modules';
 import {
+  DEMO_CALENDAR,
+  DEMO_CAMPUS_CODE,
   DEMO_CLASSROOMS,
   DEMO_ELECTRICITY,
+  DEMO_ELECTRICITY_DUAL,
   DEMO_EXAMS,
   DEMO_GRADES,
+  DEMO_LIBRARY,
   DEMO_NOTIFICATIONS,
   DEMO_RANKING,
   DEMO_SCHEDULE_BLOCKS,
   DEMO_STUDENT,
   DEMO_TODAY_COURSES,
+  DEMO_TRANSACTIONS,
 } from './demo-data';
-import { Bell, CloudSun, GraduationCap, MapPin, Search, User } from 'lucide-react';
+import {
+  Bell,
+  BookOpen,
+  Calendar,
+  CloudSun,
+  GraduationCap,
+  MapPin,
+  QrCode,
+  Search,
+  User,
+  Wallet,
+  Zap,
+} from 'lucide-react';
 
 /**
  * 首页视觉对齐 Tauri `Dashboard.vue`：
@@ -382,22 +399,146 @@ function NotificationsScreen() {
 }
 
 function ElectricityScreen() {
+  const dual = DEMO_ELECTRICITY_DUAL;
   const e = DEMO_ELECTRICITY;
   return (
     <AppShell screen="electricity" showNav={false}>
-      <PageHeader title="电费查询" />
+      <PageHeader title="电费查询" icon={<Zap className="h-4 w-4 text-rose-500" />} />
       <div className="phone-feature-body">
-        <div className="phone-gradient-banner phone-gradient-rose">
-          <p className="phone-banner-label">
-            {e.building} · {e.room}
+        <div className="phone-card phone-card-shadow">
+          <p className="text-[10px] font-medium text-gray-500">
+            {dual.building} · {dual.room}
           </p>
-          <p className="phone-banner-value phone-banner-value-lg">¥{e.balance}</p>
-          <p className="phone-banner-sub">剩余余额 · 更新于 {e.updatedAt}</p>
-          <div className="phone-banner-footer">
-            <span>今日用电 {e.usage} 度</span>
-            <span>低电量提醒已开启</span>
+          <p className="mt-1 text-[9px] text-gray-400">双计费宿舍 · 更新于 {dual.updatedAt}</p>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div className="phone-gradient-banner phone-gradient-rose !p-3">
+            <p className="phone-banner-label">💡 {dual.light.label}</p>
+            <p className="phone-banner-value !text-xl">¥{dual.light.balance}</p>
+            <p className="phone-banner-sub">{dual.light.kwh} 度</p>
+          </div>
+          <div className="phone-gradient-banner phone-gradient-indigo !p-3">
+            <p className="phone-banner-label">❄️ {dual.ac.label}</p>
+            <p className="phone-banner-value !text-xl">¥{dual.ac.balance}</p>
+            <p className="phone-banner-sub">{dual.ac.kwh} 度</p>
           </div>
         </div>
+        <div className="phone-list-item">
+          <div>
+            <p className="phone-list-item-title">今日用电</p>
+            <p className="phone-list-item-sub">照明 + 空调合计</p>
+          </div>
+          <span className="text-sm font-bold text-rose-500">{e.usage} 度</span>
+        </div>
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-[10px] text-rose-600">
+          低电量提醒已开启 · 余额低于 10 度将推送通知
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function CampusCodeScreen() {
+  const c = DEMO_CAMPUS_CODE;
+  return (
+    <AppShell screen="home" showNav={false}>
+      <PageHeader title="校园码" icon={<QrCode className="h-4 w-4 text-teal-600" />} />
+      <div className="phone-feature-body">
+        <div className="phone-card phone-card-shadow text-center">
+          <span className="inline-flex rounded-full bg-teal-50 px-2 py-0.5 text-[9px] font-semibold text-teal-700">
+            {c.mode}
+          </span>
+          <div className="mx-auto mt-3 flex h-36 w-36 items-center justify-center rounded-2xl bg-gradient-to-br from-slate-900 to-slate-700 shadow-inner">
+            <div className="grid grid-cols-5 gap-1 p-3">
+              {Array.from({ length: 25 }).map((_, i) => (
+                <span
+                  key={i}
+                  className={`h-2.5 w-2.5 rounded-[2px] ${i % 3 === 0 || i % 7 === 0 ? 'bg-white' : 'bg-white/20'}`}
+                />
+              ))}
+            </div>
+          </div>
+          <p className="mt-3 text-sm font-bold text-gray-800">{c.name}</p>
+          <p className="text-[10px] text-gray-500">学号 {c.serial}</p>
+          <p className="mt-2 text-lg font-bold text-teal-600">¥{c.balance}</p>
+          <p className="mt-1 text-[9px] text-gray-400">{c.hint}</p>
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function TransactionsScreen() {
+  return (
+    <AppShell screen="home" showNav={false}>
+      <PageHeader title="交易记录" icon={<Wallet className="h-4 w-4 text-rose-500" />} />
+      <div className="phone-feature-body">
+        {DEMO_TRANSACTIONS.map((t) => (
+          <div key={`${t.title}-${t.time}`} className="phone-list-item">
+            <div>
+              <p className="phone-list-item-title">{t.title}</p>
+              <p className="phone-list-item-sub">
+                {t.type} · {t.time}
+              </p>
+            </div>
+            <span
+              className={`text-sm font-bold ${t.amount.startsWith('+') ? 'text-emerald-600' : 'text-gray-800'}`}
+            >
+              {t.amount}
+            </span>
+          </div>
+        ))}
+      </div>
+    </AppShell>
+  );
+}
+
+function LibraryScreen() {
+  return (
+    <AppShell screen="home" showNav={false}>
+      <PageHeader title="图书查询" icon={<BookOpen className="h-4 w-4 text-teal-700" />} />
+      <div className="phone-feature-body">
+        <div className="phone-dashboard-search mx-0 mb-1 max-w-none">
+          <Search className="phone-dashboard-search-icon" />
+          搜索书名 / ISBN
+        </div>
+        {DEMO_LIBRARY.map((b) => (
+          <div key={b.title} className="phone-list-item">
+            <div className="min-w-0">
+              <p className="phone-list-item-title truncate">{b.title}</p>
+              <p className="phone-list-item-sub">{b.loc}</p>
+            </div>
+            <span
+              className={`phone-status-pill ${b.status === '已借出' ? 'phone-status-pill--busy' : 'phone-status-pill--free'}`}
+            >
+              {b.status}
+            </span>
+          </div>
+        ))}
+      </div>
+    </AppShell>
+  );
+}
+
+function CalendarScreen() {
+  return (
+    <AppShell screen="home" showNav={false}>
+      <PageHeader title="校历" icon={<Calendar className="h-4 w-4 text-blue-500" />} />
+      <div className="phone-feature-body">
+        <div className="phone-gradient-banner phone-gradient-indigo">
+          <p className="phone-banner-label">2025-2026 学年 · 第 1 学期</p>
+          <p className="phone-banner-value !text-2xl">第 14 教学周</p>
+          <p className="phone-banner-sub">当前周次</p>
+        </div>
+        {DEMO_CALENDAR.map((w) => (
+          <div key={w.week} className="phone-list-item">
+            <div>
+              <p className="phone-list-item-title">{w.week}</p>
+              <p className="phone-list-item-sub">{w.range}</p>
+            </div>
+            <span className="text-[10px] text-gray-500">{w.note}</span>
+          </div>
+        ))}
       </div>
     </AppShell>
   );
@@ -466,7 +607,7 @@ function AllFeaturesScreen() {
               {modulesByCategory(cat).map((mod) => (
                 <div key={mod.id} className="phone-module-item">
                   <div className="phone-module-icon" style={{ backgroundColor: mod.color }}>
-                    <mod.icon className="phone-module-svg" />
+                    <mod.icon className="phone-module-svg" strokeWidth={2.2} />
                   </div>
                   <span className="phone-module-label">{mod.name}</span>
                 </div>
@@ -474,6 +615,28 @@ function AllFeaturesScreen() {
             </div>
           </div>
         ))}
+        {/* 扩展模块视觉预览（对齐 Tauri 全量入口） */}
+        <div className="phone-feature-category">
+          <h3 className="phone-feature-category-title">生活与扩展</h3>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="phone-card !p-2.5">
+              <p className="text-[10px] font-bold text-gray-800">校园码</p>
+              <p className="text-[8px] text-gray-500">在线 / 高能模式二维码</p>
+            </div>
+            <div className="phone-card !p-2.5">
+              <p className="text-[10px] font-bold text-gray-800">交易记录</p>
+              <p className="text-[8px] text-gray-500">一码通流水筛选</p>
+            </div>
+            <div className="phone-card !p-2.5">
+              <p className="text-[10px] font-bold text-gray-800">图书查询</p>
+              <p className="text-[8px] text-gray-500">馆藏检索与状态</p>
+            </div>
+            <div className="phone-card !p-2.5">
+              <p className="text-[10px] font-bold text-gray-800">校历</p>
+              <p className="text-[8px] text-gray-500">教学周与假期</p>
+            </div>
+          </div>
+        </div>
       </div>
     </AppShell>
   );
@@ -488,13 +651,34 @@ function MeScreen() {
             <div className="phone-profile-avatar" style={{ width: 52, height: 52 }}>
               <User className="h-6 w-6" />
             </div>
-            <div>
-              <p className="phone-profile-name">{DEMO_STUDENT.id}</p>
-              <p className="phone-profile-college">{DEMO_STUDENT.college}</p>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1">
+                <p className="phone-profile-name">{DEMO_STUDENT.id}</p>
+                <span className="phone-profile-badge">本科生</span>
+              </div>
+              <p className="phone-profile-college">湖北工业大学 · {DEMO_STUDENT.college}</p>
             </div>
+            <span className="session-status-dot is-green" title="会话已连接" />
           </div>
         </div>
-        {['设置中心', '云同步', '导出数据', '关于 Mini-HBUT'].map((item) => (
+        <div className="phone-card phone-card-shadow">
+          <div className="phone-section-head">
+            <h3>登录状态</h3>
+            <span className="text-[9px] font-medium text-emerald-600">静默登录已开启</span>
+          </div>
+          <p className="text-[9px] text-gray-500">门户会话本地缓存 · 临时会话自动失效处理</p>
+        </div>
+        <div className="phone-module-grid !grid-cols-4">
+          {['设置中心', '导出中心', '检查更新', '意见反馈'].map((label) => (
+            <div key={label} className="phone-module-item">
+              <div className="phone-module-icon bg-slate-100 !text-slate-600">
+                <span className="text-[10px] font-bold">{label.slice(0, 1)}</span>
+              </div>
+              <span className="phone-module-label">{label}</span>
+            </div>
+          ))}
+        </div>
+        {['云同步', '隐私政策', '开源协议', '关于 Mini-HBUT'].map((item) => (
           <div key={item} className="phone-list-item">
             <span className="phone-list-item-title">{item}</span>
             <span className="text-gray-300">›</span>
@@ -544,27 +728,39 @@ function ScreenLayer({
   );
 }
 
+/** 官网手机演示可用的屏 ID（与 scroll-utils AppScreen 对齐） */
+export type PhoneDemoScreen = AppScreen;
+
 export default function PhoneAppScreen({
   screenFrom,
   screenTo,
-  screenBlend,
+  screenBlend = 1,
+  blend,
 }: {
   screenFrom: AppScreen;
   screenTo: AppScreen;
-  screenBlend: number;
+  /** 兼容旧调用 */
+  screenBlend?: number;
+  /** Hero / Showcase 简写 */
+  blend?: number;
 }) {
-  const blending = screenBlend > 0.02 && screenFrom !== screenTo;
+  const resolvedBlend = blend ?? screenBlend;
+  const blending = resolvedBlend > 0.02 && screenFrom !== screenTo;
 
   return (
     <div className="phone-app-viewport phone-app-root">
       {blending ? (
         <>
-          <ScreenLayer screen={screenFrom} opacity={1 - screenBlend} scale={1 - screenBlend * 0.03} />
+          <ScreenLayer
+            screen={screenFrom}
+            opacity={1 - resolvedBlend}
+            scale={1 - resolvedBlend * 0.03}
+          />
           <ScreenLayer
             screen={screenTo}
-            opacity={screenBlend}
-            translateY={(1 - screenBlend) * 10}
-            scale={0.98 + screenBlend * 0.02}
+            opacity={resolvedBlend}
+            translateY={(1 - resolvedBlend) * 10}
+            scale={0.98 + resolvedBlend * 0.02}
           />
         </>
       ) : (

--- a/website/src/components/phone-app/demo-data.ts
+++ b/website/src/components/phone-app/demo-data.ts
@@ -62,3 +62,39 @@ export const DEMO_RANKING = {
   gpa: '3.72',
   avg: '3.21',
 };
+
+/** 电费双计费演示（对齐 ElectricityView） */
+export const DEMO_ELECTRICITY_DUAL = {
+  building: '东苑 12栋',
+  room: '312',
+  light: { balance: '23.60', kwh: '42.6', label: '照明' },
+  ac: { balance: '18.20', kwh: '31.4', label: '空调' },
+  updatedAt: '2 分钟前',
+};
+
+export const DEMO_TRANSACTIONS = [
+  { title: '食堂一楼', amount: '-12.50', time: '今天 12:18', type: '消费' },
+  { title: '超市便利店', amount: '-8.00', time: '今天 08:42', type: '消费' },
+  { title: '电费充值', amount: '+50.00', time: '昨天 21:05', type: '充值' },
+  { title: '浴室热水', amount: '-2.00', time: '昨天 19:30', type: '消费' },
+];
+
+export const DEMO_LIBRARY = [
+  { title: '深入理解计算机系统', status: '可借', loc: '逸夫图书馆 3F' },
+  { title: '现代操作系统', status: '在架', loc: '西区图书馆 2F' },
+  { title: '算法导论', status: '已借出', loc: '逸夫图书馆 4F' },
+];
+
+export const DEMO_CALENDAR = [
+  { week: '第 14 周', range: '04.07 - 04.13', note: '正常教学' },
+  { week: '第 15 周', range: '04.14 - 04.20', note: '正常教学' },
+  { week: '第 16 周', range: '04.21 - 04.27', note: '复习周' },
+];
+
+export const DEMO_CAMPUS_CODE = {
+  mode: '在线模式',
+  name: '张同学',
+  serial: '****3456',
+  balance: '86.40',
+  hint: '每 60 秒自动刷新',
+};

--- a/website/src/data/home-content.ts
+++ b/website/src/data/home-content.ts
@@ -1,0 +1,120 @@
+/** 首页 Hero / Showcase 产品文案（对齐 Kimi 交付包） */
+export const EYEBROW = 'Mini-HBUT · 校园信息聚合客户端';
+export const H1_A = '一个入口，';
+export const H1_B = '看清整个校园日程';
+export const SUB =
+  '课表、成绩、考试、通知、电费、空教室——湖工大校园信息一手掌握。数据本地存储，请求由你的设备发起，安全又畅快。';
+
+export const CHIPS = ['课表', '成绩', '考试', '通知', '电费', '空教室'] as const;
+
+export const TRUST_ITEMS = [
+  'Windows',
+  'macOS',
+  'Linux',
+  'Android',
+  'iOS',
+  '开源免费',
+  '数据本地存储',
+] as const;
+
+export const GITHUB_URL = 'https://github.com/superdaobo/mini-hbut';
+export const SITE_URL = 'https://hbut.6661111.xyz';
+
+export type ShowcaseStage = {
+  tag: string;
+  title: string;
+  desc: string;
+  side: 'left' | 'right' | 'center';
+  /** 手机内展示的 App 屏 */
+  screen:
+    | 'home'
+    | 'schedule'
+    | 'grades'
+    | 'exams'
+    | 'notifications'
+    | 'electricity'
+    | 'classroom'
+    | 'ranking'
+    | 'all-features'
+    | 'me';
+};
+
+export const SHOWCASE_STAGES: ShowcaseStage[] = [
+  {
+    tag: '首页',
+    title: '今日校园，一眼看懂',
+    desc: '课程、电费、考试倒计时、最新通知——开机第一屏，全部就位。',
+    side: 'left',
+    screen: 'home',
+  },
+  {
+    tag: '课表',
+    title: '周视图课表',
+    desc: '整周课程一屏尽览，自动同步教务系统，调课变动即时更新。',
+    side: 'right',
+    screen: 'schedule',
+  },
+  {
+    tag: '成绩',
+    title: '绩点与成绩明细',
+    desc: 'GPA、专业排名、单科分数本地缓存，教务系统维护时照样可查。',
+    side: 'left',
+    screen: 'grades',
+  },
+  {
+    tag: '考试',
+    title: '考试倒计时',
+    desc: '每一场考试的时间、地点、剩余天数，安排得明明白白。',
+    side: 'right',
+    screen: 'exams',
+  },
+  {
+    tag: '通知',
+    title: '校园通知聚合',
+    desc: '教务、图书馆、后勤、学工……全校通知汇入同一条时间线。',
+    side: 'left',
+    screen: 'notifications',
+  },
+  {
+    tag: '电费',
+    title: '宿舍电费查询',
+    desc: '余额、日均用电、趋势图一目了然，还能一键跳转充值。',
+    side: 'right',
+    screen: 'electricity',
+  },
+  {
+    tag: '空教室',
+    title: '空教室速查',
+    desc: '按楼栋、插座、人数筛选，自习找教室不再一间间敲门。',
+    side: 'left',
+    screen: 'classroom',
+  },
+  {
+    tag: '下载',
+    title: '全平台，免费下载',
+    desc: 'Windows / macOS / Linux / Android / iOS，开源免费，即刻上手。',
+    side: 'center',
+    screen: 'all-features',
+  },
+];
+
+/** Hero 手机自动轮播序列 */
+export const HERO_PHONE_SEQUENCE = [
+  'home',
+  'schedule',
+  'grades',
+  'exams',
+  'notifications',
+  'electricity',
+  'classroom',
+] as const;
+
+export const HERO_PHONE_CAPTIONS: Record<(typeof HERO_PHONE_SEQUENCE)[number], string> = {
+  home: '今日校园，一眼看懂',
+  schedule: '周视图课表',
+  grades: '绩点与成绩明细',
+  exams: '考试倒计时',
+  notifications: '校园通知聚合',
+  electricity: '宿舍电费查询',
+  classroom: '空教室速查',
+};

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -397,6 +397,161 @@
   background-clip: text;
 }
 
+/* ========== Kimi Hero / Showcase 视觉系统 ========== */
+
+@keyframes aurora-drift {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  33% {
+    transform: translate3d(4%, -6%, 0) scale(1.12);
+  }
+  66% {
+    transform: translate3d(-5%, 4%, 0) scale(0.94);
+  }
+}
+.aurora-blob {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(90px);
+  will-change: transform;
+  animation: aurora-drift 18s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.bg-grid {
+  background-image: linear-gradient(to right, rgba(148, 163, 184, 0.055) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(148, 163, 184, 0.055) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 30%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 30%, transparent 75%);
+}
+
+.text-gradient {
+  background: linear-gradient(120deg, #fff 20%, #a5f3fc 55%, #38bdf8 90%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.kimi-glass {
+  background: rgba(10, 15, 26, 0.55);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+@keyframes float-y {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-12px);
+  }
+}
+.animate-float {
+  animation: float-y 5s ease-in-out infinite;
+}
+.animate-float-slow {
+  animation: float-y 7.5s ease-in-out infinite;
+}
+.animate-float-delay {
+  animation: float-y 6.2s ease-in-out 1.2s infinite;
+}
+
+@keyframes spin-slow {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.animate-spin-slower {
+  animation: spin-slow 22s linear infinite;
+}
+.animate-spin-slower-rev {
+  animation: spin-slow 30s linear infinite reverse;
+}
+
+@keyframes scroll-hint {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  70% {
+    transform: translateY(10px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+}
+.animate-scroll-hint {
+  animation: scroll-hint 1.8s ease-in-out infinite;
+}
+
+@keyframes screen-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+.animate-screen-in {
+  animation: screen-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.phone-scene {
+  perspective: 1400px;
+}
+.phone-3d {
+  transform-style: preserve-3d;
+  will-change: transform;
+  transition: transform 0.12s linear;
+}
+
+@keyframes shine-sweep {
+  0% {
+    transform: translateX(-120%) skewX(-18deg);
+  }
+  100% {
+    transform: translateX(240%) skewX(-18deg);
+  }
+}
+.btn-shine {
+  position: relative;
+  overflow: hidden;
+}
+.btn-shine::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+  animation: shine-sweep 3.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-blob,
+  .animate-float,
+  .animate-float-slow,
+  .animate-float-delay,
+  .animate-spin-slower,
+  .animate-spin-slower-rev,
+  .animate-scroll-hint,
+  .btn-shine::after {
+    animation: none !important;
+  }
+  .phone-3d {
+    transition: none;
+  }
+}
+
 /* Cyber Button */
 .cyber-btn {
   position: relative;

--- a/website/src/lib/screen-captions.ts
+++ b/website/src/lib/screen-captions.ts
@@ -65,4 +65,28 @@ export const SCREEN_CAPTIONS: Record<
     blurb: '账号、主题与数据管理',
     accent: '#94a3b8',
   },
+  'campus-code': {
+    label: '校园码',
+    title: '一码通校园码',
+    blurb: '在线 / 高能模式二维码，门口通行即扫即过',
+    accent: '#14b8a6',
+  },
+  transactions: {
+    label: '交易',
+    title: '一码通流水',
+    blurb: '消费与充值记录本地可查',
+    accent: '#f43f5e',
+  },
+  library: {
+    label: '图书',
+    title: '馆藏检索',
+    blurb: '书名 / ISBN 检索与在馆状态',
+    accent: '#0d9488',
+  },
+  calendar: {
+    label: '校历',
+    title: '教学周与假期',
+    blurb: '当前教学周与关键节点一目了然',
+    accent: '#3b82f6',
+  },
 };

--- a/website/src/lib/scroll-utils.ts
+++ b/website/src/lib/scroll-utils.ts
@@ -25,7 +25,11 @@ export type AppScreen =
   | 'classroom'
   | 'ranking'
   | 'all-features'
-  | 'me';
+  | 'me'
+  | 'campus-code'
+  | 'transactions'
+  | 'library'
+  | 'calendar';
 
 export interface Vec3 {
   x: number;


### PR DESCRIPTION
## Summary
- 用 **Kimi 风格短 Hero**（粒子背景 + CSS 3D 手机轮播 + 文案）替换原先超长 R3F/GSAP 滚动驱动首页。
- 新增 **ScrollShowcase**：多阶段 sticky 运镜，机内使用真实 PhoneAppScreen 演示（非 SVG 占位）。
- **phone-app 视觉全量移植**：Dashboard 对齐 Tauri、电费双计费、以及校园码/交易/图书/校历等演示屏与 demo 数据。
- HomeExperience 主路径：Navbar + HeroSection + ScrollShowcase + HomeClassicSections；不再挂载 SceneCanvas。

对应 issues：#407 #408 #409 #410

## Scope
- 仅 website/ 源码与样式；无 docs/CDN 重写；无 Vue-in-Next；静态演示，无后端 API。

## Test plan
- [x] website/ 下 
pm run build（Next.js 15）通过，首页与 docs 静态导出成功
- [ ] 本地 
pm run dev：Hero 手机轮播、鼠标 3D 倾斜、prefers-reduced-motion 降级
- [ ] 滚动 Showcase：各阶段文案/屏幕切换、移动端布局、末段下载 CTA
- [ ] 经典区块（Features / Download / About）与 Navbar pastHero 行为正常
- [ ] 确认首页不再加载 R3F SceneCanvas 主路径

Closes #407
Closes #408
Closes #409
Closes #410