### PR TITLE
fix(ui): align academic pages surface style with GradeView

### DIFF
--- a/src/components/AcademicProgressView.vue
+++ b/src/components/AcademicProgressView.vue
@@ -367,9 +367,10 @@ onMounted(() => {
 </template>
 
 <style scoped>
+/* 页级背景对齐成绩查询：中性浅底，避免 --ui-bg-gradient 蓝青全页染色 */
 .progress-view {
   min-height: 100vh;
-  background: var(--ui-bg-gradient, #f5f7fa);
+  background: #f6fafe;
   color: var(--ui-text);
 }
 
@@ -378,9 +379,11 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 14px 16px;
-  background: var(--ui-surface);
-  border-bottom: 1px solid var(--ui-surface-border);
-  box-shadow: var(--ui-shadow-soft);
+  background: rgba(246, 250, 254, 0.86);
+  border-bottom: 1px solid rgba(226, 232, 240, 0.86);
+  box-shadow: none;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
 
 .back-btn {
@@ -388,7 +391,7 @@ onMounted(() => {
   padding: 0 12px;
   border-radius: 999px;
   border: 1px solid color-mix(in oklab, var(--ui-primary) 26%, transparent);
-  background: var(--ui-primary-soft);
+  background: #eff6ff;
   color: var(--ui-primary);
   font-weight: 700;
   cursor: pointer;
@@ -397,15 +400,17 @@ onMounted(() => {
 .view-header h1 {
   margin: 0;
   font-size: 20px;
+  font-weight: 800;
+  color: #1e293b;
 }
 
 .offline-banner {
   margin: 12px 16px 0;
   padding: 10px 12px;
   border-radius: 12px;
-  background: color-mix(in oklab, var(--ui-danger) 14%, var(--ui-surface, #fff) 86%);
-  border: 1px solid color-mix(in oklab, var(--ui-danger) 36%, transparent);
-  color: var(--ui-danger);
+  background: #fef3c7;
+  border: 1px solid color-mix(in oklab, #f59e0b 36%, transparent);
+  color: #b45309;
   font-weight: 600;
   font-size: 13px;
 }
@@ -414,12 +419,13 @@ onMounted(() => {
   margin: 12px 16px 0;
   padding: 12px;
   border-radius: 14px;
-  border: 1px solid var(--ui-surface-border);
-  background: var(--ui-surface);
-  box-shadow: var(--ui-shadow-soft);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  background: #ffffff;
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
   display: flex;
   align-items: center;
   gap: 10px;
+  animation: progress-fade-up 0.28s ease both;
 }
 
 .controls label {
@@ -445,12 +451,14 @@ onMounted(() => {
   padding: 24px 12px;
   color: var(--ui-muted);
   border-radius: 14px;
-  border: 1px solid var(--ui-surface-border);
-  background: var(--ui-surface);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  background: #ffffff;
 }
 
 .content {
   padding: 12px 14px 120px;
+  animation: progress-fade-up 0.32s ease both;
+  animation-delay: 0.04s;
 }
 
 .summary-card {
@@ -460,10 +468,11 @@ onMounted(() => {
 }
 
 .summary-item {
-  border: 1px solid var(--ui-surface-border);
-  border-radius: 10px;
-  padding: 8px 10px;
-  background: var(--ui-surface);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #ffffff;
+  box-shadow: 0 4px 16px -4px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -477,6 +486,7 @@ onMounted(() => {
 .summary-value {
   font-size: 14px;
   font-weight: 700;
+  color: #1e293b;
 }
 
 .category-section {
@@ -487,11 +497,12 @@ onMounted(() => {
 }
 
 .category-card {
-  border: 1px solid var(--ui-surface-border);
-  border-radius: 14px;
-  padding: 12px;
-  background: var(--ui-surface);
-  box-shadow: var(--ui-shadow-soft);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 16px;
+  padding: 14px;
+  background: #ffffff;
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
+  animation: progress-fade-up 0.3s ease both;
 }
 
 .category-header {
@@ -504,6 +515,8 @@ onMounted(() => {
 .category-header h2 {
   margin: 0;
   font-size: 16px;
+  font-weight: 800;
+  color: #1e293b;
 }
 
 .category-path,
@@ -517,8 +530,8 @@ onMounted(() => {
   min-height: 28px;
   padding: 0 10px;
   border-radius: 999px;
-  background: var(--ui-primary-soft);
-  color: var(--ui-primary);
+  background: #eff6ff;
+  color: #2563eb;
   font-size: 12px;
   font-weight: 700;
   display: inline-flex;
@@ -533,10 +546,10 @@ onMounted(() => {
 }
 
 .course-card {
-  border: 1px solid var(--ui-surface-border);
-  border-radius: 10px;
-  background: color-mix(in oklab, var(--ui-primary-soft) 62%, var(--ui-surface, #fff) 38%);
-  padding: 8px 10px;
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 10px 12px;
   text-align: left;
   cursor: pointer;
   width: 100%;
@@ -546,6 +559,13 @@ onMounted(() => {
   align-items: flex-start;
   white-space: normal;
   overflow: hidden;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.course-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 22px -6px rgba(15, 23, 42, 0.12);
+  border-color: color-mix(in oklab, var(--ui-primary) 28%, transparent);
 }
 
 .course-title {
@@ -557,6 +577,7 @@ onMounted(() => {
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  color: #1e293b;
 }
 
 .course-meta {
@@ -575,8 +596,9 @@ onMounted(() => {
   min-height: 20px;
   padding: 0 6px;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--ui-primary-soft) 50%, #fff 50%);
+  background: #eff6ff;
   border: 1px solid color-mix(in oklab, var(--ui-primary) 18%, transparent);
+  color: #334155;
 }
 
 .status-pill {
@@ -586,25 +608,25 @@ onMounted(() => {
 }
 
 .state-done {
-  background: color-mix(in oklab, var(--ui-success, #10b981) 18%, var(--ui-surface, #fff) 82%);
-  color: var(--ui-success, #0f9f6e);
+  background: #d1fae5;
+  color: #047857;
   border-color: color-mix(in oklab, var(--ui-success, #10b981) 40%, transparent);
 }
 
 .state-todo {
-  background: color-mix(in oklab, var(--ui-danger, #ef4444) 16%, var(--ui-surface, #fff) 84%);
-  color: var(--ui-danger, #dc2626);
+  background: #fee2e2;
+  color: #dc2626;
   border-color: color-mix(in oklab, var(--ui-danger, #ef4444) 40%, transparent);
 }
 
 .state-pending {
-  background: color-mix(in oklab, var(--ui-warning, #f59e0b) 18%, var(--ui-surface, #fff) 82%);
-  color: var(--ui-warning, #c26c00);
+  background: #fef3c7;
+  color: #b45309;
   border-color: color-mix(in oklab, var(--ui-warning, #f59e0b) 40%, transparent);
 }
 
 .state-unknown {
-  background: color-mix(in oklab, var(--ui-primary-soft) 55%, var(--ui-surface, #fff) 45%);
+  background: #eff6ff;
   color: var(--ui-primary);
   border-color: color-mix(in oklab, var(--ui-primary) 24%, transparent);
 }
@@ -624,11 +646,12 @@ onMounted(() => {
   width: min(920px, 100%);
   max-height: min(86vh, 860px);
   overflow: auto;
-  background: var(--ui-surface);
-  border: 1px solid var(--ui-surface-border);
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
   border-radius: 18px;
   box-shadow: var(--ui-shadow-strong);
   padding: 16px;
+  animation: progress-slide-up 0.28s ease;
 }
 
 .modal-close {
@@ -637,7 +660,7 @@ onMounted(() => {
   height: 30px;
   border-radius: 999px;
   border: 1px solid color-mix(in oklab, var(--ui-primary) 22%, transparent);
-  background: var(--ui-primary-soft);
+  background: #eff6ff;
   color: var(--ui-primary);
   font-size: 18px;
   font-weight: 700;
@@ -662,7 +685,7 @@ onMounted(() => {
   min-height: 24px;
   padding: 0 8px;
   border-radius: 999px;
-  background: var(--ui-primary-soft);
+  background: #eff6ff;
   color: var(--ui-primary);
   font-size: 12px;
   display: inline-flex;
@@ -683,10 +706,10 @@ onMounted(() => {
 }
 
 .detail-item {
-  border: 1px solid var(--ui-surface-border);
+  border: 1px solid rgba(226, 232, 240, 0.9);
   border-radius: 10px;
   padding: 8px 10px;
-  background: color-mix(in oklab, var(--ui-primary-soft) 62%, var(--ui-surface, #fff) 38%);
+  background: #f8fafc;
   display: flex;
   flex-direction: column;
   gap: 3px;
@@ -702,6 +725,45 @@ onMounted(() => {
   line-height: 1.35;
   word-break: break-word;
   white-space: pre-wrap;
+}
+
+@keyframes progress-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes progress-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .controls,
+  .content,
+  .category-card,
+  .modal-content {
+    animation: none;
+  }
+
+  .course-card {
+    transition: none;
+  }
+
+  .course-card:hover {
+    transform: none;
+  }
 }
 
 @media (max-width: 760px) {

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -372,9 +372,10 @@ onMounted(() => {
 </template>
 
 <style scoped>
+/* 页级背景对齐成绩查询：中性浅底，避免 --ui-bg-gradient 蓝青全页染色 */
 .calendar-view {
   min-height: 100vh;
-  background: var(--ui-bg-gradient);
+  background: #f6fafe;
   color: var(--ui-text);
   padding: 16px 14px 120px;
 }
@@ -407,11 +408,12 @@ onMounted(() => {
   flex-direction: column;
   gap: 10px;
   padding: 16px;
-  background: var(--ui-surface);
-  border: 1px solid var(--ui-surface-border);
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
   border-radius: 16px;
-  box-shadow: var(--ui-shadow-soft);
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
   margin-bottom: 16px;
+  animation: calendar-fade-up 0.28s ease both;
 }
 
 .controls select {
@@ -419,7 +421,7 @@ onMounted(() => {
   border-radius: 10px;
   border: 1px solid var(--ui-surface-border);
   color: var(--ui-text);
-  background: color-mix(in oklab, var(--ui-surface) 88%, #fff 12%);
+  background: #f0f4f8;
 }
 
 .meta {
@@ -434,9 +436,9 @@ onMounted(() => {
   min-height: 28px;
   padding: 0 10px;
   border-radius: 999px;
-  border: 1px solid color-mix(in oklab, var(--ui-primary) 24%, transparent);
-  background: color-mix(in oklab, var(--ui-primary-soft) 70%, #fff 30%);
-  color: var(--ui-text);
+  border: 1px solid color-mix(in oklab, var(--ui-primary) 18%, transparent);
+  background: #eff6ff;
+  color: var(--ui-primary);
   font-size: 12px;
   font-weight: 700;
 }
@@ -445,35 +447,34 @@ onMounted(() => {
   padding: 20px 12px;
   text-align: center;
   color: var(--ui-muted);
-  background: var(--ui-surface);
-  border: 1px solid var(--ui-surface-border);
+  background: #ffffff;
+  border: 1px solid rgba(226, 232, 240, 0.9);
   border-radius: 14px;
-  box-shadow: var(--ui-shadow-soft);
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
   margin-bottom: 16px;
 }
 
 .calendar-table-wrapper {
   padding: 0 0 24px;
   overflow-x: auto;
+  animation: calendar-fade-up 0.32s ease both;
+  animation-delay: 0.04s;
 }
 
 .calendar-table {
   width: 100%;
   min-width: 980px;
   border-collapse: collapse;
-  background: var(--ui-surface);
+  background: #ffffff;
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: var(--ui-shadow-soft);
-  border: 1px solid var(--ui-surface-border);
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(226, 232, 240, 0.9);
 }
 
+/* 表头用中性 surface，避免 primary-soft 蓝渐变与死白对比 */
 .calendar-table thead th {
-  background: linear-gradient(
-    135deg,
-    color-mix(in oklab, var(--ui-primary-soft) 78%, #fff 22%),
-    color-mix(in oklab, var(--ui-secondary) 12%, #fff 88%)
-  );
+  background: #f0f4f8;
   color: var(--ui-text);
   font-weight: 700;
   padding: 12px 8px;
@@ -493,7 +494,8 @@ onMounted(() => {
 }
 
 .calendar-table tbody tr.is-current {
-  background: color-mix(in oklab, var(--ui-primary-soft) 64%, #fff 36%);
+  background: #eff6ff;
+  transition: background-color 0.2s ease;
 }
 
 .month-col, .week-col {
@@ -507,7 +509,7 @@ onMounted(() => {
 .month-cell {
   font-weight: 600;
   color: var(--ui-text);
-  background: color-mix(in oklab, var(--ui-primary-soft) 44%, #fff 56%);
+  background: #f0f4f8;
 }
 
 .week-cell {
@@ -540,7 +542,7 @@ onMounted(() => {
   display: inline-block;
   padding: 2px 6px;
   border-radius: 999px;
-  background: color-mix(in oklab, var(--ui-danger) 14%, #ffffff 86%);
+  background: color-mix(in oklab, var(--ui-danger) 14%, var(--ui-surface, #fff) 86%);
   color: var(--ui-danger);
   border: 1px solid color-mix(in oklab, var(--ui-danger) 32%, transparent);
   font-weight: 600;
@@ -554,10 +556,32 @@ onMounted(() => {
 .offline-banner {
   margin: 12px 0 0;
   padding: 10px 14px;
-  background: color-mix(in oklab, var(--ui-danger) 14%, #ffffff 86%);
-  border: 1px solid color-mix(in oklab, var(--ui-danger) 40%, transparent);
-  color: var(--ui-danger);
+  background: #fef3c7;
+  border: 1px solid color-mix(in oklab, #f59e0b 40%, transparent);
+  color: #b45309;
   border-radius: 12px;
   font-weight: 600;
+}
+
+@keyframes calendar-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .controls,
+  .calendar-table-wrapper {
+    animation: none;
+  }
+
+  .calendar-table tbody tr.is-current {
+    transition: none;
+  }
 }
 </style>

--- a/src/components/TrainingPlanView.vue
+++ b/src/components/TrainingPlanView.vue
@@ -416,9 +416,10 @@ onMounted(async () => {
 </template>
 
 <style scoped>
+/* 页级背景对齐成绩查询：中性浅底，避免 --ui-bg-gradient 蓝青全页染色 */
 .training-plan-view {
   min-height: 100vh;
-  background: var(--ui-bg-gradient, #f5f7fa);
+  background: #f6fafe;
   color: var(--ui-text);
 }
 
@@ -427,27 +428,32 @@ onMounted(async () => {
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  background: var(--ui-surface);
+  background: rgba(246, 250, 254, 0.86);
   color: var(--ui-text);
+  border-bottom: 1px solid rgba(226, 232, 240, 0.86);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
 
 .back-btn,
 .logout-btn {
   padding: 8px 16px;
-  border-radius: 8px;
-  border: none;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--ui-primary) 22%, transparent);
   cursor: pointer;
-  background: var(--ui-primary-soft);
+  background: #eff6ff;
   color: var(--ui-primary);
+  font-weight: 700;
 }
 
 .filters {
-  background: var(--ui-surface);
+  background: #ffffff;
   margin: 16px;
   padding: 16px;
-  border-radius: 12px;
-  border: 1px solid var(--ui-surface-border);
-  box-shadow: var(--ui-shadow-soft);
+  border-radius: 16px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
+  animation: training-fade-up 0.28s ease both;
 }
 
 .filter-grid {
@@ -471,10 +477,10 @@ onMounted(async () => {
 .filter-grid select,
 .filter-grid input {
   padding: 8px 10px;
-  border-radius: 8px;
+  border-radius: 10px;
   border: 1px solid var(--ui-surface-border);
   font-size: 13px;
-  background: var(--ui-surface);
+  background: #f0f4f8;
   color: var(--ui-text);
 }
 
@@ -493,7 +499,7 @@ onMounted(async () => {
 
 .filter-actions button {
   padding: 8px 16px;
-  border-radius: 8px;
+  border-radius: 10px;
   border: none;
   cursor: pointer;
   font-weight: 600;
@@ -505,12 +511,14 @@ onMounted(async () => {
 }
 
 .filter-actions .ghost {
-  background: var(--ui-primary-soft);
+  background: #eff6ff;
   color: var(--ui-primary);
 }
 
 .content {
   padding: 0 16px 24px;
+  animation: training-fade-up 0.32s ease both;
+  animation-delay: 0.04s;
 }
 
 .state {
@@ -529,24 +537,26 @@ onMounted(async () => {
 }
 
 .course-card {
-  background: var(--ui-surface);
+  background: #ffffff;
   border-radius: 16px;
   padding: 16px;
-  border: 1px solid var(--ui-surface-border);
-  box-shadow: var(--ui-shadow-soft);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  box-shadow: 0 4px 20px -2px rgba(15, 23, 42, 0.05);
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  animation: training-fade-up 0.3s ease both;
 }
 
 .course-card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--ui-shadow-strong);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 28px -8px rgba(15, 23, 42, 0.14);
+  border-color: color-mix(in oklab, var(--ui-primary) 28%, transparent);
 }
 
 .course-title {
   font-size: 16px;
-  font-weight: 700;
-  color: var(--ui-text);
+  font-weight: 800;
+  color: #1e293b;
   margin-bottom: 10px;
 }
 
@@ -561,19 +571,21 @@ onMounted(async () => {
   font-size: 12px;
   padding: 4px 10px;
   border-radius: 999px;
-  background: var(--ui-primary-soft);
-  color: var(--ui-primary);
+  background: #eff6ff;
+  color: #2563eb;
   font-weight: 600;
+  border: 1px solid color-mix(in oklab, var(--ui-primary) 18%, transparent);
 }
 
 .tag.primary {
-  background: var(--ui-primary-soft-strong);
-  color: var(--ui-primary);
+  background: #dbeafe;
+  color: #1d4ed8;
 }
 
 .tag.ghost {
-  background: color-mix(in oklab, var(--ui-success, #10b981) 14%, transparent);
-  color: var(--ui-success);
+  background: #d1fae5;
+  color: #047857;
+  border-color: color-mix(in oklab, var(--ui-success, #10b981) 28%, transparent);
 }
 
 .course-sub {
@@ -599,9 +611,9 @@ onMounted(async () => {
 
 .pagination button {
   padding: 6px 12px;
-  border-radius: 6px;
-  border: 1px solid var(--ui-surface-border);
-  background: var(--ui-surface);
+  border-radius: 10px;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  background: #ffffff;
   color: var(--ui-text);
   cursor: pointer;
 }
@@ -623,12 +635,13 @@ onMounted(async () => {
 }
 
 .modal-content {
-  background: var(--ui-surface);
-  border-radius: 16px;
+  background: #ffffff;
+  border-radius: 18px;
   width: min(520px, 100%);
   padding: 20px;
-  border: 1px solid var(--ui-surface-border);
+  border: 1px solid rgba(226, 232, 240, 0.9);
   box-shadow: var(--ui-shadow-strong);
+  animation: training-slide-up 0.28s ease;
 }
 
 .modal-header {
@@ -641,7 +654,8 @@ onMounted(async () => {
 .modal-header h3 {
   margin: 0;
   font-size: 18px;
-  color: var(--ui-text);
+  color: #1e293b;
+  font-weight: 800;
 }
 
 .close-btn {
@@ -649,7 +663,7 @@ onMounted(async () => {
   height: 28px;
   border-radius: 50%;
   border: none;
-  background: var(--ui-primary-soft);
+  background: #eff6ff;
   color: var(--ui-primary);
   font-size: 18px;
   cursor: pointer;
@@ -682,10 +696,49 @@ onMounted(async () => {
 .offline-banner {
   margin: 12px 16px 0;
   padding: 10px 14px;
-  background: color-mix(in oklab, var(--ui-danger, #ef4444) 14%, var(--ui-surface, #fff) 86%);
-  border: 1px solid color-mix(in oklab, var(--ui-danger, #ef4444) 36%, transparent);
-  color: var(--ui-danger, #b91c1c);
+  background: #fef3c7;
+  border: 1px solid color-mix(in oklab, #f59e0b 36%, transparent);
+  color: #b45309;
   border-radius: 12px;
   font-weight: 600;
+}
+
+@keyframes training-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes training-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .filters,
+  .content,
+  .course-card,
+  .modal-content {
+    animation: none;
+  }
+
+  .course-card {
+    transition: none;
+  }
+
+  .course-card:hover {
+    transform: none;
+  }
 }
 </style>

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -1598,13 +1598,19 @@ html.dark body :is(
   .feedback-view,
   .config-editor,
   .campus-code-view,
-  .calendar-view,
   .more-module-host-view,
   .ai-view
 ) {
   background:
     radial-gradient(120% 90% at 8% 0%, rgba(37, 99, 235, 0.16), transparent 44%),
     linear-gradient(180deg, #07111f 0%, #0f172a 58%, #111c2f 100%) !important;
+  color: #e2e8f0 !important;
+}
+
+/* 校历页级背景对齐成绩查询：中性 slate，去掉蓝径向染色 */
+html.dark body .calendar-view {
+  background: #0f172a !important;
+  background-color: #0f172a !important;
   color: #e2e8f0 !important;
 }
 
@@ -1739,11 +1745,12 @@ html.dark body .campus-code-view .banner.success {
   color: #bbf7d0 !important;
 }
 
-/* 校历 */
-html.dark body .calendar-view :is(.controls, .calendar-table) {
+/* 校历：表面/表头/当前周在暗色下可读，无死白 thead */
+html.dark body .calendar-view :is(.controls, .calendar-table, .loading, .error) {
   background: #1e293b !important;
   border-color: rgba(148, 163, 184, 0.24) !important;
   color: #e2e8f0 !important;
+  box-shadow: none !important;
 }
 
 html.dark body .calendar-view .calendar-table :is(th, td) {
@@ -1762,12 +1769,24 @@ html.dark body .calendar-view .calendar-table tbody tr.is-current :is(td, .month
 }
 
 html.dark body .calendar-view :is(.month-cell, .meta span) {
-  background: rgba(15, 23, 42, 0.72) !important;
+  background: rgba(30, 41, 59, 0.95) !important;
   color: #e2e8f0 !important;
+  border-color: rgba(96, 165, 250, 0.28) !important;
+}
+
+html.dark body .calendar-view .meta span {
+  background: rgba(37, 99, 235, 0.22) !important;
+  color: #bfdbfe !important;
 }
 
 html.dark body .calendar-view :is(.day-lunar, .remark-cell) {
   color: #94a3b8 !important;
+}
+
+html.dark body .calendar-view .offline-banner {
+  background: rgba(120, 53, 15, 0.4) !important;
+  border-color: rgba(251, 191, 36, 0.34) !important;
+  color: #fde68a !important;
 }
 
 /* 更多模块宿主 */
@@ -1864,8 +1883,6 @@ html.dark body .ai-view .rich-text :is(pre, code) {
    ═══════════════════════════════════════════════════════════════ */
 
 html.dark body :is(
-  .progress-view,
-  .training-plan-view,
   .more-shuake-view,
   .resource-share-view,
   .campus-map-view
@@ -1873,6 +1890,13 @@ html.dark body :is(
   background:
     radial-gradient(120% 90% at 8% 0%, rgba(37, 99, 235, 0.14), transparent 44%),
     linear-gradient(180deg, #07111f 0%, #0f172a 58%, #111827 100%) !important;
+  color: #e2e8f0 !important;
+}
+
+/* 学业情况 / 培养方案：页级中性深底，对齐成绩查询 */
+html.dark body :is(.progress-view, .training-plan-view) {
+  background: #0f172a !important;
+  background-color: #0f172a !important;
   color: #e2e8f0 !important;
 }
 
@@ -1890,10 +1914,18 @@ html.dark body :is(.progress-view, .training-plan-view) :is(
   .empty,
   .pagination button
 ) {
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.94), rgba(30, 41, 59, 0.88)) !important;
+  background: #1e293b !important;
   border-color: rgba(148, 163, 184, 0.24) !important;
-  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.28) !important;
+  box-shadow: 0 12px 28px rgba(2, 6, 23, 0.28) !important;
   color: #e2e8f0 !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+html.dark body :is(.progress-view, .training-plan-view) .offline-banner {
+  background: rgba(120, 53, 15, 0.4) !important;
+  border-color: rgba(251, 191, 36, 0.34) !important;
+  color: #fde68a !important;
 }
 
 html.dark body :is(.progress-view, .training-plan-view) :is(

--- a/src/utils/academic_views_surface_contract.spec.ts
+++ b/src/utils/academic_views_surface_contract.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const readText = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+
+/** 提取 Vue SFC 中 scoped style 块，便于约束页级背景写法 */
+const extractStyleBlock = (source: string) => {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/)
+  return match?.[1] || ''
+}
+
+const extractRootRule = (style: string, selector: string) => {
+  const re = new RegExp(
+    `\\.${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([\\s\\S]*?)\\n\\}`,
+  )
+  return style.match(re)?.[1] || ''
+}
+
+const VIEW_FILES = [
+  {
+    path: 'src/components/CalendarView.vue',
+    rootClass: 'calendar-view',
+    label: '校历',
+  },
+  {
+    path: 'src/components/AcademicProgressView.vue',
+    rootClass: 'progress-view',
+    label: '学业情况',
+  },
+  {
+    path: 'src/components/TrainingPlanView.vue',
+    rootClass: 'training-plan-view',
+    label: '培养方案',
+  },
+] as const
+
+describe('academic views surface polish contract (#465)', () => {
+  it('does not paint full-page blue/cyan --ui-bg-gradient on the three academic views', () => {
+    for (const view of VIEW_FILES) {
+      const source = readText(view.path)
+      const style = extractStyleBlock(source)
+      const rootRule = extractRootRule(style, view.rootClass)
+
+      expect(rootRule, `${view.label} root rule missing`).toBeTruthy()
+      // 禁止页级整页使用蓝青渐变 token
+      expect(rootRule).not.toMatch(/--ui-bg-gradient/)
+      expect(rootRule).not.toMatch(/radial-gradient\s*\(/i)
+      // 对齐成绩查询中性浅底（或 surface 级中性 token）
+      expect(rootRule).toMatch(/background:\s*(#f6fafe|var\(--ui-surface)/)
+    }
+  })
+
+  it('keeps modest enter motion and reduced-motion fallbacks on academic views', () => {
+    for (const view of VIEW_FILES) {
+      const style = extractStyleBlock(readText(view.path))
+      expect(style, `${view.label} should define keyframes`).toMatch(/@keyframes/)
+      expect(style, `${view.label} should respect reduced motion`).toContain(
+        'prefers-reduced-motion: reduce',
+      )
+    }
+  })
+
+  it('dark mode uses neutral slate page backgrounds for the three views (no blue radial wash)', () => {
+    const dark = readText('src/styles/dark-mode.css')
+
+    // 页级应有独立中性深底，且不应再把 calendar/progress/training 塞进带蓝径向的 :is 组
+    expect(dark).toMatch(
+      /html\.dark body \.calendar-view\s*\{[\s\S]*?background(?:-color)?:\s*#0f172a/,
+    )
+    expect(dark).toMatch(
+      /html\.dark body :is\(\.progress-view, \.training-plan-view\)\s*\{[\s\S]*?background(?:-color)?:\s*#0f172a/,
+    )
+
+    // 仍在同一 :is 组里带蓝径向 = 回归
+    const blueWashGroup =
+      dark.match(
+        /html\.dark body :is\(([^)]*)\)\s*\{[\s\S]*?radial-gradient\([^)]*rgba\(37,\s*99,\s*235/g,
+      ) || []
+    for (const block of blueWashGroup) {
+      expect(block).not.toMatch(/\.calendar-view/)
+      expect(block).not.toMatch(/\.progress-view/)
+      expect(block).not.toMatch(/\.training-plan-view/)
+    }
+
+    // 表头暗色可读，非死白
+    expect(dark).toContain('html.dark body .calendar-view .calendar-table thead th')
+    expect(dark).toMatch(
+      /html\.dark body \.calendar-view \.calendar-table thead th\s*\{[\s\S]*?background:\s*#334155/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Aligns **校历 / 学业情况 / 培养方案** visual style with **成绩查询 (GradeView)**:
- Page backgrounds: `#f6fafe` instead of blue/cyan `--ui-bg-gradient`
- Cards, pills, thead use neutral surface hierarchy
- Modest fade/slide motion + `prefers-reduced-motion`
- Dark mode: solid `#0f172a` page bg (no blue radial wash); readable thead/surfaces

**No data API or business logic changes.**

## Files
- `src/components/CalendarView.vue`
- `src/components/AcademicProgressView.vue`
- `src/components/TrainingPlanView.vue`
- `src/styles/dark-mode.css` (page-level dark surfaces for the three views)
- `src/utils/academic_views_surface_contract.spec.ts` (new)

## Test plan
- [x] `npx vitest run src/utils/academic_views_surface_contract.spec.ts` (3 passed)
- [ ] Light theme: open 校历 / 学业情况 / 培养方案 — no full-page blue wash
- [ ] Compare with 成绩查询 — similar surface language
- [ ] Dark theme: tables/cards/modals readable, no dead-white thead
- [ ] Semester switch / expand / detail modal still work

Closes #465