### PR TITLE
fix(app-store): 真实登录解锁合规包全功能

### DIFF
--- a/docs/app-store/APP_REVIEW_NOTES.md
+++ b/docs/app-store/APP_REVIEW_NOTES.md
@@ -43,9 +43,9 @@ Free; no ads; no subscriptions; no IAP in this version.
 
 On this App Store candidate build:
 
-- The **Sponsor / WeChat tip QR** entry on **Me** is **not shown** when the user is signed out or signed in with the demo account (`reviewer`).
-- Reviewers following the demo path above will not see in-app tip/sponsorship UI.
-- There is no digital goods purchase flow and no App Store IAP in this version.
+- Reviewers following the **demo path** above see a **restricted feature surface** (core readonly tools + fixtures). High-risk modules (campus code, course selection, remote modules, AI, etc.) and the **Sponsor / WeChat tip QR** entry are **not shown**.
+- Real student logins may unlock the full in-app tool surface; the demo path is the supported review path.
+- There is no digital goods purchase flow and no App Store IAP on the demo path.
 
 ## Support & privacy
 

--- a/docs/app-store/FEATURE_SCOPE_1.4.3.md
+++ b/docs/app-store/FEATURE_SCOPE_1.4.3.md
@@ -2,7 +2,9 @@
 
 Version remains **1.4.3**. Compliance applies only when `VITE_APP_STORE_BUILD=1` (iOS TestFlight workflow).
 
-| Module / capability | iOS App Store (flag on) | Android | Desktop | Demo mode (flag on) |
+**Session model (flag on):** guest and demo (`reviewer`) use the restricted surface below; a **real** school / Chaoxing login unlocks the full feature tree (same as Android/Desktop).
+
+| Module / capability | iOS App Store (flag on, guest/demo) | Android | Desktop | Demo mode (flag on) |
 |---------------------|-------------------------|---------|---------|---------------------|
 | Home | Allowed | Allowed | Allowed | Local fixtures |
 | Schedule | Allowed | Allowed | Allowed | Local fixtures |
@@ -18,7 +20,7 @@ Version remains **1.4.3**. Compliance applies only when `VITE_APP_STORE_BUILD=1`
 | Export center | Allowed | Allowed | Allowed | Local fixtures |
 | Settings / About | Allowed | Allowed | Allowed | Same UI |
 | Privacy & data | Allowed | Allowed | Allowed | Same UI |
-| Sponsor / WeChat tip QR (Me) | **Hidden** for guest + demo; allowed only when real-logged-in | Allowed | Allowed | Hidden (demo path) |
+| Sponsor / WeChat tip QR (Me) | **Hidden** for guest + demo; allowed when real-logged-in | Allowed | Allowed | Hidden (demo path) |
 | Today course widget | Allowed | Allowed | N/A | Demo snapshot |
 | Course selection | **Blocked** | Allowed | Allowed | N/A (hidden) |
 | Ranking | **Blocked** | Allowed | Allowed | N/A |
@@ -43,4 +45,4 @@ Version remains **1.4.3**. Compliance applies only when `VITE_APP_STORE_BUILD=1`
 | Config admin tool | **Blocked** | Allowed | Allowed | N/A |
 | Remote config fetch | **Still fetched** (safe fields) | Fetched | Fetched | Default clamped config |
 
-**Demo vs normal (flag on):** identical feature tree; demo only swaps data source to local fixtures (`reviewer` / `Test2026`).
+**Demo vs real (flag on):** demo keeps the restricted review surface + local fixtures (`reviewer` / `Test2026`). Real login unlocks modules/views that are blocked for guest/demo.

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -499,11 +499,17 @@ const baseModules = [
 ]
 
 const modules = computed(() => {
+  // 依赖登录态：合规包真实登录后应展开全功能模块列表
+  void props.isLoggedIn
+  void props.studentId
   const scoped = !isChaoxingMethod(loginMethod.value)
     ? baseModules
     : baseModules.filter((mod) => JWXT_MODULE_ALLOWLIST.has(mod.id))
-  // App Store 合规构建：统一过滤高风险模块（与 reviewer 无关）
-  return filterAllowedModules(scoped)
+  // 合规包：仅 guest / 演示会话过滤高风险模块；真实登录不过滤
+  return filterAllowedModules(scoped, {
+    isLoggedIn: props.isLoggedIn,
+    isDemoSession: isTestAccountSession()
+  })
 })
 
 const homeWorkspaceRef = ref(null)
