### PR TITLE
fix(app-store): 合规包 guest/演示会话隐藏赞助入口

### DIFF
--- a/docs/app-store/APP_REVIEW_NOTES.md
+++ b/docs/app-store/APP_REVIEW_NOTES.md
@@ -41,6 +41,12 @@ Background fetch / processing identifiers support optional refresh of schedule/e
 
 Free; no ads; no subscriptions; no IAP in this version.
 
+On this App Store candidate build:
+
+- The **Sponsor / WeChat tip QR** entry on **Me** is **not shown** when the user is signed out or signed in with the demo account (`reviewer`).
+- Reviewers following the demo path above will not see in-app tip/sponsorship UI.
+- There is no digital goods purchase flow and no App Store IAP in this version.
+
 ## Support & privacy
 
 - Support / docs: https://hbut.6661111.xyz/docs

--- a/docs/app-store/FEATURE_SCOPE_1.4.3.md
+++ b/docs/app-store/FEATURE_SCOPE_1.4.3.md
@@ -18,6 +18,7 @@ Version remains **1.4.3**. Compliance applies only when `VITE_APP_STORE_BUILD=1`
 | Export center | Allowed | Allowed | Allowed | Local fixtures |
 | Settings / About | Allowed | Allowed | Allowed | Same UI |
 | Privacy & data | Allowed | Allowed | Allowed | Same UI |
+| Sponsor / WeChat tip QR (Me) | **Hidden** for guest + demo; allowed only when real-logged-in | Allowed | Allowed | Hidden (demo path) |
 | Today course widget | Allowed | Allowed | N/A | Demo snapshot |
 | Course selection | **Blocked** | Allowed | Allowed | N/A (hidden) |
 | Ranking | **Blocked** | Allowed | Allowed | N/A |

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -8,6 +8,7 @@ import {
   NON_OFFICIAL_DISCLAIMER_EN,
   NON_OFFICIAL_DISCLAIMER_ZH,
   PRIVACY_POLICY_URL,
+  isSponsorEntryAllowed,
   isViewAllowed
 } from '../config/app_store_policy'
 import { isTestAccountSession, clearTestAccountSession } from '../utils/test_account.js'
@@ -42,8 +43,19 @@ const sponsorImageLoading = ref(false)
 const SPONSOR_IMAGE_CACHE_KEY = 'hbu_sponsor_qr_cache'
 const SPONSOR_IMAGE_SRC = 'https://raw.gitcode.com/superdaobo/mini-hbut-config/raw/main/%E8%B5%9E%E8%B5%8F%E7%A0%81.JPG'
 
