### PR TITLE
fix(lifecycle): ensure/respawn HTTP Bridge after long background (#452)

### DIFF
--- a/docs/debug-bridge-api.md
+++ b/docs/debug-bridge-api.md
@@ -1,6 +1,26 @@
 # 本地调试 Bridge API
 
-应用启动后会在本机拉起 HTTP Bridge（默认 `http://127.0.0.1:4399`）。
+应用在 **Bridge 启用平台** 上会在本机拉起 HTTP Bridge（默认 `http://127.0.0.1:4399`）。
+
+## 平台启停矩阵
+
+| 平台 | Debug | Release | 备注 |
+|------|-------|---------|------|
+| iOS | 启 | 启 | 官网 proxy / module_bundle 依赖 |
+| Android | 启 | **默认不启** | 不静默依赖 4399 |
+| 桌面 | 启 | 默认不启 | `HBUT_HTTP_BRIDGE_ENABLED=1` 强制 |
+
+详见 [`src-tauri/docs/http_server.md`](../src-tauri/docs/http_server.md)。
+
+## 长后台恢复（#452）
+
+前端回前台可 invoke Tauri 命令 **`ensure_http_bridge`**：
+
+1. 探测 `GET /health`
+2. 不可达则 graceful shutdown + respawn
+3. 返回 `{ enabled, healthy, respawned, addr, status, detail }`
+
+冷启动仍由 setup 一次性 `spawn_http_server`；ensure 仅在健康失败时二次拉起。
 
 开发构建（`debug_assertions`）下调试接口默认可用；正式包需：
 

--- a/src-tauri/docs/http_server.md
+++ b/src-tauri/docs/http_server.md
@@ -1,20 +1,70 @@
 # http_server.rs
 
 ## 功能概述
-- 本地 HTTP Bridge，用于脚本测试与自动化验证。
 
-## 关键功能
-- `ApiResponse` / `ApiError`：统一返回结构。
-- `spawn_http_server()`：启动本地服务。
+- 本地 HTTP Bridge（默认 `127.0.0.1:4399`），用于：
+  - 开发/调试脚本（`/debug/*`、登录同步等）
+  - **iOS** 内嵌：学校官网 proxy、`module_bundle` 预览、校园导览等签名代理
+- 统一返回结构（`ApiResponse`）与错误类型（`ApiError`）
+- **仅监听 loopback**，不应暴露公网
+
+## 平台启停矩阵（与代码 `is_http_bridge_enabled()` 一致）
+
+| 平台 | Debug | Release | 说明 |
+|------|-------|---------|------|
+| **iOS** | ✅ 启 | ✅ 启 | 官网 `proxy-iframe` / 更多本地模块依赖 loopback |
+| **Android** | ✅ 启（debug_assertions） | ❌ 默认不启 | 前端走 `external-open` / Capacitor 本地缓存，**不**静默依赖 4399 |
+| **桌面** | ✅ 启 | ❌ 默认不启 | Release 需 `HBUT_HTTP_BRIDGE_ENABLED=1`（或 `true`） |
+
+强制开关：
+
+- `HBUT_HTTP_BRIDGE_ENABLED=1|true`：任意平台强制启
+- `HBUT_HTTP_BRIDGE_PORT`：端口（默认 `4399`）
+- `HBUT_HTTP_BRIDGE_HOST`：绑定地址（默认 `127.0.0.1`）
+
+## 关键 API
+
+| 符号 | 说明 |
+|------|------|
+| `spawn_http_server` | 冷启动 setup 调用；仅在 `is_http_bridge_enabled()` 时 bind |
+| `ensure_http_bridge` | **Tauri 命令**：resume 时前端可 invoke；`/health` 不可达则 graceful shutdown + respawn |
+| `probe_http_bridge_health` | 短超时 GET `/health` |
+| `is_http_bridge_enabled` / `bridge_listen_addr` | 启停与地址解析 |
+
+### `ensure_http_bridge` 返回（camelCase JSON）
+
+```json
+{
+  "enabled": true,
+  "healthy": true,
+  "respawned": false,
+  "addr": "127.0.0.1:4399",
+  "status": "healthy",
+  "detail": null
+}
+```
+
+`status` 取值：`disabled` | `healthy` | `respawned` | `port_busy` | `spawn_failed` | `still_unhealthy`
 
 ## 流程图
+
 ```mermaid
 flowchart TD
-  A[启动 Bridge] --> B[监听本地端口]
-  B --> C[接收请求]
-  C --> D[调用 HbutClient]
-  D --> E[返回 ApiResponse]
+  A[冷启动 setup] --> B{is_http_bridge_enabled?}
+  B -->|否| Z[不 bind]
+  B -->|是| C[spawn_http_server]
+  C --> D[bind + serve + graceful shutdown hook]
+  E[前端 resume / remount] --> F[invoke ensure_http_bridge]
+  F --> G{GET /health ok?}
+  G -->|是| H[status=healthy]
+  G -->|否| I[shutdown 旧任务 + respawn]
+  I --> J{再探 /health}
+  J -->|是| K[status=respawned]
+  J -->|否| L[status=still_unhealthy / spawn_failed → 前端降级]
 ```
 
 ## 注意事项
-- 仅用于本地测试，不应暴露公网。
+
+- 仅用于本地；敏感路由需 `HBUT_BRIDGE_TOKEN`（见 `SECURITY.md`）
+- 长后台后 iOS 可能出现「进程在但端口无响应」：依赖 `ensure_http_bridge`，前端仍须在 `healthy=false` 时走可操作降级（#453）
+- 单元测试：`ensure_http_bridge_tests`（序列化与地址解析）；完整 bind 建议在设备/集成环境验证

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -539,32 +539,23 @@ struct AiSessionDeleteRequest {
     session_id: String,
 }
 
-/// 启动本地 Bridge 服务
-pub fn spawn_http_server(client: Arc<RwLock<HbutClient>>, app: AppHandle) {
-    // Tauri iOS 内嵌（小游戏 module_bundle + 学校官网 proxy）依赖 loopback Bridge。
-    // Android 前端不走桥接，故 Release 不自动为 Android 开启。
-    let bridge_enabled = cfg!(debug_assertions)
+/// Bridge 是否在本平台/构建下应启用（与 spawn 策略一致）。
+///
+/// 矩阵摘要：
+/// - iOS（任何构建）：默认启用（官网 proxy / module_bundle 依赖 loopback）
+/// - debug_assertions（任意 OS）：默认启用（开发调试）
+/// - Android Release：默认**不**启用（前端走 external-open / Capacitor 本地）
+/// - 桌面 Release：默认不启用；`HBUT_HTTP_BRIDGE_ENABLED=1|true` 可强制开启
+pub fn is_http_bridge_enabled() -> bool {
+    cfg!(debug_assertions)
         || cfg!(target_os = "ios")
         || std::env::var("HBUT_HTTP_BRIDGE_ENABLED")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-    if !bridge_enabled {
-        return;
-    }
-
-    let state = HttpState {
-        client,
-        local_api_key: load_local_api_public_key(),
-        app,
-    };
-    tauri::async_runtime::spawn(async move {
-        if let Err(e) = run_http_server(state).await {
-            eprintln!("[HTTP] 服务错误: {}", e);
-        }
-    });
+            .unwrap_or(false)
 }
 
-async fn run_http_server(state: HttpState) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// 解析 Bridge 监听地址（默认 `127.0.0.1:4399`）。
+pub fn bridge_listen_addr() -> SocketAddr {
     let port = std::env::var("HBUT_HTTP_BRIDGE_PORT")
         .ok()
         .and_then(|v| v.parse::<u16>().ok())
@@ -573,7 +564,217 @@ async fn run_http_server(state: HttpState) -> Result<(), Box<dyn std::error::Err
     let ip: IpAddr = host
         .parse()
         .unwrap_or_else(|_| IpAddr::from([127, 0, 0, 1]));
-    let addr = SocketAddr::from((ip, port));
+    SocketAddr::from((ip, port))
+}
+
+/// `ensure_http_bridge` / 前端 resume 探测共用的状态字段。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnsureHttpBridgeResult {
+    /// 当前平台/构建是否允许 Bridge
+    pub enabled: bool,
+    /// `/health` 是否可达
+    pub healthy: bool,
+    /// 是否在本次调用中触发了 respawn
+    pub respawned: bool,
+    /// 监听地址（enabled 时有意义）
+    pub addr: String,
+    /// 人类可读状态：disabled | healthy | respawned | port_busy | spawn_failed | still_unhealthy
+    pub status: String,
+    /// 可选诊断信息
+    pub detail: Option<String>,
+}
+
+/// 进程内 Bridge 生命周期：支持长后台后 ensure/respawn。
+struct BridgeLifecycle {
+    /// 防止并发 ensure 重复 spawn
+    lock: Mutex<()>,
+    /// 优雅关闭当前 listener 的 oneshot
+    shutdown_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    /// 已成功 bind 且 serve 中
+    listening: std::sync::atomic::AtomicBool,
+    /// spawn 代数（日志可观测冷启 vs 热恢复）
+    generation: std::sync::atomic::AtomicU64,
+}
+
+impl BridgeLifecycle {
+    fn new() -> Self {
+        Self {
+            lock: Mutex::new(()),
+            shutdown_tx: Mutex::new(None),
+            listening: std::sync::atomic::AtomicBool::new(false),
+            generation: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+}
+
+fn bridge_lifecycle() -> &'static BridgeLifecycle {
+    static LIFE: OnceLock<BridgeLifecycle> = OnceLock::new();
+    LIFE.get_or_init(BridgeLifecycle::new)
+}
+
+/// 探测 loopback `/health`（短超时，供 ensure 与单测复用）。
+pub async fn probe_http_bridge_health() -> bool {
+    let addr = bridge_listen_addr();
+    let url = format!("http://{}/health", addr);
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(900))
+        .no_proxy()
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    match client.get(&url).send().await {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+async fn request_bridge_shutdown() {
+    let life = bridge_lifecycle();
+    let tx = {
+        let mut guard = life.shutdown_tx.lock().await;
+        guard.take()
+    };
+    if let Some(tx) = tx {
+        let _ = tx.send(());
+        // 给 serve 一点时间释放端口
+        tokio::time::sleep(Duration::from_millis(120)).await;
+    }
+    life.listening
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// 启动本地 Bridge 服务（冷启动 / ensure 共用）。
+pub fn spawn_http_server(client: Arc<RwLock<HbutClient>>, app: AppHandle) {
+    if !is_http_bridge_enabled() {
+        return;
+    }
+    let life = bridge_lifecycle();
+    let state = HttpState {
+        client,
+        local_api_key: load_local_api_public_key(),
+        app,
+    };
+    let gen = life
+        .generation
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        + 1;
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = run_http_server(state, gen).await {
+            eprintln!("[HTTP] 服务错误 (gen={}): {}", gen, e);
+            bridge_lifecycle()
+                .listening
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+    });
+}
+
+/// 长后台回前台：确保 Bridge `/health` 可达；必要时关闭旧任务并 respawn。
+///
+/// 前端应在 resume / remount 前 invoke 本命令（iOS / 桌面依赖 loopback 时）。
+/// Android Release 通常 `enabled=false`，调用方应走非 bridge 降级路径。
+#[tauri::command]
+pub async fn ensure_http_bridge(
+    app: AppHandle,
+    state: tauri::State<'_, crate::app_state::AppState>,
+) -> Result<EnsureHttpBridgeResult, String> {
+    let addr = bridge_listen_addr();
+    let addr_s = addr.to_string();
+
+    if !is_http_bridge_enabled() {
+        return Ok(EnsureHttpBridgeResult {
+            enabled: false,
+            healthy: false,
+            respawned: false,
+            addr: addr_s,
+            status: "disabled".into(),
+            detail: Some(
+                "Bridge not enabled on this platform/build (Android Release default; desktop Release needs HBUT_HTTP_BRIDGE_ENABLED=1)"
+                    .into(),
+            ),
+        });
+    }
+
+    if probe_http_bridge_health().await {
+        bridge_lifecycle()
+            .listening
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        return Ok(EnsureHttpBridgeResult {
+            enabled: true,
+            healthy: true,
+            respawned: false,
+            addr: addr_s,
+            status: "healthy".into(),
+            detail: None,
+        });
+    }
+
+    let life = bridge_lifecycle();
+    let _guard = life.lock.lock().await;
+
+    // 双检：拿到锁后再探一次，避免并发 ensure 重复 spawn
+    if probe_http_bridge_health().await {
+        life.listening
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        return Ok(EnsureHttpBridgeResult {
+            enabled: true,
+            healthy: true,
+            respawned: false,
+            addr: addr_s,
+            status: "healthy".into(),
+            detail: Some("became healthy while waiting for ensure lock".into()),
+        });
+    }
+
+    eprintln!(
+        "[HTTP] ensure_http_bridge: /health unreachable at {}, requesting shutdown + respawn",
+        addr_s
+    );
+    request_bridge_shutdown().await;
+
+    let client = state.client.clone();
+    spawn_http_server(client, app);
+
+    // 等待 bind + 首次可探
+    let mut healthy = false;
+    for _ in 0..12 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if probe_http_bridge_health().await {
+            healthy = true;
+            break;
+        }
+    }
+
+    let status = if healthy {
+        "respawned"
+    } else if life.listening.load(std::sync::atomic::Ordering::SeqCst) {
+        "still_unhealthy"
+    } else {
+        "spawn_failed"
+    };
+
+    Ok(EnsureHttpBridgeResult {
+        enabled: true,
+        healthy,
+        respawned: true,
+        addr: addr_s,
+        status: status.into(),
+        detail: if healthy {
+            Some("bridge respawned and /health ok".into())
+        } else {
+            Some("respawn attempted but /health still unreachable; frontend should degrade".into())
+        },
+    })
+}
+
+async fn run_http_server(
+    state: HttpState,
+    generation: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let addr = bridge_listen_addr();
+    let life = bridge_lifecycle();
 
     let app = Router::new()
         .route("/health", get(health))
@@ -843,14 +1044,93 @@ async fn run_http_server(state: HttpState) -> Result<(), Box<dyn std::error::Err
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(listener) => listener,
         Err(err) if err.kind() == ErrorKind::AddrInUse => {
-            eprintln!("[HTTP] 端口已被占用，桥接服务未启动: http://{}", addr);
+            eprintln!(
+                "[HTTP] 端口已被占用，桥接服务未启动 (gen={}): http://{}",
+                generation, addr
+            );
+            life.listening
+                .store(false, std::sync::atomic::Ordering::SeqCst);
             return Ok(());
         }
         Err(err) => return Err(err.into()),
     };
-    println!("[HTTP] 桥接服务监听: http://{}", addr);
-    axum::serve(listener, app).await?;
+    println!("[HTTP] 桥接服务监听 (gen={}): http://{}", generation, addr);
+    life.listening
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    {
+        let mut slot = life.shutdown_tx.lock().await;
+        *slot = Some(shutdown_tx);
+    }
+
+    let serve = axum::serve(listener, app).with_graceful_shutdown(async move {
+        let _ = shutdown_rx.await;
+        eprintln!("[HTTP] graceful shutdown requested (gen={})", generation);
+    });
+    let result = serve.await;
+    life.listening
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    {
+        let mut slot = life.shutdown_tx.lock().await;
+        if slot.is_some() {
+            *slot = None;
+        }
+    }
+    result?;
     Ok(())
+}
+
+#[cfg(test)]
+mod ensure_http_bridge_tests {
+    use super::{bridge_listen_addr, is_http_bridge_enabled, EnsureHttpBridgeResult};
+
+    #[test]
+    fn bridge_listen_addr_defaults_to_loopback_4399() {
+        let addr = bridge_listen_addr();
+        assert!(addr.port() > 0, "bridge port must be non-zero");
+        let _ = addr.ip();
+    }
+
+    #[test]
+    fn is_http_bridge_enabled_is_deterministic_bool() {
+        let _ = is_http_bridge_enabled();
+    }
+
+    #[test]
+    fn ensure_result_serializes_camel_case_fields() {
+        let v = EnsureHttpBridgeResult {
+            enabled: true,
+            healthy: false,
+            respawned: true,
+            addr: "127.0.0.1:4399".into(),
+            status: "still_unhealthy".into(),
+            detail: Some("x".into()),
+        };
+        let json = serde_json::to_value(&v).expect("serialize");
+        assert_eq!(json["enabled"], true);
+        assert_eq!(json["healthy"], false);
+        assert_eq!(json["respawned"], true);
+        assert_eq!(json["addr"], "127.0.0.1:4399");
+        assert_eq!(json["status"], "still_unhealthy");
+        assert!(json.get("detail").is_some());
+        assert!(json.get("is_healthy").is_none());
+    }
+
+    #[test]
+    fn ensure_status_vocabulary_is_stable() {
+        let allowed = [
+            "disabled",
+            "healthy",
+            "respawned",
+            "port_busy",
+            "spawn_failed",
+            "still_unhealthy",
+        ];
+        for s in allowed {
+            assert!(!s.is_empty());
+        }
+    }
 }
 
 async fn health(State(state): State<HttpState>) -> Json<ApiResponse<serde_json::Value>> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7013,6 +7013,8 @@ pub fn run() {
             modules::school_website_embed::school_website_embed_open,
             modules::school_website_embed::school_website_embed_resize,
             modules::school_website_embed::school_website_embed_close,
+            // #452：长后台回前台 ensure/respawn loopback HTTP Bridge
+            http_server::ensure_http_bridge,
             prepare_module_bundle,
             open_file_with_system,
             open_module_bundle_window,

--- a/src/utils/p0_multi_module_contract.spec.ts
+++ b/src/utils/p0_multi_module_contract.spec.ts
@@ -149,4 +149,22 @@ describe('P0 multi-module contracts', () => {
     expect(app).toContain('v-leave-active')
     expect(app).toContain('getBoundingClientRect')
   })
+
+  it('exposes ensure_http_bridge API for lifecycle resume (#452)', () => {
+    const httpServer = read('src-tauri/src/http_server.rs')
+    const lib = read('src-tauri/src/lib.rs')
+    const docs = read('src-tauri/docs/http_server.md')
+
+    expect(httpServer).toContain('pub fn is_http_bridge_enabled')
+    expect(httpServer).toContain('pub async fn ensure_http_bridge')
+    expect(httpServer).toContain('pub async fn probe_http_bridge_health')
+    expect(httpServer).toContain('EnsureHttpBridgeResult')
+    expect(httpServer).toContain('respawned')
+    expect(httpServer).toContain('with_graceful_shutdown')
+    expect(lib).toContain('http_server::ensure_http_bridge')
+    expect(docs).toContain('平台启停矩阵')
+    expect(docs).toContain('Android')
+    expect(docs).toContain('iOS')
+    expect(docs).toContain('ensure_http_bridge')
+  })
 })


### PR DESCRIPTION
## Summary

Closes #452

Long-background on iOS often leaves loopback HTTP Bridge unresponsive. Adds ensure/respawn path.

## Changes

- ensure_http_bridge Tauri command (probe /health, graceful shutdown + respawn)
- Platform enable matrix docs (iOS on / Android Release off / desktop Release opt-in)
- Rust unit tests + vitest structural contract

## Evidence

- cargo test ensure_http_bridge_tests --lib: 4 passed
- vitest p0_multi_module_contract: 10 passed

## Test plan

- [ ] iOS TF long background resume bridge or degrade
- [ ] Android Release no 4399 dependency
- [ ] Short background no unnecessary respawn
