### PR TITLE
feat: 合规 iOS 包走 App Store 更新引导 (#441)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -27,6 +27,8 @@ env:
   MINI_HBUT_BUILD_PROFILE: release
   # App Store / TestFlight 合规编译开关：仅本 workflow 注入。dev-build/release/本地默认 build 不设置。
   VITE_APP_STORE_BUILD: "1"
+  # App Store Connect → App 信息 → Apple ID（公开数字 id，非密钥）
+  VITE_APPLE_APP_ID: "6787857278"
   npm_config_audit: "false"
   npm_config_fund: "false"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/docs/app-store/APP_STORE_RELEASE_CHECKLIST.md
+++ b/docs/app-store/APP_STORE_RELEASE_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 - [ ] Version strings still `1.4.3` (package.json, tauri.conf.json)
 - [ ] `ios-testflight.yml` has `VITE_APP_STORE_BUILD: "1"`
-- [ ] 合规包更新仅走 App Store Lookup / 商店引导（无 GitHub/CDN IPA）；可选 `VITE_APPLE_APP_ID`
+- [ ] 合规包更新仅走 App Store Lookup / 商店引导（无 GitHub/CDN IPA）；`VITE_APPLE_APP_ID=6787857278`
 - [ ] `dev-build.yml` / `release.yml` do **not** set compliance flag
 - [ ] Default `npm run build` compliance flag off
 - [ ] Policy unit tests green

--- a/docs/app-store/APP_STORE_RELEASE_CHECKLIST.md
+++ b/docs/app-store/APP_STORE_RELEASE_CHECKLIST.md
@@ -2,6 +2,7 @@
 
 - [ ] Version strings still `1.4.3` (package.json, tauri.conf.json)
 - [ ] `ios-testflight.yml` has `VITE_APP_STORE_BUILD: "1"`
+- [ ] 合规包更新仅走 App Store Lookup / 商店引导（无 GitHub/CDN IPA）；可选 `VITE_APPLE_APP_ID`
 - [ ] `dev-build.yml` / `release.yml` do **not** set compliance flag
 - [ ] Default `npm run build` compliance flag off
 - [ ] Policy unit tests green

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,11 @@ import {
   SCHEDULE_POPUP_PENDING_KEY,
   SCHEDULE_SWITCH_PENDING_KEY
 } from './utils/schedule_prefetch.js'
+import {
+  checkAppleStoreUpdate,
+  getSkippedAppleStoreVersion,
+  openAppStoreUpdatePage
+} from './utils/apple_app_update'
 import { checkForUpdates, getCurrentVersion, toGhProxyUrl } from './utils/updater.js'
 import {
   fetchRemoteConfig,
@@ -78,7 +83,7 @@ import {
   isLoginRequiredView,
   normalizeViewName
 } from './navigation/app_navigation.ts'
-import { isViewAllowed } from './config/app_store_policy'
+import { allowsInAppGithubUpdater, isViewAllowed } from './config/app_store_policy'
 import {
   resolvePolicySafeSnapshotView,
   resolvePolicySafeView
@@ -553,11 +558,19 @@ const showForceUpdate = ref(false)
 const forceUpdateInfo = ref(null)
 const protectedViewPromptTitle = computed(() => getProtectedViewLabel(pendingProtectedView.value?.view))
 const forceUpdateResolvedUrl = computed(() => {
+  // 合规包禁止旁加载 / GitHub 下载链，只走 App Store
+  if (!allowsInAppGithubUpdater()) {
+    const store = String(forceUpdateInfo.value?.store_url || '').trim()
+    return store
+  }
   const raw = String(forceUpdateInfo.value?.download_url || '').trim()
   if (!raw) return ''
   return toGhProxyUrl(raw) || raw
 })
 const forceUpdateDisplayUrl = computed(() => {
+  if (!allowsInAppGithubUpdater() && !forceUpdateResolvedUrl.value) {
+    return '请在 App Store 中更新'
+  }
   const target = String(forceUpdateResolvedUrl.value || '').trim()
   if (!target) return '未提供下载地址'
   return target.length > 68 ? `${target.slice(0, 65)}...` : target
@@ -2412,16 +2425,28 @@ const dismissSplash = (reason = '') => {
   }
 }
 
-// 自动检查更新（尊重用户频道：默认 stable，开启 dev 后才查 beta）
+// 自动检查更新：
+// - 合规 iOS 包：仅 App Store Lookup（无 GitHub/CDN）
+// - 其它构建：尊重用户频道（默认 stable，开启 dev 后才查 beta）
 const autoCheckUpdate = async () => {
   // 官网 Hero 离线演示：禁止版本检查外连
   if (isWebsiteDemoBuild() || isTestAccountSession()) return
   try {
-    const { getUpdateChannel, getSkippedVersion } = await import('./utils/updater.js')
     const currentVersion = await getCurrentVersion()
+
+    if (!allowsInAppGithubUpdater()) {
+      const result = await checkAppleStoreUpdate(currentVersion)
+      const skipped = getSkippedAppleStoreVersion()
+      if (result?.hasUpdate && result.storeVersion && result.storeVersion !== skipped) {
+        showUpdateDialog.value = true
+      }
+      return
+    }
+
+    const { getUpdateChannel, getSkippedVersion } = await import('./utils/updater.js')
     const channel = getUpdateChannel()
     const skippedVersion = getSkippedVersion(channel)
-    
+
     const result = await checkForUpdates(currentVersion, { channel })
     if (result?.hasUpdate && result.latestVersion !== skippedVersion) {
       showUpdateDialog.value = true
@@ -2432,6 +2457,16 @@ const autoCheckUpdate = async () => {
 }
 
 const handleForceUpdate = async () => {
+  if (!allowsInAppGithubUpdater()) {
+    const opened = await openAppStoreUpdatePage({
+      trackViewUrl: forceUpdateInfo.value?.store_url,
+      trackId: forceUpdateInfo.value?.apple_app_id
+    })
+    if (!opened && forceUpdateResolvedUrl.value) {
+      await openExternal(forceUpdateResolvedUrl.value)
+    }
+    return
+  }
   if (forceUpdateResolvedUrl.value) {
     await openExternal(forceUpdateResolvedUrl.value)
     return
@@ -2495,12 +2530,26 @@ const applyRemoteConfig = async () => {
     if (minVersion) {
       const currentVersion = await getCurrentVersion()
       if (compareVersions(currentVersion, minVersion) < 0) {
-        forceUpdateInfo.value = {
-          min_version: minVersion,
-          message: config.force_update?.message || '当前版本过低，请更新后继续使用。',
-          download_url: config.force_update?.download_url || ''
+        if (!allowsInAppGithubUpdater()) {
+          // 合规包：强制更新只引导 App Store，禁止旁加载 download_url
+          forceUpdateInfo.value = {
+            min_version: minVersion,
+            message:
+              config.force_update?.message ||
+              '当前版本过低，请通过 App Store 更新后继续使用。',
+            download_url: '',
+            store_url: '',
+            apple_app_id: ''
+          }
+          showForceUpdate.value = true
+        } else {
+          forceUpdateInfo.value = {
+            min_version: minVersion,
+            message: config.force_update?.message || '当前版本过低，请更新后继续使用。',
+            download_url: config.force_update?.download_url || ''
+          }
+          showForceUpdate.value = true
         }
-        showForceUpdate.value = true
       }
     }
 

--- a/src/components/UpdateDialog.vue
+++ b/src/components/UpdateDialog.vue
@@ -1,5 +1,12 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { getUpdateCheckMode } from '../config/app_store_policy'
+import {
+  checkAppleStoreUpdate,
+  openAppStoreUpdatePage,
+  openTestFlightApp,
+  setSkippedAppleStoreVersion
+} from '../utils/apple_app_update'
 import {
   checkForUpdates,
   describeUpdateDownloadSource,
@@ -16,16 +23,20 @@ const emit = defineEmits(['close'])
 
 const checking = ref(true)
 const updateInfo = ref(null)
+const appleInfo = ref(null)
 const downloading = ref(false)
 const downloadProgress = ref(0)
 const error = ref('')
 const currentVersion = ref('')
 const updateChannel = ref(getUpdateChannel())
+const updateMode = ref(getUpdateCheckMode())
+const openingStore = ref(false)
 
 // 下载源速度测试
 const sourceSpeedResults = ref({}) // { url: { ms: number, status: 'testing'|'ok'|'fail'|'slow' } }
 const showSourceTable = ref(false)
 
+const isAppleMode = computed(() => updateMode.value === 'apple_storefront')
 const isDevChannel = computed(() => updateChannel.value === 'dev')
 /** 接收更新偏好（开关），不是安装身份 */
 const channelBadge = computed(() => (isDevChannel.value ? '开发版' : '正式版'))
@@ -41,10 +52,23 @@ const checkUpdate = async () => {
   error.value = ''
   showSourceTable.value = false
   sourceSpeedResults.value = {}
-  
+  updateInfo.value = null
+  appleInfo.value = null
+  updateMode.value = getUpdateCheckMode()
+
   try {
     const version = currentVersion.value || await getCurrentVersion()
     currentVersion.value = version
+
+    if (isAppleMode.value) {
+      const result = await checkAppleStoreUpdate(version)
+      appleInfo.value = result
+      if (result.error) {
+        error.value = result.message || '检查更新失败，请稍后重试'
+      }
+      return
+    }
+
     const result = await checkForUpdates(version, { channel: updateChannel.value })
     updateInfo.value = result
   } catch (e) {
@@ -53,6 +77,40 @@ const checkUpdate = async () => {
   } finally {
     checking.value = false
   }
+}
+
+const handleOpenAppStore = async () => {
+  openingStore.value = true
+  try {
+    const ok = await openAppStoreUpdatePage({
+      trackId: appleInfo.value?.trackId,
+      trackViewUrl: appleInfo.value?.trackViewUrl
+    })
+    if (!ok) {
+      error.value = '无法打开 App Store，请手动在商店中搜索 Mini-HBUT'
+    }
+  } finally {
+    openingStore.value = false
+  }
+}
+
+const handleOpenTestFlight = async () => {
+  openingStore.value = true
+  try {
+    const ok = await openTestFlightApp(appleInfo.value?.trackId)
+    if (!ok) {
+      error.value = '无法打开 TestFlight，请从主屏幕打开 TestFlight App'
+    }
+  } finally {
+    openingStore.value = false
+  }
+}
+
+const handleSkipApple = () => {
+  if (appleInfo.value?.storeVersion) {
+    setSkippedAppleStoreVersion(appleInfo.value.storeVersion)
+  }
+  emit('close')
 }
 
 const handleChannelToggle = () => {
@@ -174,132 +232,201 @@ onMounted(() => {
   <div class="update-dialog-overlay" @click.self="emit('close')">
     <div class="update-dialog">
       <div class="dialog-header">
-        <span class="material-symbols-outlined dialog-header-icon">sync</span>
-        <h3>版本更新</h3>
+        <span class="material-symbols-outlined dialog-header-icon">{{ isAppleMode ? 'shop' : 'sync' }}</span>
+        <h3>{{ isAppleMode ? 'App 更新' : '版本更新' }}</h3>
       </div>
 
       <div class="dialog-content">
-        <!-- 频道选择：用户可选接收开发版推送 -->
-        <div class="channel-row">
-          <div class="channel-copy">
-            <strong>接收开发版更新（Beta）</strong>
-            <p>开启后从 CDN / GitHub <code>dev-latest</code> 检查预发布构建，可能不稳定。</p>
-          </div>
-          <button
-            type="button"
-            class="channel-switch"
-            :class="{ on: isDevChannel }"
-            :aria-pressed="isDevChannel"
-            @click="handleChannelToggle"
-          >
-            <span class="channel-knob" />
-          </button>
-        </div>
-        <div class="channel-badge-row">
-          <span class="channel-pill" :data-channel="isInstallDev ? 'dev' : 'stable'">
-            当前安装：{{ installBadge }}
-          </span>
-          <span class="channel-pill" :data-channel="updateChannel">接收频道：{{ channelBadge }}</span>
-        </div>
-        <p v-if="isInstallDev && !isDevChannel" class="install-hint">
-          当前安装为开发版。若要继续接收 Beta 推送，请打开上方开关。
-        </p>
-
-        <!-- 检查中 -->
-        <div v-if="checking" class="checking">
-          <div class="spinner"></div>
-          <p>正在检查{{ isDevChannel ? '开发版' : '正式版' }}更新...</p>
-        </div>
-
-        <!-- 有更新 -->
-        <template v-else-if="updateInfo?.hasUpdate">
-          <div class="version-info">
-            <div class="version-badge current" :data-install="isInstallDev ? 'dev' : 'stable'">
-              {{ currentVersionLabel }}
-            </div>
-            <span class="arrow">→</span>
-            <div class="version-badge new" :data-channel="updateInfo.channel || updateChannel">
-              {{ updateInfo.isPrerelease || isDevChannel ? '开发版' : '新版本' }}
-              v{{ updateInfo.latestVersion }}
-            </div>
-          </div>
-          
-          <div class="release-notes">
-            <h4>更新内容:</h4>
-            <div class="notes-content" v-html="updateInfo.releaseNotes.replace(/\n/g, '<br>')"></div>
+        <!-- 合规包：苹果商店路径（无 GitHub/CDN 频道与下载） -->
+        <template v-if="isAppleMode">
+          <p class="apple-lead">
+            本安装通过 App Store / TestFlight 分发。版本检查仅对照 App Store 正式版，不会下载 GitHub 安装包。
+          </p>
+          <div class="channel-badge-row">
+            <span class="channel-pill" data-channel="stable">当前 v{{ currentVersion || '--' }}</span>
+            <span v-if="appleInfo?.storeVersion" class="channel-pill" data-channel="stable">
+              商店 v{{ appleInfo.storeVersion }}
+            </span>
           </div>
 
-          <!-- 下载进度条 -->
-          <div v-if="downloading" class="download-progress">
-            <div class="progress-bar">
-              <div class="progress-fill" :style="{ width: downloadProgress + '%' }"></div>
-            </div>
-            <span class="progress-text">{{ downloadProgress }}%</span>
+          <div v-if="checking" class="checking">
+            <div class="spinner"></div>
+            <p>正在查询 App Store…</p>
           </div>
 
-          <!-- 下载源选择表 -->
-          <div v-if="showSourceTable && !downloading" class="source-table">
-            <div class="source-table-header">
-              <span>选择下载线路</span>
-              <button class="retest-btn" @click="testAllSources">重新测速</button>
+          <template v-else-if="appleInfo?.hasUpdate">
+            <div class="version-info">
+              <div class="version-badge current">当前 v{{ appleInfo.currentVersion }}</div>
+              <span class="arrow">→</span>
+              <div class="version-badge new">商店 v{{ appleInfo.storeVersion }}</div>
             </div>
-            <div class="source-list">
-              <div
-                v-for="source in downloadSources"
-                :key="source.url"
-                class="source-row"
-                @click="handleDownloadFromSource(source.url)"
-              >
-                <div class="source-label">
-                  <span class="material-symbols-outlined source-icon">{{ source.tag === 'github' ? 'code' : 'link' }}</span>
-                  <span>{{ source.label }}</span>
-                </div>
-                <div class="source-speed">
-                  <span
-                    :class="['speed-badge', getSpeedColor(sourceSpeedResults[source.url]?.status)]"
-                  >
-                    {{ getSpeedText(sourceSpeedResults[source.url]) }}
-                  </span>
+            <p class="apple-message">{{ appleInfo.message }}</p>
+          </template>
+
+          <template v-else-if="appleInfo && !appleInfo.error">
+            <div class="up-to-date">
+              <span class="material-symbols-outlined status-icon status-icon--success">check_circle</span>
+              <p>{{ appleInfo.notOnStore ? '商店暂无正式版记录' : '已是 App Store 最新正式版' }}</p>
+              <span class="version">当前 v{{ currentVersion }}</span>
+              <span v-if="appleInfo.storeVersion" class="version muted">商店 v{{ appleInfo.storeVersion }}</span>
+              <p class="apple-tf-hint">
+                若你安装的是 TestFlight 测试版，请打开 TestFlight 查看是否有新的测试构建。
+              </p>
+            </div>
+          </template>
+
+          <div v-else-if="error || appleInfo?.error" class="error">
+            <span class="material-symbols-outlined status-icon status-icon--warn">error</span>
+            <p>{{ error || appleInfo?.message || '无法查询 App Store' }}</p>
+            <button class="retry-btn" @click="checkUpdate">重试</button>
+          </div>
+        </template>
+
+        <!-- 非合规：原 GitHub/CDN 更新 -->
+        <template v-else>
+          <!-- 频道选择：用户可选接收开发版推送 -->
+          <div class="channel-row">
+            <div class="channel-copy">
+              <strong>接收开发版更新（Beta）</strong>
+              <p>开启后从 CDN / GitHub <code>dev-latest</code> 检查预发布构建，可能不稳定。</p>
+            </div>
+            <button
+              type="button"
+              class="channel-switch"
+              :class="{ on: isDevChannel }"
+              :aria-pressed="isDevChannel"
+              @click="handleChannelToggle"
+            >
+              <span class="channel-knob" />
+            </button>
+          </div>
+          <div class="channel-badge-row">
+            <span class="channel-pill" :data-channel="isInstallDev ? 'dev' : 'stable'">
+              当前安装：{{ installBadge }}
+            </span>
+            <span class="channel-pill" :data-channel="updateChannel">接收频道：{{ channelBadge }}</span>
+          </div>
+          <p v-if="isInstallDev && !isDevChannel" class="install-hint">
+            当前安装为开发版。若要继续接收 Beta 推送，请打开上方开关。
+          </p>
+
+          <!-- 检查中 -->
+          <div v-if="checking" class="checking">
+            <div class="spinner"></div>
+            <p>正在检查{{ isDevChannel ? '开发版' : '正式版' }}更新...</p>
+          </div>
+
+          <!-- 有更新 -->
+          <template v-else-if="updateInfo?.hasUpdate">
+            <div class="version-info">
+              <div class="version-badge current" :data-install="isInstallDev ? 'dev' : 'stable'">
+                {{ currentVersionLabel }}
+              </div>
+              <span class="arrow">→</span>
+              <div class="version-badge new" :data-channel="updateInfo.channel || updateChannel">
+                {{ updateInfo.isPrerelease || isDevChannel ? '开发版' : '新版本' }}
+                v{{ updateInfo.latestVersion }}
+              </div>
+            </div>
+            
+            <div class="release-notes">
+              <h4>更新内容:</h4>
+              <div class="notes-content" v-html="updateInfo.releaseNotes.replace(/\n/g, '<br>')"></div>
+            </div>
+
+            <!-- 下载进度条 -->
+            <div v-if="downloading" class="download-progress">
+              <div class="progress-bar">
+                <div class="progress-fill" :style="{ width: downloadProgress + '%' }"></div>
+              </div>
+              <span class="progress-text">{{ downloadProgress }}%</span>
+            </div>
+
+            <!-- 下载源选择表 -->
+            <div v-if="showSourceTable && !downloading" class="source-table">
+              <div class="source-table-header">
+                <span>选择下载线路</span>
+                <button class="retest-btn" @click="testAllSources">重新测速</button>
+              </div>
+              <div class="source-list">
+                <div
+                  v-for="source in downloadSources"
+                  :key="source.url"
+                  class="source-row"
+                  @click="handleDownloadFromSource(source.url)"
+                >
+                  <div class="source-label">
+                    <span class="material-symbols-outlined source-icon">{{ source.tag === 'github' ? 'code' : 'link' }}</span>
+                    <span>{{ source.label }}</span>
+                  </div>
+                  <div class="source-speed">
+                    <span
+                      :class="['speed-badge', getSpeedColor(sourceSpeedResults[source.url]?.status)]"
+                    >
+                      {{ getSpeedText(sourceSpeedResults[source.url]) }}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <div class="platform-info">
-            <span class="platform-line"><span class="material-symbols-outlined platform-icon">smartphone</span> 检测到平台: {{ updateInfo.platform }}</span>
-            <span v-if="updateInfo.assetName" class="platform-line"><span class="material-symbols-outlined platform-icon">inventory_2</span> {{ updateInfo.assetName }}</span>
+            <div class="platform-info">
+              <span class="platform-line"><span class="material-symbols-outlined platform-icon">smartphone</span> 检测到平台: {{ updateInfo.platform }}</span>
+              <span v-if="updateInfo.assetName" class="platform-line"><span class="material-symbols-outlined platform-icon">inventory_2</span> {{ updateInfo.assetName }}</span>
+            </div>
+          </template>
+
+          <!-- 构建中/无可用下载资产 -->
+          <template v-else-if="updateInfo?.pending">
+            <div class="up-to-date">
+              <span class="material-symbols-outlined status-icon">hourglass_top</span>
+              <p>新版本正在构建中，请稍后再试</p>
+              <span class="version">v{{ updateInfo.latestVersion }}</span>
+            </div>
+          </template>
+
+          <!-- 已是最新 -->
+          <template v-else-if="updateInfo && !updateInfo.hasUpdate && !updateInfo.error">
+            <div class="up-to-date">
+              <span class="material-symbols-outlined status-icon status-icon--success">check_circle</span>
+              <p>{{ isDevChannel ? '已是最新开发版' : '已是最新正式版' }}</p>
+              <span class="version">{{ currentVersionLabel }}</span>
+              <span v-if="updateInfo.latestVersion" class="version muted">远端 {{ updateInfo.latestVersion }}</span>
+            </div>
+          </template>
+
+          <!-- 错误 -->
+          <div v-else-if="error || updateInfo?.error" class="error">
+            <span class="material-symbols-outlined status-icon status-icon--warn">error</span>
+            <p>{{ error || updateInfo?.message || '无法获取更新信息，请检查网络连接' }}</p>
+            <button class="retry-btn" @click="checkUpdate">重试</button>
           </div>
         </template>
-
-        <!-- 构建中/无可用下载资产 -->
-        <template v-else-if="updateInfo?.pending">
-          <div class="up-to-date">
-            <span class="material-symbols-outlined status-icon">hourglass_top</span>
-            <p>新版本正在构建中，请稍后再试</p>
-            <span class="version">v{{ updateInfo.latestVersion }}</span>
-          </div>
-        </template>
-
-        <!-- 已是最新 -->
-        <template v-else-if="updateInfo && !updateInfo.hasUpdate && !updateInfo.error">
-          <div class="up-to-date">
-            <span class="material-symbols-outlined status-icon status-icon--success">check_circle</span>
-            <p>{{ isDevChannel ? '已是最新开发版' : '已是最新正式版' }}</p>
-            <span class="version">{{ currentVersionLabel }}</span>
-            <span v-if="updateInfo.latestVersion" class="version muted">远端 {{ updateInfo.latestVersion }}</span>
-          </div>
-        </template>
-
-        <!-- 错误 -->
-        <div v-else-if="error || updateInfo?.error" class="error">
-          <span class="material-symbols-outlined status-icon status-icon--warn">error</span>
-          <p>{{ error || updateInfo?.message || '无法获取更新信息，请检查网络连接' }}</p>
-          <button class="retry-btn" @click="checkUpdate">重试</button>
-        </div>
       </div>
 
       <div class="dialog-actions">
-        <template v-if="updateInfo?.hasUpdate">
+        <template v-if="isAppleMode && appleInfo?.hasUpdate">
+          <button class="btn-secondary update-action-secondary" @click="handleSkipApple">稍后</button>
+          <button
+            class="btn-primary update-action-primary"
+            :disabled="openingStore"
+            @click="handleOpenAppStore"
+          >
+            {{ openingStore ? '打开中…' : '前往 App Store 更新' }}
+          </button>
+        </template>
+        <template v-else-if="isAppleMode">
+          <button
+            v-if="!checking"
+            class="btn-secondary update-action-secondary"
+            :disabled="openingStore"
+            @click="handleOpenTestFlight"
+          >
+            打开 TestFlight
+          </button>
+          <button class="btn-primary" @click="emit('close')">关闭</button>
+        </template>
+        <template v-else-if="updateInfo?.hasUpdate">
           <button class="btn-secondary update-action-secondary" @click="handleSkip">跳过此版本</button>
           <button class="btn-primary update-action-primary" @click="handleDownload" :disabled="downloading || showSourceTable">
             {{ downloading ? '下载中...' : showSourceTable ? '请选择线路' : '立即更新' }}
@@ -314,6 +441,24 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.apple-lead {
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary, #64748b);
+}
+.apple-message {
+  margin: 12px 0 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-primary, #0f172a);
+}
+.apple-tf-hint {
+  margin: 10px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary, #64748b);
+}
 .update-dialog-overlay {
   position: fixed;
   top: 0;

--- a/src/config/app_store_policy.spec.ts
+++ b/src/config/app_store_policy.spec.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  allowsInAppGithubUpdater,
   filterAllowedModules,
   getFeaturePolicy,
+  getUpdateCheckMode,
   isAppStoreBuild,
   isCustomJavaScriptAllowed,
   isDeepLinkAllowed,
@@ -19,6 +21,19 @@ describe('app_store_policy', () => {
   afterEach(() => {
     setAppStoreBuildOverrideForTests(null)
     setAppStoreSessionOverrideForTests(null)
+  })
+
+  it('update path: github allowed only when not app-store build (even if logged in)', () => {
+    setAppStoreBuildOverrideForTests(false)
+    expect(allowsInAppGithubUpdater()).toBe(true)
+    expect(getUpdateCheckMode()).toBe('github_cdn')
+
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: true, isDemoSession: false })
+    // 真实登录后 session 收紧关闭，但更新仍走苹果路径
+    expect(shouldApplyAppStoreRestrictions()).toBe(false)
+    expect(allowsInAppGithubUpdater()).toBe(false)
+    expect(getUpdateCheckMode()).toBe('apple_storefront')
   })
 
   it('flag off: allows representative high-risk modules and views', () => {

--- a/src/config/app_store_policy.ts
+++ b/src/config/app_store_policy.ts
@@ -38,6 +38,21 @@ export function isAppStoreBuild(): boolean {
   return IS_APP_STORE_BUILD
 }
 
+/**
+ * 是否允许软件内 GitHub / CDN 更新与旁加载安装包。
+ * 必须挂在 isAppStoreBuild()：真实登录后 session 收紧会放开，不能用来关更新。
+ */
+export function allowsInAppGithubUpdater(): boolean {
+  return !isAppStoreBuild()
+}
+
+/** 检查更新路径：合规包走苹果商店，其它构建走 GitHub/CDN */
+export type UpdateCheckMode = 'github_cdn' | 'apple_storefront'
+
+export function getUpdateCheckMode(): UpdateCheckMode {
+  return isAppStoreBuild() ? 'apple_storefront' : 'github_cdn'
+}
+
 const readStoredUsername = (): string => {
   try {
     return String(globalThis.localStorage?.getItem('hbu_username') || '').trim()

--- a/src/utils/apple_app_update.spec.ts
+++ b/src/utils/apple_app_update.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setAppStoreBuildOverrideForTests } from '../config/app_store_policy'
+import {
+  buildAppStoreOpenUrls,
+  buildTestFlightOpenUrls,
+  checkAppleStoreUpdate
+} from './apple_app_update'
+
+describe('apple_app_update', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    setAppStoreBuildOverrideForTests(true)
+  })
+
+  afterEach(() => {
+    setAppStoreBuildOverrideForTests(null)
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('builds App Store and TestFlight open URLs', () => {
+    const storeUrls = buildAppStoreOpenUrls({
+      trackId: '123',
+      trackViewUrl: 'https://apps.apple.com/app/id123'
+    })
+    expect(storeUrls[0]).toBe('https://apps.apple.com/app/id123')
+    expect(storeUrls).toContain('itms-apps://apps.apple.com/app/id123')
+    expect(buildTestFlightOpenUrls('123')).toContain('itms-beta://beta.itunes.apple.com/v1/app/123')
+    expect(buildTestFlightOpenUrls()).toContain('itms-beta://')
+  })
+
+  it('reports update when store version is newer', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        resultCount: 1,
+        results: [
+          {
+            version: '9.9.9',
+            trackId: 424242,
+            trackViewUrl: 'https://apps.apple.com/cn/app/id424242'
+          }
+        ]
+      })
+    })) as unknown as typeof fetch
+
+    const result = await checkAppleStoreUpdate('1.0.0')
+    expect(result.mode).toBe('apple_storefront')
+    expect(result.hasUpdate).toBe(true)
+    expect(result.storeVersion).toBe('9.9.9')
+    expect(result.trackId).toBe('424242')
+    expect(result.trackViewUrl).toContain('apps.apple.com')
+  })
+
+  it('reports no update when current is ahead of store (typical TestFlight)', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        resultCount: 1,
+        results: [{ version: '1.4.0', trackId: 1, trackViewUrl: 'https://apps.apple.com/app/id1' }]
+      })
+    })) as unknown as typeof fetch
+
+    const result = await checkAppleStoreUpdate('1.4.3')
+    expect(result.hasUpdate).toBe(false)
+    expect(result.storeVersion).toBe('1.4.0')
+    expect(result.error).toBeFalsy()
+  })
+
+  it('handles empty store listing without falling back to github semantics', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ resultCount: 0, results: [] })
+    })) as unknown as typeof fetch
+
+    const result = await checkAppleStoreUpdate('1.0.0')
+    expect(result.hasUpdate).toBe(false)
+    expect(result.notOnStore).toBe(true)
+    expect(result.message || '').toMatch(/TestFlight|正式版/)
+  })
+
+  it('rejects check when github updater is allowed (non compliance build)', async () => {
+    setAppStoreBuildOverrideForTests(false)
+    const result = await checkAppleStoreUpdate('1.0.0')
+    expect(result.error).toBe(true)
+    expect(result.hasUpdate).toBe(false)
+  })
+})

--- a/src/utils/apple_app_update.spec.ts
+++ b/src/utils/apple_app_update.spec.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setAppStoreBuildOverrideForTests } from '../config/app_store_policy'
 import {
+  DEFAULT_APPLE_APP_ID,
   buildAppStoreOpenUrls,
   buildTestFlightOpenUrls,
-  checkAppleStoreUpdate
+  checkAppleStoreUpdate,
+  getConfiguredAppleAppId
 } from './apple_app_update'
 
 describe('apple_app_update', () => {
@@ -20,6 +22,8 @@ describe('apple_app_update', () => {
   })
 
   it('builds App Store and TestFlight open URLs', () => {
+    expect(DEFAULT_APPLE_APP_ID).toBe('6787857278')
+    expect(getConfiguredAppleAppId()).toMatch(/^\d+$/)
     const storeUrls = buildAppStoreOpenUrls({
       trackId: '123',
       trackViewUrl: 'https://apps.apple.com/app/id123'
@@ -27,7 +31,9 @@ describe('apple_app_update', () => {
     expect(storeUrls[0]).toBe('https://apps.apple.com/app/id123')
     expect(storeUrls).toContain('itms-apps://apps.apple.com/app/id123')
     expect(buildTestFlightOpenUrls('123')).toContain('itms-beta://beta.itunes.apple.com/v1/app/123')
-    expect(buildTestFlightOpenUrls()).toContain('itms-beta://')
+    expect(buildTestFlightOpenUrls()).toContain(
+      `itms-beta://beta.itunes.apple.com/v1/app/${DEFAULT_APPLE_APP_ID}`
+    )
   })
 
   it('reports update when store version is newer', async () => {

--- a/src/utils/apple_app_update.ts
+++ b/src/utils/apple_app_update.ts
@@ -1,0 +1,222 @@
+/**
+ * App Store / TestFlight 合规包的更新检查：
+ * - 仅查询苹果公开 Lookup（商店正式版）
+ * - 不引导 GitHub/CDN IPA 旁加载
+ * - TestFlight 测试包更新仍由系统 TestFlight 负责
+ */
+
+import { allowsInAppGithubUpdater } from '../config/app_store_policy'
+import { openExternal, openExternalRaw } from './external_link'
+import { compareVersions } from './updater.js'
+
+export const APPLE_BUNDLE_ID = 'com.hbut.mini'
+const SKIPPED_APPLE_VERSION_KEY = 'hbu_skipped_apple_store_version'
+const DEFAULT_LOOKUP_URLS = [
+  `https://itunes.apple.com/lookup?bundleId=${APPLE_BUNDLE_ID}&country=cn`,
+  `https://itunes.apple.com/lookup?bundleId=${APPLE_BUNDLE_ID}`
+]
+
+export type AppleStoreUpdateResult = {
+  mode: 'apple_storefront'
+  hasUpdate: boolean
+  currentVersion: string
+  storeVersion: string
+  trackId: string
+  trackViewUrl: string
+  /** lookup 无结果 / 网络失败等 */
+  error?: boolean
+  message?: string
+  /** 商店尚无该 bundle（未上架或查不到） */
+  notOnStore?: boolean
+}
+
+const stripVersion = (value: unknown) => String(value || '').trim().replace(/^v/i, '')
+
+export function getConfiguredAppleAppId(): string {
+  try {
+    const fromEnv = String(
+      (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_APPLE_APP_ID || ''
+    ).trim()
+    if (fromEnv) return fromEnv.replace(/^id/i, '')
+  } catch {
+    // ignore
+  }
+  return ''
+}
+
+export function getSkippedAppleStoreVersion(): string {
+  try {
+    return String(globalThis.localStorage?.getItem(SKIPPED_APPLE_VERSION_KEY) || '').trim()
+  } catch {
+    return ''
+  }
+}
+
+export function setSkippedAppleStoreVersion(version: string): void {
+  const text = stripVersion(version)
+  if (!text) return
+  try {
+    globalThis.localStorage?.setItem(SKIPPED_APPLE_VERSION_KEY, text)
+  } catch {
+    // ignore
+  }
+}
+
+export function buildAppStoreOpenUrls(options: {
+  trackId?: string
+  trackViewUrl?: string
+  appId?: string
+} = {}): string[] {
+  const trackViewUrl = String(options.trackViewUrl || '').trim()
+  const id = String(options.trackId || options.appId || getConfiguredAppleAppId() || '')
+    .trim()
+    .replace(/^id/i, '')
+  const urls: string[] = []
+  if (trackViewUrl) urls.push(trackViewUrl)
+  if (id) {
+    urls.push(`itms-apps://apps.apple.com/app/id${id}`)
+    urls.push(`https://apps.apple.com/app/id${id}`)
+  }
+  return [...new Set(urls.filter(Boolean))]
+}
+
+export function buildTestFlightOpenUrls(appId?: string): string[] {
+  const id = String(appId || getConfiguredAppleAppId() || '')
+    .trim()
+    .replace(/^id/i, '')
+  const urls: string[] = []
+  if (id) {
+    urls.push(`itms-beta://beta.itunes.apple.com/v1/app/${id}`)
+    urls.push(`https://beta.itunes.apple.com/v1/app/${id}`)
+  }
+  urls.push('itms-beta://')
+  return [...new Set(urls.filter(Boolean))]
+}
+
+export async function openAppStoreUpdatePage(options: {
+  trackId?: string
+  trackViewUrl?: string
+  appId?: string
+} = {}): Promise<boolean> {
+  for (const url of buildAppStoreOpenUrls(options)) {
+    if (/^https?:\/\//i.test(url)) {
+      if (await openExternal(url)) return true
+    } else if (await openExternalRaw(url)) {
+      return true
+    }
+  }
+  return false
+}
+
+export async function openTestFlightApp(appId?: string): Promise<boolean> {
+  for (const url of buildTestFlightOpenUrls(appId)) {
+    if (/^https?:\/\//i.test(url)) {
+      if (await openExternal(url)) return true
+    } else if (await openExternalRaw(url)) {
+      return true
+    }
+  }
+  return false
+}
+
+type LookupPayload = {
+  resultCount?: number
+  results?: Array<{
+    version?: string
+    trackId?: number | string
+    trackViewUrl?: string
+  }>
+}
+
+async function fetchLookupJson(url: string, timeoutMs = 8000): Promise<LookupPayload | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { Accept: 'application/json' }
+    })
+    if (!res.ok) return null
+    return (await res.json()) as LookupPayload
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * 查询 App Store 正式版相对当前安装是否有更新。
+ * 注意：不反映 TestFlight 内部 build。
+ */
+export async function checkAppleStoreUpdate(
+  currentVersion: string,
+  options: { lookupUrls?: string[] } = {}
+): Promise<AppleStoreUpdateResult> {
+  const current = stripVersion(currentVersion) || '0.0.0'
+  const base: AppleStoreUpdateResult = {
+    mode: 'apple_storefront',
+    hasUpdate: false,
+    currentVersion: current,
+    storeVersion: '',
+    trackId: getConfiguredAppleAppId(),
+    trackViewUrl: ''
+  }
+
+  // 非合规包不应走此路径；调用方应判断 allowsInAppGithubUpdater
+  if (allowsInAppGithubUpdater()) {
+    return {
+      ...base,
+      error: true,
+      message: '当前构建应使用 GitHub/CDN 内部更新'
+    }
+  }
+
+  const urls = (options.lookupUrls || DEFAULT_LOOKUP_URLS).filter(Boolean)
+  let lastError = '无法连接 App Store 查询服务'
+
+  for (const url of urls) {
+    const payload = await fetchLookupJson(url)
+    if (!payload) {
+      lastError = '无法连接 App Store 查询服务'
+      continue
+    }
+
+    const count = Number(payload.resultCount || 0)
+    const row = Array.isArray(payload.results) ? payload.results[0] : null
+    if (!count || !row) {
+      return {
+        ...base,
+        notOnStore: true,
+        hasUpdate: false,
+        message: 'App Store 暂无此应用的正式版记录。若使用 TestFlight，请打开 TestFlight 查看测试更新。'
+      }
+    }
+
+    const storeVersion = stripVersion(row.version)
+    const trackId = String(row.trackId || base.trackId || '').trim()
+    const trackViewUrl = String(row.trackViewUrl || '').trim()
+    const hasUpdate = Boolean(storeVersion && compareVersions(storeVersion, current) > 0)
+
+    return {
+      mode: 'apple_storefront',
+      hasUpdate,
+      currentVersion: current,
+      storeVersion,
+      trackId,
+      trackViewUrl,
+      message: hasUpdate
+        ? `App Store 最新 v${storeVersion}，当前 v${current}。请通过 App Store 更新。`
+        : storeVersion
+          ? `已是 App Store 最新正式版（v${storeVersion}）。TestFlight 测试包请在 TestFlight 中查看。`
+          : '已是最新正式版。TestFlight 测试包请在 TestFlight 中查看。'
+    }
+  }
+
+  return {
+    ...base,
+    error: true,
+    message: lastError
+  }
+}

--- a/src/utils/apple_app_update.ts
+++ b/src/utils/apple_app_update.ts
@@ -10,6 +10,8 @@ import { openExternal, openExternalRaw } from './external_link'
 import { compareVersions } from './updater.js'
 
 export const APPLE_BUNDLE_ID = 'com.hbut.mini'
+/** App Store Connect「Apple ID」；与 Bundle ID 不同，用于打开商店 / TestFlight 深链 */
+export const DEFAULT_APPLE_APP_ID = '6787857278'
 const SKIPPED_APPLE_VERSION_KEY = 'hbu_skipped_apple_store_version'
 const DEFAULT_LOOKUP_URLS = [
   `https://itunes.apple.com/lookup?bundleId=${APPLE_BUNDLE_ID}&country=cn`,
@@ -41,7 +43,7 @@ export function getConfiguredAppleAppId(): string {
   } catch {
     // ignore
   }
-  return ''
+  return DEFAULT_APPLE_APP_ID
 }
 
 export function getSkippedAppleStoreVersion(): string {

--- a/src/utils/updater.js
+++ b/src/utils/updater.js
@@ -255,7 +255,7 @@ function parseVersion(version) {
   }
 }
 
-function compareVersions(v1, v2) {
+export function compareVersions(v1, v2) {
   const left = parseVersion(v1)
   const right = parseVersion(v2)
   const len = Math.max(left.core.length, right.core.length)
@@ -725,6 +725,23 @@ const buildUpdateResultFromRelease = (release, currentVersion, channel) => {
 }
 
 export async function checkForUpdates(currentVersion, options = {}) {
+  // 合规 iOS 包禁止 GitHub/CDN 更新；调用方应改走 apple_app_update
+  try {
+    const { allowsInAppGithubUpdater } = await import('../config/app_store_policy')
+    if (!allowsInAppGithubUpdater()) {
+      return {
+        mode: 'apple_storefront',
+        hasUpdate: false,
+        error: false,
+        message: '本安装通过 App Store / TestFlight 分发，请使用苹果更新。',
+        currentVersion,
+        channel: normalizeUpdateChannel(options.channel ?? getUpdateChannel())
+      }
+    }
+  } catch {
+    // 策略模块异常时不阻断非合规路径
+  }
+
   const channel = normalizeUpdateChannel(options.channel ?? getUpdateChannel())
   try {
     const release = await fetchReleaseInfo(currentVersion, channel)

--- a/src/utils/updater_app_store_gate.spec.ts
+++ b/src/utils/updater_app_store_gate.spec.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setAppStoreBuildOverrideForTests } from '../config/app_store_policy'
+import { checkForUpdates } from './updater.js'
+
+describe('updater app store gate', () => {
+  afterEach(() => {
+    setAppStoreBuildOverrideForTests(null)
+    vi.restoreAllMocks()
+  })
+
+  it('short-circuits checkForUpdates on compliance builds without network', async () => {
+    setAppStoreBuildOverrideForTests(true)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('network should not be used')
+    })
+
+    const result = await checkForUpdates('1.0.0')
+    expect(result.mode).toBe('apple_storefront')
+    expect(result.hasUpdate).toBe(false)
+    expect(result.message || '').toMatch(/App Store|TestFlight/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_BUILD_PROFILE?: string
   /** `'1'` only for iOS TestFlight App Store compliance builds */
   readonly VITE_APP_STORE_BUILD?: string
+  /** App Store numeric id (optional), e.g. 1234567890 */
+  readonly VITE_APPLE_APP_ID?: string
   readonly VITE_API_BASE?: string
   /** 官网 Hero 嵌入离线演示构建标记 */
   readonly VITE_WEBSITE_DEMO?: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,8 @@ const isReleaseProfile = buildProfile === 'release'
 const isDevFastProfile = buildProfile === 'dev-fast'
 // 仅当环境变量显式为 1 时开启（ios-testflight.yml）。默认 release/dev/本地 build 保持全功能。
 const appStoreBuildFlag = process.env.VITE_APP_STORE_BUILD === '1' ? '1' : ''
+// App Store 数字 ID（可选）；合规包打开商店页时使用，也可由 Lookup trackId 回填
+const appleAppId = String(process.env.VITE_APPLE_APP_ID || '').trim().replace(/^id/i, '')
 
 const toPosix = (value: string) => value.replace(/\\/g, '/')
 
@@ -63,7 +65,8 @@ export default defineConfig({
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
     'import.meta.env.VITE_BUILD_PROFILE': JSON.stringify(buildProfile),
-    'import.meta.env.VITE_APP_STORE_BUILD': JSON.stringify(appStoreBuildFlag)
+    'import.meta.env.VITE_APP_STORE_BUILD': JSON.stringify(appStoreBuildFlag),
+    'import.meta.env.VITE_APPLE_APP_ID': JSON.stringify(appleAppId)
   },
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,8 @@ const isReleaseProfile = buildProfile === 'release'
 const isDevFastProfile = buildProfile === 'dev-fast'
 // 仅当环境变量显式为 1 时开启（ios-testflight.yml）。默认 release/dev/本地 build 保持全功能。
 const appStoreBuildFlag = process.env.VITE_APP_STORE_BUILD === '1' ? '1' : ''
-// App Store 数字 ID（可选）；合规包打开商店页时使用，也可由 Lookup trackId 回填
-const appleAppId = String(process.env.VITE_APPLE_APP_ID || '').trim().replace(/^id/i, '')
+// App Store 数字 ID（App Store Connect → Apple ID）；合规包打开商店页；也可由 Lookup trackId 回填
+const appleAppId = String(process.env.VITE_APPLE_APP_ID || '6787857278').trim().replace(/^id/i, '')
 
 const toPosix = (value: string) => value.replace(/\\/g, '/')
 


### PR DESCRIPTION
## Summary
- TestFlight/App Store 合规包（`VITE_APP_STORE_BUILD=1`）禁用 GitHub/CDN 内部更新与 IPA 旁加载
- 自动/手动检查改为 iTunes Lookup；有新版本弹窗引导「前往 App Store」
- 未签名 IPA 与其它平台保持原 updater 行为
- 远程 `force_update` 在合规包上不再使用 GitHub `download_url`

Closes #441

## Test plan
- [x] vitest: app_store_policy / apple_app_update / updater gate / channel / download sources
- [ ] 本地无 flag：检查更新仍走 CDN/GitHub
- [ ] `VITE_APP_STORE_BUILD=1`：自动检查不请求 GitHub release；对话框为苹果模式
- [ ] 真机 TF：无商店新版时不弹 GitHub 下载