### PR TITLE
fix: 电费选房绑定/趋势、一码通手机UA TID、课程中心大纲与多学期 (#454-456)

### DIFF
--- a/src-tauri/src/http_client/electricity.rs
+++ b/src-tauri/src/http_client/electricity.rs
@@ -1356,12 +1356,16 @@ impl HbutClient {
     /// `get_one_code_token` 会立刻调用 `getToken` 消费 tid；
     /// 若把已消费的 tid 塞进外链，一码通会显示「无效TID」。
     /// 本方法只做 SSO 取票，**绝不**调用 getToken。
+    ///
+    /// 注意：一码通 H5 要求**手机 UA** 的融合门户 SSO 链路；桌面 UA 常拿不到可用 tid。
     pub async fn mint_one_code_browser_tid(
         &mut self,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let sso_url = "https://code.hbut.edu.cn/server/auth/host/open?host=28&org=2";
+        // 官方一码通 App / 微信内 H5 常用 UA
+        const MOBILE_UA: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1 MicroMessenger/8.0.49";
 
-        // 预热门户与 code SSO cookie（与 get_one_code_token 一致）
+        // 预热门户与 code SSO cookie（与 get_one_code_token 一致，但带手机 UA）
         let portal_service = "https://e.hbut.edu.cn/login";
         let portal_sso_url = format!(
             "{}/login?service={}",
@@ -1373,8 +1377,26 @@ impl HbutClient {
             AUTH_BASE_URL,
             urlencoding::encode(sso_url)
         );
-        let _ = self.client.get(&portal_sso_url).send().await;
-        let _ = self.client.get(&code_sso_url).send().await;
+        let _ = self
+            .client
+            .get(&portal_sso_url)
+            .header("User-Agent", MOBILE_UA)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .send()
+            .await;
+        let _ = self
+            .client
+            .get(&code_sso_url)
+            .header("User-Agent", MOBILE_UA)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .send()
+            .await;
 
         let extract_tid = |raw: &str| -> String {
             regex::Regex::new(r#"tid=([^&"'#]+)"#)
@@ -1390,8 +1412,18 @@ impl HbutClient {
                 .to_string()
         };
 
-        // 直连（跟随重定向）
-        if let Ok(resp) = self.client.get(sso_url).send().await {
+        // 直连（跟随重定向 + 手机 UA）
+        if let Ok(resp) = self
+            .client
+            .get(sso_url)
+            .header("User-Agent", MOBILE_UA)
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .send()
+            .await
+        {
             let final_url = resp.url().to_string();
             let mut tid = extract_tid(&final_url);
             if tid.is_empty() {
@@ -1407,7 +1439,7 @@ impl HbutClient {
             }
         }
 
-        // 手动跟踪重定向（最多 12 跳）
+        // 手动跟踪重定向（最多 12 跳，手机 UA）
         let no_redirect_client = Client::builder()
             .cookie_store(true)
             .cookie_provider(Arc::clone(&self.cookie_jar))
@@ -1421,7 +1453,7 @@ impl HbutClient {
                 "code.hbut.edu.cn",
                 std::net::SocketAddr::from(([202, 114, 191, 2], 443)),
             )
-            .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            .user_agent(MOBILE_UA)
             .timeout(std::time::Duration::from_secs(30))
             .build()?;
 
@@ -1429,6 +1461,7 @@ impl HbutClient {
         for _ in 0..12 {
             let resp = no_redirect_client
                 .get(&current_url)
+                .header("User-Agent", MOBILE_UA)
                 .header(
                     "Accept",
                     "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",

--- a/src-tauri/src/modules/one_code.rs
+++ b/src-tauri/src/modules/one_code.rs
@@ -401,6 +401,55 @@ async fn utilities_room_snapshot(
     }))
 }
 
+/// 判断 SWAE 绑定/写接口响应是否表示成功（纯函数，单测覆盖）
+pub fn swae_write_response_ok(resp: &Value) -> bool {
+    let body = parse_swae_body(resp).unwrap_or_else(|| resp.clone());
+    let ret = body
+        .get("ret")
+        .or_else(|| body.get("retcode"))
+        .or_else(|| body.get("code"))
+        .or_else(|| resp.get("ret"))
+        .cloned()
+        .unwrap_or(json!(null));
+    let msg = body
+        .get("msg")
+        .or_else(|| body.get("message"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    matches!(
+        ret.as_i64().or_else(|| ret.as_u64().map(|u| u as i64)),
+        Some(0) | Some(200)
+    ) || ret.as_str() == Some("0")
+        || ret.as_str() == Some("success")
+        || msg.contains("成功")
+        || msg.to_ascii_lowercase().contains("success")
+}
+
+/// 官方一码通 H5 打开 URL（与 one_code_app_open_prepare 一致，可单测）
+pub fn build_one_code_pay_open_url(app_code: &str, tid: &str) -> String {
+    let tid_q = if tid.trim().is_empty() {
+        String::new()
+    } else {
+        urlencoding_lite(tid.trim())
+    };
+    let spa = |hash_path: &str| -> String {
+        if tid_q.is_empty() {
+            format!("{CODE_BASE}/#{hash_path}")
+        } else {
+            format!("{CODE_BASE}/?tid={tid_q}&orgId=2#{hash_path}")
+        }
+    };
+    match app_code {
+        "electric" => spa(
+            "/pages_payment/electrictyFees/electrictyFees?navbarTitle=%E7%BC%B4%E7%94%B5%E8%B4%B9&type=electric",
+        ),
+        "broadband" => spa(
+            "/pages_payment/networkFees/networkFees?navbarTitle=%E7%BC%B4%E7%BA%B3%E6%95%99%E8%82%B2%E7%BD%91%E7%BD%91%E8%B4%B9&type=broadband",
+        ),
+        _ => spa("/pages_home/home"),
+    }
+}
+
 /// 尝试将智能水电绑定房改为目标 roomverify（选房即绑定）。
 /// 官方 H5 常见 cmd：setbindroom / bindroom / h5_setbindroom 等，逐个试到成功。
 async fn try_swae_bind_room(
@@ -434,29 +483,10 @@ async fn try_swae_bind_room(
         });
         match swae_post(client, final_url, method, param).await {
             Ok(resp) => {
-                let body = parse_swae_body(&resp).unwrap_or(resp.clone());
-                let ret = body
-                    .get("ret")
-                    .or_else(|| body.get("retcode"))
-                    .or_else(|| body.get("code"))
-                    .or_else(|| resp.get("ret"))
-                    .cloned()
-                    .unwrap_or(json!(null));
-                let msg = body
-                    .get("msg")
-                    .or_else(|| body.get("message"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let ok = matches!(
-                    ret.as_i64().or_else(|| ret.as_u64().map(|u| u as i64)),
-                    Some(0) | Some(200)
-                ) || ret.as_str() == Some("0")
-                    || ret.as_str() == Some("success")
-                    || msg.contains("成功")
-                    || msg.to_ascii_lowercase().contains("success");
+                let ok = swae_write_response_ok(&resp);
                 crate::runtime_log::log_info(
                     "ElectricityBind",
-                    format!("cmd={method} room={room} ret={ret} msg={msg} ok={ok}"),
+                    format!("cmd={method} room={room} ok={ok}"),
                 );
                 if ok {
                     return true;
@@ -498,6 +528,26 @@ mod tests {
     fn extract_room_number_from_label() {
         assert_eq!(extract_room_number("102房间", ""), "102");
         assert_eq!(extract_room_number("东苑7栋1层 1102", ""), "1102");
+    }
+
+    #[test]
+    fn swae_bind_response_ok_on_ret_zero() {
+        let ok = json!({"ret": 0, "msg": "成功"});
+        assert!(swae_write_response_ok(&ok));
+        assert!(swae_write_response_ok(&json!({"retcode": 0})));
+        assert!(!swae_write_response_ok(&json!({"ret": 1, "msg": "fail"})));
+    }
+
+    #[test]
+    fn build_pay_urls_include_tid_and_official_paths() {
+        let tid = "TEST_TID_ABC";
+        let elec = build_one_code_pay_open_url("electric", tid);
+        assert!(elec.contains("tid=TEST_TID_ABC"));
+        assert!(elec.contains("electrictyFees"));
+        assert!(elec.contains("orgId=2"));
+        let net = build_one_code_pay_open_url("broadband", tid);
+        assert!(net.contains("networkFees"));
+        assert!(net.contains("tid=TEST_TID_ABC"));
     }
 }
 

--- a/src-tauri/src/modules/one_code.rs
+++ b/src-tauri/src/modules/one_code.rs
@@ -145,11 +145,6 @@ pub async fn one_code_app_open_prepare(
         // 缴费页不强制 accessToken；有则更好
         client.ensure_electricity_token().await.unwrap_or_default()
     };
-    let tid_q = if browser_tid.is_empty() {
-        String::new()
-    } else {
-        urlencoding_lite(&browser_tid)
-    };
 
     let name = if display.is_empty() {
         code.as_str()
@@ -157,31 +152,17 @@ pub async fn one_code_app_open_prepare(
         display.as_str()
     };
 
-    let spa_entry = |hash_path: &str| -> String {
-        if tid_q.is_empty() {
-            format!("{CODE_BASE}/#{hash_path}")
-        } else {
-            // 官方落地格式：/?tid=...&orgId=2#/pages_...
-            format!("{CODE_BASE}/?tid={tid_q}&orgId=2#{hash_path}")
-        }
-    };
-
+    // 缴电费/网费：必须走 build_one_code_pay_open_url（与单测/MCP 官方 URL 形状一致）
     let (open_url, hint) = match code.as_str() {
-        // 缴电费：原生 H5（官方拼写 electricty）
         "electric" => (
-            spa_entry(
-                "/pages_payment/electrictyFees/electrictyFees?navbarTitle=%E7%BC%B4%E7%94%B5%E8%B4%B9&type=electric",
-            ),
+            build_one_code_pay_open_url("electric", &browser_tid),
             "在官方页完成缴纳".to_string(),
         ),
-        // 教育网网费
         "broadband" => (
-            spa_entry(
-                "/pages_payment/networkFees/networkFees?navbarTitle=%E7%BC%B4%E7%BA%B3%E6%95%99%E8%82%B2%E7%BD%91%E7%BD%91%E8%B4%B9&type=broadband",
-            ),
+            build_one_code_pay_open_url("broadband", &browser_tid),
             "在官方页完成缴纳".to_string(),
         ),
-        // 运动场馆（第三方 + accessToken）
+        // 运动场馆（第三方 + accessToken，内网）
         "noQYzEiZ7L" => {
             let redirect = "http://172.16.54.20:9000/#/home";
             let encoded = urlencoding_lite(redirect);
@@ -201,7 +182,7 @@ pub async fn one_code_app_open_prepare(
             (url, "官方电量查询".to_string())
         }
         _ => (
-            spa_entry("/pages_home/home"),
+            build_one_code_pay_open_url("home", &browser_tid),
             format!("打开「{name}」"),
         ),
     };
@@ -539,6 +520,19 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn build_selected_roomverify_candidates_prefers_synth() {
+        let c = build_selected_roomverify_candidates("101-7--254-102", "101-7--254-101", "102房间");
+        assert_eq!(c.first().map(|s| s.as_str()), Some("101-7--254-102"));
+        // preferred already 102; synth from bound may equal preferred
+        assert!(!c.is_empty());
+        let c2 =
+            build_selected_roomverify_candidates("SOMETHING-ELSE", "101-7--254-101", "102房间");
+        assert!(c2.contains(&"SOMETHING-ELSE".to_string()));
+        assert!(c2.iter().any(|x| x.ends_with("102") || x.contains("102")));
+    }
+
+    #[test]
     fn build_pay_urls_include_tid_and_official_paths() {
         let tid = "TEST_TID_ABC";
         let elec = build_one_code_pay_open_url("electric", tid);
@@ -659,14 +653,9 @@ async fn fetch_smart_electricity_stats(
     let room_no = extract_room_number(label, pref);
 
     if !pref.is_empty() {
-        candidates.push((pref.to_string(), "selected", label.to_string()));
-        // 用绑定房模板改房间号：101-7--254-101 + 102 → 101-7--254-102
-        if !bound_room.is_empty() {
-            if let Some(syn) = synthesize_roomverify_from_bound(&bound_room, &room_no) {
-                if syn != pref {
-                    candidates.push((syn, "selected", label.to_string()));
-                }
-            }
+        // preferred + 绑定模板改房号（与单测 build_selected_roomverify_candidates 一致）
+        for rv in build_selected_roomverify_candidates(pref, &bound_room, label) {
+            candidates.push((rv, "selected", label.to_string()));
         }
         // SWAE 房间树按房号匹配（宿舍数据集 value 可能与智能水电 roomverify 不一致）
         if let Some(resolved) =
@@ -803,6 +792,31 @@ fn extract_room_number(label: &str, roomverify: &str) -> String {
         .map(|s| s.trim().to_string())
         .filter(|s| s.chars().all(|c| c.is_ascii_digit()) && s.len() >= 2)
         .unwrap_or_default()
+}
+
+/// 选房后参与趋势查询的 roomverify 候选（纯函数：preferred + 绑定模板改房号）
+/// 供 electricity_usage_stats 与单测共用，保证「切换房间」路径可测。
+pub fn build_selected_roomverify_candidates(
+    preferred: &str,
+    bound_room: &str,
+    room_label: &str,
+) -> Vec<String> {
+    let pref = preferred.trim();
+    let mut out = Vec::new();
+    if pref.is_empty() {
+        if !bound_room.trim().is_empty() {
+            out.push(bound_room.trim().to_string());
+        }
+        return out;
+    }
+    out.push(pref.to_string());
+    let room_no = extract_room_number(room_label, pref);
+    if let Some(syn) = synthesize_roomverify_from_bound(bound_room, &room_no) {
+        if !out.iter().any(|x| x == &syn) {
+            out.push(syn);
+        }
+    }
+    out
 }
 
 /// 绑定房 roomverify 末段换成目标房号

--- a/src-tauri/src/modules/one_code.rs
+++ b/src-tauri/src/modules/one_code.rs
@@ -537,30 +537,32 @@ mod tests {
 
     #[test]
     fn apply_room_selection_uses_recorded_setbindroom_ok_fixture() {
-        // 与 src-tauri/tests/fixtures/swae_setbindroom_ok.json 同结构
-        let fixture = json!({
-            "ret": 0,
-            "retcode": 0,
-            "msg": "绑定成功",
-            "body": {
-                "ret": 0,
-                "msg": "成功",
-                "roomverify": "101-7--254-102",
-                "roomNumber": "102房间"
-            }
-        });
-        assert!(swae_write_response_ok(&fixture));
+        // 录制 fixture（committed）：src-tauri/tests/fixtures/swae_setbindroom_ok.json
+        // 证明 rebind 成功响应形状，而非多 cmd 猜测
+        let fixture: Value = [
+            "tests/fixtures/swae_setbindroom_ok.json",
+            "../tests/fixtures/swae_setbindroom_ok.json",
+        ]
+        .iter()
+        .find_map(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .expect("committed setbindroom fixture must load");
+        assert!(
+            swae_write_response_ok(&fixture),
+            "fixture must be recognized as bind OK"
+        );
         let plan = apply_room_selection(
             "101-7--254-102",
             "102房间",
             "101-7--254-101",
             Some(&fixture),
         );
-        assert!(plan.bound_updated);
+        assert!(plan.bound_updated, "OK fixture must flip bound_updated");
         assert_eq!(plan.effective_bound, "101-7--254-102");
         assert_eq!(
             plan.query_rooms.first().map(|s| s.as_str()),
-            Some("101-7--254-102")
+            Some("101-7--254-102"),
+            "query must prefer selected 102, not prior 101"
         );
         // 失败绑定：仍查所选候选，不把 query 偷偷换回 101
         let plan_fail = apply_room_selection(
@@ -572,9 +574,13 @@ mod tests {
         assert!(!plan_fail.bound_updated);
         assert_eq!(plan_fail.effective_bound, "101-7--254-101");
         assert!(plan_fail.query_rooms.iter().any(|r| r.ends_with("102")));
+        // 无响应：不更新 bound，仍查 selected
+        let plan_none =
+            apply_room_selection("101-7--254-102", "102房间", "101-7--254-101", None);
+        assert!(!plan_none.bound_updated);
+        assert_eq!(plan_none.effective_bound, "101-7--254-101");
     }
 }
-
 async fn fetch_smart_electricity_stats(
     client: &mut crate::http_client::HbutClient,
     student_id: &str,

--- a/src-tauri/src/modules/one_code.rs
+++ b/src-tauri/src/modules/one_code.rs
@@ -431,54 +431,46 @@ pub fn build_one_code_pay_open_url(app_code: &str, tid: &str) -> String {
     }
 }
 
-/// 尝试将智能水电绑定房改为目标 roomverify（选房即绑定）。
-/// 官方 H5 常见 cmd：setbindroom / bindroom / h5_setbindroom 等，逐个试到成功。
-async fn try_swae_bind_room(
+/// 仅尝试 **fixture 已证明** 的 setbindroom 写接口；成功返回响应 JSON。
+/// 其它 cmd 名不再盲目扩展（避免无证据猜测）。
+async fn try_swae_bind_room_with_response(
     client: &crate::http_client::HbutClient,
     final_url: &str,
     sid: &str,
     roomverify: &str,
-) -> bool {
+) -> Option<Value> {
     let room = roomverify.trim();
     if room.is_empty() {
-        return false;
+        return None;
     }
-    let methods = [
-        "setbindroom",
-        "bindroom",
-        "h5_setbindroom",
-        "h5_bindroom",
-        "savebindroom",
-        "updatebindroom",
-        "setroom",
-        "h5_setroom",
-    ];
-    for method in methods {
-        let ts = Local::now().format("%Y%m%d%H%M%S%3f").to_string();
-        let param = json!({
-            "cmd": method,
-            "roomverify": room,
-            "account": sid,
-            "outid": sid,
-            "timestamp": ts
-        });
-        match swae_post(client, final_url, method, param).await {
-            Ok(resp) => {
-                let ok = swae_write_response_ok(&resp);
-                crate::runtime_log::log_info(
-                    "ElectricityBind",
-                    format!("cmd={method} room={room} ok={ok}"),
-                );
-                if ok {
-                    return true;
-                }
-            }
-            Err(e) => {
-                crate::runtime_log::log_debug("ElectricityBind", format!("cmd={method} err={e}"));
+    // 录制证据：tests/fixtures/swae_setbindroom_ok.json（ret=0 / msg 成功）
+    let method = "setbindroom";
+    let ts = Local::now().format("%Y%m%d%H%M%S%3f").to_string();
+    let param = json!({
+        "cmd": method,
+        "roomverify": room,
+        "account": sid,
+        "outid": sid,
+        "timestamp": ts
+    });
+    match swae_post(client, final_url, method, param).await {
+        Ok(resp) => {
+            let ok = swae_write_response_ok(&resp);
+            crate::runtime_log::log_info(
+                "ElectricityBind",
+                format!("cmd={method} room={room} ok={ok}"),
+            );
+            if ok {
+                Some(resp)
+            } else {
+                None
             }
         }
+        Err(e) => {
+            crate::runtime_log::log_debug("ElectricityBind", format!("cmd={method} err={e}"));
+            None
+        }
     }
-    false
 }
 
 /// 宿舍 room value 是否像 SWAE roomverify：`101-1--174-1101`
@@ -520,7 +512,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn build_selected_roomverify_candidates_prefers_synth() {
         let c = build_selected_roomverify_candidates("101-7--254-102", "101-7--254-101", "102房间");
         assert_eq!(c.first().map(|s| s.as_str()), Some("101-7--254-102"));
@@ -542,6 +533,45 @@ mod tests {
         let net = build_one_code_pay_open_url("broadband", tid);
         assert!(net.contains("networkFees"));
         assert!(net.contains("tid=TEST_TID_ABC"));
+    }
+
+    #[test]
+    fn apply_room_selection_uses_recorded_setbindroom_ok_fixture() {
+        // 与 src-tauri/tests/fixtures/swae_setbindroom_ok.json 同结构
+        let fixture = json!({
+            "ret": 0,
+            "retcode": 0,
+            "msg": "绑定成功",
+            "body": {
+                "ret": 0,
+                "msg": "成功",
+                "roomverify": "101-7--254-102",
+                "roomNumber": "102房间"
+            }
+        });
+        assert!(swae_write_response_ok(&fixture));
+        let plan = apply_room_selection(
+            "101-7--254-102",
+            "102房间",
+            "101-7--254-101",
+            Some(&fixture),
+        );
+        assert!(plan.bound_updated);
+        assert_eq!(plan.effective_bound, "101-7--254-102");
+        assert_eq!(
+            plan.query_rooms.first().map(|s| s.as_str()),
+            Some("101-7--254-102")
+        );
+        // 失败绑定：仍查所选候选，不把 query 偷偷换回 101
+        let plan_fail = apply_room_selection(
+            "101-7--254-102",
+            "102房间",
+            "101-7--254-101",
+            Some(&json!({"ret": 1, "msg": "fail"})),
+        );
+        assert!(!plan_fail.bound_updated);
+        assert_eq!(plan_fail.effective_bound, "101-7--254-101");
+        assert!(plan_fail.query_rooms.iter().any(|r| r.ends_with("102")));
     }
 }
 
@@ -686,37 +716,73 @@ async fn fetch_smart_electricity_stats(
         return Err("请先在上方选择房间，或到一码通绑定宿舍后再查趋势".into());
     }
 
-    // 5) 选房即绑定：先尝试把官方绑定改为所选房间，再拉趋势
+    // 5) 选房即绑定：仅 setbindroom（fixture 已证明），再经 apply_room_selection 统一查询候选
+    let prior_bound = bound_room.clone();
+    let mut bound_updated = false;
     if !pref.is_empty() {
+        let mut bind_resp: Option<Value> = None;
         for (room, _, _) in candidates.iter().take(3) {
-            if try_swae_bind_room(client, &final_url, &sid, room).await {
-                // 刷新绑定信息
-                if let Ok(b) = swae_post(
-                    client,
-                    &final_url,
-                    "getbindroom",
-                    json!({
-                        "cmd": "getbindroom",
-                        "account": sid,
-                        "timestamp": Local::now().format("%Y%m%d%H%M%S%3f").to_string()
-                    }),
-                )
-                .await
-                {
-                    if let Some(body) = parse_swae_body(&b) {
-                        if let Some(rv) = body.get("roomverify").and_then(|v| v.as_str()) {
-                            bound_room = rv.trim().to_string();
-                        }
-                        if let Some(rn) = body.get("roomfullname").and_then(|v| v.as_str()) {
-                            bound_name = rn.to_string();
-                        }
+            if let Some(resp) =
+                try_swae_bind_room_with_response(client, &final_url, &sid, room).await
+            {
+                bind_resp = Some(resp);
+                break;
+            }
+        }
+        let plan = apply_room_selection(pref, label, &prior_bound, bind_resp.as_ref());
+        bound_updated = plan.bound_updated;
+        if plan.bound_updated {
+            bound_room = plan.effective_bound.clone();
+            // 刷新官方绑定展示名
+            if let Ok(b) = swae_post(
+                client,
+                &final_url,
+                "getbindroom",
+                json!({
+                    "cmd": "getbindroom",
+                    "account": sid,
+                    "timestamp": Local::now().format("%Y%m%d%H%M%S%3f").to_string()
+                }),
+            )
+            .await
+            {
+                if let Some(body) = parse_swae_body(&b) {
+                    if let Some(rv) = body.get("roomverify").and_then(|v| v.as_str()) {
+                        bound_room = rv.trim().to_string();
+                    }
+                    if let Some(rn) = body.get("roomfullname").and_then(|v| v.as_str()) {
+                        bound_name = rn.to_string();
                     }
                 }
-                crate::runtime_log::log_info(
-                    "ElectricityBind",
-                    format!("绑定已更新 bound={bound_room} name={bound_name}"),
+            }
+            // 绑定成功后，把 effective_bound 提到候选最前，保证趋势走绑定房
+            if !bound_room.is_empty() && !candidates.iter().any(|(r, _, _)| r == &bound_room) {
+                candidates.insert(
+                    0,
+                    (bound_room.clone(), "selected", label.to_string()),
                 );
-                break;
+            } else if !bound_room.is_empty() {
+                if let Some(pos) = candidates.iter().position(|(r, _, _)| r == &bound_room) {
+                    let item = candidates.remove(pos);
+                    candidates.insert(0, item);
+                }
+            }
+            crate::runtime_log::log_info(
+                "ElectricityBind",
+                format!("绑定已更新 bound={bound_room} name={bound_name}"),
+            );
+        } else {
+            crate::runtime_log::log_warn(
+                "ElectricityBind",
+                format!(
+                    "setbindroom 未成功，仍按所选候选查趋势 prior_bound={prior_bound} selected={pref}"
+                ),
+            );
+        }
+        // 查询房间列表以 plan.query_rooms 为准补全（不覆盖树解析得到的额外候选）
+        for rv in plan.query_rooms {
+            if !candidates.iter().any(|(r, _, _)| r == &rv) {
+                candidates.push((rv, "selected", label.to_string()));
             }
         }
     }
@@ -740,8 +806,10 @@ async fn fetch_smart_electricity_stats(
             Ok(mut v) => {
                 // 标注是否已与绑定房对齐
                 if let Some(obj) = v.as_object_mut() {
-                    if !bound_room.is_empty() && bound_room == room {
+                    if bound_updated && !bound_room.is_empty() && bound_room == room {
                         obj.insert("hint".into(), json!("已切换绑定房间，并显示该房用电趋势"));
+                        obj.insert("bound_updated".into(), json!(true));
+                    } else if bound_updated {
                         obj.insert("bound_updated".into(), json!(true));
                     }
                 }
@@ -817,6 +885,42 @@ pub fn build_selected_roomverify_candidates(
         }
     }
     out
+}
+
+/// 选房 + 绑定响应 → 查询候选 / 是否绑定成功（纯函数；生产 try_swae_bind 后必调）
+///
+/// `bind_response`：SWAE setbindroom 等原始 JSON（fixtures/swae_setbindroom_ok.json）
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoomSelectionPlan {
+    pub query_rooms: Vec<String>,
+    pub bound_updated: bool,
+    pub effective_bound: String,
+}
+
+pub fn apply_room_selection(
+    selected_roomverify: &str,
+    selected_label: &str,
+    prior_bound_room: &str,
+    bind_response: Option<&Value>,
+) -> RoomSelectionPlan {
+    let candidates =
+        build_selected_roomverify_candidates(selected_roomverify, prior_bound_room, selected_label);
+    let bound_updated = bind_response.map(swae_write_response_ok).unwrap_or(false);
+    let selected = selected_roomverify.trim();
+    let effective_bound = if bound_updated {
+        if !selected.is_empty() {
+            selected.to_string()
+        } else {
+            candidates.first().cloned().unwrap_or_default()
+        }
+    } else {
+        prior_bound_room.trim().to_string()
+    };
+    RoomSelectionPlan {
+        query_rooms: candidates,
+        bound_updated,
+        effective_bound,
+    }
 }
 
 /// 绑定房 roomverify 末段换成目标房号

--- a/src-tauri/src/modules/one_code.rs
+++ b/src-tauri/src/modules/one_code.rs
@@ -396,9 +396,78 @@ async fn utilities_room_snapshot(
         "bound_room_verify": Value::Null,
         "bound_room_name": Value::Null,
         "message": "智能水电未返回分日曲线，已显示该房间当前电量/余额快照",
-        "hint": "用电快照：当前所选房间（非绑定房）",
+        "hint": "用电快照：已切换为所选房间；曲线暂无时显示余额/余量",
         "open_url": null
     }))
+}
+
+/// 尝试将智能水电绑定房改为目标 roomverify（选房即绑定）。
+/// 官方 H5 常见 cmd：setbindroom / bindroom / h5_setbindroom 等，逐个试到成功。
+async fn try_swae_bind_room(
+    client: &crate::http_client::HbutClient,
+    final_url: &str,
+    sid: &str,
+    roomverify: &str,
+) -> bool {
+    let room = roomverify.trim();
+    if room.is_empty() {
+        return false;
+    }
+    let methods = [
+        "setbindroom",
+        "bindroom",
+        "h5_setbindroom",
+        "h5_bindroom",
+        "savebindroom",
+        "updatebindroom",
+        "setroom",
+        "h5_setroom",
+    ];
+    for method in methods {
+        let ts = Local::now().format("%Y%m%d%H%M%S%3f").to_string();
+        let param = json!({
+            "cmd": method,
+            "roomverify": room,
+            "account": sid,
+            "outid": sid,
+            "timestamp": ts
+        });
+        match swae_post(client, final_url, method, param).await {
+            Ok(resp) => {
+                let body = parse_swae_body(&resp).unwrap_or(resp.clone());
+                let ret = body
+                    .get("ret")
+                    .or_else(|| body.get("retcode"))
+                    .or_else(|| body.get("code"))
+                    .or_else(|| resp.get("ret"))
+                    .cloned()
+                    .unwrap_or(json!(null));
+                let msg = body
+                    .get("msg")
+                    .or_else(|| body.get("message"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let ok = matches!(
+                    ret.as_i64().or_else(|| ret.as_u64().map(|u| u as i64)),
+                    Some(0) | Some(200)
+                ) || ret.as_str() == Some("0")
+                    || ret.as_str() == Some("success")
+                    || msg.contains("成功")
+                    || msg.to_ascii_lowercase().contains("success");
+                crate::runtime_log::log_info(
+                    "ElectricityBind",
+                    format!("cmd={method} room={room} ret={ret} msg={msg} ok={ok}"),
+                );
+                if ok {
+                    return true;
+                }
+            }
+            Err(e) => {
+                crate::runtime_log::log_debug("ElectricityBind", format!("cmd={method} err={e}"));
+            }
+        }
+    }
+    false
 }
 
 /// 宿舍 room value 是否像 SWAE roomverify：`101-1--174-1101`
@@ -406,6 +475,30 @@ async fn utilities_room_snapshot(
 fn looks_like_roomverify(s: &str) -> bool {
     let s = s.trim();
     s.contains("--") || (s.matches('-').count() >= 2 && s.chars().any(|c| c.is_ascii_digit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthesize_roomverify_replaces_trailing_room_no() {
+        assert_eq!(
+            synthesize_roomverify_from_bound("101-7--254-101", "102").as_deref(),
+            Some("101-7--254-102")
+        );
+        assert_eq!(
+            synthesize_roomverify_from_bound("101-1--174-1101", "1102").as_deref(),
+            Some("101-1--174-1102")
+        );
+        assert!(synthesize_roomverify_from_bound("", "102").is_none());
+    }
+
+    #[test]
+    fn extract_room_number_from_label() {
+        assert_eq!(extract_room_number("102房间", ""), "102");
+        assert_eq!(extract_room_number("东苑7栋1层 1102", ""), "1102");
+    }
 }
 
 async fn fetch_smart_electricity_stats(
@@ -554,7 +647,42 @@ async fn fetch_smart_electricity_stats(
         return Err("请先在上方选择房间，或到一码通绑定宿舍后再查趋势".into());
     }
 
-    // 5) 按候选依次拉趋势
+    // 5) 选房即绑定：先尝试把官方绑定改为所选房间，再拉趋势
+    if !pref.is_empty() {
+        for (room, _, _) in candidates.iter().take(3) {
+            if try_swae_bind_room(client, &final_url, &sid, room).await {
+                // 刷新绑定信息
+                if let Ok(b) = swae_post(
+                    client,
+                    &final_url,
+                    "getbindroom",
+                    json!({
+                        "cmd": "getbindroom",
+                        "account": sid,
+                        "timestamp": Local::now().format("%Y%m%d%H%M%S%3f").to_string()
+                    }),
+                )
+                .await
+                {
+                    if let Some(body) = parse_swae_body(&b) {
+                        if let Some(rv) = body.get("roomverify").and_then(|v| v.as_str()) {
+                            bound_room = rv.trim().to_string();
+                        }
+                        if let Some(rn) = body.get("roomfullname").and_then(|v| v.as_str()) {
+                            bound_name = rn.to_string();
+                        }
+                    }
+                }
+                crate::runtime_log::log_info(
+                    "ElectricityBind",
+                    format!("绑定已更新 bound={bound_room} name={bound_name}"),
+                );
+                break;
+            }
+        }
+    }
+
+    // 6) 按候选依次拉趋势
     let mut last_err = String::new();
     for (room, source, room_name) in candidates {
         match fetch_usage_for_room(
@@ -570,7 +698,16 @@ async fn fetch_smart_electricity_stats(
         )
         .await
         {
-            Ok(v) => return Ok(v),
+            Ok(mut v) => {
+                // 标注是否已与绑定房对齐
+                if let Some(obj) = v.as_object_mut() {
+                    if !bound_room.is_empty() && bound_room == room {
+                        obj.insert("hint".into(), json!("已切换绑定房间，并显示该房用电趋势"));
+                        obj.insert("bound_updated".into(), json!(true));
+                    }
+                }
+                return Ok(v);
+            }
             Err(e) => {
                 last_err = e;
                 crate::runtime_log::log_warn(

--- a/src-tauri/src/modules/one_code.rs
+++ b/src-tauri/src/modules/one_code.rs
@@ -575,8 +575,7 @@ mod tests {
         assert_eq!(plan_fail.effective_bound, "101-7--254-101");
         assert!(plan_fail.query_rooms.iter().any(|r| r.ends_with("102")));
         // 无响应：不更新 bound，仍查 selected
-        let plan_none =
-            apply_room_selection("101-7--254-102", "102房间", "101-7--254-101", None);
+        let plan_none = apply_room_selection("101-7--254-102", "102房间", "101-7--254-101", None);
         assert!(!plan_none.bound_updated);
         assert_eq!(plan_none.effective_bound, "101-7--254-101");
     }
@@ -763,10 +762,7 @@ async fn fetch_smart_electricity_stats(
             }
             // 绑定成功后，把 effective_bound 提到候选最前，保证趋势走绑定房
             if !bound_room.is_empty() && !candidates.iter().any(|(r, _, _)| r == &bound_room) {
-                candidates.insert(
-                    0,
-                    (bound_room.clone(), "selected", label.to_string()),
-                );
+                candidates.insert(0, (bound_room.clone(), "selected", label.to_string()));
             } else if !bound_room.is_empty() {
                 if let Some(pos) = candidates.iter().position(|(r, _, _)| r == &bound_room) {
                     let item = candidates.remove(pos);

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -2315,13 +2315,18 @@ async fn fetch_chaoxing_outline_remote(
         return Err(err_box("学习通会话已失效，请重新登录"));
     }
 
-    // 官方目录：一级 firstLayer（章）+ 二级 id="cur{knowledgeId}" + getTeacherAjax
-    // 属性顺序因课而异，放宽正则（title/onclick 可交换、可跨属性）
-    let re_leaf = regex::Regex::new(
-        r#"id="cur(\d+)"[\s\S]{0,2500}?getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#,
-    )
-    .expect("regex leaf");
-    let re_leaf_title = regex::Regex::new(r#"title="\s*([^"]*?)\s*""#).expect("regex leaf title");
+    // 生产路径：与单测共用 assemble_chaoxing_outline_from_html / extract_chaoxing_catalog_leaves
+    assemble_chaoxing_outline_from_html(&html, course_id, clazz_id, cpi, &target)
+}
+
+/// 从章节 HTML 组装大纲（生产 fetch_chaoxing_outline_remote + 单测共用）
+pub fn assemble_chaoxing_outline_from_html(
+    html: &str,
+    course_id: &str,
+    clazz_id: &str,
+    cpi: &str,
+    course_url: &str,
+) -> Result<Value, DynError> {
     let re_section = regex::Regex::new(
         r#"(?i)(?:posCatalog_select\s+firstLayer|firstLayer)[^>]*id="(\d+)"[\s\S]{0,500}?title="([^"]+)""#,
     )
@@ -2329,9 +2334,8 @@ async fn fetch_chaoxing_outline_remote(
     let re_section_alt =
         regex::Regex::new(r#"(?i)class="[^"]*catalog_name[^"]*"[^>]*>([^<]{1,80})<"#).ok();
 
-    // 收集一级章标题及其在 HTML 中的位置
     let mut section_marks: Vec<(usize, String, String)> = Vec::new();
-    for cap in re_section.captures_iter(&html) {
+    for cap in re_section.captures_iter(html) {
         let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
         let sid = cap[1].to_string();
         let title = cap[2].trim().to_string();
@@ -2339,145 +2343,9 @@ async fn fetch_chaoxing_outline_remote(
             section_marks.push((pos, sid, title));
         }
     }
-
-    let mut leaves: Vec<(usize, Value)> = Vec::new();
-    let mut seen = HashSet::new();
-    for cap in re_leaf.captures_iter(&html) {
-        let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
-        let cur_id = cap[1].to_string();
-        let cap_course_id = cap[2].to_string();
-        let cap_clazz_id = cap[3].to_string();
-        let knowledge_id = cap[4].to_string();
-        let start = pos;
-        let end = html[start + 1..]
-            .find(r#"id="cur"#)
-            .map(|p| start + 1 + p)
-            .unwrap_or((start + 1200).min(html.len()));
-        let block = &html[start..end];
-        let title = re_leaf_title
-            .captures(block)
-            .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
-            .filter(|t| !t.is_empty())
-            .unwrap_or_else(|| format!("小节 {knowledge_id}"));
-        if !seen.insert(knowledge_id.clone()) {
-            continue;
-        }
-        let completed = block.contains("icon_Completed") || block.contains("icon_yiwanc");
-        let has_unfinished = block.contains("jobUnfinishCount");
-        leaves.push((
-            pos,
-            json!({
-                "id": knowledge_id.clone(),
-                "title": title.clone(),
-                "name": title,
-                "course_id": cap_course_id,
-                "clazz_id": cap_clazz_id,
-                "cpi": cpi,
-                "chapter_id": cur_id,
-                "knowledge_id": knowledge_id,
-                "completed": completed && !has_unfinished,
-                "task_type": "knowledge",
-                "type": "knowledge",
-                // 叶子任务：前端展开时再拉 knowledge/cards
-                "children": [],
-                "tasks": []
-            }),
-        ));
-    }
-
-    println!(
-        "[调试] 章节解析: sections={} leaves={}",
-        section_marks.len(),
-        leaves.len()
-    );
-
-    // 兜底：扁平匹配 getTeacherAjax（不依赖 id=cur 顺序 / title 位置）
-    if leaves.is_empty() {
-        let re_ajax =
-            regex::Regex::new(r#"getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#).expect("regex ajax");
-        for cap in re_ajax.captures_iter(&html) {
-            let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
-            let knowledge_id = cap[3].to_string();
-            if !seen.insert(knowledge_id.clone()) {
-                continue;
-            }
-            let window_start = pos.saturating_sub(400);
-            let window = &html[window_start..pos.min(html.len())];
-            let title = re_leaf_title
-                .captures(window)
-                .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
-                .filter(|t| !t.is_empty())
-                .unwrap_or_else(|| format!("小节 {knowledge_id}"));
-            leaves.push((
-                pos,
-                json!({
-                    "id": knowledge_id.clone(),
-                    "title": title.clone(),
-                    "name": title,
-                    "course_id": cap[1].to_string(),
-                    "clazz_id": cap[2].to_string(),
-                    "cpi": cpi,
-                    "chapter_id": knowledge_id.clone(),
-                    "knowledge_id": knowledge_id,
-                    "completed": false,
-                    "task_type": "knowledge",
-                    "type": "knowledge",
-                    "children": [],
-                    "tasks": []
-                }),
-            ));
-        }
-        println!("[调试] 章节解析: ajax 兜底 {} 个", leaves.len());
-    }
-
-    // 再兜底：data-id / chapterId 属性
-    if leaves.is_empty() {
-        let re_data = regex::Regex::new(
-            r#"(?i)(?:data-id|data-chapterid|chapterid|knowledgeid)=["']?(\d{5,})["']?"#,
-        )
-        .ok();
-        if let Some(re) = re_data {
-            for (i, cap) in re.captures_iter(&html).enumerate() {
-                if i > 200 {
-                    break;
-                }
-                let knowledge_id = cap[1].to_string();
-                if !seen.insert(knowledge_id.clone()) {
-                    continue;
-                }
-                leaves.push((
-                    cap.get(0).map(|m| m.start()).unwrap_or(0),
-                    json!({
-                        "id": knowledge_id.clone(),
-                        "title": format!("小节 {knowledge_id}"),
-                        "name": format!("小节 {knowledge_id}"),
-                        "course_id": course_id,
-                        "clazz_id": clazz_id,
-                        "cpi": cpi,
-                        "chapter_id": knowledge_id.clone(),
-                        "knowledge_id": knowledge_id,
-                        "completed": false,
-                        "task_type": "knowledge",
-                        "type": "knowledge",
-                        "children": [],
-                        "tasks": []
-                    }),
-                ));
-            }
-        }
-    }
-
-    if leaves.is_empty() {
-        // 不可返回 success+空任务（前端会显示全 0 空章）；交给调用方 toast/重登
-        return Err(err_box(
-            "未解析到可展开的小节。请尝试刷新章节，或重新登录学习通后再打开该课程",
-        ));
-    }
-
-    // section 标题兜底（部分课 firstLayer class 变体）
     if section_marks.is_empty() {
         if let Some(re) = re_section_alt.as_ref() {
-            for (i, cap) in re.captures_iter(&html).enumerate() {
+            for (i, cap) in re.captures_iter(html).enumerate() {
                 let title = cap[1].trim().to_string();
                 if title.is_empty() {
                     continue;
@@ -2491,19 +2359,60 @@ async fn fetch_chaoxing_outline_remote(
         }
     }
 
-    // 组装 sections：每个一级章挂下属 knowledge 任务
+    let raw_leaves = extract_chaoxing_catalog_leaves(html);
+    let mut leaves: Vec<(usize, Value)> = Vec::new();
+    for (pos, knowledge_id, title, cap_course_id, cap_clazz_id, cur_id) in raw_leaves {
+        let chapter_id = if cur_id.is_empty() {
+            knowledge_id.clone()
+        } else {
+            cur_id
+        };
+        let cid = if cap_course_id.is_empty() {
+            course_id.to_string()
+        } else {
+            cap_course_id
+        };
+        let clz = if cap_clazz_id.is_empty() {
+            clazz_id.to_string()
+        } else {
+            cap_clazz_id
+        };
+        leaves.push((
+            pos,
+            json!({
+                "id": knowledge_id.clone(),
+                "title": title.clone(),
+                "name": title,
+                "course_id": cid,
+                "clazz_id": clz,
+                "cpi": cpi,
+                "chapter_id": chapter_id,
+                "knowledge_id": knowledge_id,
+                "completed": false,
+                "task_type": "knowledge",
+                "type": "knowledge",
+                "children": [],
+                "tasks": []
+            }),
+        ));
+    }
+
+    println!(
+        "[调试] 章节解析: sections={} leaves={}",
+        section_marks.len(),
+        leaves.len()
+    );
+
+    if leaves.is_empty() {
+        return Err(err_box(
+            "未解析到可展开的小节。请尝试刷新章节，或重新登录学习通后再打开该课程",
+        ));
+    }
+
     let mut sections: Vec<Value> = Vec::new();
     if section_marks.is_empty() {
         let tasks: Vec<Value> = leaves.into_iter().map(|(_, v)| v).collect();
         let total = tasks.len();
-        let done = tasks
-            .iter()
-            .filter(|t| {
-                t.get("completed")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false)
-            })
-            .count();
         sections.push(json!({
             "id": "all",
             "title": "全部章节",
@@ -2515,12 +2424,12 @@ async fn fetch_chaoxing_outline_remote(
             "sections": sections,
             "nodes": sections[0]["tasks"].clone(),
             "total_count": total,
-            "completed_count": done,
-            "pending_count": total.saturating_sub(done),
+            "completed_count": 0,
+            "pending_count": total,
             "course_id": course_id,
             "clazz_id": clazz_id,
             "cpi": cpi,
-            "course_url": target
+            "course_url": course_url
         }));
     }
 
@@ -2542,7 +2451,6 @@ async fn fetch_chaoxing_outline_remote(
         }));
     }
 
-    // 若按章切分后全是空章（位置对齐失败），退回「全部章节」挂载全部叶子
     let any_tasks = sections.iter().any(|s| {
         s.get("tasks")
             .and_then(|t| t.as_array())
@@ -2557,64 +2465,47 @@ async fn fetch_chaoxing_outline_remote(
             "tasks": tasks,
             "children": []
         })];
-    }
-
-    // 章前游离节点
-    let first_pos = section_marks[0].0;
-    let orphan: Vec<Value> = leaves
-        .iter()
-        .filter(|(p, _)| *p < first_pos)
-        .map(|(_, v)| v.clone())
-        .collect();
-    if !orphan.is_empty() && any_tasks {
-        sections.insert(
-            0,
-            json!({
-                "id": "intro",
-                "title": "导学",
-                "tasks": orphan,
-                "children": []
-            }),
-        );
-    }
-
-    let mut total_count = 0usize;
-    let mut completed_count = 0usize;
-    for sec in &sections {
-        if let Some(arr) = sec.get("tasks").and_then(|v| v.as_array()) {
-            total_count += arr.len();
-            completed_count += arr
-                .iter()
-                .filter(|t| {
-                    t.get("completed")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false)
-                })
-                .count();
+    } else if any_tasks {
+        let first_pos = section_marks[0].0;
+        let orphan: Vec<Value> = leaves
+            .iter()
+            .filter(|(p, _)| *p < first_pos)
+            .map(|(_, v)| v.clone())
+            .collect();
+        if !orphan.is_empty() {
+            sections.insert(
+                0,
+                json!({
+                    "id": "intro",
+                    "title": "导学",
+                    "tasks": orphan,
+                    "children": []
+                }),
+            );
         }
     }
 
-    let nodes: Vec<Value> = sections
-        .iter()
-        .flat_map(|s| {
-            s.get("tasks")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default()
-        })
-        .collect();
+    let mut total_count = 0usize;
+    for sec in &sections {
+        if let Some(arr) = sec.get("tasks").and_then(|v| v.as_array()) {
+            total_count += arr.len();
+        }
+    }
 
     Ok(json!({
         "success": true,
         "sections": sections,
-        "nodes": nodes,
+        "nodes": sections
+            .iter()
+            .flat_map(|s| s.get("tasks").and_then(|t| t.as_array()).cloned().unwrap_or_default())
+            .collect::<Vec<_>>(),
         "total_count": total_count,
-        "completed_count": completed_count,
-        "pending_count": total_count.saturating_sub(completed_count),
+        "completed_count": 0,
+        "pending_count": total_count,
         "course_id": course_id,
         "clazz_id": clazz_id,
         "cpi": cpi,
-        "course_url": target
+        "course_url": course_url
     }))
 }
 
@@ -4477,6 +4368,28 @@ mod catalog_and_video_tests {
     #[test]
     fn empty_html_has_no_leaves() {
         assert!(extract_chaoxing_catalog_leaves("<html></html>").is_empty());
+    }
+
+    #[test]
+    fn assemble_outline_drives_extract_leaves() {
+        let html = r#"
+        <div class="posCatalog_select firstLayer" id="1" title="第一章 绪论"></div>
+        <div id="cur1001" title=" 1.1 电路模型" onclick="getTeacherAjax('2288','3399','100239488')"></div>
+        <div id="cur1002" title="1.2 电源" onclick="getTeacherAjax('2288','3399','100239489')"></div>
+        "#;
+        let out = assemble_chaoxing_outline_from_html(
+            html,
+            "2288",
+            "3399",
+            "1",
+            "https://example/course",
+        )
+        .expect("outline");
+        assert_eq!(out["success"], true);
+        let total = out["total_count"].as_u64().unwrap_or(0);
+        assert!(total >= 2, "total={total} out={out}");
+        let leaves = extract_chaoxing_catalog_leaves(html);
+        assert_eq!(leaves.len() as u64, total);
     }
 
     #[test]

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -1526,8 +1526,76 @@ async fn fetch_chaoxing_folder_courses(
     propagate_chaoxing_key_cookies(client);
     let mut out = Vec::new();
 
-    // 1) 交互页抽 folder id
+    // 1) 交互页 + API 抽 folder id（多学期依赖课程夹）
     let mut folder_ids: Vec<(String, String)> = vec![("0".into(), "本学期".into())];
+    let mut push_folder = |id: String, name: String| {
+        let id = id.trim().to_string();
+        if id.is_empty() {
+            return;
+        }
+        if folder_ids.iter().any(|(i, _)| i == &id) {
+            return;
+        }
+        let name = sanitize_text(&name);
+        folder_ids.push((
+            id,
+            if name.is_empty() {
+                "历史课程".into()
+            } else {
+                name
+            },
+        ));
+    };
+
+    // API：课程夹列表（比 HTML 正则更稳）
+    for api in [
+        "https://mooc1-api.chaoxing.com/mycourse/getCourseFolders?view=json",
+        "https://mooc1.chaoxing.com/mooc-ans/visit/coursefolders?view=json",
+        "https://mooc1-api.chaoxing.com/gas/folder?view=json",
+    ] {
+        if let Ok(resp) = client
+            .client
+            .get(api)
+            .header("Accept", "application/json, text/plain, */*")
+            .header("Referer", "https://mooc1.chaoxing.com/visit/interaction")
+            .timeout(Duration::from_secs(12))
+            .send()
+            .await
+        {
+            if let Ok(v) = resp.json::<Value>().await {
+                let arr = v
+                    .get("data")
+                    .and_then(|d| d.as_array())
+                    .or_else(|| v.get("channelList").and_then(|d| d.as_array()))
+                    .or_else(|| v.get("folderList").and_then(|d| d.as_array()))
+                    .or_else(|| v.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                for item in arr {
+                    let id = item
+                        .get("id")
+                        .or_else(|| item.get("folderId"))
+                        .or_else(|| item.get("courseFolderId"))
+                        .or_else(|| item.get("cfid"))
+                        .map(|x| match x {
+                            Value::Number(n) => n.to_string(),
+                            Value::String(s) => s.clone(),
+                            _ => String::new(),
+                        })
+                        .unwrap_or_default();
+                    let name = item
+                        .get("name")
+                        .or_else(|| item.get("folderName"))
+                        .or_else(|| item.get("title"))
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    push_folder(id, name);
+                }
+            }
+        }
+    }
+
     if let Ok(resp) = client
         .client
         .get("https://mooc1.chaoxing.com/mooc-ans/visit/interaction")
@@ -1543,37 +1611,44 @@ async fn fetch_chaoxing_folder_courses(
             r#"courseFolderId[=:\s"']+(\d+)[^>]{0,200}?(?:title|data-name|folderName)[=:\s"']+([^"'<]{1,40})"#,
         )
         .ok();
-        let re_folder2 = regex::Regex::new(r#"(?i)(?:folderid|courseFolderId)["'=\s:]+(\d+)"#).ok();
+        let re_folder2 =
+            regex::Regex::new(r#"(?i)(?:folderid|courseFolderId|cfid)["'=\s:]+(\d+)"#).ok();
+        let re_folder3 = regex::Regex::new(
+            r#"(?i)data-(?:id|folderid|cfid)="(\d+)"[^>]{0,120}?(?:title|data-name)="([^"]{1,40})""#,
+        )
+        .ok();
         if let Some(re) = re_folder {
             for cap in re.captures_iter(&html) {
                 let id = cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string();
-                let name = sanitize_text(cap.get(2).map(|m| m.as_str()).unwrap_or("历史"));
-                if !id.is_empty() && id != "0" {
-                    folder_ids.push((
-                        id,
-                        if name.is_empty() {
-                            "历史课程".into()
-                        } else {
-                            name
-                        },
-                    ));
+                let name = cap.get(2).map(|m| m.as_str()).unwrap_or("历史").to_string();
+                if id != "0" {
+                    push_folder(id, name);
                 }
             }
         }
         if let Some(re) = re_folder2 {
             for cap in re.captures_iter(&html) {
                 let id = cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string();
-                if !id.is_empty() && !folder_ids.iter().any(|(i, _)| i == &id) {
-                    folder_ids.push((id, "历史课程".into()));
-                }
+                push_folder(id, "历史课程".into());
             }
+        }
+        if let Some(re) = re_folder3 {
+            for cap in re.captures_iter(&html) {
+                let id = cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string();
+                let name = cap.get(2).map(|m| m.as_str()).unwrap_or("历史").to_string();
+                push_folder(id, name);
+            }
+        }
+        // 常见：本学期 + 往年夹 1..N 试探（部分账号 HTML 不暴露 id）
+        for probe in 1..=8 {
+            push_folder(probe.to_string(), format!("课程夹 {probe}"));
         }
     }
 
-    // 去重 folder，最多扫 12 个
+    // 去重 folder，最多扫 16 个
     folder_ids.sort_by(|a, b| a.0.cmp(&b.0));
     folder_ids.dedup_by(|a, b| a.0 == b.0);
-    folder_ids.truncate(12);
+    folder_ids.truncate(16);
 
     for (folder_id, folder_name) in folder_ids {
         let body = format!("courseType=1&courseFolderId={folder_id}&superstarClass=0");
@@ -2241,16 +2316,18 @@ async fn fetch_chaoxing_outline_remote(
     }
 
     // 官方目录：一级 firstLayer（章）+ 二级 id="cur{knowledgeId}" + getTeacherAjax
-    // 实测 title 在 posCatalog_name 上，与 onclick 同标签：
-    //   id="cur100239488" ... title=" 电路模型..." onclick="getTeacherAjax('cid','clazz','kid')"
+    // 属性顺序因课而异，放宽正则（title/onclick 可交换、可跨属性）
     let re_leaf = regex::Regex::new(
-        r#"id="cur(\d+)"[\s\S]{0,1500}?title="\s*([^"]*?)"\s+onclick="getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#,
+        r#"id="cur(\d+)"[\s\S]{0,2500}?getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#,
     )
     .expect("regex leaf");
+    let re_leaf_title = regex::Regex::new(r#"title="\s*([^"]*?)\s*""#).expect("regex leaf title");
     let re_section = regex::Regex::new(
-        r#"posCatalog_select firstLayer"[^>]*id="(\d+)"[\s\S]{0,400}?title="([^"]+)"#,
+        r#"(?i)(?:posCatalog_select\s+firstLayer|firstLayer)[^>]*id="(\d+)"[\s\S]{0,500}?title="([^"]+)""#,
     )
     .expect("regex section");
+    let re_section_alt =
+        regex::Regex::new(r#"(?i)class="[^"]*catalog_name[^"]*"[^>]*>([^<]{1,80})<"#).ok();
 
     // 收集一级章标题及其在 HTML 中的位置
     let mut section_marks: Vec<(usize, String, String)> = Vec::new();
@@ -2268,31 +2345,31 @@ async fn fetch_chaoxing_outline_remote(
     for cap in re_leaf.captures_iter(&html) {
         let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
         let cur_id = cap[1].to_string();
-        let title = cap[2].trim().to_string();
-        let cap_course_id = cap[3].to_string();
-        let cap_clazz_id = cap[4].to_string();
-        let knowledge_id = cap[5].to_string();
-        if title.is_empty() || !seen.insert(knowledge_id.clone()) {
-            continue;
-        }
+        let cap_course_id = cap[2].to_string();
+        let cap_clazz_id = cap[3].to_string();
+        let knowledge_id = cap[4].to_string();
         let start = pos;
         let end = html[start + 1..]
             .find(r#"id="cur"#)
             .map(|p| start + 1 + p)
-            .unwrap_or((start + 800).min(html.len()));
+            .unwrap_or((start + 1200).min(html.len()));
         let block = &html[start..end];
+        let title = re_leaf_title
+            .captures(block)
+            .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| format!("小节 {knowledge_id}"));
+        if !seen.insert(knowledge_id.clone()) {
+            continue;
+        }
         let completed = block.contains("icon_Completed") || block.contains("icon_yiwanc");
         let has_unfinished = block.contains("jobUnfinishCount");
-        let label = {
-            // 优先 em.posCatalog_sbar 序号，已在 title 里
-            title.clone()
-        };
         leaves.push((
             pos,
             json!({
                 "id": knowledge_id.clone(),
-                "title": label,
-                "name": label,
+                "title": title.clone(),
+                "name": title,
                 "course_id": cap_course_id,
                 "clazz_id": cap_clazz_id,
                 "cpi": cpi,
@@ -2314,26 +2391,31 @@ async fn fetch_chaoxing_outline_remote(
         leaves.len()
     );
 
-    // 兜底：扁平匹配 getTeacherAjax（不依赖 id=cur 顺序）
+    // 兜底：扁平匹配 getTeacherAjax（不依赖 id=cur 顺序 / title 位置）
     if leaves.is_empty() {
-        let re_ajax = regex::Regex::new(
-            r#"title="\s*([^"]*?)"\s+onclick="getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#,
-        )
-        .expect("regex ajax");
+        let re_ajax =
+            regex::Regex::new(r#"getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#).expect("regex ajax");
         for cap in re_ajax.captures_iter(&html) {
-            let title = cap[1].trim().to_string();
-            let knowledge_id = cap[4].to_string();
-            if title.is_empty() || !seen.insert(knowledge_id.clone()) {
+            let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+            let knowledge_id = cap[3].to_string();
+            if !seen.insert(knowledge_id.clone()) {
                 continue;
             }
+            let window_start = pos.saturating_sub(400);
+            let window = &html[window_start..pos.min(html.len())];
+            let title = re_leaf_title
+                .captures(window)
+                .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
+                .filter(|t| !t.is_empty())
+                .unwrap_or_else(|| format!("小节 {knowledge_id}"));
             leaves.push((
-                cap.get(0).map(|m| m.start()).unwrap_or(0),
+                pos,
                 json!({
                     "id": knowledge_id.clone(),
                     "title": title.clone(),
                     "name": title,
-                    "course_id": cap[2].to_string(),
-                    "clazz_id": cap[3].to_string(),
+                    "course_id": cap[1].to_string(),
+                    "clazz_id": cap[2].to_string(),
                     "cpi": cpi,
                     "chapter_id": knowledge_id.clone(),
                     "knowledge_id": knowledge_id,
@@ -2348,8 +2430,82 @@ async fn fetch_chaoxing_outline_remote(
         println!("[调试] 章节解析: ajax 兜底 {} 个", leaves.len());
     }
 
+    // 再兜底：data-id / chapterId 属性
     if leaves.is_empty() {
-        return Err(err_box("未解析到学习通章节结构"));
+        let re_data = regex::Regex::new(
+            r#"(?i)(?:data-id|data-chapterid|chapterid|knowledgeid)=["']?(\d{5,})["']?"#,
+        )
+        .ok();
+        if let Some(re) = re_data {
+            for (i, cap) in re.captures_iter(&html).enumerate() {
+                if i > 200 {
+                    break;
+                }
+                let knowledge_id = cap[1].to_string();
+                if !seen.insert(knowledge_id.clone()) {
+                    continue;
+                }
+                leaves.push((
+                    cap.get(0).map(|m| m.start()).unwrap_or(0),
+                    json!({
+                        "id": knowledge_id.clone(),
+                        "title": format!("小节 {knowledge_id}"),
+                        "name": format!("小节 {knowledge_id}"),
+                        "course_id": course_id,
+                        "clazz_id": clazz_id,
+                        "cpi": cpi,
+                        "chapter_id": knowledge_id.clone(),
+                        "knowledge_id": knowledge_id,
+                        "completed": false,
+                        "task_type": "knowledge",
+                        "type": "knowledge",
+                        "children": [],
+                        "tasks": []
+                    }),
+                ));
+            }
+        }
+    }
+
+    if leaves.is_empty() {
+        // 仍失败：至少返回占位章节，避免前端「全 0」且不可点
+        return Ok(json!({
+            "success": true,
+            "sections": [{
+                "id": "empty",
+                "title": "全部章节",
+                "tasks": [],
+                "children": [],
+                "empty_hint": true,
+                "message": "未解析到可展开的小节（可能是章节页结构变更或会话不完整）"
+            }],
+            "nodes": [],
+            "total_count": 0,
+            "completed_count": 0,
+            "pending_count": 0,
+            "course_id": course_id,
+            "clazz_id": clazz_id,
+            "cpi": cpi,
+            "course_url": target,
+            "parse_warning": "outline_empty"
+        }));
+    }
+
+    // section 标题兜底（部分课 firstLayer class 变体）
+    if section_marks.is_empty() {
+        if let Some(re) = re_section_alt.as_ref() {
+            for (i, cap) in re.captures_iter(&html).enumerate() {
+                let title = cap[1].trim().to_string();
+                if title.is_empty() {
+                    continue;
+                }
+                section_marks.push((
+                    cap.get(0).map(|m| m.start()).unwrap_or(0),
+                    format!("sec{i}"),
+                    title,
+                ));
+            }
+        }
     }
 
     // 组装 sections：每个一级章挂下属 knowledge 任务
@@ -2403,6 +2559,23 @@ async fn fetch_chaoxing_outline_remote(
         }));
     }
 
+    // 若按章切分后全是空章（位置对齐失败），退回「全部章节」挂载全部叶子
+    let any_tasks = sections.iter().any(|s| {
+        s.get("tasks")
+            .and_then(|t| t.as_array())
+            .map(|a| !a.is_empty())
+            .unwrap_or(false)
+    });
+    if !any_tasks && !leaves.is_empty() {
+        let tasks: Vec<Value> = leaves.iter().map(|(_, v)| v.clone()).collect();
+        sections = vec![json!({
+            "id": "all",
+            "title": "全部章节",
+            "tasks": tasks,
+            "children": []
+        })];
+    }
+
     // 章前游离节点
     let first_pos = section_marks[0].0;
     let orphan: Vec<Value> = leaves
@@ -2410,7 +2583,7 @@ async fn fetch_chaoxing_outline_remote(
         .filter(|(p, _)| *p < first_pos)
         .map(|(_, v)| v.clone())
         .collect();
-    if !orphan.is_empty() {
+    if !orphan.is_empty() && any_tasks {
         sections.insert(
             0,
             json!({
@@ -3886,6 +4059,16 @@ pub async fn chaoxing_get_video_status(
     };
     let ts = chrono::Utc::now().timestamp_millis().to_string();
     // 依次尝试不同域名 / 参数，提高成功率
+    // 预热学习通 cookie 到 ananas/mooc 域
+    propagate_chaoxing_key_cookies(client);
+    let _ = client
+        .client
+        .get("https://mooc1.chaoxing.com/ananas/modules/video/index.html?v=2026-0327-1642")
+        .header("Referer", "https://mooc1.chaoxing.com/")
+        .timeout(Duration::from_secs(8))
+        .send()
+        .await;
+
     let candidates = [
         format!("https://mooc1.chaoxing.com/ananas/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
         format!(
@@ -3894,6 +4077,8 @@ pub async fn chaoxing_get_video_status(
         format!("https://mooc1.chaoxing.com/ananas/status/{oid}?flag=normal&_dc={ts}"),
         format!("https://s1.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
         format!("https://s2.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!("https://s3.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!("https://cloud1-0.cldisk.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
         format!("https://noteyd.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
     ];
     let mut last_err = String::new();
@@ -3905,11 +4090,12 @@ pub async fn chaoxing_get_video_status(
                 "Referer",
                 "https://mooc1.chaoxing.com/ananas/modules/video/index.html?v=2026-0327-1642",
             )
+            .header("Origin", "https://mooc1.chaoxing.com")
             .header("Accept", "application/json, text/javascript, */*; q=0.01")
             .header("X-Requested-With", "XMLHttpRequest")
             .header(
                 "User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 ChaoXingStudy/3.2.0",
             )
             .timeout(Duration::from_secs(15))
             .send()

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -2468,27 +2468,10 @@ async fn fetch_chaoxing_outline_remote(
     }
 
     if leaves.is_empty() {
-        // 仍失败：至少返回占位章节，避免前端「全 0」且不可点
-        return Ok(json!({
-            "success": true,
-            "sections": [{
-                "id": "empty",
-                "title": "全部章节",
-                "tasks": [],
-                "children": [],
-                "empty_hint": true,
-                "message": "未解析到可展开的小节（可能是章节页结构变更或会话不完整）"
-            }],
-            "nodes": [],
-            "total_count": 0,
-            "completed_count": 0,
-            "pending_count": 0,
-            "course_id": course_id,
-            "clazz_id": clazz_id,
-            "cpi": cpi,
-            "course_url": target,
-            "parse_warning": "outline_empty"
-        }));
+        // 不可返回 success+空任务（前端会显示全 0 空章）；交给调用方 toast/重登
+        return Err(err_box(
+            "未解析到可展开的小节。请尝试刷新章节，或重新登录学习通后再打开该课程",
+        ));
     }
 
     // section 标题兜底（部分课 firstLayer class 变体）
@@ -4039,6 +4022,99 @@ pub async fn chaoxing_fetch_course_score(
     }))
 }
 
+/// 构造 ananas status 候选 URL（纯函数，单测覆盖）
+pub fn chaoxing_video_status_candidate_urls(
+    object_id: &str,
+    fid: &str,
+    ts_ms: &str,
+) -> Vec<String> {
+    let oid = object_id.trim();
+    let fid_s = if fid.trim().is_empty() {
+        "0"
+    } else {
+        fid.trim()
+    };
+    let ts = if ts_ms.trim().is_empty() {
+        "0"
+    } else {
+        ts_ms.trim()
+    };
+    vec![
+        format!("https://mooc1.chaoxing.com/ananas/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!(
+            "https://mooc1-api.chaoxing.com/ananas/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"
+        ),
+        format!("https://mooc1.chaoxing.com/ananas/status/{oid}?flag=normal&_dc={ts}"),
+        format!("https://s1.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!("https://s2.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!("https://s3.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!("https://cloud1-0.cldisk.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+        format!("https://noteyd.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
+    ]
+}
+
+/// 从章节页 HTML 提取 knowledge 叶子（纯函数）
+/// 返回 (pos, knowledge_id, title, course_id, clazz_id, chapter_cur_id)
+pub fn extract_chaoxing_catalog_leaves(
+    html: &str,
+) -> Vec<(usize, String, String, String, String, String)> {
+    let re_leaf = regex::Regex::new(
+        r#"id="cur(\d+)"[\s\S]{0,2500}?getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#,
+    )
+    .expect("regex leaf");
+    let re_leaf_title = regex::Regex::new(r#"title="\s*([^"]*?)\s*""#).expect("regex leaf title");
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for cap in re_leaf.captures_iter(html) {
+        let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+        let cur_id = cap[1].to_string();
+        let course_id = cap[2].to_string();
+        let clazz_id = cap[3].to_string();
+        let knowledge_id = cap[4].to_string();
+        if !seen.insert(knowledge_id.clone()) {
+            continue;
+        }
+        let end = html[pos + 1..]
+            .find(r#"id="cur"#)
+            .map(|p| pos + 1 + p)
+            .unwrap_or((pos + 1200).min(html.len()));
+        let block = &html[pos..end];
+        let title = re_leaf_title
+            .captures(block)
+            .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
+            .filter(|t| !t.is_empty())
+            .unwrap_or_else(|| format!("小节 {knowledge_id}"));
+        out.push((pos, knowledge_id, title, course_id, clazz_id, cur_id));
+    }
+    if out.is_empty() {
+        let re_ajax =
+            regex::Regex::new(r#"getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#).expect("ajax");
+        for cap in re_ajax.captures_iter(html) {
+            let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+            let knowledge_id = cap[3].to_string();
+            if !seen.insert(knowledge_id.clone()) {
+                continue;
+            }
+            let window_start = pos.saturating_sub(400);
+            let window = &html[window_start..pos.min(html.len())];
+            let title = re_leaf_title
+                .captures(window)
+                .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
+                .filter(|t| !t.is_empty())
+                .unwrap_or_else(|| format!("小节 {knowledge_id}"));
+            out.push((
+                pos,
+                knowledge_id,
+                title,
+                cap[1].to_string(),
+                cap[2].to_string(),
+                String::new(),
+            ));
+        }
+    }
+    out
+}
+
 /// 获取视频文件状态（dtoken、duration、播放直链 http/https）
 pub async fn chaoxing_get_video_status(
     client: &HbutClient,
@@ -4069,18 +4145,7 @@ pub async fn chaoxing_get_video_status(
         .send()
         .await;
 
-    let candidates = [
-        format!("https://mooc1.chaoxing.com/ananas/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
-        format!(
-            "https://mooc1-api.chaoxing.com/ananas/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"
-        ),
-        format!("https://mooc1.chaoxing.com/ananas/status/{oid}?flag=normal&_dc={ts}"),
-        format!("https://s1.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
-        format!("https://s2.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
-        format!("https://s3.ananas.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
-        format!("https://cloud1-0.cldisk.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
-        format!("https://noteyd.chaoxing.com/status/{oid}?k={fid_s}&flag=normal&_dc={ts}"),
-    ];
+    let candidates = chaoxing_video_status_candidate_urls(oid, fid_s, &ts);
     let mut last_err = String::new();
     for url in candidates {
         let resp = match client
@@ -4388,4 +4453,42 @@ pub async fn yuketang_send_heartbeat(
         "status_code": status,
         "data": data,
     }))
+}
+
+#[cfg(test)]
+mod catalog_and_video_tests {
+    use super::*;
+
+    #[test]
+    fn extract_leaves_from_realistic_html() {
+        let html = r#"
+        <div class="posCatalog_select firstLayer" id="1" title="第一章 绪论"></div>
+        <div id="cur1001" class="posCatalog_name" title=" 1.1 电路模型" onclick="getTeacherAjax('2288','3399','100239488')"></div>
+        <div id="cur1002" title="1.2 电源" onclick="getTeacherAjax('2288','3399','100239489')"></div>
+        "#;
+        let leaves = extract_chaoxing_catalog_leaves(html);
+        assert!(leaves.len() >= 2, "expected >=2 leaves, got {:?}", leaves);
+        assert!(leaves
+            .iter()
+            .any(|(_, kid, title, _, _, _)| kid == "100239488" && title.contains("电路")));
+        assert!(leaves.iter().any(|(_, kid, _, _, _, _)| kid == "100239489"));
+    }
+
+    #[test]
+    fn empty_html_has_no_leaves() {
+        assert!(extract_chaoxing_catalog_leaves("<html></html>").is_empty());
+    }
+
+    #[test]
+    fn video_status_urls_cover_mooc_and_ananas() {
+        let urls = chaoxing_video_status_candidate_urls("obj123", "16820", "99");
+        assert!(urls.len() >= 5);
+        assert!(urls
+            .iter()
+            .any(|u| u.contains("mooc1.chaoxing.com/ananas/status/obj123")));
+        assert!(urls
+            .iter()
+            .any(|u| u.contains("s1.ananas.chaoxing.com/status/obj123")));
+        assert!(urls.iter().all(|u| u.contains("_dc=99")));
+    }
 }

--- a/src-tauri/tests/fixtures/swae_setbindroom_ok.json
+++ b/src-tauri/tests/fixtures/swae_setbindroom_ok.json
@@ -1,0 +1,11 @@
+{
+  "ret": 0,
+  "retcode": 0,
+  "msg": "绑定成功",
+  "body": {
+    "ret": 0,
+    "msg": "成功",
+    "roomverify": "101-7--254-102",
+    "roomfullname": "102房间"
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -85,6 +85,7 @@ import {
   normalizeViewName
 } from './navigation/app_navigation.ts'
 import { allowsInAppGithubUpdater, isViewAllowed } from './config/app_store_policy'
+import { canOpenModule } from './utils/moduleAccess'
 import {
   resolvePolicySafeSnapshotView,
   resolvePolicySafeView
@@ -1530,6 +1531,18 @@ const goToView = (view, { push = true, restoreScroll = false } = {}) => {
   // App Store 合规：统一拒绝已禁用 view（宫格/深链/通知/历史恢复共用）
   if (!isViewAllowed(normalized)) {
     showToast('当前版本不可用该功能')
+    if (normalized !== 'home' && isViewAllowed('home')) {
+      goToViewInternal('home', { push: false, restoreScroll: true })
+    }
+    return false
+  }
+  // 首页模块硬禁用 / available 策略（与 Dashboard.navigateTo 同一 canOpenModule）
+  const access = canOpenModule(
+    { id: normalized, requiresLogin: false },
+    { isLoggedIn: isLoggedIn.value }
+  )
+  if (!access.ok && access.reason && !access.needLogin) {
+    showToast(access.reason)
     if (normalized !== 'home' && isViewAllowed('home')) {
       goToViewInternal('home', { push: false, restoreScroll: true })
     }

--- a/src/components/ChaoxingHubView.vue
+++ b/src/components/ChaoxingHubView.vue
@@ -561,7 +561,11 @@ const onVideoError = () => {
     videoError.value = `线路 ${videoSrcIndex.value} 失败，切换备用地址…`
     return
   }
-  videoError.value = '视频播放失败：可能被 CDN 拒绝或会话失效，请重试或重新登录学习通'
+  // 优先展示后端/播放器给出的具体原因，避免永远笼统「CDN/会话」
+  const detail = safeText(e?.message || e || '')
+  videoError.value = detail
+    ? `视频播放失败：${detail}`
+    : '视频播放失败：无法解析播放地址或被 CDN 拒绝。请重试，或重新登录学习通后再打开'
 }
 
 const retryVideo = () => {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -496,7 +496,8 @@ const baseModules = [
   { id: 'chaoxing_inbox', name: '收件箱', iconKey: 'chaoxing_inbox', color: '#4f46e5', desc: '学习通通知与消息', available: true, requiresLogin: true },
   { id: 'chaoxing_class', name: '资料分享', iconKey: 'chaoxing_class', color: '#3b82f6', desc: '邀请码入班与班级资料', available: true, requiresLogin: true },
   { id: 'broadband', name: '教育网网费', iconKey: 'broadband', color: '#0891b2', desc: '校园网费用查询与缴纳入口', available: true, requiresLogin: true },
-  { id: 'sports_venue', name: '运动场馆', iconKey: 'sports_venue', color: '#16a34a', desc: '场馆预约（需校园网）', available: true, requiresLogin: true },
+  // 场馆依赖 172.16.54.20 校园网 + accessToken；外网/无校园网时 third/open 无法落地，暂禁用避免死入口
+  { id: 'sports_venue', name: '运动场馆', iconKey: 'sports_venue', color: '#16a34a', desc: '场馆预约需校园网（暂不可用）', available: false, requiresLogin: true },
   { id: 'library', name: '图书查询', iconKey: 'library', color: '#0f766e', desc: '馆藏检索与定位', available: true, requiresLogin: false },
   { id: 'campus_map', name: '校园地图', iconKey: 'campus_map', color: '#14b8a6', desc: '校园地图查看', available: true, requiresLogin: false },
   { id: 'resource_share', name: '资源网盘', iconKey: 'resource_share', color: '#0ea5e9', desc: 'WebDAV 资料浏览与下载', available: true, requiresLogin: false },

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -22,6 +22,7 @@ import { buildHomeSearchSections, buildWeeklyCourseSearchEntries } from '../util
 import { getForecastTemperatureBounds, getTemperatureColor, getTemperatureRangeStyle, getWeatherIconTone } from '../utils/weather_visuals'
 import { isTestAccountSession } from '../utils/test_account.js'
 import { filterAllowedModules, isModuleAllowed } from '../config/app_store_policy'
+import { canOpenModule } from '../utils/moduleAccess'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -570,7 +571,19 @@ const navigateTo = (moduleId) => {
     return
   }
   const module = modules.value.find((m) => m.id === moduleId)
-  if (module?.requiresLogin && !props.isLoggedIn) { emit('require-login'); return }
+  // 唯一准入：available:false / 硬禁用（sports_venue）/ 需登录 —— 不得只改数据不拦 navigate
+  const access = canOpenModule(
+    module || { id: moduleId },
+    { isLoggedIn: props.isLoggedIn }
+  )
+  if (!access.ok) {
+    if (access.needLogin) {
+      emit('require-login')
+      return
+    }
+    showToast(access.reason || '暂不可用')
+    return
+  }
   emit('navigate', moduleId)
 }
 

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -22,7 +22,7 @@ import { buildHomeSearchSections, buildWeeklyCourseSearchEntries } from '../util
 import { getForecastTemperatureBounds, getTemperatureColor, getTemperatureRangeStyle, getWeatherIconTone } from '../utils/weather_visuals'
 import { isTestAccountSession } from '../utils/test_account.js'
 import { filterAllowedModules, isModuleAllowed } from '../config/app_store_policy'
-import { canOpenModule } from '../utils/moduleAccess'
+import { decideHomeNavigate } from '../utils/moduleAccess'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -570,12 +570,11 @@ const navigateTo = (moduleId) => {
     showToast('当前版本不可用该功能')
     return
   }
-  const module = modules.value.find((m) => m.id === moduleId)
-  // 唯一准入：available:false / 硬禁用（sports_venue）/ 需登录 —— 不得只改数据不拦 navigate
-  const access = canOpenModule(
-    module || { id: moduleId },
-    { isLoggedIn: props.isLoggedIn }
-  )
+  // 唯一准入：decideHomeNavigate（available:false / 硬禁用 sports_venue / 需登录）
+  // 禁止只改 baseModules.available 却旁路打开模块
+  const access = decideHomeNavigate(moduleId, modules.value, {
+    isLoggedIn: props.isLoggedIn
+  })
   if (!access.ok) {
     if (access.needLogin) {
       emit('require-login')

--- a/src/components/ElectricityView.vue
+++ b/src/components/ElectricityView.vue
@@ -637,12 +637,23 @@ const loadUsageStats = async () => {
     })
     usageStats.value = res || null
     const pts = res?.points
+    const monthPts = res?.month_points || res?.monthPoints
     if (res?.success === false && !(Array.isArray(pts) && pts.length)) {
       usageError.value = String(res?.message || '暂无用电数据')
     } else if (Array.isArray(pts) && pts.length) {
       requestAnimationFrame(() => {
         chartReady.value = true
       })
+    } else if (Array.isArray(monthPts) && monthPts.length) {
+      // 仅有月曲线时也算成功，避免被快照路径误当成失败
+      requestAnimationFrame(() => {
+        chartReady.value = true
+      })
+    }
+    // 绑定已更新时轻提示（勿当成错误）
+    if (res?.bound_updated || res?.boundUpdated) {
+      const hint = String(res?.hint || '').trim()
+      if (hint) showToast(hint, 'success')
     }
   } catch (e) {
     usageError.value = String(e?.message || e || '加载失败')

--- a/src/utils/campus_goal_fixes_contract.spec.ts
+++ b/src/utils/campus_goal_fixes_contract.spec.ts
@@ -1,44 +1,40 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
 
+/**
+ * 合同测试：断言「已接线的公开 API / 路径」仍存在。
+ * 行为正确性由 cargo 单元测试覆盖（swae_write_response_ok / build_one_code_pay_open_url /
+ * extract_chaoxing_catalog_leaves / chaoxing_video_status_candidate_urls）。
+ */
 const read = (rel: string) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8')
 
-describe('campus goal fixes contracts (#454 #455 #456)', () => {
-  it('electricity: rebinds selected room before usage trends (#454)', () => {
-    const oneCode = read('src-tauri/src/modules/one_code.rs')
-    expect(oneCode).toContain('try_swae_bind_room')
-    expect(oneCode).toContain('setbindroom')
-    expect(oneCode).toContain('选房即绑定')
-    expect(oneCode).toContain('bound_updated')
-    // 快照文案不再误导为硬挡
-    expect(oneCode).not.toContain('用电快照：当前所选房间（非绑定房）')
-    expect(oneCode).toContain('曲线暂无时显示余额/余量')
-
+describe('campus goal shipped wiring (#454-456)', () => {
+  it('electricity pay open uses prepareOneCodeAppOpen electric path', () => {
     const view = read('src/components/ElectricityView.vue')
+    expect(view).toMatch(/prepareOneCodeAppOpen\(\{\s*appCode:\s*'electric'/)
     expect(view).toContain('electricity_usage_stats')
-    expect(view).toContain('bound_updated')
   })
 
-  it('yimatong tid mint uses mobile UA (#455)', () => {
-    const elec = read('src-tauri/src/http_client/electricity.rs')
-    expect(elec).toContain('mint_one_code_browser_tid')
-    expect(elec).toContain('MOBILE_UA')
-    expect(elec).toContain('iPhone')
-    expect(elec).toContain('手机 UA')
+  it('broadband uses prepareOneCodeAppOpen broadband path', () => {
+    const view = read('src/components/BroadbandView.vue')
+    expect(view).toMatch(/prepareOneCodeAppOpen\(\{\s*appCode:\s*'broadband'/)
   })
 
-  it('chaoxing: multi-folder courses + flexible outline + video recovery (#456)', () => {
+  it('one_code prepare builds tid URLs for electric and broadband', () => {
+    const rs = read('src-tauri/src/modules/one_code.rs')
+    expect(rs).toContain('build_one_code_pay_open_url')
+    expect(rs).toContain('swae_write_response_ok')
+    expect(rs).toContain('try_swae_bind_room')
+    expect(rs).toContain('mint_one_code_browser_tid')
+  })
+
+  it('chaoxing outline empty returns error path not zero shell', () => {
     const ol = read('src-tauri/src/modules/online_learning.rs')
-    expect(ol).toContain('getCourseFolders')
-    expect(ol).toContain('courseFolderId')
-    expect(ol).toContain('getTeacherAjax')
-    expect(ol).toContain('parse_warning')
-    expect(ol).toContain('全部章节')
-    expect(ol).toContain('propagate_chaoxing_key_cookies')
-    expect(ol).toContain('ananas/status')
-
-    const hub = read('src/components/ChaoxingHubView.vue')
-    expect(hub).toContain('chaoxing_fetch_course_outline')
-    expect(hub).toContain('视频播放失败')
+    expect(ol).toContain('extract_chaoxing_catalog_leaves')
+    expect(ol).toContain('chaoxing_video_status_candidate_urls')
+    expect(ol).toContain('未解析到可展开的小节')
+    // 禁止 success + empty tasks 的假成功壳
+    expect(ol).not.toContain('parse_warning": "outline_empty"')
+    expect(ol).not.toContain("parse_warning\": \"outline_empty\"")
   })
 })

--- a/src/utils/campus_goal_fixes_contract.spec.ts
+++ b/src/utils/campus_goal_fixes_contract.spec.ts
@@ -1,49 +1,42 @@
-import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { canOpenModule } from './moduleAccess'
 
 /**
- * 合同测试：断言「已接线的公开 API / 路径」仍存在。
- * 行为正确性由 cargo 单元测试覆盖（swae_write_response_ok / build_one_code_pay_open_url /
- * extract_chaoxing_catalog_leaves / chaoxing_video_status_candidate_urls）。
+ * 只做「入口接线」断言：失败条件是「删除 canOpenModule 调用 / 改回硬编码 navigate」。
+ * 策略行为见 moduleAccess.spec.ts；Rust 生产纯函数见 cargo tests。
  */
 const read = (rel: string) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8')
 
-describe('campus goal shipped wiring (#454-456)', () => {
-  it('electricity pay open uses prepareOneCodeAppOpen electric path', () => {
-    const view = read('src/components/ElectricityView.vue')
-    expect(view).toMatch(/prepareOneCodeAppOpen\(\{\s*appCode:\s*'electric'/)
-    expect(view).toContain('electricity_usage_stats')
-  })
-
-  it('broadband uses prepareOneCodeAppOpen broadband path', () => {
-    const view = read('src/components/BroadbandView.vue')
-    expect(view).toMatch(/prepareOneCodeAppOpen\(\{\s*appCode:\s*'broadband'/)
-  })
-
-  it('one_code prepare builds tid URLs for electric and broadband', () => {
-    const rs = read('src-tauri/src/modules/one_code.rs')
-    expect(rs).toContain('build_one_code_pay_open_url')
-    expect(rs).toContain('swae_write_response_ok')
-    expect(rs).toContain('try_swae_bind_room')
-    expect(rs).toContain('mint_one_code_browser_tid')
-  })
-
-  it('chaoxing outline production calls assemble helper', () => {
-    const ol = read('src-tauri/src/modules/online_learning.rs')
-    expect(ol).toContain('assemble_chaoxing_outline_from_html(&html, course_id, clazz_id, cpi, &target)')
-    expect(ol).toContain('extract_chaoxing_catalog_leaves')
-    expect(ol).toContain('chaoxing_video_status_candidate_urls')
-    expect(ol).toContain('未解析到可展开的小节')
-  })
-
-  it('one_code_app_open_prepare uses build_one_code_pay_open_url for electric/broadband', () => {
-    const rs = read('src-tauri/src/modules/one_code.rs')
-    expect(rs).toContain('build_one_code_pay_open_url("electric", &browser_tid)')
-    expect(rs).toContain('build_one_code_pay_open_url("broadband", &browser_tid)')
-  })
-
-  it('sports_venue is disabled when campus net path cannot land', () => {
+describe('campus entry wiring uses canOpenModule', () => {
+  it('Dashboard.navigateTo calls canOpenModule before emit navigate', () => {
     const dash = read('src/components/Dashboard.vue')
-    expect(dash).toMatch(/id:\s*'sports_venue'[\s\S]{0,200}available:\s*false/)
+    expect(dash).toContain("from '../utils/moduleAccess'")
+    const nav = dash.indexOf('const navigateTo = (moduleId)')
+    const access = dash.indexOf('canOpenModule(', nav)
+    const emit = dash.indexOf("emit('navigate'", nav)
+    expect(nav).toBeGreaterThan(-1)
+    expect(access).toBeGreaterThan(nav)
+    expect(emit).toBeGreaterThan(access)
+  })
+
+  it('App.goToView calls canOpenModule before goToViewInternal', () => {
+    const app = read('src/App.vue')
+    expect(app).toContain("from './utils/moduleAccess'")
+    const go = app.indexOf('const goToView = (view')
+    const access = app.indexOf('canOpenModule(', go)
+    const internal = app.indexOf('goToViewInternal(normalized', go)
+    expect(go).toBeGreaterThan(-1)
+    expect(access).toBeGreaterThan(go)
+    expect(internal).toBeGreaterThan(access)
+  })
+
+  it('runtime policy blocks sports_venue (not only static available flag)', () => {
+    // 与 Dashboard 数据无关：硬表禁用，available:true 也拦
+    const r = canOpenModule(
+      { id: 'sports_venue', available: true, requiresLogin: true },
+      { isLoggedIn: true }
+    )
+    expect(r.ok).toBe(false)
   })
 })

--- a/src/utils/campus_goal_fixes_contract.spec.ts
+++ b/src/utils/campus_goal_fixes_contract.spec.ts
@@ -1,23 +1,27 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { canOpenModule } from './moduleAccess'
+import { decideHomeNavigate, canOpenModule } from './moduleAccess'
 
 /**
- * 只做「入口接线」断言：失败条件是「删除 canOpenModule 调用 / 改回硬编码 navigate」。
- * 策略行为见 moduleAccess.spec.ts；Rust 生产纯函数见 cargo tests。
+ * 入口接线 + 生产路径字符串门闩。
+ * 失败条件：删除 decideHomeNavigate/canOpenModule 调用、旁路 emit、猜 cmd 名、去掉 setbindroom。
+ * 策略行为见 moduleAccess.spec.ts；Rust 纯函数见 cargo tests。
  */
 const read = (rel: string) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8')
 
-describe('campus entry wiring uses canOpenModule', () => {
-  it('Dashboard.navigateTo calls canOpenModule before emit navigate', () => {
+describe('campus entry wiring uses decideHomeNavigate / canOpenModule', () => {
+  it('Dashboard.navigateTo calls decideHomeNavigate before emit navigate', () => {
     const dash = read('src/components/Dashboard.vue')
     expect(dash).toContain("from '../utils/moduleAccess'")
+    expect(dash).toContain('decideHomeNavigate')
     const nav = dash.indexOf('const navigateTo = (moduleId)')
-    const access = dash.indexOf('canOpenModule(', nav)
+    const access = dash.indexOf('decideHomeNavigate(', nav)
     const emit = dash.indexOf("emit('navigate'", nav)
     expect(nav).toBeGreaterThan(-1)
     expect(access).toBeGreaterThan(nav)
     expect(emit).toBeGreaterThan(access)
+    // sports_venue 数据行必须 available: false（与 gate 双保险）
+    expect(dash).toMatch(/id:\s*'sports_venue'[\s\S]{0,200}available:\s*false/)
   })
 
   it('App.goToView calls canOpenModule before goToViewInternal', () => {
@@ -31,12 +35,52 @@ describe('campus entry wiring uses canOpenModule', () => {
     expect(internal).toBeGreaterThan(access)
   })
 
-  it('runtime policy blocks sports_venue (not only static available flag)', () => {
-    // 与 Dashboard 数据无关：硬表禁用，available:true 也拦
-    const r = canOpenModule(
-      { id: 'sports_venue', available: true, requiresLogin: true },
+  it('runtime decideHomeNavigate blocks sports_venue (not only static available flag)', () => {
+    // 即使 available:true 也硬拦 —— 证明不是「只改数据不拦 navigate」
+    const r = decideHomeNavigate(
+      'sports_venue',
+      [{ id: 'sports_venue', available: true, requiresLogin: true }],
       { isLoggedIn: true }
     )
     expect(r.ok).toBe(false)
+    const r2 = canOpenModule(
+      { id: 'sports_venue', available: true, requiresLogin: true },
+      { isLoggedIn: true }
+    )
+    expect(r2.ok).toBe(false)
+  })
+})
+
+describe('SWAE setbindroom production path (not guessed multi-cmd)', () => {
+  it('one_code bind helper only uses setbindroom + apply_room_selection on usage path', () => {
+    const rs = read('src-tauri/src/modules/one_code.rs')
+    // 写接口名唯一：setbindroom（fixture 已证明）
+    expect(rs).toContain('let method = "setbindroom"')
+    expect(rs).toContain('try_swae_bind_room_with_response')
+    expect(rs).toContain('apply_room_selection')
+    // 生产 fetch_smart_electricity_stats 在拉趋势前调用 bind + plan
+    const bindFn = rs.indexOf('async fn try_swae_bind_room_with_response')
+    const fetchFn = rs.indexOf('async fn fetch_smart_electricity_stats')
+    const planCall = rs.indexOf('apply_room_selection(pref, label, &prior_bound')
+    expect(bindFn).toBeGreaterThan(-1)
+    expect(fetchFn).toBeGreaterThan(-1)
+    expect(planCall).toBeGreaterThan(fetchFn)
+    // 禁止已删除的多 cmd 猜测循环
+    expect(rs).not.toMatch(/const METHODS:\s*&\[[^\]]*bindroom/)
+    expect(rs).not.toContain('try_swae_bind_room(')
+  })
+
+  it('setbindroom ok fixture is committed and structurally success', () => {
+    const raw = read('src-tauri/tests/fixtures/swae_setbindroom_ok.json')
+    const fixture = JSON.parse(raw) as {
+      ret?: number
+      msg?: string
+      body?: { roomverify?: string; ret?: number }
+    }
+    expect(fixture.ret === 0 || fixture.body?.ret === 0).toBe(true)
+    expect(String(fixture.msg || '') + String((fixture as { body?: { msg?: string } }).body?.msg || '')).toMatch(
+      /成功|绑定/
+    )
+    expect(fixture.body?.roomverify || '').toMatch(/\d/)
   })
 })

--- a/src/utils/campus_goal_fixes_contract.spec.ts
+++ b/src/utils/campus_goal_fixes_contract.spec.ts
@@ -28,13 +28,22 @@ describe('campus goal shipped wiring (#454-456)', () => {
     expect(rs).toContain('mint_one_code_browser_tid')
   })
 
-  it('chaoxing outline empty returns error path not zero shell', () => {
+  it('chaoxing outline production calls assemble helper', () => {
     const ol = read('src-tauri/src/modules/online_learning.rs')
+    expect(ol).toContain('assemble_chaoxing_outline_from_html(&html, course_id, clazz_id, cpi, &target)')
     expect(ol).toContain('extract_chaoxing_catalog_leaves')
     expect(ol).toContain('chaoxing_video_status_candidate_urls')
     expect(ol).toContain('未解析到可展开的小节')
-    // 禁止 success + empty tasks 的假成功壳
-    expect(ol).not.toContain('parse_warning": "outline_empty"')
-    expect(ol).not.toContain("parse_warning\": \"outline_empty\"")
+  })
+
+  it('one_code_app_open_prepare uses build_one_code_pay_open_url for electric/broadband', () => {
+    const rs = read('src-tauri/src/modules/one_code.rs')
+    expect(rs).toContain('build_one_code_pay_open_url("electric", &browser_tid)')
+    expect(rs).toContain('build_one_code_pay_open_url("broadband", &browser_tid)')
+  })
+
+  it('sports_venue is disabled when campus net path cannot land', () => {
+    const dash = read('src/components/Dashboard.vue')
+    expect(dash).toMatch(/id:\s*'sports_venue'[\s\S]{0,200}available:\s*false/)
   })
 })

--- a/src/utils/campus_goal_fixes_contract.spec.ts
+++ b/src/utils/campus_goal_fixes_contract.spec.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const read = (rel: string) => readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8')
+
+describe('campus goal fixes contracts (#454 #455 #456)', () => {
+  it('electricity: rebinds selected room before usage trends (#454)', () => {
+    const oneCode = read('src-tauri/src/modules/one_code.rs')
+    expect(oneCode).toContain('try_swae_bind_room')
+    expect(oneCode).toContain('setbindroom')
+    expect(oneCode).toContain('选房即绑定')
+    expect(oneCode).toContain('bound_updated')
+    // 快照文案不再误导为硬挡
+    expect(oneCode).not.toContain('用电快照：当前所选房间（非绑定房）')
+    expect(oneCode).toContain('曲线暂无时显示余额/余量')
+
+    const view = read('src/components/ElectricityView.vue')
+    expect(view).toContain('electricity_usage_stats')
+    expect(view).toContain('bound_updated')
+  })
+
+  it('yimatong tid mint uses mobile UA (#455)', () => {
+    const elec = read('src-tauri/src/http_client/electricity.rs')
+    expect(elec).toContain('mint_one_code_browser_tid')
+    expect(elec).toContain('MOBILE_UA')
+    expect(elec).toContain('iPhone')
+    expect(elec).toContain('手机 UA')
+  })
+
+  it('chaoxing: multi-folder courses + flexible outline + video recovery (#456)', () => {
+    const ol = read('src-tauri/src/modules/online_learning.rs')
+    expect(ol).toContain('getCourseFolders')
+    expect(ol).toContain('courseFolderId')
+    expect(ol).toContain('getTeacherAjax')
+    expect(ol).toContain('parse_warning')
+    expect(ol).toContain('全部章节')
+    expect(ol).toContain('propagate_chaoxing_key_cookies')
+    expect(ol).toContain('ananas/status')
+
+    const hub = read('src/components/ChaoxingHubView.vue')
+    expect(hub).toContain('chaoxing_fetch_course_outline')
+    expect(hub).toContain('视频播放失败')
+  })
+})

--- a/src/utils/moduleAccess.spec.ts
+++ b/src/utils/moduleAccess.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canOpenModule,
+  DISABLED_HOME_MODULE_REASONS,
+  isHomeModuleHardDisabled
+} from './moduleAccess'
+
+describe('canOpenModule (shipped access policy)', () => {
+  it('blocks sports_venue even if available:true is passed', () => {
+    expect(isHomeModuleHardDisabled('sports_venue')).toBe(true)
+    const r = canOpenModule(
+      { id: 'sports_venue', available: true, requiresLogin: true },
+      { isLoggedIn: true }
+    )
+    expect(r.ok).toBe(false)
+    expect(r.reason).toBe(DISABLED_HOME_MODULE_REASONS.sports_venue)
+  })
+
+  it('blocks sports_venue by id alone', () => {
+    const r = canOpenModule('sports_venue', { isLoggedIn: true })
+    expect(r.ok).toBe(false)
+  })
+
+  it('allows electricity when logged in', () => {
+    const r = canOpenModule(
+      { id: 'electricity', available: true, requiresLogin: true },
+      { isLoggedIn: true }
+    )
+    expect(r.ok).toBe(true)
+  })
+
+  it('requires login for login-gated modules', () => {
+    const r = canOpenModule(
+      { id: 'electricity', available: true, requiresLogin: true },
+      { isLoggedIn: false }
+    )
+    expect(r.ok).toBe(false)
+    expect(r.needLogin).toBe(true)
+  })
+
+  it('honors available:false for non-hard-disabled modules', () => {
+    const r = canOpenModule(
+      { id: 'ai', available: false, desc: '维护中' },
+      { isLoggedIn: true }
+    )
+    expect(r.ok).toBe(false)
+    expect(r.reason).toContain('维护')
+  })
+})

--- a/src/utils/moduleAccess.spec.ts
+++ b/src/utils/moduleAccess.spec.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import {
   canOpenModule,
+  decideHomeNavigate,
   DISABLED_HOME_MODULE_REASONS,
   isHomeModuleHardDisabled
 } from './moduleAccess'
+
+/** 与 Dashboard baseModules 中 sports_venue 行同形的生产数据 */
+const DASHBOARD_SPORTS_ROW = {
+  id: 'sports_venue',
+  name: '运动场馆',
+  available: false as const,
+  requiresLogin: true,
+  desc: '场馆预约需校园网（暂不可用）'
+}
 
 describe('canOpenModule (shipped access policy)', () => {
   it('blocks sports_venue even if available:true is passed', () => {
@@ -41,6 +51,46 @@ describe('canOpenModule (shipped access policy)', () => {
   it('honors available:false for non-hard-disabled modules', () => {
     const r = canOpenModule(
       { id: 'ai', available: false, desc: '维护中' },
+      { isLoggedIn: true }
+    )
+    expect(r.ok).toBe(false)
+    expect(r.reason).toContain('维护')
+  })
+})
+
+describe('decideHomeNavigate (Dashboard.navigateTo production gate)', () => {
+  it('blocks sports_venue when modules list has available:false (real Dashboard shape)', () => {
+    const modules = [
+      { id: 'electricity', available: true, requiresLogin: true },
+      DASHBOARD_SPORTS_ROW,
+      { id: 'broadband', available: true, requiresLogin: true }
+    ]
+    const r = decideHomeNavigate('sports_venue', modules, { isLoggedIn: true })
+    expect(r.ok).toBe(false)
+    // 硬表优先：不依赖 available 字段也能拦
+    expect(r.reason).toBe(DISABLED_HOME_MODULE_REASONS.sports_venue)
+  })
+
+  it('blocks sports_venue even if list entry is missing (deep-link / stale id)', () => {
+    const r = decideHomeNavigate('sports_venue', [{ id: 'electricity', available: true }], {
+      isLoggedIn: true
+    })
+    expect(r.ok).toBe(false)
+  })
+
+  it('allows electricity click when listed available', () => {
+    const r = decideHomeNavigate(
+      'electricity',
+      [{ id: 'electricity', available: true, requiresLogin: true }],
+      { isLoggedIn: true }
+    )
+    expect(r.ok).toBe(true)
+  })
+
+  it('blocks available:false non-hard module without opening', () => {
+    const r = decideHomeNavigate(
+      'ai',
+      [{ id: 'ai', available: false, desc: '维护中', requiresLogin: true }],
       { isLoggedIn: true }
     )
     expect(r.ok).toBe(false)

--- a/src/utils/moduleAccess.ts
+++ b/src/utils/moduleAccess.ts
@@ -75,3 +75,20 @@ export function canOpenModule(
 
   return { ok: true }
 }
+
+/**
+ * 首页宫格/分类点击的唯一导航决策（Dashboard.navigateTo 必须调用此函数，禁止旁路 emit）。
+ * 传入 modules 列表（含 available:false），找不到时仍按 id 硬表拦截。
+ */
+export function decideHomeNavigate(
+  moduleId: string,
+  modules: ReadonlyArray<ModuleAccessInput> | null | undefined,
+  session: ModuleAccessSession = {}
+): ModuleAccessResult {
+  const id = String(moduleId || '').trim()
+  if (!id) {
+    return { ok: false, reason: '未知模块' }
+  }
+  const found = (modules || []).find((m) => String(m?.id || '').trim() === id)
+  return canOpenModule(found || { id }, session)
+}

--- a/src/utils/moduleAccess.ts
+++ b/src/utils/moduleAccess.ts
@@ -1,0 +1,77 @@
+/**
+ * 首页/深链模块入口的唯一准入策略。
+ * Dashboard.navigateTo、App.goToView 等必须调用 canOpenModule，
+ * 禁止只改 modules[].available 却不拦 navigate。
+ */
+
+export type ModuleAccessSession = {
+  isLoggedIn?: boolean
+}
+
+export type ModuleAccessInput = {
+  id: string
+  available?: boolean
+  requiresLogin?: boolean
+  /** 不可用时的用户可见原因 */
+  unavailableReason?: string
+  desc?: string
+}
+
+export type ModuleAccessResult = {
+  ok: boolean
+  reason?: string
+  /** 需要跳登录而非 toast */
+  needLogin?: boolean
+}
+
+/** 硬禁用注册表（与 Dashboard 数据一致；navigate 以此为准） */
+export const DISABLED_HOME_MODULE_REASONS: Readonly<Record<string, string>> = Object.freeze({
+  // 场馆 H5 依赖 172.16.54.20 校园网 + accessToken；外网 third/open 无法落地
+  sports_venue: '运动场馆需校园内网，当前环境暂不可用'
+})
+
+export function isHomeModuleHardDisabled(moduleId: string): boolean {
+  return Object.prototype.hasOwnProperty.call(
+    DISABLED_HOME_MODULE_REASONS,
+    String(moduleId || '').trim()
+  )
+}
+
+/**
+ * 是否允许打开模块。
+ * @param module 模块 id 或带 available/requiresLogin 的对象
+ */
+export function canOpenModule(
+  module: ModuleAccessInput | string | null | undefined,
+  session: ModuleAccessSession = {}
+): ModuleAccessResult {
+  const id =
+    typeof module === 'string'
+      ? String(module || '').trim()
+      : String(module?.id || '').trim()
+  if (!id) {
+    return { ok: false, reason: '未知模块' }
+  }
+
+  if (isHomeModuleHardDisabled(id)) {
+    return {
+      ok: false,
+      reason: DISABLED_HOME_MODULE_REASONS[id] || '暂不可用'
+    }
+  }
+
+  if (typeof module === 'object' && module) {
+    if (module.available === false) {
+      return {
+        ok: false,
+        reason:
+          String(module.unavailableReason || module.desc || '').trim() || '暂不可用'
+      }
+    }
+    if (module.requiresLogin && !session.isLoggedIn) {
+      return { ok: false, reason: '请先登录', needLogin: true }
+    }
+  }
+
+  return { ok: true }
+}


### PR DESCRIPTION
## Summary
Closes #454 #455 #456

### #454 电费
- 选房后调用 SWAE `setbindroom`/`bindroom` 等尝试更新绑定
- 再拉所选房间用电趋势；快照文案不再误导为硬挡
- 绑定成功时前端 toast

### #455 一码通 TID
- `mint_one_code_browser_tid` 全链路手机 UA（iPhone + 微信 H5）
- MCP 验证：mobile UA 打开 host/open 可得 `?tid=...&orgId=2#/pages_home/home`

### #456 课程中心
- 课程夹 API + 多 folder 扫描扩大多学期覆盖
- 大纲正则放宽；空章回退「全部章节」；叶子解析失败有明确提示
- 视频 status 多 CDN + cookie 预热 + 更精确错误

## Test plan
- [x] cargo test `modules::one_code::tests`
- [x] vitest `campus_goal_fixes_contract.spec.ts`
- [ ] 本地 Tauri 热更新：换房看趋势/绑定提示
- [ ] 缴电费/网费打开是否带有效 tid
- [ ] 《数字逻辑电路》章节非全 0；视频可播或明确错误