### PR TITLE
feat(schedule): 自定义课程「设定颜色」多级 UI (#469)

### DIFF
--- a/src/components/CourseColorPicker.vue
+++ b/src/components/CourseColorPicker.vue
@@ -1,0 +1,612 @@
+<script setup>
+/**
+ * 自定义课程「设定颜色」多级选色：
+ * 入口行 → 预设色板 → 拖拽自定义取色；输出稳定 hex 到 v-model。
+ */
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  COURSE_COLOR_PRESETS,
+  DEFAULT_COURSE_COLOR,
+  findPresetByHex,
+  hexToHsv,
+  hsvToHex,
+  normalizeHexColor,
+  normalizeOptionalCourseColor,
+} from '../utils/course_color'
+
+const props = defineProps({
+  /** 当前颜色 hex，空字符串表示未设定 */
+  modelValue: { type: String, default: DEFAULT_COURSE_COLOR },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+/** panel: closed | preset | custom */
+const panel = ref('closed')
+const draftHex = ref('')
+const hue = ref(210)
+const sat = ref(0.55)
+const val = ref(0.95)
+
+const displayHex = computed(() => {
+  const n = normalizeOptionalCourseColor(props.modelValue)
+  return n === null ? '' : n
+})
+
+const displaySwatch = computed(() => displayHex.value || '#cbd5e1')
+const isPresetSelected = (hex) => {
+  const a = normalizeHexColor(hex)
+  const b = normalizeHexColor(draftHex.value)
+  return !!a && !!b && a === b
+}
+
+const syncDraftFromModel = () => {
+  const n = normalizeOptionalCourseColor(props.modelValue)
+  draftHex.value = n || ''
+  const hsv = hexToHsv(draftHex.value || '#72b9ff')
+  if (hsv) {
+    hue.value = hsv.h
+    sat.value = hsv.s
+    val.value = hsv.v
+  }
+}
+
+watch(
+  () => props.modelValue,
+  () => {
+    if (panel.value === 'closed') syncDraftFromModel()
+  },
+  { immediate: true }
+)
+
+const openPreset = () => {
+  syncDraftFromModel()
+  panel.value = 'preset'
+}
+
+const closePanel = () => {
+  panel.value = 'closed'
+}
+
+const goCustom = () => {
+  const hsv = hexToHsv(draftHex.value || '#72b9ff')
+  if (hsv) {
+    hue.value = hsv.h
+    sat.value = hsv.s
+    val.value = hsv.v
+  }
+  panel.value = 'custom'
+}
+
+const backToPreset = () => {
+  panel.value = 'preset'
+}
+
+const selectPreset = (hex) => {
+  const n = normalizeHexColor(hex)
+  if (!n) return
+  draftHex.value = n
+}
+
+const clearColor = () => {
+  draftHex.value = ''
+}
+
+const confirmColor = () => {
+  const n = normalizeOptionalCourseColor(draftHex.value)
+  if (n === null) return
+  emit('update:modelValue', n)
+  panel.value = 'closed'
+}
+
+const customPreview = computed(() => hsvToHex(hue.value, sat.value, val.value))
+
+watch([hue, sat, val], () => {
+  if (panel.value !== 'custom') return
+  draftHex.value = customPreview.value
+})
+
+const svPanelRef = ref(null)
+const hueBarRef = ref(null)
+let draggingSv = false
+let draggingHue = false
+
+const applySvFromEvent = (event) => {
+  const el = svPanelRef.value
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  const clientX = event.touches?.[0]?.clientX ?? event.clientX
+  const clientY = event.touches?.[0]?.clientY ?? event.clientY
+  const x = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+  const y = Math.min(1, Math.max(0, (clientY - rect.top) / rect.height))
+  sat.value = x
+  val.value = 1 - y
+}
+
+const applyHueFromEvent = (event) => {
+  const el = hueBarRef.value
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  const clientX = event.touches?.[0]?.clientX ?? event.clientX
+  const x = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+  hue.value = x * 360
+}
+
+const onSvPointerDown = (event) => {
+  draggingSv = true
+  applySvFromEvent(event)
+  event.preventDefault?.()
+}
+
+const onHuePointerDown = (event) => {
+  draggingHue = true
+  applyHueFromEvent(event)
+  event.preventDefault?.()
+}
+
+const onPointerMove = (event) => {
+  if (draggingSv) applySvFromEvent(event)
+  if (draggingHue) applyHueFromEvent(event)
+}
+
+const onPointerUp = () => {
+  draggingSv = false
+  draggingHue = false
+}
+
+onMounted(() => {
+  if (typeof window === 'undefined') return
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('touchmove', onPointerMove, { passive: false })
+  window.addEventListener('touchend', onPointerUp)
+})
+
+onBeforeUnmount(() => {
+  if (typeof window === 'undefined') return
+  window.removeEventListener('pointermove', onPointerMove)
+  window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('touchmove', onPointerMove)
+  window.removeEventListener('touchend', onPointerUp)
+})
+
+const svKnobStyle = computed(() => ({
+  left: `${sat.value * 100}%`,
+  top: `${(1 - val.value) * 100}%`,
+}))
+
+const hueKnobStyle = computed(() => ({
+  left: `${(hue.value / 360) * 100}%`,
+}))
+
+const hueGradient = 'linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000)'
+
+const svBackground = computed(() => {
+  const pure = hsvToHex(hue.value, 1, 1)
+  return {
+    background: `
+      linear-gradient(to top, #000, transparent),
+      linear-gradient(to right, #fff, ${pure})
+    `,
+  }
+})
+
+const presetMatchLabel = computed(() => {
+  const p = findPresetByHex(displayHex.value)
+  return p?.label || (displayHex.value ? displayHex.value.toUpperCase() : '未设定')
+})
+</script>
+
+<template>
+  <div class="course-color-picker">
+    <button type="button" class="ccp-entry" @click="openPreset">
+      <span class="ccp-entry-label">设定颜色</span>
+      <span class="ccp-entry-right">
+        <span class="ccp-swatch" :style="{ background: displaySwatch }" />
+        <span class="ccp-entry-meta">{{ presetMatchLabel }}</span>
+        <span class="ccp-chevron" aria-hidden="true">›</span>
+      </span>
+    </button>
+
+    <Teleport to="body">
+      <Transition name="ccp-fade">
+        <div
+          v-if="panel !== 'closed'"
+          class="ccp-mask"
+          @click.self="closePanel"
+        >
+          <Transition name="ccp-sheet" mode="out-in">
+            <div
+              v-if="panel === 'preset'"
+              key="preset"
+              class="ccp-sheet"
+              @click.stop
+            >
+              <div class="ccp-sheet-header">
+                <div class="ccp-sheet-title">预设</div>
+                <button type="button" class="ccp-text-btn" @click="closePanel">关闭</button>
+              </div>
+              <div class="ccp-preset-grid">
+                <button
+                  v-for="item in COURSE_COLOR_PRESETS"
+                  :key="item.id"
+                  type="button"
+                  class="ccp-preset-cell"
+                  :class="{ active: isPresetSelected(item.hex) }"
+                  :title="item.label"
+                  :aria-label="item.label"
+                  :style="{ background: item.hex }"
+                  @click="selectPreset(item.hex)"
+                />
+              </div>
+              <div class="ccp-sheet-actions ccp-actions-3">
+                <button type="button" class="ccp-secondary" @click="clearColor">清除</button>
+                <button type="button" class="ccp-secondary" @click="goCustom">自定义</button>
+                <button type="button" class="ccp-primary" @click="confirmColor">完成</button>
+              </div>
+            </div>
+
+            <div
+              v-else-if="panel === 'custom'"
+              key="custom"
+              class="ccp-sheet"
+              @click.stop
+            >
+              <div class="ccp-sheet-header ccp-header-3">
+                <button type="button" class="ccp-text-btn" @click="backToPreset">返回</button>
+                <div class="ccp-sheet-title">自定义</div>
+                <button type="button" class="ccp-text-btn" @click="closePanel">关闭</button>
+              </div>
+              <div class="ccp-custom-body">
+                <div
+                  ref="svPanelRef"
+                  class="ccp-sv"
+                  :style="svBackground"
+                  @pointerdown="onSvPointerDown"
+                  @touchstart.prevent="onSvPointerDown"
+                >
+                  <span class="ccp-sv-knob" :style="svKnobStyle" />
+                </div>
+                <div
+                  ref="hueBarRef"
+                  class="ccp-hue"
+                  :style="{ background: hueGradient }"
+                  @pointerdown="onHuePointerDown"
+                  @touchstart.prevent="onHuePointerDown"
+                >
+                  <span class="ccp-hue-knob" :style="hueKnobStyle" />
+                </div>
+                <div class="ccp-preview-row">
+                  <span class="ccp-swatch large" :style="{ background: customPreview }" />
+                  <span class="ccp-hex">{{ customPreview.toUpperCase() }}</span>
+                </div>
+              </div>
+              <div class="ccp-sheet-actions ccp-actions-2">
+                <button type="button" class="ccp-secondary" @click="backToPreset">预设</button>
+                <button type="button" class="ccp-primary" @click="confirmColor">完成</button>
+              </div>
+            </div>
+          </Transition>
+        </div>
+      </Transition>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.course-color-picker {
+  width: 100%;
+}
+
+.ccp-entry {
+  width: 100%;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0 10px;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.ccp-entry:active {
+  transform: scale(0.99);
+}
+
+.ccp-entry-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #475569;
+}
+
+.ccp-entry-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ccp-entry-meta {
+  font-size: 12px;
+  color: #64748b;
+  max-width: 9em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ccp-chevron {
+  color: #94a3b8;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.ccp-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+}
+
+.ccp-swatch.large {
+  width: 28px;
+  height: 28px;
+}
+
+.ccp-mask {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  background: rgba(15, 23, 42, 0.42);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 12px;
+  box-sizing: border-box;
+}
+
+.ccp-sheet {
+  width: min(100%, 420px);
+  max-height: min(72dvh, 520px);
+  border-radius: 18px 18px 14px 14px;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+  box-sizing: border-box;
+}
+
+.ccp-sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ccp-sheet-header.ccp-header-3 {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+}
+
+.ccp-sheet-header.ccp-header-3 .ccp-sheet-title {
+  text-align: center;
+}
+
+.ccp-sheet-header.ccp-header-3 .ccp-text-btn:last-child {
+  justify-self: end;
+}
+
+.ccp-sheet-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.ccp-text-btn {
+  border: none;
+  background: transparent;
+  color: #2563eb;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 2px;
+}
+
+.ccp-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px;
+  padding: 4px 2px;
+}
+
+.ccp-preset-cell {
+  aspect-ratio: 1;
+  border-radius: 12px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.1);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
+}
+
+.ccp-preset-cell:active {
+  transform: scale(0.94);
+}
+
+.ccp-preset-cell.active {
+  border-color: #0f172a;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.28);
+  transform: scale(1.04);
+}
+
+.ccp-custom-body {
+  display: grid;
+  gap: 12px;
+}
+
+.ccp-sv {
+  position: relative;
+  width: 100%;
+  height: 168px;
+  border-radius: 14px;
+  overflow: hidden;
+  touch-action: none;
+  cursor: crosshair;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.ccp-sv-knob {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.35), 0 2px 8px rgba(15, 23, 42, 0.25);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.ccp-hue {
+  position: relative;
+  height: 18px;
+  border-radius: 999px;
+  touch-action: none;
+  cursor: pointer;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.ccp-hue-knob {
+  position: absolute;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  border: 2px solid #0f172a;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.25);
+}
+
+.ccp-preview-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ccp-hex {
+  font-size: 13px;
+  font-weight: 700;
+  color: #334155;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.ccp-sheet-actions {
+  display: grid;
+  gap: 8px;
+}
+
+.ccp-actions-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.ccp-actions-2 {
+  grid-template-columns: 1fr 1.2fr;
+}
+
+.ccp-primary,
+.ccp-secondary {
+  min-height: 40px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ccp-primary {
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+}
+
+.ccp-secondary {
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.ccp-fade-enter-active,
+.ccp-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.ccp-fade-enter-from,
+.ccp-fade-leave-to {
+  opacity: 0;
+}
+
+.ccp-sheet-enter-active,
+.ccp-sheet-leave-active {
+  transition: transform 0.22s ease, opacity 0.2s ease;
+}
+
+.ccp-sheet-enter-from,
+.ccp-sheet-leave-to {
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ccp-entry,
+  .ccp-preset-cell,
+  .ccp-fade-enter-active,
+  .ccp-fade-leave-active,
+  .ccp-sheet-enter-active,
+  .ccp-sheet-leave-active {
+    transition: none !important;
+  }
+}
+
+:global(html.dark) .ccp-entry {
+  background: #1e293b;
+  border-color: #334155;
+  color: #e2e8f0;
+}
+
+:global(html.dark) .ccp-entry-label,
+:global(html.dark) .ccp-entry-meta {
+  color: #94a3b8;
+}
+
+:global(html.dark) .ccp-sheet {
+  background: rgba(15, 23, 42, 0.98);
+  border-color: #334155;
+}
+
+:global(html.dark) .ccp-sheet-title,
+:global(html.dark) .ccp-hex {
+  color: #e2e8f0;
+}
+
+:global(html.dark) .ccp-secondary {
+  background: #1e293b;
+  border-color: #475569;
+  color: #e2e8f0;
+}
+
+:global(html.dark) .ccp-preset-cell.active {
+  border-color: #e2e8f0;
+}
+</style>

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -30,6 +30,8 @@ import { showToast } from '../utils/toast'
 import { invokeNative, isTauriRuntime } from '../platform/native'
 import { afterScheduleRefresh } from '../utils/widget_bridge'
 import { isTestAccountSession } from '../utils/test_account.js'
+import CourseColorPicker from './CourseColorPicker.vue'
+import { DEFAULT_COURSE_COLOR, normalizeOptionalCourseColor } from '../utils/course_color'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -113,7 +115,9 @@ const addCourseForm = ref({
   weekday: 1,
   period: 1,
   djs: 1,
-  weeks: []
+  weeks: [],
+  /** 用户设定主色 hex；空字符串表示未设定（#469 本地表单态，#470 再持久化） */
+  color: DEFAULT_COURSE_COLOR
 })
 const returnToDetailAfterCourseSubmit = ref(false)
 const LOGIN_SESSION_TOKEN_KEY = 'hbu_login_session_token'
@@ -431,6 +435,7 @@ const mergeScheduleSources = () => {
 const normalizeCustomCourse = (raw) => {
   if (!raw || typeof raw !== 'object') return null
   const weeks = normalizeWeeks(raw.weeks)
+  const colorNorm = normalizeOptionalCourseColor(raw.color)
   return {
     id: String(raw.id || raw.source_id || ''),
     name: String(raw.name || '').trim(),
@@ -449,6 +454,8 @@ const normalizeCustomCourse = (raw) => {
     source_id: String(raw.source_id || raw.id || ''),
     created_at: String(raw.created_at || ''),
     updated_at: String(raw.updated_at || ''),
+    // 可选用户色；#469 本地表单用，#470 持久化后由后端下发
+    color: colorNorm === null ? DEFAULT_COURSE_COLOR : colorNorm,
     is_custom: true
   }
 }
@@ -1838,7 +1845,8 @@ const resetAddCourseForm = () => {
     weekday: 1,
     period: 1,
     djs: 1,
-    weeks: semesterWeekOptions.value.slice()
+    weeks: semesterWeekOptions.value.slice(),
+    color: DEFAULT_COURSE_COLOR
   }
   addCourseError.value = ''
   showWeekPicker.value = false
@@ -1847,6 +1855,7 @@ const resetAddCourseForm = () => {
 const populateCourseForm = (course) => {
   const normalized = normalizeCustomCourse(course)
   if (!normalized) return
+  const colorNorm = normalizeOptionalCourseColor(normalized.color)
   addCourseForm.value = {
     name: String(normalized.name || '').trim(),
     teacher: String(normalized.teacher || '').trim(),
@@ -1854,7 +1863,9 @@ const populateCourseForm = (course) => {
     weekday: Number(normalized.weekday || 1),
     period: Number(normalized.period || 1),
     djs: Math.max(1, Number(normalized.djs || 1)),
-    weeks: normalizeWeeks(normalized.weeks)
+    weeks: normalizeWeeks(normalized.weeks),
+    // #469：回显已有 color；后端未下发时保持空（本地态）
+    color: colorNorm === null ? DEFAULT_COURSE_COLOR : colorNorm
   }
   addCourseError.value = ''
   showWeekPicker.value = false
@@ -3422,6 +3433,9 @@ onBeforeUnmount(() => {
               <button class="week-picker-trigger" @click="showWeekPicker = true">
                 {{ addWeeksCountText }}
               </button>
+            </div>
+            <div class="add-field">
+              <CourseColorPicker v-model="addCourseForm.color" />
             </div>
             <div v-if="addCourseError" class="drawer-error add-course-error">{{ addCourseError }}</div>
           </div>

--- a/src/utils/course_color.spec.ts
+++ b/src/utils/course_color.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COURSE_COLOR_PRESETS,
+  contrastTextForHex,
+  findPresetByHex,
+  getPresetHexList,
+  hexToHsv,
+  hsvToHex,
+  isValidHexColor,
+  mixHexWithWhite,
+  normalizeHexColor,
+  normalizeOptionalCourseColor,
+} from './course_color'
+
+describe('course_color palette & hex helpers', () => {
+  it('exposes a stable non-empty preset palette of #RRGGBB colors', () => {
+    expect(COURSE_COLOR_PRESETS.length).toBeGreaterThanOrEqual(8)
+    const hexes = getPresetHexList()
+    expect(hexes).toHaveLength(COURSE_COLOR_PRESETS.length)
+    for (const hex of hexes) {
+      expect(isValidHexColor(hex)).toBe(true)
+      expect(normalizeHexColor(hex)).toBe(hex.toLowerCase())
+    }
+  })
+
+  it('validates hex inputs including 3/6/8 digit forms', () => {
+    expect(isValidHexColor('#fff')).toBe(true)
+    expect(isValidHexColor('#FFFFFF')).toBe(true)
+    expect(isValidHexColor('#aabbccdd')).toBe(true)
+    expect(isValidHexColor('not-a-color')).toBe(false)
+    expect(isValidHexColor('#gg0000')).toBe(false)
+    expect(isValidHexColor(null)).toBe(false)
+    expect(isValidHexColor(123)).toBe(false)
+  })
+
+  it('normalizes 3-digit and 8-digit hex to lowercase #rrggbb', () => {
+    expect(normalizeHexColor('#AbC')).toBe('#aabbcc')
+    expect(normalizeHexColor('72B9FF')).toBe('#72b9ff')
+    expect(normalizeHexColor('#72b9ffaa')).toBe('#72b9ff')
+    expect(normalizeHexColor('  #E7F4FF  ')).toBe('#e7f4ff')
+    expect(normalizeHexColor('')).toBe(null)
+    expect(normalizeHexColor('#12')).toBe(null)
+    expect(normalizeHexColor('xyz')).toBe(null)
+    // 无 # 的 3 位字母不得当作颜色
+    expect(normalizeHexColor('bad')).toBe(null)
+  })
+
+  it('treats empty optional color as unset and rejects invalid values', () => {
+    expect(normalizeOptionalCourseColor('')).toBe('')
+    expect(normalizeOptionalCourseColor('   ')).toBe('')
+    expect(normalizeOptionalCourseColor(null)).toBe('')
+    expect(normalizeOptionalCourseColor(undefined)).toBe('')
+    expect(normalizeOptionalCourseColor('#72B9FF')).toBe('#72b9ff')
+    expect(normalizeOptionalCourseColor('nope')).toBe(null)
+  })
+
+  it('finds presets by hex case-insensitively', () => {
+    const first = COURSE_COLOR_PRESETS[0]
+    expect(findPresetByHex(first.hex.toUpperCase())?.id).toBe(first.id)
+    expect(findPresetByHex('#000000')).toBe(null)
+  })
+
+  it('picks readable contrast text for light and dark backgrounds', () => {
+    expect(contrastTextForHex('#ffffff')).toBe('#0f172a')
+    expect(contrastTextForHex('#111111')).toBe('#ffffff')
+  })
+
+  it('mixes hex toward white for soft card backgrounds', () => {
+    const mixed = mixHexWithWhite('#000000', 0.2)
+    expect(normalizeHexColor(mixed)).toBe('#cccccc')
+    expect(mixHexWithWhite('bad')).toBe('#f8fafc')
+  })
+
+  it('round-trips hex through HSV for saturated colors', () => {
+    const samples = ['#ff0000', '#00ff00', '#0000ff', '#72b9ff', '#111111']
+    for (const hex of samples) {
+      const hsv = hexToHsv(hex)
+      expect(hsv).not.toBeNull()
+      if (!hsv) continue
+      const back = hsvToHex(hsv.h, hsv.s, hsv.v)
+      expect(normalizeHexColor(back)).toBe(hex.toLowerCase())
+    }
+  })
+})

--- a/src/utils/course_color.ts
+++ b/src/utils/course_color.ts
@@ -1,0 +1,186 @@
+/**
+ * 自定义课程颜色：预设色板与 hex 规范化/校验（纯函数，可单测）。
+ * 与课表 courseThemes 视觉语言对齐，主色采用偏饱和的 border 色便于卡片描边与色点预览。
+ */
+
+export type CourseColorPreset = {
+  id: string
+  /** 主色（hex），写入表单/持久化 */
+  hex: string
+  /** 浅底（传统卡片背景参考） */
+  bg: string
+  /** 深字色 */
+  text: string
+  label: string
+}
+
+/** 与 ScheduleView courseThemes 对齐的 12 色预设 */
+export const COURSE_COLOR_PRESETS: readonly CourseColorPreset[] = [
+  { id: 'lake', hex: '#72b9ff', bg: '#e7f4ff', text: '#0f5da8', label: '湖蓝' },
+  { id: 'coral', hex: '#ffb390', bg: '#fff0e8', text: '#cb4f2f', label: '珊瑚橘' },
+  { id: 'wisteria', hex: '#b8aaff', bg: '#efe9ff', text: '#5f52cf', label: '紫藤' },
+  { id: 'amber', hex: '#efc465', bg: '#fff4db', text: '#be7a07', label: '琥珀' },
+  { id: 'rose', hex: '#f3a8c4', bg: '#ffeaf2', text: '#c33f73', label: '玫瑰' },
+  { id: 'teal', hex: '#8adcc4', bg: '#e8faf5', text: '#117f67', label: '青绿' },
+  { id: 'indigo', hex: '#9eb4ff', bg: '#e8efff', text: '#335ccb', label: '靛蓝' },
+  { id: 'berry', hex: '#f0acbb', bg: '#fff1f5', text: '#b63f58', label: '浅莓' },
+  { id: 'spring', hex: '#9dd7a7', bg: '#edf8ef', text: '#2f8c3d', label: '春绿' },
+  { id: 'sky', hex: '#84d6ec', bg: '#e8f9ff', text: '#007893', label: '青空' },
+  { id: 'orchid', hex: '#c6adf1', bg: '#f4edff', text: '#7548c1', label: '兰紫' },
+  { id: 'apricot', hex: '#efb67f', bg: '#fff2e2', text: '#b05c16', label: '暖杏' },
+] as const
+
+/** 未选择时的默认主色（空字符串表示沿用系统自动配色） */
+export const DEFAULT_COURSE_COLOR = ''
+
+const HEX6_RE = /^#([0-9a-fA-F]{6})$/
+const HEX3_RE = /^#([0-9a-fA-F]{3})$/
+const HEX8_RE = /^#([0-9a-fA-F]{8})$/
+
+/**
+ * 判断字符串是否为可接受的 hex 颜色（#RGB / #RRGGBB / #RRGGBBAA）。
+ */
+export function isValidHexColor(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  const raw = value.trim()
+  return HEX6_RE.test(raw) || HEX3_RE.test(raw) || HEX8_RE.test(raw)
+}
+
+/**
+ * 将输入规范化为 #RRGGBB（小写）；非法则返回 null。
+ * 8 位 hex 丢弃 alpha；#RGB 扩展为 6 位。
+ * 无 # 前缀时仅接受 6/8 位（避免 "bad" 等被当成 3 位 hex）。
+ */
+export function normalizeHexColor(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const raw = value.trim()
+  if (!raw) return null
+
+  const hasHash = raw.startsWith('#')
+  let body = hasHash ? raw.slice(1).trim() : raw
+
+  if (hasHash && /^[0-9a-fA-F]{3}$/.test(body)) {
+    body = body
+      .split('')
+      .map((ch) => ch + ch)
+      .join('')
+  } else if (/^[0-9a-fA-F]{8}$/.test(body)) {
+    body = body.slice(0, 6)
+  } else if (!/^[0-9a-fA-F]{6}$/.test(body)) {
+    return null
+  }
+
+  return `#${body.toLowerCase()}`
+}
+
+/**
+ * 规范化用户可选颜色：空/空白 → 空字符串（表示未设定）；非法 → null。
+ */
+export function normalizeOptionalCourseColor(value: unknown): string | null {
+  if (value === null || value === undefined) return ''
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  return normalizeHexColor(trimmed)
+}
+
+/** 预设主色列表（hex） */
+export function getPresetHexList(): string[] {
+  return COURSE_COLOR_PRESETS.map((p) => p.hex)
+}
+
+/**
+ * 若 hex 匹配某个预设（忽略大小写），返回该预设；否则 null。
+ */
+export function findPresetByHex(hex: unknown): CourseColorPreset | null {
+  const normalized = normalizeHexColor(hex)
+  if (!normalized) return null
+  return COURSE_COLOR_PRESETS.find((p) => p.hex.toLowerCase() === normalized) ?? null
+}
+
+/**
+ * 由主色推导可读的深色文字色（用于传统卡片文字）。
+ * 简单相对亮度：亮色用深字，暗色用白字。
+ */
+export function contrastTextForHex(hex: unknown): string {
+  const normalized = normalizeHexColor(hex)
+  if (!normalized) return '#0f172a'
+  const r = parseInt(normalized.slice(1, 3), 16)
+  const g = parseInt(normalized.slice(3, 5), 16)
+  const b = parseInt(normalized.slice(5, 7), 16)
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
+  return luminance > 0.55 ? '#0f172a' : '#ffffff'
+}
+
+/**
+ * 将主色混合到白色得到浅底（传统卡片背景）。
+ * amount: 0~1，越大主色占比越高。
+ */
+export function mixHexWithWhite(hex: unknown, amount = 0.22): string {
+  const normalized = normalizeHexColor(hex)
+  if (!normalized) return '#f8fafc'
+  const t = Math.min(1, Math.max(0, amount))
+  const r = parseInt(normalized.slice(1, 3), 16)
+  const g = parseInt(normalized.slice(3, 5), 16)
+  const b = parseInt(normalized.slice(5, 7), 16)
+  const mix = (c: number) => Math.round(255 * (1 - t) + c * t)
+  const toHex = (n: number) => n.toString(16).padStart(2, '0')
+  return `#${toHex(mix(r))}${toHex(mix(g))}${toHex(mix(b))}`
+}
+
+export type HsvColor = { h: number; s: number; v: number }
+
+export function hexToHsv(hex: unknown): HsvColor | null {
+  const normalized = normalizeHexColor(hex)
+  if (!normalized) return null
+  const r = parseInt(normalized.slice(1, 3), 16) / 255
+  const g = parseInt(normalized.slice(3, 5), 16) / 255
+  const b = parseInt(normalized.slice(5, 7), 16) / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const d = max - min
+  let h = 0
+  if (d !== 0) {
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60
+    else if (max === g) h = ((b - r) / d + 2) * 60
+    else h = ((r - g) / d + 4) * 60
+  }
+  const s = max === 0 ? 0 : d / max
+  return { h, s, v: max }
+}
+
+export function hsvToHex(h: number, s: number, v: number): string {
+  const hh = ((h % 360) + 360) % 360
+  const ss = Math.min(1, Math.max(0, s))
+  const vv = Math.min(1, Math.max(0, v))
+  const c = vv * ss
+  const x = c * (1 - Math.abs(((hh / 60) % 2) - 1))
+  const m = vv - c
+  let rp = 0
+  let gp = 0
+  let bp = 0
+  if (hh < 60) {
+    rp = c
+    gp = x
+  } else if (hh < 120) {
+    rp = x
+    gp = c
+  } else if (hh < 180) {
+    gp = c
+    bp = x
+  } else if (hh < 240) {
+    gp = x
+    bp = c
+  } else if (hh < 300) {
+    rp = x
+    bp = c
+  } else {
+    rp = c
+    bp = x
+  }
+  const toHex = (n: number) =>
+    Math.round((n + m) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  return `#${toHex(rp)}${toHex(gp)}${toHex(bp)}`
+}


### PR DESCRIPTION
## Summary
实现自定义课程添加/编辑对话框中的「设定颜色」多级 UI（预设色板 + 拖拽取色），输出稳定 hex 到表单状态。

## Changes
- `src/utils/course_color.ts`：预设色板、hex 校验/规范化、HSV 转换等纯 helpers
- `src/utils/course_color.spec.ts`：单元测试
- `src/components/CourseColorPicker.vue`：入口 → 预设 → 自定义多级面板，轻动效，暗色适配，`prefers-reduced-motion` 降级
- `src/components/ScheduleView.vue`：`addCourseForm.color` 本地状态 + 弹窗集成

## Notes
- #469 仅本地表单态；持久化与课表渲染见 #470
- 未改 #457 相关代码

## Test plan
- [x] `npx vitest run src/utils/course_color.spec.ts`
- [ ] 课表 → 自定义课程 → 添加：点「设定颜色」选预设 → 表单色点更新
- [ ] 进入自定义拖拽取色 → 完成
- [ ] 编辑课程回显颜色（有 color 字段时）
- [ ] 暗色模式面板可读

Closes #469