### PR TITLE
fix: 首页功能分类切换时避免页面上跳

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -949,9 +949,72 @@ const persistHomeFeatureTab = () => {
     // ignore storage failure
   }
 }
+/** 所有功能宫格列数（与 template grid-cols-4 一致） */
+const FEATURE_GRID_COLS = 4
+
+/**
+ * 各分类模块数不同会导致宫格高度骤变：
+ * 滑到底后从「教务服务」切到「学习通」时内容变矮，滚动被夹断，页面上跳。
+ * 用「最满分类」的行数锁定 min-height，切换时占位稳定。
+ */
+const featureGridMaxRows = computed(() => {
+  const counts = moduleCategories.value.map((c) => (Array.isArray(c.modules) ? c.modules.length : 0))
+  const maxCount = counts.length ? Math.max(...counts) : 1
+  return Math.max(1, Math.ceil(maxCount / FEATURE_GRID_COLS))
+})
+
+/** 单行约 74px（图标+间距+文案），行间距 gap-y-6=24px */
+const featureGridMinHeightPx = computed(() => {
+  const rows = featureGridMaxRows.value
+  const rowBody = 74
+  const rowGap = 24
+  return rows * rowBody + Math.max(0, rows - 1) * rowGap
+})
+
+const featureGridStyle = computed(() => ({
+  minHeight: `${featureGridMinHeightPx.value}px`
+}))
+
+const readHomeShellScrollTop = () => {
+  try {
+    const shell = typeof document !== 'undefined' ? document.querySelector('.app-shell') : null
+    if (shell && typeof shell.scrollTop === 'number' && Number.isFinite(shell.scrollTop)) {
+      return Math.max(0, shell.scrollTop)
+    }
+  } catch {
+    // ignore
+  }
+  return null
+}
+
+const restoreHomeShellScrollTop = (top) => {
+  if (top == null || !Number.isFinite(top)) return
+  try {
+    const shell = typeof document !== 'undefined' ? document.querySelector('.app-shell') : null
+    if (!shell) return
+    const maxTop = Math.max(0, (shell.scrollHeight || 0) - (shell.clientHeight || 0))
+    shell.scrollTop = Math.min(Math.max(0, top), maxTop)
+  } catch {
+    // ignore
+  }
+}
+
 const setActiveFeatureTab = (title) => {
+  if (title === activeFeatureTab.value) {
+    persistHomeFeatureTab()
+    return
+  }
+  // 切换前记住滚动，避免高度变化时视口被浏览器夹断上跳
+  const prevTop = readHomeShellScrollTop()
   activeFeatureTab.value = title
   persistHomeFeatureTab()
+  nextTick(() => {
+    restoreHomeShellScrollTop(prevTop)
+    // 再等一帧，等 grid 完成布局
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => restoreHomeShellScrollTop(prevTop))
+    }
+  })
 }
 const navigateFromHome = (moduleId) => {
   persistHomeFeatureTab()
@@ -1528,7 +1591,10 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
             {{ cat.title }}
           </button>
         </div>
-        <div class="grid grid-cols-4 gap-y-6 gap-x-2 mt-4">
+        <div
+          class="grid grid-cols-4 gap-y-6 gap-x-2 mt-4 home-feature-grid"
+          :style="featureGridStyle"
+        >
           <div
             v-for="mod in featureTabModules"
             :key="mod.id"
@@ -1919,5 +1985,10 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
   border-color: #3b82f6;
   color: #fff;
   box-shadow: 0 6px 14px rgba(59, 130, 246, 0.25);
+}
+/* 锁定宫格最小高度，避免分类模块数差异导致滚动跳变 */
+.home-feature-grid {
+  align-content: start;
+  box-sizing: border-box;
 }
 </style>

--- a/src/styles/home_dashboard_contract.spec.ts
+++ b/src/styles/home_dashboard_contract.spec.ts
@@ -97,6 +97,19 @@ describe('home dashboard interaction contract', () => {
     expect(source).toContain('home-feature-tab')
   })
 
+  it('keeps all-features grid min-height by fullest category to avoid scroll jump on tab switch', () => {
+    const source = dashboardVue()
+
+    // 最满分类行数 → min-height，防止「教务」→「学习通」底部内容变矮导致上跳
+    expect(source).toContain('featureGridMaxRows')
+    expect(source).toContain('featureGridMinHeightPx')
+    expect(source).toContain('featureGridStyle')
+    expect(source).toContain('home-feature-grid')
+    expect(source).toContain('readHomeShellScrollTop')
+    expect(source).toContain('restoreHomeShellScrollTop')
+    expect(source).toContain('FEATURE_GRID_COLS')
+  })
+
   it('restores the home scroll position when returning from a module', () => {
     const source = appVue()
 


### PR DESCRIPTION
## Summary
- 首页「所有功能」各分类模块数量不同，滑到底从「教务服务」切到「学习通」时内容变矮，滚动被夹断导致页面上跳
- 按最满分类的行数锁定宫格 `min-height`，切换时占位稳定
- 切换分类时恢复 `.app-shell` 滚动位置作为双保险

## Test plan
- [x] vitest `home_dashboard_contract.spec.ts`
- [ ] 首页滑到底 → 教务服务 → 学习通：视口不应明显上跳
- [ ] 学习通 → 教务服务：布局正常，底部可继续滚
- [ ] 分类记忆与进模块后返回仍正常