### PR TITLE
feat(ui): polish privacy & about Mini-HBUT visuals (#464)

### DIFF
--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -327,7 +327,7 @@ const handleShowLegal = async (tab) => {
       </button>
     </section>
 
-    <section class="legal-card">
+    <section class="legal-card about-minihbut-card">
       <h3 class="legal-title">关于 Mini-HBUT</h3>
       <div class="legal-content">
         <p>{{ NON_OFFICIAL_DISCLAIMER_ZH }}</p>
@@ -335,8 +335,19 @@ const handleShowLegal = async (tab) => {
         <p v-if="isDemoSession">
           演示模式说明：当前会话使用本地虚构数据，不连接真实校园服务。可在上方重置演示数据或退出演示。
         </p>
-        <button type="button" class="grid-item privacy-link" @click="openExternal(PRIVACY_POLICY_URL)">
-          打开隐私政策（Safari / 系统浏览器）
+        <button
+          type="button"
+          class="privacy-policy-entry"
+          @click="openExternal(PRIVACY_POLICY_URL)"
+        >
+          <span class="privacy-policy-entry__icon" aria-hidden="true">
+            <span class="material-symbols-outlined">shield</span>
+          </span>
+          <span class="privacy-policy-entry__body">
+            <span class="privacy-policy-entry__title">隐私政策</span>
+            <span class="privacy-policy-entry__desc">在系统浏览器中打开完整政策</span>
+          </span>
+          <span class="privacy-policy-entry__chev material-symbols-outlined" aria-hidden="true">open_in_new</span>
         </button>
       </div>
     </section>
@@ -702,12 +713,13 @@ const handleShowLegal = async (tab) => {
   line-height: 1.3;
 }
 
-/* Legal Section */
+/* Legal Section — token-aligned with GradeView / surface system */
 .legal-card {
-  background: #ffffff;
+  background: var(--ui-surface, #ffffff);
+  border: 1px solid var(--ui-surface-border, rgba(148, 163, 184, 0.22));
   border-radius: 24px;
   padding: 24px 20px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--ui-shadow-soft, 0 2px 12px rgba(0, 0, 0, 0.06));
   margin-bottom: 16px;
 }
 
@@ -715,7 +727,7 @@ const handleShowLegal = async (tab) => {
   margin: 0 0 14px;
   font-size: 17px;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--ui-text, #1f2937);
 }
 
 .legal-tabs {
@@ -731,9 +743,9 @@ const handleShowLegal = async (tab) => {
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  background: #f3f4f6;
-  color: #6b7280;
-  transition: all 0.2s;
+  background: color-mix(in oklab, var(--ui-primary-soft, #eff6ff) 70%, var(--ui-surface, #fff) 30%);
+  color: var(--ui-muted, #6b7280);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.16s ease;
 }
 
 .legal-tab.active {
@@ -742,9 +754,20 @@ const handleShowLegal = async (tab) => {
 }
 
 .legal-content {
-  color: #4b5563;
+  color: var(--ui-muted, #4b5563);
   line-height: 1.7;
   font-size: 14px;
+}
+
+.legal-content p {
+  margin: 0 0 10px;
+  color: inherit;
+}
+
+.legal-content .muted-en {
+  color: var(--ui-muted, #64748b);
+  font-size: 12px;
+  line-height: 1.55;
 }
 
 .legal-content ul {
@@ -754,6 +777,84 @@ const handleShowLegal = async (tab) => {
 
 .legal-content li {
   margin: 6px 0;
+}
+
+/* 关于 Mini-HBUT：品牌化隐私政策入口 */
+.privacy-policy-entry {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 6px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--ui-surface-border, rgba(148, 163, 184, 0.28));
+  background: color-mix(in oklab, var(--ui-primary-soft, #eff6ff) 55%, var(--ui-surface, #fff) 45%);
+  color: var(--ui-text, #1f2937);
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.privacy-policy-entry:active {
+  transform: scale(0.985);
+}
+
+.privacy-policy-entry:hover {
+  border-color: color-mix(in oklab, var(--ui-primary, #2563eb) 30%, transparent);
+  box-shadow: 0 8px 18px color-mix(in oklab, var(--ui-primary, #2563eb) 12%, transparent);
+}
+
+.privacy-policy-entry__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: color-mix(in oklab, var(--ui-primary, #2563eb) 16%, var(--ui-surface, #fff) 84%);
+  color: var(--ui-primary, #2563eb);
+}
+
+.privacy-policy-entry__icon .material-symbols-outlined {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.privacy-policy-entry__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.privacy-policy-entry__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ui-text, #1f2937);
+}
+
+.privacy-policy-entry__desc {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ui-muted, #64748b);
+}
+
+.privacy-policy-entry__chev {
+  font-size: 18px;
+  line-height: 1;
+  color: var(--ui-muted, #94a3b8);
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .privacy-policy-entry,
+  .legal-tab {
+    transition: none;
+  }
 }
 
 /* ICP 备案号 — 页底次要公示 */

--- a/src/components/PrivacyDataView.vue
+++ b/src/components/PrivacyDataView.vue
@@ -17,6 +17,7 @@ import {
   isTestAccountSession
 } from '../utils/test_account.js'
 import { showToast } from '../utils/toast'
+import { TPageHeader } from './templates'
 
 const emit = defineEmits(['back', 'logout', 'cleared'])
 
@@ -133,124 +134,289 @@ const exportLocalMeta = () => {
 
 <template>
   <div class="privacy-data-view">
-    <header class="privacy-data-view__header">
-      <button type="button" class="back-btn" @click="emit('back')">返回</button>
-      <h1>隐私与数据</h1>
-      <span class="spacer" />
-    </header>
+    <TPageHeader title="隐私与数据" icon="shield" @back="emit('back')" />
 
-    <section class="card">
-      <h2>非官方声明</h2>
-      <p>{{ NON_OFFICIAL_DISCLAIMER_ZH }}</p>
-      <p class="muted">{{ NON_OFFICIAL_DISCLAIMER_EN }}</p>
-    </section>
+    <main class="privacy-data-view__main">
+      <section class="privacy-card privacy-card--enter" style="--enter-delay: 0ms">
+        <div class="privacy-card__head">
+          <span class="privacy-card__icon" aria-hidden="true">
+            <span class="material-symbols-outlined">info</span>
+          </span>
+          <h2>非官方声明</h2>
+        </div>
+        <p>{{ NON_OFFICIAL_DISCLAIMER_ZH }}</p>
+        <p class="muted">{{ NON_OFFICIAL_DISCLAIMER_EN }}</p>
+      </section>
 
-    <section class="card">
-      <h2>政策与支持</h2>
-      <button type="button" class="link-btn" @click="openUrl(PRIVACY_POLICY_URL)">查看隐私政策</button>
-      <button type="button" class="link-btn" @click="openUrl(SECURITY_DOCS_URL)">数据与安全说明</button>
-      <button type="button" class="link-btn" @click="openUrl(SUPPORT_DOCS_URL)">用户文档</button>
-      <button type="button" class="link-btn" @click="openUrl(PROJECT_HOME_URL)">项目官网</button>
-      <button type="button" class="link-btn" @click="openUrl(GITHUB_URL)">开源仓库</button>
-      <button type="button" class="link-btn" @click="openUrl(FEEDBACK_URL)">联系支持 / 反馈</button>
-    </section>
+      <section class="privacy-card privacy-card--enter" style="--enter-delay: 60ms">
+        <div class="privacy-card__head">
+          <span class="privacy-card__icon privacy-card__icon--policy" aria-hidden="true">
+            <span class="material-symbols-outlined">policy</span>
+          </span>
+          <h2>政策与支持</h2>
+        </div>
+        <div class="privacy-link-list">
+          <button type="button" class="link-btn" @click="openUrl(PRIVACY_POLICY_URL)">
+            <span class="link-btn__icon material-symbols-outlined">privacy_tip</span>
+            <span class="link-btn__label">查看隐私政策</span>
+            <span class="link-btn__chev material-symbols-outlined">open_in_new</span>
+          </button>
+          <button type="button" class="link-btn" @click="openUrl(SECURITY_DOCS_URL)">
+            <span class="link-btn__icon material-symbols-outlined">security</span>
+            <span class="link-btn__label">数据与安全说明</span>
+            <span class="link-btn__chev material-symbols-outlined">open_in_new</span>
+          </button>
+          <button type="button" class="link-btn" @click="openUrl(SUPPORT_DOCS_URL)">
+            <span class="link-btn__icon material-symbols-outlined">menu_book</span>
+            <span class="link-btn__label">用户文档</span>
+            <span class="link-btn__chev material-symbols-outlined">open_in_new</span>
+          </button>
+          <button type="button" class="link-btn" @click="openUrl(PROJECT_HOME_URL)">
+            <span class="link-btn__icon material-symbols-outlined">public</span>
+            <span class="link-btn__label">项目官网</span>
+            <span class="link-btn__chev material-symbols-outlined">open_in_new</span>
+          </button>
+          <button type="button" class="link-btn" @click="openUrl(GITHUB_URL)">
+            <span class="link-btn__icon material-symbols-outlined">code</span>
+            <span class="link-btn__label">开源仓库</span>
+            <span class="link-btn__chev material-symbols-outlined">open_in_new</span>
+          </button>
+          <button type="button" class="link-btn" @click="openUrl(FEEDBACK_URL)">
+            <span class="link-btn__icon material-symbols-outlined">support_agent</span>
+            <span class="link-btn__label">联系支持 / 反馈</span>
+            <span class="link-btn__chev material-symbols-outlined">open_in_new</span>
+          </button>
+        </div>
+      </section>
 
-    <section class="card">
-      <h2>本应用数据控制</h2>
-      <p class="muted">
-        Mini-HBUT 使用你已有的校园登录凭据查询你本人有权访问的信息，不创建独立的校园机构账号，因此无法删除学校侧账号。
-      </p>
-      <button type="button" class="action-btn" :disabled="!!busy" @click="clearLocalCaches">
-        清除离线缓存
-      </button>
-      <button type="button" class="action-btn" :disabled="!!busy" @click="clearSession">
-        清除登录会话
-      </button>
-      <button type="button" class="action-btn danger" :disabled="!!busy" @click="clearAllLocal">
-        清除全部本地数据
-      </button>
-      <button type="button" class="action-btn" @click="disableCloudAndStats">
-        关闭云同步与使用统计
-      </button>
-      <button type="button" class="action-btn" @click="exportLocalMeta">
-        导出个人数据元信息
-      </button>
-      <p class="muted">
-        删除 Mini-HBUT 云端数据：若你曾开启云同步，请在关闭同步后通过反馈渠道申请删除服务端关联记录（学号哈希/设备标识）。本页不会删除学校系统中的成绩或账号。
-      </p>
-    </section>
+      <section class="privacy-card privacy-card--enter" style="--enter-delay: 120ms">
+        <div class="privacy-card__head">
+          <span class="privacy-card__icon privacy-card__icon--control" aria-hidden="true">
+            <span class="material-symbols-outlined">database</span>
+          </span>
+          <h2>本应用数据控制</h2>
+        </div>
+        <p class="muted">
+          Mini-HBUT 使用你已有的校园登录凭据查询你本人有权访问的信息，不创建独立的校园机构账号，因此无法删除学校侧账号。
+        </p>
+        <div class="privacy-action-list">
+          <button type="button" class="action-btn" :disabled="!!busy" @click="clearLocalCaches">
+            <span class="action-btn__icon material-symbols-outlined">cached</span>
+            <span>清除离线缓存</span>
+          </button>
+          <button type="button" class="action-btn" :disabled="!!busy" @click="clearSession">
+            <span class="action-btn__icon material-symbols-outlined">logout</span>
+            <span>清除登录会话</span>
+          </button>
+          <button type="button" class="action-btn danger" :disabled="!!busy" @click="clearAllLocal">
+            <span class="action-btn__icon material-symbols-outlined">delete_forever</span>
+            <span>清除全部本地数据</span>
+          </button>
+          <button type="button" class="action-btn" @click="disableCloudAndStats">
+            <span class="action-btn__icon material-symbols-outlined">cloud_off</span>
+            <span>关闭云同步与使用统计</span>
+          </button>
+          <button type="button" class="action-btn" @click="exportLocalMeta">
+            <span class="action-btn__icon material-symbols-outlined">download</span>
+            <span>导出个人数据元信息</span>
+          </button>
+        </div>
+        <p class="muted">
+          删除 Mini-HBUT 云端数据：若你曾开启云同步，请在关闭同步后通过反馈渠道申请删除服务端关联记录（学号哈希/设备标识）。本页不会删除学校系统中的成绩或账号。
+        </p>
+      </section>
 
-    <p v-if="message" class="status">{{ message }}</p>
+      <p v-if="message" class="status privacy-card--enter" style="--enter-delay: 160ms">{{ message }}</p>
+    </main>
   </div>
 </template>
 
 <style scoped>
 .privacy-data-view {
-  padding: 12px 14px 96px;
+  min-height: 100vh;
+  background: var(--ui-bg-gradient, #f6fafe);
+  color: var(--ui-text, #1e293b);
+}
+
+.privacy-data-view__main {
+  display: grid;
+  gap: 14px;
+  padding: 16px 16px calc(96px + env(safe-area-inset-bottom));
   max-width: 720px;
   margin: 0 auto;
 }
-.privacy-data-view__header {
-  display: grid;
-  grid-template-columns: 90px 1fr 90px;
+
+.privacy-card {
+  background: var(--ui-surface, rgba(255, 255, 255, 0.92));
+  border: 1px solid var(--ui-surface-border, rgba(148, 163, 184, 0.28));
+  border-radius: 20px;
+  padding: 16px 16px 14px;
+  box-shadow: var(--ui-shadow-soft, 0 10px 30px rgba(15, 23, 42, 0.08));
+}
+
+.privacy-card--enter {
+  animation: privacySlideUp 0.38s ease both;
+  animation-delay: var(--enter-delay, 0ms);
+}
+
+.privacy-card__head {
+  display: flex;
   align-items: center;
-  margin-bottom: 12px;
+  gap: 10px;
+  margin-bottom: 10px;
 }
-.privacy-data-view__header h1 {
+
+.privacy-card__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--ui-primary, #667eea) 14%, var(--ui-surface, #fff) 86%);
+  color: var(--ui-primary, #3b82f6);
+  flex-shrink: 0;
+}
+
+.privacy-card__icon--policy {
+  background: color-mix(in oklab, #0ea5e9 16%, var(--ui-surface, #fff) 84%);
+  color: #0284c7;
+}
+
+.privacy-card__icon--control {
+  background: color-mix(in oklab, #8b5cf6 16%, var(--ui-surface, #fff) 84%);
+  color: #7c3aed;
+}
+
+.privacy-card__icon .material-symbols-outlined {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.privacy-card h2 {
   margin: 0;
-  text-align: center;
-  font-size: 18px;
-}
-.spacer {
-  display: block;
-}
-.card {
-  background: color-mix(in oklab, #fff 92%, var(--ui-primary, #667eea) 8%);
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 14px;
-  padding: 14px;
-  margin-bottom: 12px;
-}
-.card h2 {
-  margin: 0 0 8px;
   font-size: 15px;
+  font-weight: 700;
+  color: var(--ui-text, #1e293b);
 }
-.card p {
+
+.privacy-card p {
   margin: 0 0 8px;
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.55;
+  color: var(--ui-text, #1e293b);
 }
+
 .muted {
-  color: #64748b;
+  color: var(--ui-muted, #64748b);
   font-size: 12px !important;
 }
+
+.privacy-link-list,
+.privacy-action-list {
+  display: grid;
+  gap: 8px;
+  margin: 4px 0 10px;
+}
+
 .link-btn,
 .action-btn {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   width: 100%;
   text-align: left;
-  margin: 6px 0;
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: #fff;
+  margin: 0;
+  padding: 11px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--ui-surface-border, rgba(148, 163, 184, 0.35));
+  background: color-mix(in oklab, var(--ui-surface, #fff) 88%, var(--ui-primary-soft, #eff6ff) 12%);
+  color: var(--ui-text, #1e293b);
   cursor: pointer;
   font-size: 13px;
+  font-weight: 600;
+  transition: transform 0.16s ease, background 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+  -webkit-tap-highlight-color: transparent;
 }
+
+.link-btn:active,
+.action-btn:active:not(:disabled) {
+  transform: scale(0.985);
+}
+
+.link-btn:hover,
+.action-btn:hover:not(:disabled) {
+  border-color: color-mix(in oklab, var(--ui-primary, #3b82f6) 28%, transparent);
+  box-shadow: 0 6px 16px color-mix(in oklab, var(--ui-primary, #3b82f6) 10%, transparent);
+}
+
+.link-btn__icon,
+.action-btn__icon {
+  font-size: 18px;
+  line-height: 1;
+  color: var(--ui-primary, #3b82f6);
+  flex-shrink: 0;
+}
+
+.link-btn__label {
+  flex: 1;
+  min-width: 0;
+}
+
+.link-btn__chev {
+  font-size: 16px;
+  line-height: 1;
+  color: var(--ui-muted, #94a3b8);
+  flex-shrink: 0;
+}
+
+.action-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
 .action-btn.danger {
-  border-color: color-mix(in oklab, #ef4444 45%, transparent);
+  border-color: color-mix(in oklab, #ef4444 40%, transparent);
   color: #b91c1c;
+  background: color-mix(in oklab, #fef2f2 70%, var(--ui-surface, #fff) 30%);
 }
+
+.action-btn.danger .action-btn__icon {
+  color: #dc2626;
+}
+
 .status {
+  margin: 0;
   font-size: 12px;
+  font-weight: 600;
   color: #0f766e;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: color-mix(in oklab, #ccfbf1 55%, var(--ui-surface, #fff) 45%);
+  border: 1px solid color-mix(in oklab, #14b8a6 24%, transparent);
 }
-.back-btn {
-  min-width: 72px;
-  height: 36px;
-  border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: #fff;
-  cursor: pointer;
+
+@keyframes privacySlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .privacy-card--enter {
+    animation: none;
+  }
+
+  .link-btn,
+  .action-btn {
+    transition: none;
+  }
 }
 </style>

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -663,6 +663,60 @@ html.dark .grade-view .semester-header {
   color: #e2e8f0 !important;
 }
 
+/* ─── 隐私与数据页（#464） ─── */
+html.dark .privacy-data-view {
+  background: var(--ui-bg-gradient, linear-gradient(180deg, #0f172a 0%, #1e293b 100%)) !important;
+  color: var(--ui-text, #e2e8f0) !important;
+}
+
+html.dark .privacy-data-view .privacy-card {
+  background: var(--ui-surface, rgba(30, 41, 59, 0.9)) !important;
+  border-color: var(--ui-surface-border, rgba(148, 163, 184, 0.18)) !important;
+  box-shadow: none !important;
+}
+
+html.dark .privacy-data-view .privacy-card h2,
+html.dark .privacy-data-view .privacy-card p {
+  color: var(--ui-text, #e2e8f0) !important;
+}
+
+html.dark .privacy-data-view .muted {
+  color: var(--ui-muted, #94a3b8) !important;
+}
+
+html.dark .privacy-data-view .link-btn,
+html.dark .privacy-data-view .action-btn {
+  background: color-mix(in oklab, #0f172a 55%, #1e293b 45%) !important;
+  border-color: rgba(148, 163, 184, 0.22) !important;
+  color: #e2e8f0 !important;
+}
+
+html.dark .privacy-data-view .action-btn.danger {
+  background: color-mix(in oklab, #7f1d1d 35%, #1e293b 65%) !important;
+  border-color: color-mix(in oklab, #ef4444 40%, transparent) !important;
+  color: #fca5a5 !important;
+}
+
+html.dark .privacy-data-view .action-btn.danger .action-btn__icon {
+  color: #f87171 !important;
+}
+
+html.dark .privacy-data-view .status {
+  background: color-mix(in oklab, #134e4a 45%, #1e293b 55%) !important;
+  border-color: color-mix(in oklab, #14b8a6 30%, transparent) !important;
+  color: #5eead4 !important;
+}
+
+html.dark .privacy-data-view .privacy-card__icon--policy {
+  background: color-mix(in oklab, #0ea5e9 22%, #0f172a 78%) !important;
+  color: #7dd3fc !important;
+}
+
+html.dark .privacy-data-view .privacy-card__icon--control {
+  background: color-mix(in oklab, #8b5cf6 22%, #0f172a 78%) !important;
+  color: #c4b5fd !important;
+}
+
 /* ─── 我的页面 ─── */
 html.dark .me-view {
   background-color: #0f172a !important;
@@ -674,6 +728,36 @@ html.dark .func-grid,
 html.dark .legal-card {
   background-color: #1e293b !important;
   border: 1px solid rgba(148, 163, 184, 0.15) !important;
+}
+
+html.dark .me-view .privacy-policy-entry {
+  background: color-mix(in oklab, #0f172a 50%, #1e293b 50%) !important;
+  border-color: rgba(148, 163, 184, 0.22) !important;
+  color: #e2e8f0 !important;
+}
+
+html.dark .me-view .privacy-policy-entry__title {
+  color: #e2e8f0 !important;
+}
+
+html.dark .me-view .privacy-policy-entry__desc,
+html.dark .me-view .privacy-policy-entry__chev {
+  color: #94a3b8 !important;
+}
+
+html.dark .me-view .privacy-policy-entry__icon {
+  background: color-mix(in oklab, #3b82f6 22%, #0f172a 78%) !important;
+  color: #93c5fd !important;
+}
+
+html.dark .me-view .legal-tab:not(.active) {
+  background: #0f172a !important;
+  color: #94a3b8 !important;
+}
+
+html.dark .me-view .legal-content,
+html.dark .me-view .legal-content .muted-en {
+  color: #94a3b8 !important;
 }
 
 html.dark .me-view .icp-beian-link {

--- a/src/utils/privacy_about_ui_contract.spec.ts
+++ b/src/utils/privacy_about_ui_contract.spec.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = process.cwd()
+const readText = (relativePath: string) => {
+  const full = resolve(repoRoot, relativePath)
+  return existsSync(full) ? readFileSync(full, 'utf8') : ''
+}
+
+/** Structural contract for PrivacyDataView + MeView "关于 Mini-HBUT" polish (#464). */
+describe('privacy & about Mini-HBUT UI contract (#464)', () => {
+  const privacyPath = 'src/components/PrivacyDataView.vue'
+  const mePath = 'src/components/MeView.vue'
+  const darkPath = 'src/styles/dark-mode.css'
+
+  it('exists and uses unified page header + surface tokens on Privacy & Data', () => {
+    const source = readText(privacyPath)
+    expect(existsSync(resolve(repoRoot, privacyPath))).toBe(true)
+
+    // Prefer TPageHeader; allow grade-stitch-style tokens as alternate shell language
+    const hasTPageHeader = source.includes('<TPageHeader') && source.includes("from './templates'")
+    const hasGradeStitchTokens =
+      source.includes('grade-stitch-header') || source.includes('--ui-surface')
+    expect(hasTPageHeader || hasGradeStitchTokens).toBe(true)
+
+    expect(source).toContain('--ui-surface')
+    expect(source).toContain('--ui-surface-border')
+    expect(source).toContain('--ui-text')
+    expect(source).toContain('--ui-muted')
+    expect(source).toContain('privacy-card')
+    expect(source).toContain('privacySlideUp')
+    expect(source).toContain('prefers-reduced-motion')
+  })
+
+  it('keeps all data-control actions and external policy links (no behavior regression)', () => {
+    const source = readText(privacyPath)
+
+    expect(source).toContain('PRIVACY_POLICY_URL')
+    expect(source).toContain('SECURITY_DOCS_URL')
+    expect(source).toContain('SUPPORT_DOCS_URL')
+    expect(source).toContain('PROJECT_HOME_URL')
+    expect(source).toContain('GITHUB_URL')
+    expect(source).toContain('FEEDBACK_URL')
+    expect(source).toContain('clearLocalCaches')
+    expect(source).toContain('clearSession')
+    expect(source).toContain('clearAllLocal')
+    expect(source).toContain('disableCloudAndStats')
+    expect(source).toContain('exportLocalMeta')
+    expect(source).toContain("emit('logout')")
+    expect(source).toContain("emit('cleared')")
+    expect(source).toContain("emit('back')")
+
+    // Must not hard-require secrets / passwords in this page
+    expect(source).not.toMatch(/password\s*[:=]/i)
+    expect(source).not.toMatch(/api[_-]?key/i)
+    expect(source).not.toMatch(/secret[_-]?key/i)
+    expect(source).not.toContain('localStorage.getItem(\'password')
+  })
+
+  it('does not hardcode pure white card/button surfaces on Privacy & Data', () => {
+    const source = readText(privacyPath)
+    const styleBlock = source.match(/<style[\s\S]*?<\/style>/)?.[0] || ''
+
+    // Old prototype used background: #fff on cards/buttons
+    expect(styleBlock).not.toMatch(/background:\s*#fff\b/i)
+    expect(styleBlock).not.toMatch(/background:\s*#ffffff\b/i)
+    expect(styleBlock).toContain('var(--ui-surface')
+  })
+
+  it('brands MeView about Mini-HBUT privacy entry with icon + tokens', () => {
+    const source = readText(mePath)
+    expect(existsSync(resolve(repoRoot, mePath))).toBe(true)
+
+    expect(source).toContain('关于 Mini-HBUT')
+    expect(source).toContain('privacy-policy-entry')
+    expect(source).toContain('PRIVACY_POLICY_URL')
+    expect(source).toContain('openExternal(PRIVACY_POLICY_URL)')
+    expect(source).toMatch(/privacy-policy-entry[\s\S]*shield|material-symbols-outlined[\s\S]*shield/)
+    expect(source).toContain('--ui-surface')
+    expect(source).toContain('--ui-text')
+    expect(source).toContain('--ui-muted')
+    expect(source).toContain('prefers-reduced-motion')
+  })
+
+  it('registers dark-mode readability for privacy page and about privacy entry', () => {
+    const dark = readText(darkPath)
+    expect(dark).toContain('html.dark .privacy-data-view')
+    expect(dark).toContain('html.dark .privacy-data-view .privacy-card')
+    expect(dark).toContain('html.dark .me-view .privacy-policy-entry')
+  })
+
+  it('preserves non-official disclaimer copy sources without embedding secrets', () => {
+    const privacy = readText(privacyPath)
+    const me = readText(mePath)
+
+    expect(privacy).toContain('NON_OFFICIAL_DISCLAIMER_ZH')
+    expect(privacy).toContain('NON_OFFICIAL_DISCLAIMER_EN')
+    expect(me).toContain('NON_OFFICIAL_DISCLAIMER_ZH')
+    expect(me).toContain('NON_OFFICIAL_DISCLAIMER_EN')
+
+    // Export meta still excludes password by toast/copy intent
+    expect(privacy).toContain('不含密码')
+  })
+})


### PR DESCRIPTION
## Summary
- Polish `PrivacyDataView` to match GradeView design language: `TPageHeader`, `--ui-surface` / token-based cards & buttons, staggered enter motion, reduced-motion support
- Brand MeView 「关于 Mini-HBUT」 privacy policy entry with shield icon + token styles; legal cards use surface tokens
- Add dark-mode overrides for privacy page and about privacy entry
- Add structural contract test `privacy_about_ui_contract.spec.ts` (no secrets hard-requirement)

## Scope
Closes #464

Does **not** change privacy policy semantics, clear-data behavior, or external URL handling.

## Test plan
- [x] `npx vitest run src/utils/privacy_about_ui_contract.spec.ts` (6 passed)
- [ ] Manual: 我的 → 隐私与数据 — header/cards/dark mode
- [ ] Manual: 我的 → 关于 Mini-HBUT — branded privacy entry still opens policy URL
- [ ] Manual: clear cache/session/all, disable cloud, export meta still work