+const isDemoSession = computed(() => isTestAccountSession())
+
+/** 合规包下 guest/演示会话不展示赞助；非合规包始终展示 */
+const showSponsorEntry = computed(() =>
+  isSponsorEntryAllowed({
+    isLoggedIn: props.isLoggedIn,
+    isDemoSession: isDemoSession.value
+  })
+)
+
 // 加载赞赏码（首次下载，之后缓存）
 const loadSponsorImage = async () => {
+  if (!showSponsorEntry.value) return
   // 检查缓存
   const cached = localStorage.getItem(SPONSOR_IMAGE_CACHE_KEY)
   if (cached) {
@@ -72,7 +84,19 @@ const loadSponsorImage = async () => {
 }
 
 watch(showSponsorModal, (val) => {
-  if (val && !sponsorImageUrl.value) loadSponsorImage()
+  if (!val) return
+  if (!showSponsorEntry.value) {
+    showSponsorModal.value = false
+    return
+  }
+  if (!sponsorImageUrl.value) loadSponsorImage()
+})
+
+// 会话变为 guest/demo 时强制关闭赞赏弹窗，避免残留
+watch(showSponsorEntry, (allowed) => {
+  if (!allowed && showSponsorModal.value) {
+    showSponsorModal.value = false
+  }
 })
 
 const handleLogout = () => emit('logout')
@@ -98,7 +122,6 @@ const showMoreModules = computed(() => isViewAllowed('more'))
 const showConfigTool = computed(
   () => isConfigAdmin() && isViewAllowed('config')
 )
-const isDemoSession = computed(() => isTestAccountSession())
 
 const resetDemoData = () => {
   if (!isTestAccountSession()) return
@@ -273,7 +296,11 @@ const handleShowLegal = async (tab) => {
         </div>
         <span class="grid-label">开源协议</span>
       </button>
-      <button class="grid-item" @click="showSponsorModal = true">
+      <button
+        v-if="showSponsorEntry"
+        class="grid-item"
+        @click="showSponsorModal = true"
+      >
         <div class="grid-icon-box" style="background: #FFF3E0;">
           <span class="material-symbols-outlined" style="color: #E65100;">favorite</span>
         </div>
@@ -384,8 +411,12 @@ const handleShowLegal = async (tab) => {
       </div>
     </div>
 
-    <!-- 赞助弹窗 -->
-    <div v-if="showSponsorModal" class="modal-mask" @click="showSponsorModal = false">
+    <!-- 赞助弹窗（合规包 guest/demo 不挂载） -->
+    <div
+      v-if="showSponsorModal && showSponsorEntry"
+      class="modal-mask"
+      @click="showSponsorModal = false"
+    >
       <div class="modal-card sponsor-modal" @click.stop>
         <h3>❤️ 赞助支持</h3>
         <p class="intro">如果 Mini-HBUT 对你有帮助，欢迎请作者喝杯咖啡 ☕</p>

--- a/src/config/app_store_policy.spec.ts
+++ b/src/config/app_store_policy.spec.ts
@@ -8,6 +8,7 @@ import {
   isHotUpdateAllowed,
   isModuleAllowed,
   isRemoteModulesAllowed,
+  isSponsorEntryAllowed,
   isViewAllowed,
   setAppStoreBuildOverrideForTests
 } from './app_store_policy'
@@ -113,5 +114,30 @@ describe('app_store_policy', () => {
     setAppStoreBuildOverrideForTests(true)
     expect(isModuleAllowed('secret_remote_game')).toBe(false)
     expect(isViewAllowed('unknown_view_xyz')).toBe(false)
+  })
+
+  describe('isSponsorEntryAllowed', () => {
+    it('flag off: allows sponsor for guest, demo, and real sessions', () => {
+      setAppStoreBuildOverrideForTests(false)
+      expect(isSponsorEntryAllowed({ isLoggedIn: false, isDemoSession: false })).toBe(true)
+      expect(isSponsorEntryAllowed({ isLoggedIn: true, isDemoSession: true })).toBe(true)
+      expect(isSponsorEntryAllowed({ isLoggedIn: true, isDemoSession: false })).toBe(true)
+    })
+
+    it('flag on: hides sponsor for guest (not logged in)', () => {
+      setAppStoreBuildOverrideForTests(true)
+      expect(isSponsorEntryAllowed({ isLoggedIn: false, isDemoSession: false })).toBe(false)
+      expect(isSponsorEntryAllowed({ isLoggedIn: false, isDemoSession: true })).toBe(false)
+    })
+
+    it('flag on: hides sponsor for demo session even if logged in', () => {
+      setAppStoreBuildOverrideForTests(true)
+      expect(isSponsorEntryAllowed({ isLoggedIn: true, isDemoSession: true })).toBe(false)
+    })
+
+    it('flag on: allows sponsor for real logged-in session', () => {
+      setAppStoreBuildOverrideForTests(true)
+      expect(isSponsorEntryAllowed({ isLoggedIn: true, isDemoSession: false })).toBe(true)
+    })
   })
 })

--- a/src/config/app_store_policy.ts
+++ b/src/config/app_store_policy.ts
@@ -3,7 +3,8 @@
  *
  * - 仅当编译期 `VITE_APP_STORE_BUILD === '1'` 时收紧（由 ios-testflight.yml 注入）。
  * - 默认构建 / release / dev / Android / Desktop：全部允许，行为与现网一致。
- * - 功能可见性不得根据 reviewer 用户名变化；演示账号只换数据源。
+ * - 模块/视图功能树对合规包全员统一（不因 reviewer 增减模块）；演示账号只换数据源。
+ * - 赞助/赞赏入口是唯一会话相关例外（见 isSponsorEntryAllowed）：合规包下 guest/demo 隐藏。
  * - 远程配置不能改写本模块的编译期判定。
  */
 
@@ -249,6 +250,23 @@ export function isHotUpdateAllowed(): boolean {
 
 export function isRemoteModulesAllowed(): boolean {
   return getFeaturePolicy().remoteModules
+}
+
+/**
+ * 赞助 / 微信赞赏码入口是否允许展示。
+ *
+ * - 非合规包：始终允许（与现网一致）。
+ * - 合规包（TestFlight / App Store）：仅「已登录且非演示会话」允许。
+ *   未登录与 reviewer 演示会话隐藏，避免审核路径触 Guideline 3.1.1。
+ *
+ * 调用方传入会话态，避免本模块依赖 localStorage。
+ */
+export function isSponsorEntryAllowed(options: {
+  isLoggedIn: boolean
+  isDemoSession: boolean
+}): boolean {
+  if (!isAppStoreBuild()) return true
+  return Boolean(options?.isLoggedIn) && !Boolean(options?.isDemoSession)
 }
 
 /** 非官方声明（UI 复用） */


### PR DESCRIPTION
## Summary

- 解决 App Store / TestFlight 因「我的」页微信赞赏码触 Guideline 3.1.1 的拒审路径（#431）
- 新增 `isSponsorEntryAllowed`：仅在 `VITE_APP_STORE_BUILD=1` 时对 **未登录** 与 **演示会话** 隐藏赞助；真实登录仍可见
- MeView 宫格 / 弹窗 / 图片加载均受门闩约束；非合规构建行为不变
- 更新 App Review 备注与功能范围文档；补充单测

## Test plan

- [x] `npx vitest run src/config/app_store_policy.spec.ts`（9 tests passed）
- [ ] 合规包语义自检：guest / demo → 无赞助；real logged-in → 有赞助
- [ ] 非合规构建回归：赞助仍可见

Closes #431