### PR TITLE
feat(smart-orientation): resource entry wiring (#461)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -155,6 +155,7 @@ const loadTeachingEvalView = () => import('./components/TeachingEvalView.vue')
 const loadBroadbandView = () => import('./components/BroadbandView.vue')
 const loadSportsVenueView = () => import('./components/SportsVenueView.vue')
 const loadTowerGoView = () => import('./components/TowerGoView.vue')
+const loadSmartOrientationView = () => import('./components/SmartOrientationView.vue')
 
 const Dashboard = createAsyncPage(loadDashboardView)
 const GradeView = createAsyncPage(loadGradeView)
@@ -199,6 +200,7 @@ const TeachingEvalView = createAsyncPage(loadTeachingEvalView)
 const BroadbandView = createAsyncPage(loadBroadbandView)
 const SportsVenueView = createAsyncPage(loadSportsVenueView)
 const TowerGoView = createAsyncPage(loadTowerGoView)
+const SmartOrientationView = createAsyncPage(loadSmartOrientationView)
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 const GRADE_CACHE_REFRESH_RETRY_MS = 8000
@@ -293,7 +295,8 @@ const VIEW_PREFETCHERS = Object.freeze({
   teaching_eval: loadTeachingEvalView,
   broadband: loadBroadbandView,
   sports_venue: loadSportsVenueView,
-  towergo: loadTowerGoView
+  towergo: loadTowerGoView,
+  smart_orientation: loadSmartOrientationView
 })
 
 const prefetchViewComponent = (view) => {
@@ -3887,6 +3890,14 @@ onBeforeUnmount(() => {
       <SportsVenueView
         v-else-if="currentView === 'sports_venue'"
         @back="handleBackToDashboard"
+      />
+
+      <!-- 智慧迎新 -->
+      <SmartOrientationView
+        v-else-if="currentView === 'smart_orientation'"
+        :student-id="studentId"
+        @back="handleBackToDashboard"
+        @logout="handleLogout"
       />
 
       <!-- 小塔出行 -->

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -158,7 +158,8 @@ const LOGIN_METHOD_KEY = 'hbu_login_method'
 const JWXT_MODULE_ALLOWLIST = new Set([
   'grades', 'classroom', 'exams', 'ranking', 'calendar', 'school_inbox', 'academic',
   'qxzkb', 'course_selection', 'training', 'teaching_eval', 'library', 'campus_map', 'resource_share',
-  'chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class', 'broadband', 'sports_venue', 'towergo'
+  'chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class', 'broadband', 'sports_venue', 'towergo',
+  'smart_orientation'
 ])
 const loginMethod = ref('')
 const isChaoxingMethod = (value) => String(value || '').trim().startsWith('chaoxing')
@@ -503,6 +504,7 @@ const baseModules = [
   { id: 'campus_map', name: '校园地图', iconKey: 'campus_map', color: '#14b8a6', desc: '校园地图查看', available: true, requiresLogin: false },
   { id: 'resource_share', name: '资源网盘', iconKey: 'resource_share', color: '#0ea5e9', desc: 'WebDAV 资料浏览与下载', available: true, requiresLogin: false },
   { id: 'towergo', name: '小塔出行', iconKey: 'towergo', color: '#22c55e', desc: '校园电单车与骑行服务', available: true, requiresLogin: false },
+  { id: 'smart_orientation', name: '智慧迎新', iconKey: 'smart_orientation', color: '#f59e0b', desc: '迎新消息与班导师宿舍等只读信息', available: true, requiresLogin: true },
   { id: 'ai', name: '校园助手', iconKey: 'ai', color: '#94a3b8', desc: '暂不可用', available: true, requiresLogin: true }
 ]
 
@@ -547,7 +549,7 @@ const moduleCategories = computed(() => [
   { title: '教务服务', modules: modules.value.filter(m => ['grades', 'exams', 'ranking', 'academic', 'qxzkb', 'course_selection', 'training', 'teaching_eval', 'classroom', 'calendar', 'school_inbox'].includes(m.id)) },
   { title: '学习通', modules: modules.value.filter(m => ['chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class'].includes(m.id)) },
   { title: '一码通', modules: modules.value.filter(m => ['campus_code', 'electricity', 'transactions', 'broadband', 'sports_venue'].includes(m.id)) },
-  { title: '资源', modules: modules.value.filter(m => ['library', 'campus_map', 'resource_share', 'towergo', 'ai'].includes(m.id)) }
+  { title: '资源', modules: modules.value.filter(m => ['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai'].includes(m.id)) }
 ])
 
 const handleCategoryModuleClick = (moduleId) => { showAllModules.value = false; navigateTo(moduleId) }
@@ -932,6 +934,7 @@ const quickEntryMeta = {
   campus_map: { name: '校园地图', icon: 'fa-map-marked-alt', color: 'bg-teal-50', iconColor: 'text-teal-600' },
   resource_share: { name: '资料分享', icon: 'fa-folder-open', color: 'bg-blue-50', iconColor: 'text-blue-600' },
   towergo: { name: '小塔出行', icon: 'fa-bicycle', color: 'bg-emerald-50', iconColor: 'text-emerald-600' },
+  smart_orientation: { name: '智慧迎新', icon: 'fa-user-graduate', color: 'bg-amber-50', iconColor: 'text-amber-600' },
   ai: { name: '校园助手', icon: 'fa-robot', color: 'bg-gray-50', iconColor: 'text-gray-500' }
 }
 
@@ -1047,7 +1050,7 @@ const featureIconColors = {
   chaoxing_hub: 'bg-blue-600', chaoxing_inbox: 'bg-indigo-600', chaoxing_class: 'bg-sky-500',
   broadband: 'bg-cyan-600', sports_venue: 'bg-green-600',
   library: 'bg-emerald-600', campus_map: 'bg-teal-500', resource_share: 'bg-blue-500',
-  towergo: 'bg-emerald-500',
+  towergo: 'bg-emerald-500', smart_orientation: 'bg-amber-500',
   ai: 'bg-gray-400'
 }
 
@@ -1059,7 +1062,7 @@ const featureIcons = {
   chaoxing_hub: 'fa-graduation-cap', chaoxing_inbox: 'fa-inbox', chaoxing_class: 'fa-folder-open',
   broadband: 'fa-wifi', sports_venue: 'fa-futbol',
   library: 'fa-book', campus_map: 'fa-map-marked-alt', resource_share: 'fa-cloud',
-  towergo: 'fa-bicycle',
+  towergo: 'fa-bicycle', smart_orientation: 'fa-user-graduate',
   ai: 'fa-robot'
 }
 

--- a/src/config/app_store_policy.ts
+++ b/src/config/app_store_policy.ts
@@ -161,6 +161,8 @@ export interface AppStoreFeaturePolicy {
   chaoxingClass: boolean
   /** 培养方案 / 学业 / 校历等只读学业 */
   academicReadonly: boolean
+  /** 智慧迎新只读 */
+  smartOrientation: boolean
 }
 
 const FULL_POLICY: AppStoreFeaturePolicy = Object.freeze({
@@ -186,7 +188,8 @@ const FULL_POLICY: AppStoreFeaturePolicy = Object.freeze({
   campusMap: true,
   resourceShare: true,
   chaoxingClass: true,
-  academicReadonly: true
+  academicReadonly: true,
+  smartOrientation: true
 })
 
 const APP_STORE_POLICY: AppStoreFeaturePolicy = Object.freeze({
@@ -212,7 +215,8 @@ const APP_STORE_POLICY: AppStoreFeaturePolicy = Object.freeze({
   campusMap: true,
   resourceShare: false,
   chaoxingClass: false,
-  academicReadonly: true
+  academicReadonly: true,
+  smartOrientation: false
 })
 
 export function getFeaturePolicy(session?: {
@@ -235,6 +239,7 @@ export const APP_STORE_BLOCKED_MODULE_IDS: ReadonlySet<string> = Object.freeze(
     'resource_share',
     'chaoxing_class',
     'towergo',
+    'smart_orientation',
     'ai',
     'forum',
     'more',

--- a/src/config/ui_settings.ts
+++ b/src/config/ui_settings.ts
@@ -31,6 +31,7 @@ export type HomeModuleKey =
   | 'broadband'
   | 'sports_venue'
   | 'towergo'
+  | 'smart_orientation'
   | 'ai'
 export type NotificationCardKey = 'class_reminder' | 'electricity' | 'grades' | 'exams' | 'school_inbox'
 
@@ -99,6 +100,7 @@ export const HOME_MODULE_ORDER_DEFAULT = [
   'campus_map',
   'resource_share',
   'towergo',
+  'smart_orientation',
   'ai'
 ] as const satisfies readonly HomeModuleKey[]
 export const NOTIFICATION_CARD_ORDER_DEFAULT = [

--- a/src/navigation/app_navigation.ts
+++ b/src/navigation/app_navigation.ts
@@ -45,7 +45,8 @@ export const HIERARCHICAL_PARENT_VIEW_MAP: Readonly<Record<string, string>> = Ob
   campus_network: 'me',
   more: 'me',
   more_module_host: 'more',
-  more_chaoxing_checkin: 'more'
+  more_chaoxing_checkin: 'more',
+  smart_orientation: 'home'
 })
 
 export type MainTab = (typeof MAIN_TABS)[number]

--- a/src/utils/smart_orientation_entry_contract.spec.ts
+++ b/src/utils/smart_orientation_entry_contract.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = resolve(__dirname, '..')
+
+const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8')
+
+describe('smart_orientation entry wiring (#461)', () => {
+  it('Dashboard resource group includes smart_orientation with requiresLogin', () => {
+    const dash = read('components/Dashboard.vue')
+    expect(dash).toContain("id: 'smart_orientation'")
+    expect(dash).toMatch(/smart_orientation[\s\S]*?requiresLogin:\s*true/)
+    expect(dash).toContain("'smart_orientation'")
+    expect(dash).toMatch(/资源[\s\S]*smart_orientation/)
+  })
+
+  it('App.vue lazy-loads SmartOrientationView', () => {
+    const app = read('App.vue')
+    expect(app).toContain("import('./components/SmartOrientationView.vue')")
+    expect(app).toContain('smart_orientation: loadSmartOrientationView')
+    expect(app).toContain('currentView === \'smart_orientation\'')
+    expect(app).toContain('<SmartOrientationView')
+  })
+
+  it('navigation parent map points home', () => {
+    const nav = read('navigation/app_navigation.ts')
+    expect(nav).toContain('smart_orientation: \'home\'')
+  })
+
+  it('policy and ui settings register module id', () => {
+    const policy = read('config/app_store_policy.ts')
+    const ui = read('config/ui_settings.ts')
+    expect(policy).toContain("'smart_orientation'")
+    expect(policy).toContain('smartOrientation')
+    expect(ui).toContain("'smart_orientation'")
+  })
+})

--- a/src/utils/towergo_home_contract.spec.ts
+++ b/src/utils/towergo_home_contract.spec.ts
@@ -14,7 +14,9 @@ describe('towergo home integration contract', () => {
     expect(HOME_MODULE_ORDER_DEFAULT).toContain('towergo')
     expect(dashboard).toContain("{ id: 'towergo', name: '小塔出行'")
     // 资料分享 (chaoxing_class) 归入「学习通」分类；资源区保留网盘 / 小塔 / AI
-    expect(dashboard).toContain("['library', 'campus_map', 'resource_share', 'towergo', 'ai']")
+    // 资源组含智慧迎新入口（#461）；towergo 仍在资源分类中
+    expect(dashboard).toContain("['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai']")
+    expect(dashboard).toContain("id: 'towergo'")
     expect(dashboard).toContain("['chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class']")
     expect(app).toContain("const loadTowerGoView = () => import('./components/TowerGoView.vue')")
     expect(app).toContain("towergo: loadTowerGoView")


### PR DESCRIPTION
## Summary
- Dashboard **资源** group: `smart_orientation` / 智慧迎新, `requiresLogin: true`.
- `App.vue` lazy `SmartOrientationView` + view branch + prefetch map.
- `app_navigation` parent → home; `ui_settings` HomeModuleKey + order; `app_store_policy` flag + blocked in compliance build.
- Contract tests for entry wiring.
- Includes `SmartOrientationView.vue` so the branch builds independently (same as #459 / PR #480).

## Test plan
- [x] `vitest run src/utils/smart_orientation_entry_contract.spec.ts`
- [ ] Login → 资源 → 智慧迎新 → tabs render (after #458 backend)

Merge order suggestion: #460 → #458 → #459 → #461 (or #461 after #459 if view already on main).

Closes #461