### PR TITLE
fix(lifecycle): ensure bridge then remount embeds on resume (#453)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1471,12 +1471,31 @@ const handleAppResume = (source = 'visibilitychange') => {
 
 const recoverEmbeddedWebAfterResume = async (targetView, idleMs = 0) => {
   try {
-    const { recoverSchoolWebsiteBridgeOnResume } = await import('./utils/school_website_embed.ts')
+    const {
+      recoverSchoolWebsiteBridgeOnResume,
+      invokeEnsureHttpBridge
+    } = await import('./utils/school_website_embed.ts')
+    // #453：resume 先 ensure bridge，再 remount 内嵌
+    let ensureResult = null
+    try {
+      ensureResult = await invokeEnsureHttpBridge()
+    } catch {
+      ensureResult = null
+    }
     const bridgeOk = await recoverSchoolWebsiteBridgeOnResume()
     // 挂后台超过 8s 或 bridge 曾不可达：对官网 / 模块宿主发自定义事件强制 remount
     if (idleMs >= 8000 || !bridgeOk || targetView === 'school_website' || targetView === 'more_module_host') {
       window.dispatchEvent(new CustomEvent('hbu-embed-resume', {
-        detail: { view: targetView, bridgeOk, idleMs, source: 'app-resume' }
+        detail: {
+          view: targetView,
+          bridgeOk,
+          idleMs,
+          source: 'app-resume',
+          ensureStatus: ensureResult?.status || null,
+          bridgeEnabled: ensureResult?.enabled !== false,
+          // 明确降级信号：bridge 仍不可用时宿主应展示可操作 fallback（重试/外开）
+          forceFallback: !bridgeOk && idleMs >= 8000
+        }
       }))
     }
   } catch {

--- a/src/components/MoreModuleHostView.vue
+++ b/src/components/MoreModuleHostView.vue
@@ -334,13 +334,45 @@ watch(
   { immediate: true }
 )
 
-const handleAppEmbedResumeEvent = (event) => {
+const handleAppEmbedResumeEvent = async (event) => {
   const view = String(event?.detail?.view || '')
   if (view && view !== 'more_module_host') return
-  // 后台恢复：强制换 key remount iframe，并清空错误态
+
+  const detail = event?.detail || {}
+  const usesLoopback = isLocalModuleBridgePreviewUrl(safeText(previewUrl.value))
+  let bridgeOk = detail.bridgeOk !== false
+
+  // #453：loopback 模块在 resume 时先 ensure bridge，再 remount
+  if (usesLoopback && canUseLocalModuleBridgePreview()) {
+    try {
+      const { recoverSchoolWebsiteBridgeOnResume } = await import('../utils/school_website_embed')
+      bridgeOk = await recoverSchoolWebsiteBridgeOnResume()
+    } catch {
+      bridgeOk = false
+    }
+  }
+
   loadError.value = ''
   loadHint.value = ''
+  externalOpenUrl.value = ''
   usedCapacitorLocalFallback.value = false
+
+  if (usesLoopback && !bridgeOk) {
+    // Bridge 仍死：优先 Capacitor 本地降级，否则可操作错误（重试/外开/回更多）
+    if (tryCapacitorLocalFallback()) {
+      return
+    }
+    loading.value = false
+    loadError.value =
+      '模块本地服务暂时不可用。可点右上角重试；或返回更多页重新进入/下载模块。'
+    const raw = safeText(props.session?.open_url || props.session?.preview_url)
+    if (raw && raw.startsWith('http') && !isLocalModuleBridgePreviewUrl(raw)) {
+      externalOpenUrl.value = raw
+    }
+    return
+  }
+
+  // 后台恢复：强制换 key remount iframe
   reloadFrame()
 }
 

--- a/src/components/SchoolWebsiteView.vue
+++ b/src/components/SchoolWebsiteView.vue
@@ -37,11 +37,17 @@ const clearLoadingGuardTimer = () => {
   }
 }
 
-const showBridgeUnavailable = () => {
+const showBridgeUnavailable = (reason = 'bridge') => {
   clearLoadingGuardTimer()
   loading.value = false
   loadHint.value = ''
-  loadError.value = '本地桥接服务不可用，无法在应用内加载学校官网，请点击下方按钮在浏览器中打开。'
+  // Android 等不走 loopback 的路径：避免误导为「HTTP 桥」
+  if (reason === 'external-only' || reason === 'android') {
+    loadError.value = '当前环境无法在应用内嵌学校官网，请点击下方按钮在系统浏览器中打开。'
+    return
+  }
+  loadError.value =
+    '本地桥接服务暂时不可用，无法在应用内加载学校官网。可点「重试加载」；若仍失败请在浏览器中打开。'
 }
 
 const resetIframeState = () => {
@@ -103,7 +109,10 @@ const mountEmbed = async () => {
   embedMode.value = await resolveSchoolWebsiteEmbedMode()
 
   if (embedMode.value === 'external-open') {
-    showBridgeUnavailable()
+    // Tauri Android 固定 external-open：文案不提「桥接」
+    const androidLike =
+      typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent || '')
+    showBridgeUnavailable(androidLike ? 'android' : 'external-only')
     return
   }
 
@@ -132,18 +141,29 @@ const mountEmbed = async () => {
   resetIframeState()
 }
 
-/** 后台恢复：重新探测 bridge 并 remount iframe / native embed */
-const remountAfterResume = async () => {
+/** 后台恢复：ensure bridge → 再 remount iframe / native embed（#453） */
+const remountAfterResume = async (eventDetail = null) => {
   loading.value = true
   loadError.value = ''
   loadHint.value = ''
+  try {
+    const { recoverSchoolWebsiteBridgeOnResume } = await import('../utils/school_website_embed')
+    await recoverSchoolWebsiteBridgeOnResume()
+  } catch {
+    // ensure 失败仍继续 remount，由 resolveSchoolWebsiteEmbedMode 决定降级
+  }
   await cleanupEmbed()
   await nextTick()
   await mountEmbed()
+  // forceFallback 且仍 external-open：保证用户看到可操作出口（已有重试/外开按钮）
+  if (eventDetail?.forceFallback && embedMode.value === 'external-open' && !loadError.value) {
+    showBridgeUnavailable('bridge')
+  }
 }
 
 const handleRetryEmbed = () => {
-  void remountAfterResume()
+  // 用户主动重试：同样走 ensure + remount
+  void remountAfterResume({ forceFallback: true })
 }
 
 /** #373：先关子 WebView 再返回，避免卸载竞态把内嵌撑成无返回全屏 */
@@ -189,7 +209,7 @@ const handleAppEmbedResumeEvent = (event) => {
   // 必须明确是 school_website：空 detail 时禁止 remount（会把已关闭的子 WebView 又拉起来）
   const view = String(event?.detail?.view || '')
   if (view !== 'school_website') return
-  void remountAfterResume()
+  void remountAfterResume(event?.detail || null)
 }
 
 onMounted(() => {

--- a/src/utils/p0_multi_module_contract.spec.ts
+++ b/src/utils/p0_multi_module_contract.spec.ts
@@ -167,4 +167,24 @@ describe('P0 multi-module contracts', () => {
     expect(docs).toContain('iOS')
     expect(docs).toContain('ensure_http_bridge')
   })
+
+  it('wires ensure-then-remount embed resume path (#453)', () => {
+    const app = read('src/App.vue')
+    const embed = read('src/utils/school_website_embed.ts')
+    const school = read('src/components/SchoolWebsiteView.vue')
+    const more = read('src/components/MoreModuleHostView.vue')
+
+    expect(embed).toContain('invokeEnsureHttpBridge')
+    expect(embed).toContain('ensure_http_bridge')
+    expect(embed).toContain('recoverSchoolWebsiteBridgeOnResume')
+    expect(app).toContain('invokeEnsureHttpBridge')
+    expect(app).toContain('forceFallback')
+    expect(school).toContain('recoverSchoolWebsiteBridgeOnResume')
+    expect(school).toContain('forceFallback')
+    // Android 不误导为 HTTP 桥
+    expect(school).toContain('当前环境无法在应用内嵌学校官网')
+    expect(more).toContain('recoverSchoolWebsiteBridgeOnResume')
+    expect(more).toContain('tryCapacitorLocalFallback')
+    expect(more).toContain('模块本地服务暂时不可用')
+  })
 })

--- a/src/utils/school_website_embed.ts
+++ b/src/utils/school_website_embed.ts
@@ -56,13 +56,46 @@ export const probeSchoolWebsiteProxyReachable = async () => {
   }
 }
 
+export type EnsureHttpBridgeResult = {
+  enabled?: boolean
+  healthy?: boolean
+  respawned?: boolean
+  addr?: string
+  status?: string
+  detail?: string | null
+}
+
 /**
- * 前台恢复时探测 bridge；供 App resume / 官网页 remount 使用。
+ * 调用原生 ensure_http_bridge（#452）：/health 不可达时尝试 respawn。
+ * 非 Tauri / 命令不可用 / Android 不依赖 loopback 时返回 null。
+ */
+export const invokeEnsureHttpBridge = async (): Promise<EnsureHttpBridgeResult | null> => {
+  if (!isTauriRuntime()) return null
+  // Android Release 默认不启 4399；不在此路径强依赖 bridge
+  if (isLikelyAndroidUserAgent()) {
+    return { enabled: false, healthy: false, respawned: false, status: 'disabled' }
+  }
+  try {
+    const result = await invokeNative<EnsureHttpBridgeResult>('ensure_http_bridge')
+    return result && typeof result === 'object' ? result : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 前台恢复时 ensure + 探测 bridge；供 App resume / 官网页 remount 使用。
  * 返回 true 表示 loopback 可用。
  */
 export const recoverSchoolWebsiteBridgeOnResume = async (): Promise<boolean> => {
   if (!isTauriRuntime()) return false
   if (isLikelyAndroidUserAgent()) return false
+
+  // #452/#453：先让原生 ensure/respawn，再做前端 /health 探测
+  const ensured = await invokeEnsureHttpBridge()
+  if (ensured?.healthy === true) return true
+  if (ensured?.enabled === false) return false
+
   return probeSchoolWebsiteProxyReachable()
 }
 


### PR DESCRIPTION
## Summary

Closes #453

Stacked on #476 (`fix/lifecycle-http-bridge-452`). After long background, remount alone is not enough if loopback Bridge is dead.

## Changes

- `invokeEnsureHttpBridge` + `recoverSchoolWebsiteBridgeOnResume` calls native `ensure_http_bridge` then re-probes `/health`
- `App.vue` `recoverEmbeddedWebAfterResume` ensures bridge and dispatches `hbu-embed-resume` with `forceFallback` / `ensureStatus`
- `SchoolWebsiteView` remount ensures bridge first; Android external-only copy no longer blames 「本地桥接」
- `MoreModuleHostView` on resume: ensure for loopback modules; if still dead → Capacitor local fallback or actionable error
- Vitest structural contract for #453 path

## Evidence

```
npx vitest run src/utils/p0_multi_module_contract.spec.ts → 11 passed
```

## Dependency

Requires `ensure_http_bridge` from #476. If reviewing this PR alone, include that commit stack.

## Test plan

- [ ] iOS: school website after ≥10m background — embed or retry/external works
- [ ] iOS: more module loopback — remount or clear redownload/external path
- [ ] Android: no misleading HTTP bridge copy
- [ ] Short background: no destructive full-page reload