### PR TITLE
fix(website): 详情页 Material 图标显示英文名

### DIFF
--- a/public/fonts/material-symbols-outlined.css
+++ b/public/fonts/material-symbols-outlined.css
@@ -1,15 +1,16 @@
 @font-face {
   font-family: 'Material Symbols Outlined';
   font-style: normal;
-  font-weight: 100 700;
+  /* 单一 weight：避免 100–700 范围在部分浏览器 + 子集字体下 @font-face 失败（详情页图标变英文） */
+  font-weight: 400;
   font-display: block;
-  /* 相对路径：兼容根路径部署与官网 /app-demo/ 子路径（绝对 /fonts 在子路径下 404） */
+  /* 相对路径：兼容根路径与官网 /app-demo/ 子路径 */
   src: url(./material-symbols-outlined.subset.woff2) format('woff2');
 }
 
 .material-symbols-outlined {
   font-family: 'Material Symbols Outlined', sans-serif !important;
-  font-weight: normal !important;
+  font-weight: 400 !important;
   font-style: normal;
   font-size: 24px;
   line-height: 1;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,10 +13,12 @@ import { runCampusNetworkAutoLogin } from './utils/campus_network_service'
 import { initDebugLogger, pushDebugLog } from './utils/debug_logger'
 import { invokeNative, isTauriRuntime } from './platform/native'
 import { bootstrapWebsiteDemoIfNeeded } from './utils/website_demo_boot.js'
+import { ensureMaterialSymbolsFont, loadLocalIconFonts } from './utils/icon_fonts'
 
 // 官网 Hero iframe 演示：挂载前写入演示会话 + fixtures（仅 VITE_WEBSITE_DEMO=1）
-bootstrapWebsiteDemoIfNeeded()
-
+const isWebsiteDemo = bootstrapWebsiteDemoIfNeeded()
+// 演示 / 详情页依赖 Material Symbols ligature；尽早 FontFace 加载，避免图标名英文显示
+void ensureMaterialSymbolsFont()
 
 const removeNativeSplash = () => {
   try {
@@ -46,31 +48,10 @@ const mountApp = () => {
   window.setTimeout(removeNativeSplash, 500)
 }
 
-const loadLocalIconFonts = () => {
-  // 图标字体从本地加载（无 CDN 依赖），延迟到首屏之后
-  // 按需加载：fontawesome 基础 + solid 图标，避免 brands/regular 等未使用字体
-  // BASE_URL 兼容官网 app-demo 相对路径部署（base: './'）
-  const base = String(import.meta.env.BASE_URL || '/').replace(/\/?$/, '/')
-  void Promise.all([
-    import('@fortawesome/fontawesome-free/css/fontawesome.css'),
-    import('@fortawesome/fontawesome-free/css/solid.css'),
-    new Promise((resolve, reject) => {
-      const link = document.createElement('link')
-      link.rel = 'stylesheet'
-      link.href = `${base}fonts/material-symbols-outlined.css`
-      link.onload = resolve
-      link.onerror = reject
-      document.head.appendChild(link)
-    })
-  ]).catch((e) => {
-    console.warn('[Bootstrap] local icon fonts load failed:', e)
-  })
-}
-
 const runDeferredInitializers = () => {
   const run = () => {
-    // 本地图标字体延迟加载
-    loadLocalIconFonts()
+    // 本地图标字体（含 Material Symbols FontFace，详情页图标依赖）
+    void loadLocalIconFonts()
 
     // 先完成首屏挂载，再异步初始化重任务，避免安卓首次安装时白屏等待。
     void import('./utils/markdown')
@@ -112,6 +93,12 @@ const runDeferredInitializers = () => {
     }).catch((error) => {
       console.warn('[Bootstrap] background fetch init failed:', error)
     })
+  }
+
+  // 官网演示：立即加载字体（详情页一进就要图标）
+  if (isWebsiteDemo) {
+    run()
+    return
   }
 
   if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {

--- a/src/utils/icon_fonts.ts
+++ b/src/utils/icon_fonts.ts
@@ -1,0 +1,114 @@
+/**
+ * 本地图标字体加载（无 CDN）。
+ * Material Symbols 在 /app-demo 子路径部署时，CSS @font-face 的绝对/相对解析易失败；
+ * 使用 FontFace API 显式加载 woff2，确保详情页 ligature 图标渲染（否则显示英文 icon name）。
+ */
+
+const MATERIAL_FAMILY = 'Material Symbols Outlined'
+const MATERIAL_WOFF2 = 'fonts/material-symbols-outlined.subset.woff2'
+const MATERIAL_CSS = 'fonts/material-symbols-outlined.css'
+
+let materialLoadPromise: Promise<boolean> | null = null
+
+/** 解析相对 BASE_URL 的静态资源 URL（兼容 base: './' 的 app-demo 与根路径） */
+export const resolvePublicAssetUrl = (relativePath: string): string => {
+  const raw = String(relativePath || '').replace(/^\//, '')
+  const base = String(import.meta.env.BASE_URL || './')
+  const baseNorm = base.endsWith('/') ? base : `${base}/`
+  try {
+    // 相对当前文档 URL，避免在 iframe 子路径下拼出 /fonts 根路径
+    return new URL(`${baseNorm}${raw}`, typeof location !== 'undefined' ? location.href : 'http://localhost/').href
+  } catch {
+    return `./${raw}`
+  }
+}
+
+const injectStylesheet = (href: string, id: string) => {
+  if (typeof document === 'undefined') return
+  if (document.getElementById(id)) return
+  const link = document.createElement('link')
+  link.id = id
+  link.rel = 'stylesheet'
+  link.href = href
+  document.head.appendChild(link)
+}
+
+/**
+ * 确保 Material Symbols 已注册到 document.fonts。
+ * 成功返回 true；失败不抛错（调用方已有英文 fallback）。
+ */
+export const ensureMaterialSymbolsFont = (): Promise<boolean> => {
+  if (typeof document === 'undefined' || typeof FontFace === 'undefined') {
+    return Promise.resolve(false)
+  }
+  if (materialLoadPromise) return materialLoadPromise
+
+  materialLoadPromise = (async () => {
+    const cssUrl = resolvePublicAssetUrl(MATERIAL_CSS)
+    const fontUrl = resolvePublicAssetUrl(MATERIAL_WOFF2)
+    injectStylesheet(cssUrl, 'mini-hbut-material-symbols-css')
+
+    // 清理曾失败的同名 face，避免浏览器继续用 error 状态
+    try {
+      for (const face of [...document.fonts]) {
+        if (face.family.replace(/["']/g, '') === MATERIAL_FAMILY && face.status === 'error') {
+          document.fonts.delete(face)
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    // 若已有 loaded 的同名字体，直接成功
+    try {
+      const already = [...document.fonts].some(
+        (f) => f.family.replace(/["']/g, '') === MATERIAL_FAMILY && f.status === 'loaded',
+      )
+      if (already) {
+        await document.fonts.load(`24px "${MATERIAL_FAMILY}"`).catch(() => {})
+        return true
+      }
+    } catch {
+      // continue load
+    }
+
+    try {
+      // 使用单一 weight：子集字体 + 可变轴，避免 100 700 范围在部分浏览器 @font-face 失败
+      const face = new FontFace(MATERIAL_FAMILY, `url(${fontUrl}) format("woff2")`, {
+        style: 'normal',
+        weight: '400',
+        display: 'block',
+      })
+      await face.load()
+      document.fonts.add(face)
+      await document.fonts.load(`24px "${MATERIAL_FAMILY}"`).catch(() => {})
+      // 触发已有图标节点重排，使 liga 生效
+      try {
+        document.querySelectorAll('.material-symbols-outlined').forEach((el) => {
+          const node = el as HTMLElement
+          void node.offsetWidth
+        })
+      } catch {
+        // ignore
+      }
+      return true
+    } catch (error) {
+      console.warn('[icon-fonts] Material Symbols FontFace load failed:', error)
+      // 回退：仅依赖 CSS link（根路径部署仍可用）
+      return false
+    }
+  })()
+
+  return materialLoadPromise
+}
+
+/** Font Awesome + Material Symbols（详情页图标依赖后者） */
+export const loadLocalIconFonts = (): Promise<void> => {
+  return Promise.all([
+    import('@fortawesome/fontawesome-free/css/fontawesome.css'),
+    import('@fortawesome/fontawesome-free/css/solid.css'),
+    ensureMaterialSymbolsFont(),
+  ]).then(() => undefined).catch((e) => {
+    console.warn('[Bootstrap] local icon fonts load failed:', e)
+  })
+}

--- a/src/utils/website_demo_boot.js
+++ b/src/utils/website_demo_boot.js
@@ -6,6 +6,7 @@
 import { markTestAccountSession, TEST_ACCOUNT } from './test_account.js'
 import { seedTestAccountCaches } from './test_account_fixtures.js'
 import { setCachedData } from './api.js'
+import { ensureMaterialSymbolsFont } from './icon_fonts'
 
 const LOGIN_SESSION_TOKEN_KEY = 'hbu_login_session_token'
 
@@ -71,6 +72,9 @@ export function bootstrapWebsiteDemoIfNeeded() {
   } catch {
     // ignore
   }
+
+  // 详情页大量 material-symbols；挂载前启动 FontFace，避免图标名当英文显示
+  void ensureMaterialSymbolsFont()
 
   return true
 }


### PR DESCRIPTION
## 问题

点进功能详情页（如成绩查询）后，Material Symbols 图标变成英文名（`chevron_left` / `refresh` / `search`），而非图形。

## 根因（MCP 实测）

1. 详情页用 `.material-symbols-outlined` + 文本 ligature 渲染。
2. 线上曾因 `url(/fonts/...)` 404 使 `@font-face` 进入 **error** 状态。
3. 即使修复相对路径后 woff2 已 200，浏览器仍可能保持失败的 face；图标宽约 **141px**（英文），正常应为 **~24px**。
4. 手动 `new FontFace(...).load()` 后图标宽度立即恢复为 24px。

## 修复

- `src/utils/icon_fonts.ts`：用 **FontFace API** 显式加载 `material-symbols-outlined.subset.woff2`（weight 400）
- 挂载前 / 官网 demo 启动时 `ensureMaterialSymbolsFont()`
- CSS：`font-weight: 100 700` → `400`，相对路径 woff2

## 验收

本地 Hero iframe → 成绩查询：
- Material Symbols status **loaded**
- 图标宽度 20–24px，`brokenCount: 0`（不再出现 >40px 英文宽）