### PR TITLE
feat(schedule): 自定义课程颜色持久化与课表渲染 (#470)

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -56,6 +56,9 @@ pub struct CustomScheduleCourseRecord {
     pub period: i32,
     pub djs: i32,
     pub weeks: Vec<i32>,
+    /// 用户设定主色（#RRGGBB）；空字符串表示未设定，前端回退自动配色
+    #[serde(default)]
+    pub color: String,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -100,6 +103,38 @@ fn ensure_user_session_columns(conn: &Connection) {
     );
 }
 
+/// 自定义课程可选颜色列（#470）：旧库幂等 ALTER，新建表 DDL 已含 color。
+fn ensure_custom_schedule_color_column(conn: &Connection) {
+    let _ = conn.execute(
+        "ALTER TABLE custom_schedule_courses ADD COLUMN color TEXT NOT NULL DEFAULT ''",
+        [],
+    );
+}
+
+/// 规范化用户课程色：空 → ""；合法 hex → #rrggbb；非法 → None。
+/// 无 # 时仅接受 6/8 位，避免 "bad" 等被当成 3 位 hex。
+pub fn normalize_course_color(value: Option<&str>) -> Option<String> {
+    let raw = match value {
+        None => return Some(String::new()),
+        Some(v) => v.trim(),
+    };
+    if raw.is_empty() {
+        return Some(String::new());
+    }
+    let has_hash = raw.starts_with('#');
+    let body = if has_hash { raw[1..].trim() } else { raw };
+    let expanded = if has_hash && body.len() == 3 && body.chars().all(|c| c.is_ascii_hexdigit()) {
+        body.chars().flat_map(|c| [c, c]).collect::<String>()
+    } else if body.len() == 8 && body.chars().all(|c| c.is_ascii_hexdigit()) {
+        body[..6].to_string()
+    } else if body.len() == 6 && body.chars().all(|c| c.is_ascii_hexdigit()) {
+        body.to_string()
+    } else {
+        return None;
+    };
+    Some(format!("#{}", expanded.to_ascii_lowercase()))
+}
+
 fn resolve_db_path<P: AsRef<Path>>(path: P) -> PathBuf {
     if let Ok(raw) = std::env::var("HBUT_DB_PATH") {
         let candidate = PathBuf::from(raw);
@@ -120,6 +155,8 @@ fn open_connection<P: AsRef<Path>>(path: P) -> Result<Connection> {
     let conn = Connection::open(resolved)?;
     // WAL 降低读写锁争用，改善 async 运行时中的同步 SQLite 访问体验
     let _ = conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;");
+    // 幂等补列：旧库缺少 color 时不影响后续 custom_schedule CRUD
+    ensure_custom_schedule_color_column(&conn);
     Ok(conn)
 }
 
@@ -426,11 +463,13 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> Result<()> {
             period INTEGER NOT NULL,
             djs INTEGER NOT NULL,
             weeks_json TEXT NOT NULL,
+            color TEXT NOT NULL DEFAULT '',
             created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
             updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
         )",
         [],
     )?;
+    ensure_custom_schedule_color_column(&conn);
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_custom_schedule_student_semester
          ON custom_schedule_courses (student_id, semester)",
@@ -495,6 +534,8 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> Result<()> {
     )?;
     migrate_auth_cookie_v2_table(&conn)?;
     ensure_schema_migration(&conn, 5, "auth_cookie_v2 multi-domain session cookies")?;
+    ensure_custom_schedule_color_column(&conn);
+    ensure_schema_migration(&conn, 6, "custom_schedule_courses.color optional user color")?;
     drop(conn);
 
     // 1.4.2→1.4.3 凭据迁移：base64 列迁密钥环（失败保留 base64），修复 KEYRING 空壳可恢复路径
@@ -1041,10 +1082,11 @@ pub fn add_custom_schedule_course<P: AsRef<Path>>(
 ) -> Result<()> {
     let conn = open_connection(path)?;
     let weeks_json = serde_json::to_string(&course.weeks).unwrap_or_else(|_| "[]".to_string());
+    let color = normalize_course_color(Some(course.color.as_str())).unwrap_or_default();
     conn.execute(
         "INSERT OR REPLACE INTO custom_schedule_courses (
-            id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, CURRENT_TIMESTAMP)",
+            id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, color, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, CURRENT_TIMESTAMP)",
         params![
             course.id,
             course.student_id,
@@ -1055,10 +1097,33 @@ pub fn add_custom_schedule_course<P: AsRef<Path>>(
             course.weekday,
             course.period,
             course.djs,
-            weeks_json
+            weeks_json,
+            color
         ],
     )?;
     Ok(())
+}
+
+fn map_custom_schedule_course_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CustomScheduleCourseRecord> {
+    let weeks_json: String = row.get(9)?;
+    let weeks = serde_json::from_str::<Vec<i32>>(&weeks_json).unwrap_or_default();
+    let color_raw: String = row.get(10).unwrap_or_default();
+    let color = normalize_course_color(Some(color_raw.as_str())).unwrap_or_default();
+    Ok(CustomScheduleCourseRecord {
+        id: row.get(0)?,
+        student_id: row.get(1)?,
+        semester: row.get(2)?,
+        name: row.get(3)?,
+        teacher: row.get(4)?,
+        room: row.get(5)?,
+        weekday: row.get(6)?,
+        period: row.get(7)?,
+        djs: row.get(8)?,
+        weeks,
+        color,
+        created_at: row.get(11)?,
+        updated_at: row.get(12)?,
+    })
 }
 
 pub fn list_custom_schedule_courses<P: AsRef<Path>>(
@@ -1068,7 +1133,7 @@ pub fn list_custom_schedule_courses<P: AsRef<Path>>(
 ) -> Result<Vec<CustomScheduleCourseRecord>> {
     let conn = open_connection(path)?;
     let mut stmt = conn.prepare(
-        "SELECT id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, created_at, updated_at
+        "SELECT id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, color, created_at, updated_at
          FROM custom_schedule_courses
          WHERE student_id = ?1 AND semester = ?2
          ORDER BY weekday ASC, period ASC, name ASC",
@@ -1077,22 +1142,7 @@ pub fn list_custom_schedule_courses<P: AsRef<Path>>(
     let mut rows = stmt.query(params![student_id, semester])?;
     let mut result = Vec::new();
     while let Some(row) = rows.next()? {
-        let weeks_json: String = row.get(9)?;
-        let weeks = serde_json::from_str::<Vec<i32>>(&weeks_json).unwrap_or_default();
-        result.push(CustomScheduleCourseRecord {
-            id: row.get(0)?,
-            student_id: row.get(1)?,
-            semester: row.get(2)?,
-            name: row.get(3)?,
-            teacher: row.get(4)?,
-            room: row.get(5)?,
-            weekday: row.get(6)?,
-            period: row.get(7)?,
-            djs: row.get(8)?,
-            weeks,
-            created_at: row.get(10)?,
-            updated_at: row.get(11)?,
-        });
+        result.push(map_custom_schedule_course_row(row)?);
     }
     Ok(result)
 }
@@ -1103,7 +1153,7 @@ pub fn list_all_custom_schedule_courses<P: AsRef<Path>>(
 ) -> Result<Vec<CustomScheduleCourseRecord>> {
     let conn = open_connection(path)?;
     let mut stmt = conn.prepare(
-        "SELECT id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, created_at, updated_at
+        "SELECT id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, color, created_at, updated_at
          FROM custom_schedule_courses
          WHERE student_id = ?1
          ORDER BY semester DESC, weekday ASC, period ASC, name ASC",
@@ -1112,22 +1162,7 @@ pub fn list_all_custom_schedule_courses<P: AsRef<Path>>(
     let mut rows = stmt.query(params![student_id])?;
     let mut result = Vec::new();
     while let Some(row) = rows.next()? {
-        let weeks_json: String = row.get(9)?;
-        let weeks = serde_json::from_str::<Vec<i32>>(&weeks_json).unwrap_or_default();
-        result.push(CustomScheduleCourseRecord {
-            id: row.get(0)?,
-            student_id: row.get(1)?,
-            semester: row.get(2)?,
-            name: row.get(3)?,
-            teacher: row.get(4)?,
-            room: row.get(5)?,
-            weekday: row.get(6)?,
-            period: row.get(7)?,
-            djs: row.get(8)?,
-            weeks,
-            created_at: row.get(10)?,
-            updated_at: row.get(11)?,
-        });
+        result.push(map_custom_schedule_course_row(row)?);
     }
     Ok(result)
 }
@@ -1139,29 +1174,12 @@ pub fn get_custom_schedule_course<P: AsRef<Path>>(
 ) -> Result<Option<CustomScheduleCourseRecord>> {
     let conn = open_connection(path)?;
     conn.query_row(
-        "SELECT id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, created_at, updated_at
+        "SELECT id, student_id, semester, name, teacher, room, weekday, period, djs, weeks_json, color, created_at, updated_at
          FROM custom_schedule_courses
          WHERE student_id = ?1 AND id = ?2
          LIMIT 1",
         params![student_id, course_id],
-        |row| {
-            let weeks_json: String = row.get(9)?;
-            let weeks = serde_json::from_str::<Vec<i32>>(&weeks_json).unwrap_or_default();
-            Ok(CustomScheduleCourseRecord {
-                id: row.get(0)?,
-                student_id: row.get(1)?,
-                semester: row.get(2)?,
-                name: row.get(3)?,
-                teacher: row.get(4)?,
-                room: row.get(5)?,
-                weekday: row.get(6)?,
-                period: row.get(7)?,
-                djs: row.get(8)?,
-                weeks,
-                created_at: row.get(10)?,
-                updated_at: row.get(11)?,
-            })
-        },
+        map_custom_schedule_course_row,
     )
     .optional()
 }
@@ -1188,6 +1206,7 @@ pub fn update_custom_schedule_course<P: AsRef<Path>>(
 ) -> Result<usize> {
     let conn = open_connection(path)?;
     let weeks_json = serde_json::to_string(&course.weeks).unwrap_or_else(|_| "[]".to_string());
+    let color = normalize_course_color(Some(course.color.as_str())).unwrap_or_default();
     conn.execute(
         "UPDATE custom_schedule_courses
          SET semester = ?3,
@@ -1198,6 +1217,7 @@ pub fn update_custom_schedule_course<P: AsRef<Path>>(
              period = ?8,
              djs = ?9,
              weeks_json = ?10,
+             color = ?11,
              updated_at = CURRENT_TIMESTAMP
          WHERE student_id = ?1 AND id = ?2",
         params![
@@ -1210,7 +1230,8 @@ pub fn update_custom_schedule_course<P: AsRef<Path>>(
             course.weekday,
             course.period,
             course.djs,
-            weeks_json
+            weeks_json,
+            color
         ],
     )
 }
@@ -1686,6 +1707,101 @@ mod auth_cookie_v2_tests {
         assert_eq!(session.one_code_token, "tok-abc");
         assert_eq!(session.refresh_token, "ref-xyz");
         assert!(session.cookies.contains("Code:"));
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[cfg(test)]
+mod custom_schedule_color_tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_db_path(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!("mini_hbut_ccolor_{label}_{nanos}.db"))
+    }
+
+    #[test]
+    fn normalize_course_color_accepts_and_rejects() {
+        assert_eq!(normalize_course_color(None).as_deref(), Some(""));
+        assert_eq!(normalize_course_color(Some("")).as_deref(), Some(""));
+        assert_eq!(normalize_course_color(Some("  ")).as_deref(), Some(""));
+        assert_eq!(
+            normalize_course_color(Some("#72B9FF")).as_deref(),
+            Some("#72b9ff")
+        );
+        assert_eq!(
+            normalize_course_color(Some("#AbC")).as_deref(),
+            Some("#aabbcc")
+        );
+        assert_eq!(
+            normalize_course_color(Some("72B9FF")).as_deref(),
+            Some("#72b9ff")
+        );
+        assert_eq!(normalize_course_color(Some("bad")), None);
+        assert_eq!(normalize_course_color(Some("#12")), None);
+        assert_eq!(normalize_course_color(Some("not-a-color")), None);
+    }
+
+    #[test]
+    fn custom_schedule_color_persists_roundtrip_and_legacy_empty() {
+        let path = temp_db_path("roundtrip");
+        let _ = std::fs::remove_file(&path);
+        init_db(&path).expect("init");
+
+        let now = "2026-01-01T00:00:00+08:00".to_string();
+        let record = CustomScheduleCourseRecord {
+            id: "c_color_1".to_string(),
+            student_id: "2510231000".to_string(),
+            semester: "2025-2026-1".to_string(),
+            name: "测试课".to_string(),
+            teacher: "张三".to_string(),
+            room: "A101".to_string(),
+            weekday: 1,
+            period: 1,
+            djs: 2,
+            weeks: vec![1, 2, 3],
+            color: "#72B9FF".to_string(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        };
+        add_custom_schedule_course(&path, &record).expect("add");
+        let loaded = get_custom_schedule_course(&path, "2510231000", "c_color_1")
+            .expect("get")
+            .expect("exists");
+        assert_eq!(loaded.color, "#72b9ff");
+
+        {
+            let conn = open_connection(&path).unwrap();
+            let mut stmt = conn
+                .prepare("PRAGMA table_info(custom_schedule_courses)")
+                .unwrap();
+            let names: Vec<String> = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+                .filter_map(|r| r.ok())
+                .collect();
+            assert!(
+                names.iter().any(|n| n == "color"),
+                "color column missing: {:?}",
+                names
+            );
+        }
+
+        let plain = CustomScheduleCourseRecord {
+            id: "c_color_2".to_string(),
+            color: String::new(),
+            ..record
+        };
+        add_custom_schedule_course(&path, &plain).expect("add plain");
+        let plain_loaded = get_custom_schedule_course(&path, "2510231000", "c_color_2")
+            .expect("get2")
+            .expect("exists2");
+        assert_eq!(plain_loaded.color, "");
+
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -535,7 +535,11 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> Result<()> {
     migrate_auth_cookie_v2_table(&conn)?;
     ensure_schema_migration(&conn, 5, "auth_cookie_v2 multi-domain session cookies")?;
     ensure_custom_schedule_color_column(&conn);
-    ensure_schema_migration(&conn, 6, "custom_schedule_courses.color optional user color")?;
+    ensure_schema_migration(
+        &conn,
+        6,
+        "custom_schedule_courses.color optional user color",
+    )?;
     drop(conn);
 
     // 1.4.2→1.4.3 凭据迁移：base64 列迁密钥环（失败保留 base64），修复 KEYRING 空壳可恢复路径
@@ -1104,7 +1108,9 @@ pub fn add_custom_schedule_course<P: AsRef<Path>>(
     Ok(())
 }
 
-fn map_custom_schedule_course_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CustomScheduleCourseRecord> {
+fn map_custom_schedule_course_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<CustomScheduleCourseRecord> {
     let weeks_json: String = row.get(9)?;
     let weeks = serde_json::from_str::<Vec<i32>>(&weeks_json).unwrap_or_default();
     let color_raw: String = row.get(10).unwrap_or_default();

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -403,6 +403,8 @@ struct DebugCustomScheduleCourseInput {
     period: i32,
     djs: i32,
     weeks: Vec<i32>,
+    #[serde(default)]
+    color: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1123,6 +1125,7 @@ fn format_custom_weeks_text(weeks: &[i32]) -> String {
 }
 
 fn custom_course_payload(course: &db::CustomScheduleCourseRecord) -> serde_json::Value {
+    let color = db::normalize_course_color(Some(course.color.as_str())).unwrap_or_default();
     serde_json::json!({
         "id": format!("custom:{}", course.id),
         "source_id": course.id,
@@ -1139,6 +1142,7 @@ fn custom_course_payload(course: &db::CustomScheduleCourseRecord) -> serde_json:
         "credit": "",
         "class_name": "自定义课程",
         "semester": course.semester,
+        "color": color,
         "is_custom": true,
         "created_at": course.created_at,
         "updated_at": course.updated_at
@@ -1192,6 +1196,8 @@ fn validate_debug_custom_schedule_course(
         provided_id
     };
     let now = chrono::Local::now().to_rfc3339();
+    let color = db::normalize_course_color(course.color.as_deref())
+        .ok_or_else(|| "颜色格式不合法，请使用 #RRGGBB".to_string())?;
     Ok(db::CustomScheduleCourseRecord {
         id,
         student_id: student_id.to_string(),
@@ -1208,6 +1214,7 @@ fn validate_debug_custom_schedule_course(
         period: course.period,
         djs: course.djs,
         weeks,
+        color,
         created_at: now.clone(),
         updated_at: now,
     })
@@ -1406,6 +1413,13 @@ async fn schedule_custom_add(
             "请至少选择一个上课周次".to_string(),
         ));
     }
+    let color = db::normalize_course_color(req.color.as_deref()).ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "参数错误",
+            "颜色格式不合法，请使用 #RRGGBB".to_string(),
+        )
+    })?;
 
     let mut rng = rand::thread_rng();
     let id = format!(
@@ -1425,6 +1439,7 @@ async fn schedule_custom_add(
         period: req.period,
         djs: req.djs,
         weeks,
+        color,
         created_at: now.clone(),
         updated_at: now,
     };
@@ -1686,6 +1701,13 @@ async fn schedule_custom_update(
             "学期不匹配，无法修改该课程".to_string(),
         ));
     }
+    let color = db::normalize_course_color(req.color.as_deref()).ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "参数错误",
+            "颜色格式不合法，请使用 #RRGGBB".to_string(),
+        )
+    })?;
 
     let record = db::CustomScheduleCourseRecord {
         id: existing.id,
@@ -1698,6 +1720,7 @@ async fn schedule_custom_update(
         period: req.period,
         djs: req.djs,
         weeks,
+        color,
         created_at: existing.created_at,
         updated_at: existing.updated_at,
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -418,6 +418,9 @@ pub struct AddCustomScheduleCourseRequest {
     pub djs: i32,
     pub weeks: Vec<i32>,
     pub room: Option<String>,
+    /// 可选用户主色 #RRGGBB；缺省/空表示未设定
+    #[serde(default)]
+    pub color: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -441,6 +444,9 @@ pub struct UpdateCustomScheduleCourseRequest {
     pub djs: i32,
     pub weeks: Vec<i32>,
     pub room: Option<String>,
+    /// 可选用户主色 #RRGGBB；缺省/空表示未设定
+    #[serde(default)]
+    pub color: Option<String>,
 }
 
 fn normalize_grade_match_key(value: Option<&str>) -> Option<String> {
@@ -4472,6 +4478,7 @@ pub(crate) fn strip_custom_course_id(value: &str) -> String {
 pub(crate) fn custom_course_to_payload(
     course: &db::CustomScheduleCourseRecord,
 ) -> serde_json::Value {
+    let color = db::normalize_course_color(Some(course.color.as_str())).unwrap_or_default();
     serde_json::json!({
         "id": format!("custom:{}", course.id),
         "source_id": course.id,
@@ -4488,6 +4495,7 @@ pub(crate) fn custom_course_to_payload(
         "credit": "",
         "class_name": "自定义课程",
         "semester": course.semester,
+        "color": color,
         "is_custom": true,
         "created_at": course.created_at,
         "updated_at": course.updated_at
@@ -4567,6 +4575,8 @@ async fn add_custom_schedule_course(
     if weeks.is_empty() {
         return Err("请至少选择一个上课周次".to_string());
     }
+    let color = db::normalize_course_color(req.color.as_deref())
+        .ok_or_else(|| "颜色格式不合法，请使用 #RRGGBB".to_string())?;
 
     let mut rng = rand::thread_rng();
     let id = format!(
@@ -4586,6 +4596,7 @@ async fn add_custom_schedule_course(
         period: req.period,
         djs: req.djs,
         weeks,
+        color,
         created_at: now.clone(),
         updated_at: now,
     };
@@ -4717,6 +4728,8 @@ async fn update_custom_schedule_course(
     if existing.semester != sem {
         return Err("学期不匹配，无法修改该课程".to_string());
     }
+    let color = db::normalize_course_color(req.color.as_deref())
+        .ok_or_else(|| "颜色格式不合法，请使用 #RRGGBB".to_string())?;
 
     let record = db::CustomScheduleCourseRecord {
         id: existing.id,
@@ -4729,6 +4742,7 @@ async fn update_custom_schedule_course(
         period: req.period,
         djs: req.djs,
         weeks,
+        color,
         created_at: existing.created_at,
         updated_at: existing.updated_at,
     };

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -31,7 +31,12 @@ import { invokeNative, isTauriRuntime } from '../platform/native'
 import { afterScheduleRefresh } from '../utils/widget_bridge'
 import { isTestAccountSession } from '../utils/test_account.js'
 import CourseColorPicker from './CourseColorPicker.vue'
-import { DEFAULT_COURSE_COLOR, normalizeOptionalCourseColor } from '../utils/course_color'
+import {
+  DEFAULT_COURSE_COLOR,
+  contrastTextForHex,
+  mixHexWithWhite,
+  normalizeOptionalCourseColor,
+} from '../utils/course_color'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -1666,10 +1671,20 @@ const getCourseStyle = (course) => {
 
   const theme = courseThemes[index]
   const isCustom = !!course.is_custom
-  const borderColor = isCustom ? '#111111' : (theme.border || '#cbd5e1')
-  // 传统样式：柔和彩色背景 + 同色系边框 + 深色文字（参考设计稿）
-  const traditionalBackground = isCustom ? '#111111' : theme.bg
-  const traditionalText = isCustom ? '#ffffff' : theme.text
+  // #470：自定义课若有用户色则优先使用，不再强制纯黑
+  const userColor = isCustom ? normalizeOptionalCourseColor(course.color) : null
+  const hasUserColor = !!(userColor && userColor.length)
+  const borderColor = hasUserColor
+    ? userColor
+    : (isCustom ? '#111111' : (theme.border || '#cbd5e1'))
+  // 传统样式：用户色 → 浅底+主色边框+对比字；未设色自定义课仍用黑底白字
+  const traditionalBackground = hasUserColor
+    ? mixHexWithWhite(userColor, 0.22)
+    : (isCustom ? '#111111' : theme.bg)
+  const traditionalText = hasUserColor
+    ? contrastTextForHex(traditionalBackground)
+    : (isCustom ? '#ffffff' : theme.text)
+  const modernText = hasUserColor ? userColor : theme.text
   const modernBackground = 'rgba(255, 255, 255, 0.92)'
   const classBackground = 'rgba(255, 255, 255, 0.94)'
   const normalShadow = isCustom
@@ -1682,7 +1697,7 @@ const getCourseStyle = (course) => {
   
   return {
     '--course-bg': isTraditionalCard ? traditionalBackground : (isClassCard ? classBackground : modernBackground),
-    '--course-text': isTraditionalCard ? traditionalText : theme.text,
+    '--course-text': isTraditionalCard ? traditionalText : modernText,
     '--course-border': borderColor,
     '--course-shadow': isTraditionalCard ? traditionalShadow : (isClassCard ? classShadow : normalShadow),
     '--course-span': String(span),
@@ -2032,6 +2047,7 @@ const submitAddCourse = async () => {
   }
 
   const weeks = normalizeWeeks(addCourseForm.value.weeks)
+  const colorNorm = normalizeOptionalCourseColor(addCourseForm.value.color)
   const payload = {
     student_id: sid,
     semester: sem,
@@ -2041,7 +2057,9 @@ const submitAddCourse = async () => {
     weekday: Number(addCourseForm.value.weekday),
     period: Number(addCourseForm.value.period),
     djs: Number(addCourseForm.value.djs),
-    weeks
+    weeks,
+    // #470：可选用户色；空字符串表示未设定
+    color: colorNorm === null ? DEFAULT_COURSE_COLOR : colorNorm
   }
 
   const isEditing = courseDialogMode.value === 'edit'
@@ -2469,7 +2487,8 @@ const toPortableCustomCourse = (course) => {
     weekday: Number(normalized.weekday || 1),
     period: Number(normalized.period || 1),
     djs: Number(normalized.djs || 1),
-    weeks: normalizeWeeks(normalized.weeks)
+    weeks: normalizeWeeks(normalized.weeks),
+    color: normalized.color || DEFAULT_COURSE_COLOR
   }
 }
 
@@ -2513,6 +2532,9 @@ const parseImportedCustomCourse = (item, index) => {
     throw new Error(`第 ${index + 1} 条课程 djs 不合法（最多 ${maxSpan}）`)
   }
   if (!weeksValue.length) throw new Error(`第 ${index + 1} 条课程 weeks 不能为空`)
+  const colorNorm = normalizeOptionalCourseColor(item.color)
+  // 缺 color / 非法 color：导入时按未设定处理，兼容旧 JSON
+  const colorValue = colorNorm === null ? DEFAULT_COURSE_COLOR : colorNorm
 
   return {
     source_id: sourceId,
@@ -2520,6 +2542,7 @@ const parseImportedCustomCourse = (item, index) => {
     name: nameValue,
     teacher: teacherValue,
     room: roomValue,
+    color: colorValue,
     weekday: weekdayValue,
     period: periodValue,
     djs: djsValue,
@@ -2692,7 +2715,8 @@ const importCustomCoursesFromText = async (content = '') => {
           weekday: course.weekday,
           period: course.period,
           djs: course.djs,
-          weeks: course.weeks
+          weeks: course.weeks,
+          color: course.color || DEFAULT_COURSE_COLOR
         })
         if (!updateRes.data?.success) {
           throw new Error(updateRes.data?.error || '更新失败')
@@ -2710,7 +2734,8 @@ const importCustomCoursesFromText = async (content = '') => {
         weekday: course.weekday,
         period: course.period,
         djs: course.djs,
-        weeks: course.weeks
+        weeks: course.weeks,
+        color: course.color || DEFAULT_COURSE_COLOR
       })
       if (!addRes.data?.success) {
         throw new Error(addRes.data?.error || '新增失败')


### PR DESCRIPTION
## Summary
持久化自定义课程颜色，并在课表卡片渲染中优先使用用户色。

## Depends on
- Includes #469 UI changes (`feat/course-color-ui-469` / PR #475)
- Prefer merge order: #469 then this PR (or merge this alone if #469 not merged yet — this branch already contains #469 commits)

## Changes
### Backend
- `CustomScheduleCourseRecord.color` + `normalize_course_color`
- DDL / ALTER 迁移 `custom_schedule_courses.color`
- add/update/list payload 读写 color（`lib.rs` / `http_server.rs`）
- unit tests: parse/normalize + DB roundtrip + column presence

### Frontend
- `submitAddCourse` / JSON 导入导出携带 `color`
- `getCourseStyle`：有用户色时用用户色，未设色自定义课仍默认黑底

## Test plan
- [x] `npx vitest run src/utils/course_color.spec.ts`
- [x] `cargo test custom_schedule_color`
- [ ] 添加自定义课选色 → 保存 → 重启后色仍在
- [ ] 编辑改色后课表立即更新
- [ ] 旧数据无 color 不崩

Closes #470