### PR TITLE
fix(ci): website 部署互 cancel 导致 gh-pages 不同步

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -871,8 +871,9 @@ jobs:
     needs: [meta, build-android, build-windows, build-macos, build-ios, build-linux]
     runs-on: ubuntu-latest
     concurrency:
+      # 与 Sync Website 共用写入锁；禁止 cancel，避免冲掉 gh-pages 双部署
       group: website-pages-deploy
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -800,8 +800,9 @@ jobs:
     needs: [create-release, build-android, build-windows, build-macos, build-ios, build-linux]
     runs-on: ubuntu-latest
     concurrency:
+      # 与 Sync Website 共用写入锁；禁止 cancel，避免冲掉完整双部署
       group: website-pages-deploy
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -14,8 +14,11 @@ permissions:
   contents: write
 
 concurrency:
+  # 与 Website Modules / dev-build / release 共用 website-pages 写入锁。
+  # cancel-in-progress 必须为 false：#415 合并时 Modules 与本 workflow 同秒触发，
+  # 旧配置把本 job cancel 掉 → EdgeOne 可能由 Modules 补上，但 gh-pages 永远不更新。
   group: website-pages-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sync-website:

--- a/.github/workflows/website-modules.yml
+++ b/.github/workflows/website-modules.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
+    # 仅模块源/管线变更触发。官网 UI（src/components 等）由 Sync Website 负责，
+    # 禁止与 Sync Website 抢同一 concurrency 组，否则会 cancel 掉 gh-pages 部署（#415 事故）。
     paths:
-      - "website/**"
+      - "website/modules-src/**"
+      - "website/public/modules/**"
       - "scripts/build_website_modules.mjs"
       - "scripts/build_release_manifests.mjs"
+      - "scripts/prune_website_module_versions.mjs"
       - ".github/workflows/website-modules.yml"
   workflow_dispatch:
 
@@ -15,8 +19,10 @@ permissions:
   contents: write
 
 concurrency:
+  # 与 Sync Website 共用 website-pages 写入锁，但禁止 cancel-in-progress：
+  # 否则 main 上并发触发时会把负责 gh-pages 的 Sync Website 杀掉。
   group: website-pages-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy-website-modules:


### PR DESCRIPTION
## 问题

#415 合并后官网看起来「没同步」：

| 路径 | 状态 |
|------|------|
| EdgeOne `website-pages` | 有内容（Modules/Dev Build 部署了 app-demo） |
| GitHub Pages `gh-pages` | **停在 #411**，无 app-demo |

## 根因（不是 Hero 代码错）

`Sync Website` 与 `Website Modules Deploy` 共用 concurrency：

```yaml
group: website-pages-deploy
cancel-in-progress: true
```

main 上 `website/**` 会同时触发两个 workflow。#415 合并时 **Sync Website 被 cancel（1s）**，而它是**唯一会部署 `gh-pages` 的完整双部署**。Modules 只推 `website-pages`，所以 GH Pages 永远旧。

## 修复

1. 上述 concurrency 组全部改为 `cancel-in-progress: false`（sync / modules / dev-build / release）
2. Modules 触发 paths 收窄为 `modules-src` + 模块构建脚本，官网 UI 变更只走 Sync Website

## 合并后

会 `workflow_dispatch` 跑一次 Sync Website，补齐 gh-pages。