@@ -546,7 +552,12 @@ let homeCollisionFxRaf = 0
 let homeCollisionFxLastTs = 0
 
 const navigateTo = (moduleId) => {
-  if (!isModuleAllowed(moduleId)) {
+  if (
+    !isModuleAllowed(moduleId, {
+      isLoggedIn: props.isLoggedIn,
+      isDemoSession: isTestAccountSession()
+    })
+  ) {
     showToast('当前版本不可用该功能')
     return
   }

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -114,13 +114,26 @@ const handleOpenMore = () => emit('navigate', 'more')
 const handleOpenPrivacyData = () => emit('navigate', 'privacy_data')
 const isConfigAdmin = () => Array.isArray(props.configAdminIds) && props.configAdminIds.includes(props.studentId)
 
-const showCampusNetwork = computed(() => props.isLoggedIn && isViewAllowed('campus_network'))
-const showSchoolWebsite = computed(() => props.isLoggedIn && isViewAllowed('school_website'))
-const showQuickLinks = computed(() => props.isLoggedIn && isViewAllowed('quick_links'))
-const showServiceStats = computed(() => props.isLoggedIn && isViewAllowed('service_stats'))
-const showMoreModules = computed(() => isViewAllowed('more'))
+const policySession = () => ({
+  isLoggedIn: props.isLoggedIn,
+  isDemoSession: isDemoSession.value
+})
+
+const showCampusNetwork = computed(
+  () => props.isLoggedIn && isViewAllowed('campus_network', policySession())
+)
+const showSchoolWebsite = computed(
+  () => props.isLoggedIn && isViewAllowed('school_website', policySession())
+)
+const showQuickLinks = computed(
+  () => props.isLoggedIn && isViewAllowed('quick_links', policySession())
+)
+const showServiceStats = computed(
+  () => props.isLoggedIn && isViewAllowed('service_stats', policySession())
+)
+const showMoreModules = computed(() => isViewAllowed('more', policySession()))
 const showConfigTool = computed(
-  () => isConfigAdmin() && isViewAllowed('config')
+  () => isConfigAdmin() && isViewAllowed('config', policySession())
 )
 
 const resetDemoData = () => {

--- a/src/config/app_store_policy.spec.ts
+++ b/src/config/app_store_policy.spec.ts
@@ -10,17 +10,21 @@ import {
   isRemoteModulesAllowed,
   isSponsorEntryAllowed,
   isViewAllowed,
-  setAppStoreBuildOverrideForTests
+  setAppStoreBuildOverrideForTests,
+  setAppStoreSessionOverrideForTests,
+  shouldApplyAppStoreRestrictions
 } from './app_store_policy'
 
 describe('app_store_policy', () => {
   afterEach(() => {
     setAppStoreBuildOverrideForTests(null)
+    setAppStoreSessionOverrideForTests(null)
   })
 
   it('flag off: allows representative high-risk modules and views', () => {
     setAppStoreBuildOverrideForTests(false)
     expect(isAppStoreBuild()).toBe(false)
+    expect(shouldApplyAppStoreRestrictions()).toBe(false)
     expect(isModuleAllowed('campus_code')).toBe(true)
     expect(isModuleAllowed('course_selection')).toBe(true)
     expect(isModuleAllowed('towergo')).toBe(true)
@@ -33,9 +37,11 @@ describe('app_store_policy', () => {
     expect(getFeaturePolicy().campusWriteOperations).toBe(true)
   })
 
-  it('flag on: blocks high-risk modules for all users (not reviewer-only)', () => {
+  it('flag on + guest: blocks high-risk modules', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     expect(isAppStoreBuild()).toBe(true)
+    expect(shouldApplyAppStoreRestrictions()).toBe(true)
     const blocked = [
       'campus_code',
       'course_selection',
@@ -64,8 +70,37 @@ describe('app_store_policy', () => {
     }
   })
 
-  it('flag on: keeps core readonly tools', () => {
+  it('flag on + demo session: still blocks high-risk modules', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: true, isDemoSession: true })
+    expect(shouldApplyAppStoreRestrictions()).toBe(true)
+    expect(isModuleAllowed('campus_code')).toBe(false)
+    expect(isModuleAllowed('course_selection')).toBe(false)
+    expect(isViewAllowed('more_module_host')).toBe(false)
+    expect(getFeaturePolicy().remoteCode).toBe(false)
+  })
+
+  it('flag on + real logged-in: unlocks full feature tree', () => {
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: true, isDemoSession: false })
+    expect(shouldApplyAppStoreRestrictions()).toBe(false)
+    expect(isModuleAllowed('campus_code')).toBe(true)
+    expect(isModuleAllowed('course_selection')).toBe(true)
+    expect(isModuleAllowed('towergo')).toBe(true)
+    expect(isModuleAllowed('ranking')).toBe(true)
+    expect(isModuleAllowed('secret_remote_game')).toBe(true)
+    expect(isViewAllowed('more_module_host')).toBe(true)
+    expect(isViewAllowed('school_website')).toBe(true)
+    expect(isHotUpdateAllowed()).toBe(true)
+    expect(isRemoteModulesAllowed()).toBe(true)
+    expect(isCustomJavaScriptAllowed()).toBe(true)
+    expect(getFeaturePolicy().campusWriteOperations).toBe(true)
+    expect(getFeaturePolicy().liveMobilityLocation).toBe(true)
+  })
+
+  it('flag on + guest: keeps core readonly tools', () => {
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     for (const id of [
       'home',
       'schedule',
@@ -92,9 +127,9 @@ describe('app_store_policy', () => {
     expect(isModuleAllowed('__more__')).toBe(true)
   })
 
-  it('flag on: remote policy bits stay locked even if remote would enable modules', () => {
+  it('flag on + guest: remote policy bits stay locked even if remote would enable modules', () => {
     setAppStoreBuildOverrideForTests(true)
-    // Simulate remote config trying to enable everything — policy must still deny
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     const remoteModules = [
       { id: 'campus_code', enabled: true },
       { id: 'towergo', enabled: true },
@@ -110,8 +145,9 @@ describe('app_store_policy', () => {
     expect(getFeaturePolicy().liveMobilityLocation).toBe(false)
   })
 
-  it('flag on: unknown module ids are denied', () => {
+  it('flag on + guest: unknown module ids are denied', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     expect(isModuleAllowed('secret_remote_game')).toBe(false)
     expect(isViewAllowed('unknown_view_xyz')).toBe(false)
   })

--- a/src/config/app_store_policy.ts
+++ b/src/config/app_store_policy.ts
@@ -1,12 +1,15 @@
 /**
  * iOS TestFlight / App Store 合规构建的功能策略中枢。
  *
- * - 仅当编译期 `VITE_APP_STORE_BUILD === '1'` 时收紧（由 ios-testflight.yml 注入）。
+ * - 仅当编译期 `VITE_APP_STORE_BUILD === '1'` 时可能收紧（由 ios-testflight.yml 注入）。
  * - 默认构建 / release / dev / Android / Desktop：全部允许，行为与现网一致。
- * - 模块/视图功能树对合规包全员统一（不因 reviewer 增减模块）；演示账号只换数据源。
- * - 赞助/赞赏入口是唯一会话相关例外（见 isSponsorEntryAllowed）：合规包下 guest/demo 隐藏。
- * - 远程配置不能改写本模块的编译期判定。
+ * - 合规包按**会话**收紧：
+ *   - 未登录 / 演示账号（reviewer）：应用 APP_STORE_POLICY 与模块黑名单（审核路径）
+ *   - 真实教务/学习通等已登录：全功能（与现网一致），含赞助入口
+ * - 远程配置不能在 guest/demo 下改写编译期收紧判定。
  */
+
+import { isTestAccountSession } from '../utils/test_account.js'
 
 /** 编译期注入（见 vite.config.ts define） */
 export const IS_APP_STORE_BUILD: boolean = String(
@@ -16,14 +19,80 @@ export const IS_APP_STORE_BUILD: boolean = String(
 /** 测试用覆盖；生产路径勿调用 */
 let appStoreBuildOverride: boolean | null = null
 
+/** 测试用会话覆盖；生产路径勿调用 */
+let appStoreSessionOverride: { isLoggedIn: boolean; isDemoSession: boolean } | null = null
+
 export function setAppStoreBuildOverrideForTests(value: boolean | null): void {
   appStoreBuildOverride = value
+}
+
+export function setAppStoreSessionOverrideForTests(
+  value: { isLoggedIn: boolean; isDemoSession: boolean } | null
+): void {
+  appStoreSessionOverride = value
 }
 
 /** 当前是否处于 App Store / TestFlight 合规构建 */
 export function isAppStoreBuild(): boolean {
   if (appStoreBuildOverride !== null) return appStoreBuildOverride
   return IS_APP_STORE_BUILD
+}
+
+const readStoredUsername = (): string => {
+  try {
+    return String(globalThis.localStorage?.getItem('hbu_username') || '').trim()
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * 解析当前会话（可注入，便于单测；默认读 localStorage + 演示标记）。
+ */
+export function resolveAppStoreSession(session?: {
+  isLoggedIn?: boolean
+  isDemoSession?: boolean
+}): { isLoggedIn: boolean; isDemoSession: boolean } {
+  if (appStoreSessionOverride) {
+    return {
+      isLoggedIn: Boolean(appStoreSessionOverride.isLoggedIn),
+      isDemoSession: Boolean(appStoreSessionOverride.isDemoSession)
+    }
+  }
+  if (session && (session.isLoggedIn !== undefined || session.isDemoSession !== undefined)) {
+    return {
+      isLoggedIn:
+        session.isLoggedIn !== undefined
+          ? Boolean(session.isLoggedIn)
+          : Boolean(readStoredUsername()),
+      isDemoSession:
+        session.isDemoSession !== undefined
+          ? Boolean(session.isDemoSession)
+          : isTestAccountSession()
+    }
+  }
+  return {
+    isLoggedIn: Boolean(readStoredUsername()),
+    isDemoSession: isTestAccountSession()
+  }
+}
+
+/**
+ * 合规包是否应对当前会话应用收紧策略。
+ * - 非合规构建：false
+ * - 合规 + 演示会话：true
+ * - 合规 + 真实已登录：false（全功能）
+ * - 合规 + 未登录：true
+ */
+export function shouldApplyAppStoreRestrictions(session?: {
+  isLoggedIn?: boolean
+  isDemoSession?: boolean
+}): boolean {
+  if (!isAppStoreBuild()) return false
+  const { isLoggedIn, isDemoSession } = resolveAppStoreSession(session)
+  if (isDemoSession) return true
+  if (isLoggedIn) return false
+  return true
 }
 
 /**
@@ -131,8 +200,11 @@ const APP_STORE_POLICY: AppStoreFeaturePolicy = Object.freeze({
   academicReadonly: true
 })
 
-export function getFeaturePolicy(): AppStoreFeaturePolicy {
-  return isAppStoreBuild() ? APP_STORE_POLICY : FULL_POLICY
+export function getFeaturePolicy(session?: {
+  isLoggedIn?: boolean
+  isDemoSession?: boolean
+}): AppStoreFeaturePolicy {
+  return shouldApplyAppStoreRestrictions(session) ? APP_STORE_POLICY : FULL_POLICY
 }
 
 /** 合规构建下禁止的 module / view id（与 Dashboard / App 路由对齐） */
@@ -190,29 +262,36 @@ const normalizeId = (id: unknown): string => String(id ?? '').trim()
 
 /**
  * 模块宫格 / 业务 module id 是否允许展示与打开。
- * 合规关：全部 true。合规开：黑名单拒绝，其余白名单或未列出的默认拒绝高风险未知 id。
+ * 非合规或真实登录：全部 true。
+ * 合规 guest/demo：黑名单拒绝；其余白名单；未知 id 默认拒绝。
  */
-export function isModuleAllowed(moduleId: unknown): boolean {
+export function isModuleAllowed(
+  moduleId: unknown,
+  session?: { isLoggedIn?: boolean; isDemoSession?: boolean }
+): boolean {
   const id = normalizeId(moduleId)
   if (!id) return false
   if (id === '__more__') {
     // 首页「展开更多分类」按钮，不是远程模块中心
     return true
   }
-  if (!isAppStoreBuild()) return true
+  if (!shouldApplyAppStoreRestrictions(session)) return true
   if (APP_STORE_BLOCKED_MODULE_IDS.has(id)) return false
   if (APP_STORE_ALLOWED_CORE_IDS.has(id)) return true
-  // 未知 id 在合规构建默认拒绝，避免远程/缓存注入新入口
+  // 未知 id 在合规收紧会话默认拒绝，避免远程/缓存注入新入口
   return false
 }
 
 /**
  * 应用 view 名是否允许导航（含 Me 子页、深链目标）。
  */
-export function isViewAllowed(view: unknown): boolean {
+export function isViewAllowed(
+  view: unknown,
+  session?: { isLoggedIn?: boolean; isDemoSession?: boolean }
+): boolean {
   const id = normalizeId(view)
   if (!id) return false
-  if (!isAppStoreBuild()) return true
+  if (!shouldApplyAppStoreRestrictions(session)) return true
   if (APP_STORE_BLOCKED_MODULE_IDS.has(id)) return false
   if (APP_STORE_ALLOWED_CORE_IDS.has(id)) return true
   // 主 Tab 等
@@ -220,12 +299,18 @@ export function isViewAllowed(view: unknown): boolean {
   return false
 }
 
-export function isDeepLinkAllowed(viewOrModule: unknown): boolean {
-  return isViewAllowed(viewOrModule) && isModuleAllowed(viewOrModule)
+export function isDeepLinkAllowed(
+  viewOrModule: unknown,
+  session?: { isLoggedIn?: boolean; isDemoSession?: boolean }
+): boolean {
+  return isViewAllowed(viewOrModule, session) && isModuleAllowed(viewOrModule, session)
 }
 
-export function filterAllowedModules<T extends { id?: string }>(modules: T[]): T[] {
-  return (modules || []).filter((m) => isModuleAllowed(m?.id))
+export function filterAllowedModules<T extends { id?: string }>(
+  modules: T[],
+  session?: { isLoggedIn?: boolean; isDemoSession?: boolean }
+): T[] {
+  return (modules || []).filter((m) => isModuleAllowed(m?.id, session))
 }
 
 /** 合规构建下是否允许实时定位 API */
@@ -265,8 +350,11 @@ export function isSponsorEntryAllowed(options: {
   isLoggedIn: boolean
   isDemoSession: boolean
 }): boolean {
-  if (!isAppStoreBuild()) return true
-  return Boolean(options?.isLoggedIn) && !Boolean(options?.isDemoSession)
+  // 与功能树一致：仅合规 guest/demo 隐藏；真实登录与非合规包均允许
+  return !shouldApplyAppStoreRestrictions({
+    isLoggedIn: Boolean(options?.isLoggedIn),
+    isDemoSession: Boolean(options?.isDemoSession)
+  })
 }
 
 /** 非官方声明（UI 复用） */

--- a/src/utils/campus_network_service.ts
+++ b/src/utils/campus_network_service.ts
@@ -14,7 +14,7 @@ import {
   readCampusNetworkSettings,
   writeCampusNetworkSettings
 } from './campus_network_settings'
-import { getFeaturePolicy, isAppStoreBuild } from '../config/app_store_policy'
+import { getFeaturePolicy } from '../config/app_store_policy'
 
 const FAIL_DEBOUNCE_MS = 10 * 60 * 1000
 const SUCCESS_SKIP_MS = 30 * 60 * 1000
@@ -146,8 +146,8 @@ export const runCampusNetworkAutoLogin = async (options: {
   studentId?: string
   reason?: string
 } = {}): Promise<CampusLoginResult | null> => {
-  // App Store / TestFlight 合规构建：校园网自动认证对所有用户关闭（与 UI 隐藏一致）
-  if (isAppStoreBuild() || !getFeaturePolicy().campusNetwork) {
+  // 合规包 guest/demo：校园网自动认证关闭；真实登录与策略位一致
+  if (!getFeaturePolicy().campusNetwork) {
     return null
   }
   const settings = readCampusNetworkSettings()

--- a/src/utils/cloud_sync.js
+++ b/src/utils/cloud_sync.js
@@ -1780,10 +1780,11 @@ export const runAutoCloudSyncAfterLogin = async ({
   skipDownload = false
 } = {}) => {
   try {
-    const { isAppStoreBuild } = await import('../config/app_store_policy')
+    const { shouldApplyAppStoreRestrictions } = await import('../config/app_store_policy')
     const { isTestAccountSession } = await import('./test_account.js')
-    if (isAppStoreBuild() || isTestAccountSession()) {
-      pushDebugLog('CloudSync', '跳过自动云同步：App Store 构建或演示会话', 'info')
+    // 合规 guest/demo 跳过；真实登录允许（与功能树一致）
+    if (shouldApplyAppStoreRestrictions() || isTestAccountSession()) {
+      pushDebugLog('CloudSync', '跳过自动云同步：合规收紧会话或演示会话', 'info')
       return { success: false, reason: 'app-store-or-demo' }
     }
   } catch {

--- a/src/utils/remote_config.js
+++ b/src/utils/remote_config.js
@@ -3,7 +3,7 @@ import { detectRuntime } from '../platform/runtime'
 import { DEFAULT_CLOUD_SYNC_ENDPOINT, useAppSettings } from './app_settings'
 import { DEFAULT_MODULE_CENTER as DEFAULT_GAME_MODULE_CENTER } from './module_center'
 import { isTestAccountSession } from './test_account.js'
-import { isAppStoreBuild } from '../config/app_store_policy'
+import { shouldApplyAppStoreRestrictions } from '../config/app_store_policy'
 
 const CONFIG_URLS = [
   'https://raw.gitcode.com/superdaobo/mini-hbut-config/raw/main/remote_config.json',
@@ -563,11 +563,11 @@ export function normalizeRemoteConfig(raw) {
 }
 
 /**
- * 合规构建：仍返回已拉取的配置，但锁死高风险能力（远程 true 无法打开）。
- * 非合规构建原样返回。
+ * 合规包 guest/demo：仍返回已拉取的配置，但锁死高风险能力（远程 true 无法打开）。
+ * 非合规构建或真实登录：原样返回。
  */
 export function applyAppStoreRemoteConfigClamp(config) {
-  if (!isAppStoreBuild() || !config || typeof config !== 'object') return config
+  if (!shouldApplyAppStoreRestrictions() || !config || typeof config !== 'object') return config
   const next = { ...config }
   // 公告 / force_update / OCR HTTPS 端点可保留
   next.module_center = {
@@ -879,6 +879,7 @@ export const applyOcrRuntimeConfig = async (configLike) => {
 
 export async function fetchRemoteConfig(options = {}) {
   const forceRefresh = options?.force === true
+  // 演示会话：直接用本地默认并按当前会话夹紧（不污染磁盘上的真实配置）
   if (isTestAccountSession()) {
     return applyAppStoreRemoteConfigClamp(normalizeRemoteConfig(DEFAULT_CONFIG))
   }
@@ -889,6 +890,7 @@ export async function fetchRemoteConfig(options = {}) {
   if (!forceRefresh) {
     const memory = readMemoryConfig()
     if (memory) {
+      // 内存/快照存未夹紧原文；按当前会话（guest/demo vs 真实登录）再夹紧
       return applyAppStoreRemoteConfigClamp(memory)
     }
     if (remoteConfigInFlight) {
@@ -902,23 +904,24 @@ export async function fetchRemoteConfig(options = {}) {
       if (!isLikelyRemoteConfigPayload(raw)) {
         throw new Error('invalid remote config payload')
       }
-      const normalized = applyAppStoreRemoteConfigClamp(normalizeRemoteConfig(raw))
+      // 持久化未夹紧配置，避免 guest 阶段夹紧后污染真实登录会话
+      const normalized = normalizeRemoteConfig(raw)
       // 远程返回即视为有效配置（即使公告为空/关闭 OCR），避免被旧快照反向覆盖。
       saveSnapshot(normalized)
-      return normalized
+      return applyAppStoreRemoteConfigClamp(normalized)
     } catch {
       // ignore
     }
 
     const snapshot = loadSnapshot()
     if (snapshot) {
-      const normalized = applyAppStoreRemoteConfigClamp(normalizeRemoteConfig(snapshot))
+      const normalized = normalizeRemoteConfig(snapshot)
       saveSnapshot(normalized)
-      return normalized
+      return applyAppStoreRemoteConfigClamp(normalized)
     }
-    const fallback = applyAppStoreRemoteConfigClamp(normalizeRemoteConfig(DEFAULT_CONFIG))
+    const fallback = normalizeRemoteConfig(DEFAULT_CONFIG)
     saveSnapshot(fallback)
-    return fallback
+    return applyAppStoreRemoteConfigClamp(fallback)
   })()
 
   if (forceRefresh) {

--- a/src/utils/remote_config_app_store.spec.ts
+++ b/src/utils/remote_config_app_store.spec.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { setAppStoreBuildOverrideForTests } from '../config/app_store_policy'
+import {
+  setAppStoreBuildOverrideForTests,
+  setAppStoreSessionOverrideForTests
+} from '../config/app_store_policy'
 import { applyAppStoreRemoteConfigClamp, normalizeRemoteConfig } from './remote_config.js'
 
 describe('remote_config App Store clamp', () => {
   afterEach(() => {
     setAppStoreBuildOverrideForTests(null)
+    setAppStoreSessionOverrideForTests(null)
   })
 
   it('flag off: does not empty module_center from remote-like payload', () => {
@@ -24,8 +28,9 @@ describe('remote_config App Store clamp', () => {
     expect(clamped.forum.enabled).toBe(true)
   })
 
-  it('flag on: keeps fetch-shaped config but locks dangerous capabilities', () => {
+  it('flag on + guest: keeps fetch-shaped config but locks dangerous capabilities', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     const normalized = normalizeRemoteConfig({
       announcements: {
         ticker: [{ id: 't1', title: 'ok', summary: 's', content: 'c', updated_at: '2026-01-01' }]
@@ -60,5 +65,23 @@ describe('remote_config App Store clamp', () => {
     expect(clamped.ocr.local_fallback_endpoints.every((u) => String(u).startsWith('https://'))).toBe(
       true
     )
+  })
+
+  it('flag on + real login: does not clamp remote module capabilities', () => {
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: true, isDemoSession: false })
+    const normalized = normalizeRemoteConfig({
+      module_center: {
+        channel: 'main',
+        modules: [{ id: 'jump_out_hbut', name: 'game' }]
+      },
+      resource_share: { enabled: true },
+      forum: { enabled: true },
+      cloud_sync: { enabled: true }
+    })
+    const clamped = applyAppStoreRemoteConfigClamp(normalized)
+    expect(clamped.module_center.modules.length).toBeGreaterThan(0)
+    expect(clamped.resource_share.enabled).toBe(true)
+    expect(clamped.forum.enabled).toBe(true)
   })
 })

--- a/src/utils/usage_uploader.js
+++ b/src/utils/usage_uploader.js
@@ -5,7 +5,7 @@ import {
   clearWebUsagePendingQueues,
   getWebUsagePendingQueues
 } from './usage_tracker'
-import { isAppStoreBuild } from '../config/app_store_policy'
+import { shouldApplyAppStoreRestrictions } from '../config/app_store_policy'
 import { isTestAccountSession } from './test_account.js'
 
 const CLOUD_SYNC_DEVICE_ID_KEY = 'hbu_cloud_sync_device_id'
@@ -191,8 +191,9 @@ export const runUsageStatsUpload = async ({
   reason = 'manual',
   force = false
 } = {}) => {
-  if (isAppStoreBuild() || isTestAccountSession()) {
-    return { success: false, error: 'usage 上传已在当前构建/演示会话禁用' }
+  // 合规 guest/demo 禁用；真实登录允许
+  if (shouldApplyAppStoreRestrictions() || isTestAccountSession()) {
+    return { success: false, error: 'usage 上传已在当前合规收紧会话/演示会话禁用' }
   }
   const sid = toSafeText(studentId)
   if (!isValidStudentId(sid)) {


### PR DESCRIPTION
## Summary

- **原因**：`VITE_APP_STORE_BUILD=1` 时功能树对所有用户统一收紧，真实教务/学习通账号也会被隐藏校园码、选课等模块（不是演示账号误判）。
- **修复**：引入 `shouldApplyAppStoreRestrictions` —— 仅 **未登录 / 演示会话** 收紧；**真实登录** 与现网全功能一致。
- Dashboard 登录后响应式刷新模块列表；远程配置改为「未夹紧持久化 + 按会话读时夹紧」，避免 guest 污染真实登录。
- 文档与单测同步。

## Test plan

- [x] `npx vitest run src/config/app_store_policy.spec.ts src/utils/remote_config_app_store.spec.ts src/utils/campus_network_contract.spec.ts`
- [ ] 合规包 guest：仍无高风险模块 / 赞助
- [ ] 合规包 reviewer：仍收紧
- [ ] 合规包真实登录：完整模块树恢复
