### PR TITLE
fix(#494): ChaoxingHub 视频/文档类型与学期列表

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "hbut-helper"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "aes",
  "async-stream",

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -1431,14 +1431,23 @@ pub async fn chaoxing_get_session_status(
 }
 
 /// 从课程字段推断学期标签
+/// 注意：字段缺失时优先日期/归档态，禁止一律标成「本学期」掩盖多学期
 fn guess_semester_label(content: &Value, item: &Value, course_data: Option<&Value>) -> String {
-    // 直接字段
+    // 直接字段（含嵌套 course.data）
     for path in [
         content.get("semester"),
         content.get("term"),
         content.get("yearterm"),
+        content.get("termName"),
+        content.get("semesterName"),
+        content.get("classterm"),
         item.get("semester"),
+        item.get("term"),
+        item.get("yearterm"),
         course_data.and_then(|c| c.get("semester")),
+        course_data.and_then(|c| c.get("term")),
+        course_data.and_then(|c| c.get("yearterm")),
+        course_data.and_then(|c| c.get("termName")),
         course_data.and_then(|c| c.get("appinfo")),
     ] {
         if let Some(s) = path.and_then(|v| v.as_str()) {
@@ -1451,27 +1460,36 @@ fn guess_semester_label(content: &Value, item: &Value, course_data: Option<&Valu
             }
         }
     }
-    // 起止日期 → 学年学期
-    let date_raw = content
-        .get("begindate")
-        .or_else(|| content.get("startDate"))
-        .or_else(|| content.get("starttime"))
-        .or_else(|| course_data.and_then(|c| c.get("startDate")))
-        .or_else(|| course_data.and_then(|c| c.get("begindate")))
-        .and_then(|v| {
-            v.as_str()
-                .map(|s| s.to_string())
-                .or_else(|| v.as_i64().map(|n| n.to_string()))
-                .or_else(|| v.as_u64().map(|n| n.to_string()))
-        })
-        .unwrap_or_default();
-    if let Some(label) = semester_from_date_str(&date_raw) {
-        return label;
+    // 起止日期 → 学年学期（多路径）
+    for path in [
+        content.get("begindate"),
+        content.get("startDate"),
+        content.get("starttime"),
+        content.get("createTime"),
+        content.get("createtimestamp"),
+        item.get("createTime"),
+        item.get("createtimestamp"),
+        course_data.and_then(|c| c.get("startDate")),
+        course_data.and_then(|c| c.get("begindate")),
+        course_data.and_then(|c| c.get("createTime")),
+    ] {
+        let date_raw = path
+            .and_then(|v| {
+                v.as_str()
+                    .map(|s| s.to_string())
+                    .or_else(|| v.as_i64().map(|n| n.to_string()))
+                    .or_else(|| v.as_u64().map(|n| n.to_string()))
+            })
+            .unwrap_or_default();
+        if let Some(label) = semester_from_date_str(&date_raw) {
+            return label;
+        }
     }
-    // 已结束标记
+    // 已结束 / 归档 → 历史，避免与「本学期」混在一起
     let ended = content
         .get("isFiled")
         .and_then(|v| v.as_bool())
+        .or_else(|| item.get("isFiled").and_then(|v| v.as_bool()))
         .or_else(|| {
             content
                 .get("state")
@@ -1482,7 +1500,8 @@ fn guess_semester_label(content: &Value, item: &Value, course_data: Option<&Valu
     if ended {
         "历史课程".into()
     } else {
-        "本学期".into()
+        // 无法从字段/日期判断时标「未分学期」，勿假装「本学期」
+        "未分学期".into()
     }
 }
 
@@ -1547,11 +1566,13 @@ async fn fetch_chaoxing_folder_courses(
         ));
     };
 
-    // API：课程夹列表（比 HTML 正则更稳）
+    // API：课程夹列表（比 HTML 正则更稳；兼容 data.list / folderList 等嵌套）
+    let mut folder_api_hits = 0usize;
     for api in [
         "https://mooc1-api.chaoxing.com/mycourse/getCourseFolders?view=json",
         "https://mooc1.chaoxing.com/mooc-ans/visit/coursefolders?view=json",
         "https://mooc1-api.chaoxing.com/gas/folder?view=json",
+        "https://mooc1.chaoxing.com/visit/coursefolders?view=json",
     ] {
         if let Ok(resp) = client
             .client
@@ -1563,20 +1584,15 @@ async fn fetch_chaoxing_folder_courses(
             .await
         {
             if let Ok(v) = resp.json::<Value>().await {
-                let arr = v
-                    .get("data")
-                    .and_then(|d| d.as_array())
-                    .or_else(|| v.get("channelList").and_then(|d| d.as_array()))
-                    .or_else(|| v.get("folderList").and_then(|d| d.as_array()))
-                    .or_else(|| v.as_array())
-                    .cloned()
-                    .unwrap_or_default();
+                let arr = extract_folder_array(&v);
+                let mut added = 0usize;
                 for item in arr {
                     let id = item
                         .get("id")
                         .or_else(|| item.get("folderId"))
                         .or_else(|| item.get("courseFolderId"))
                         .or_else(|| item.get("cfid"))
+                        .or_else(|| item.get("folderid"))
                         .map(|x| match x {
                             Value::Number(n) => n.to_string(),
                             Value::String(s) => s.clone(),
@@ -1587,10 +1603,18 @@ async fn fetch_chaoxing_folder_courses(
                         .get("name")
                         .or_else(|| item.get("folderName"))
                         .or_else(|| item.get("title"))
+                        .or_else(|| item.get("foldername"))
                         .and_then(|x| x.as_str())
                         .unwrap_or("")
                         .to_string();
+                    if !id.trim().is_empty() {
+                        added += 1;
+                    }
                     push_folder(id, name);
+                }
+                if added > 0 {
+                    folder_api_hits += added;
+                    println!("[调试] course folders api ok url={api} candidates={added}");
                 }
             }
         }
@@ -1649,6 +1673,15 @@ async fn fetch_chaoxing_folder_courses(
     folder_ids.sort_by(|a, b| a.0.cmp(&b.0));
     folder_ids.dedup_by(|a, b| a.0 == b.0);
     folder_ids.truncate(16);
+    println!(
+        "[调试] course folders resolved count={} api_hits={} ids={:?}",
+        folder_ids.len(),
+        folder_api_hits,
+        folder_ids
+            .iter()
+            .map(|(id, name)| format!("{id}:{name}"))
+            .collect::<Vec<_>>()
+    );
 
     for (folder_id, folder_name) in folder_ids {
         let body = format!("courseType=1&courseFolderId={folder_id}&superstarClass=0");
@@ -1735,7 +1768,42 @@ async fn fetch_chaoxing_folder_courses(
         }
     }
 
+    println!(
+        "[调试] fetch_chaoxing_folder_courses done extra_courses={}",
+        out.len()
+    );
     Ok(out)
+}
+
+/// 从课程夹 JSON 中尽量抠出 folder 数组（兼容多层嵌套）
+fn extract_folder_array(v: &Value) -> Vec<Value> {
+    if let Some(arr) = v.as_array() {
+        return arr.clone();
+    }
+    for key in [
+        "data",
+        "folderList",
+        "channelList",
+        "list",
+        "folders",
+        "result",
+    ] {
+        if let Some(node) = v.get(key) {
+            if let Some(arr) = node.as_array() {
+                return arr.clone();
+            }
+            if let Some(arr) = node.get("list").and_then(|x| x.as_array()) {
+                return arr.clone();
+            }
+            if let Some(arr) = node.get("folderList").and_then(|x| x.as_array()) {
+                return arr.clone();
+            }
+            if let Some(arr) = node.get("data").and_then(|x| x.as_array()) {
+                return arr.clone();
+            }
+        }
+    }
+    Vec::new()
 }
 
 async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, DynError> {
@@ -1929,9 +1997,16 @@ async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, Dyn
             );
 
             // 再拉课程文件夹（历史学期），合并去重
-            if let Ok(extra) = fetch_chaoxing_folder_courses(client, &mut seen).await {
-                for c in extra {
-                    courses.push(c);
+            let mut folder_extra = 0usize;
+            match fetch_chaoxing_folder_courses(client, &mut seen).await {
+                Ok(extra) => {
+                    folder_extra = extra.len();
+                    for c in extra {
+                        courses.push(c);
+                    }
+                }
+                Err(e) => {
+                    println!("[调试] fetch_chaoxing_folder_courses failed: {e}");
                 }
             }
 
@@ -1945,11 +2020,28 @@ async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, Dyn
                 .collect();
             semesters.sort();
             semesters.dedup();
-            // 本学期优先
-            if let Some(pos) = semesters.iter().position(|s| s == "本学期") {
-                let cur = semesters.remove(pos);
-                semesters.insert(0, cur);
-            }
+            // 本学期优先，其次带「年/学期」的标签
+            semesters.sort_by(|a, b| {
+                let rank = |s: &str| {
+                    if s == "本学期" {
+                        0
+                    } else if s.contains("年") || s.contains("学期") {
+                        1
+                    } else if s == "未分学期" {
+                        3
+                    } else {
+                        2
+                    }
+                };
+                rank(a).cmp(&rank(b)).then_with(|| b.cmp(a))
+            });
+
+            println!(
+                "[调试] chaoxing courses total={} folder_extra={} semesters={:?}",
+                courses.len(),
+                folder_extra,
+                semesters
+            );
 
             let pending_count = value
                 .get("pending_count")
@@ -1961,7 +2053,8 @@ async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, Dyn
                 "success": true,
                 "courses": courses,
                 "semesters": semesters,
-                "pending_count": pending_count
+                "pending_count": pending_count,
+                "folder_extra": folder_extra,
             }));
         }
     }
@@ -3379,6 +3472,95 @@ fn extract_m_arg_json(html: &str) -> Option<String> {
     None
 }
 
+/// 根据 att_type / module / 文件名推断任务类型
+/// att_type 为空时**不得**默认 video：优先扩展名与 module，未知标 unknown
+pub fn infer_attachment_kind(att_type: &str, module: &str, name: &str) -> String {
+    let t = att_type.trim().to_lowercase();
+    let m = module.trim().to_lowercase();
+    let n = name.trim().to_lowercase();
+    let ext = n
+        .rsplit_once('.')
+        .map(|(_, e)| e.trim())
+        .unwrap_or("")
+        .to_string();
+
+    let is_video_ext = matches!(
+        ext.as_str(),
+        "mp4" | "flv" | "m3u8" | "avi" | "mov" | "wmv" | "mkv" | "webm" | "ts" | "m4v"
+    );
+    let is_doc_ext = matches!(
+        ext.as_str(),
+        "pdf"
+            | "ppt"
+            | "pptx"
+            | "doc"
+            | "docx"
+            | "xls"
+            | "xlsx"
+            | "txt"
+            | "epub"
+            | "csv"
+            | "rtf"
+            | "odt"
+            | "wps"
+    );
+
+    // 显式 type 优先
+    if !t.is_empty() {
+        if t.contains("video") || t == "视频" {
+            return "video".into();
+        }
+        if t.contains("doc")
+            || t.contains("pdf")
+            || t.contains("ppt")
+            || t.contains("book")
+            || t == "document"
+            || t == "文档"
+        {
+            return "document".into();
+        }
+        if t.contains("work") || t == "作业" {
+            return "work".into();
+        }
+        if t == "unknown" || t == "task" {
+            // 继续用 module/name 细化
+        } else {
+            return t;
+        }
+    }
+
+    if m.contains("video") || m.contains("insertvideo") || m == "insertmicrocourse" {
+        return "video".into();
+    }
+    if m.contains("doc")
+        || m.contains("pdf")
+        || m.contains("ppt")
+        || m.contains("book")
+        || m.contains("insertbook")
+        || m.contains("insertfile")
+    {
+        return "document".into();
+    }
+    if m.contains("work") {
+        return "work".into();
+    }
+
+    if is_video_ext {
+        return "video".into();
+    }
+    if is_doc_ext
+        || n.contains(".ppt")
+        || n.contains("课件")
+        || n.contains("幻灯")
+        || n.contains("讲义")
+    {
+        return "document".into();
+    }
+
+    // 无可靠信号：标 unknown，禁止因有 objectId 就当视频
+    "unknown".into()
+}
+
 /// 从 knowledge/cards HTML 中兜底抠 objectId / jobid
 fn scrape_tasks_from_cards_html(html: &str, knowledge_id: &str) -> Vec<Value> {
     let mut tasks = Vec::new();
@@ -3388,6 +3570,8 @@ fn scrape_tasks_from_cards_html(html: &str, knowledge_id: &str) -> Vec<Value> {
         regex::Regex::new(r#"(?i)(?:objectid|objectId|object_id)["'\s:=]+([a-f0-9]{16,})"#).ok();
     let re_job = regex::Regex::new(r#"(?i)(?:jobid|jobId)["'\s:=]+([a-zA-Z0-9_\-]+)"#).ok();
     let re_name = regex::Regex::new(r#""name"\s*:\s*"([^"]{1,120})""#).ok();
+    let re_module = regex::Regex::new(r#""module"\s*:\s*"([^"]{1,80})""#).ok();
+    let re_type = regex::Regex::new(r#""type"\s*:\s*"([^"]{1,40})""#).ok();
 
     if let Some(re) = re_oid {
         for (idx, cap) in re.captures_iter(html).enumerate() {
@@ -3404,17 +3588,33 @@ fn scrape_tasks_from_cards_html(html: &str, knowledge_id: &str) -> Vec<Value> {
                 .as_ref()
                 .and_then(|rn| rn.captures_iter(html).nth(idx))
                 .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
-                .unwrap_or_else(|| format!("视频 {}", idx + 1));
+                .unwrap_or_else(|| format!("任务 {}", idx + 1));
+            let module = re_module
+                .as_ref()
+                .and_then(|rm| rm.captures_iter(html).nth(idx))
+                .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+                .unwrap_or_default();
+            let att_type = re_type
+                .as_ref()
+                .and_then(|rt| rt.captures_iter(html).nth(idx))
+                .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+                .unwrap_or_default();
+            let kind = infer_attachment_kind(&att_type, &module, &name);
+            let module_out = if module.is_empty() {
+                "unknown".to_string()
+            } else {
+                module
+            };
             tasks.push(json!({
                 "id": if jobid.is_empty() { format!("{knowledge_id}-{idx}") } else { jobid.clone() },
                 "title": name,
                 "name": name,
-                "type": "video",
-                "task_type": "video",
+                "type": kind.clone(),
+                "task_type": kind,
                 "objectId": oid.clone(),
                 "object_id": oid,
                 "jobid": jobid,
-                "module": "insertvideo",
+                "module": module_out,
                 "otherInfo": "",
                 "attDuration": "0",
                 "attDurationEnc": "",
@@ -3678,34 +3878,15 @@ pub async fn chaoxing_get_knowledge_cards(
             .or_else(|| att.get("passed").and_then(|v| v.as_bool()))
             .unwrap_or(false);
 
-        let kind = if att_type == "video"
-            || module.contains("video")
-            || module.eq_ignore_ascii_case("insertvideo")
-        {
-            "video"
-        } else if att_type == "document"
-            || module.contains("doc")
-            || module.contains("pdf")
-            || module.contains("book")
-            || module.contains("insertbook")
-        {
-            "document"
-        } else if att_type == "work" || module.contains("work") {
-            "work"
-        } else if att_type.is_empty() && !object_id.is_empty() {
-            "video"
-        } else if att_type.is_empty() {
-            "task"
-        } else {
-            att_type.as_str()
-        };
+        // 以后端 type/module/文件名为准；有 objectId 也不默认 video
+        let kind = infer_attachment_kind(&att_type, &module, &name);
 
         let task = json!({
             "id": if !jobid.is_empty() { jobid.clone() } else { format!("{knowledge_id}-{idx}") },
             "title": if name.is_empty() { format!("任务 {}", idx + 1) } else { name.clone() },
             "name": name,
-            "type": kind,
-            "task_type": kind,
+            "type": kind.clone(),
+            "task_type": kind.clone(),
             "objectId": object_id.clone(),
             "object_id": object_id,
             "jobid": jobid,
@@ -4083,6 +4264,10 @@ pub async fn chaoxing_get_video_status(
                 }
 
                 let play_urls = collect_play_urls(&data);
+                // 官方 ananas 播放器页：直链被 CDN 拒时可由前端 iframe 兜底
+                let player_url = format!(
+                    "https://mooc1.chaoxing.com/ananas/modules/video/index.html?objectid={oid}&fid={fid_s}&isPhone=true"
+                );
                 let mut out = data.clone();
                 if let Some(obj) = out.as_object_mut() {
                     if let Some(first) = play_urls.first() {
@@ -4091,6 +4276,7 @@ pub async fn chaoxing_get_video_status(
                         obj.insert("http".into(), json!(first));
                     }
                     obj.insert("play_urls".into(), json!(play_urls.clone()));
+                    obj.insert("player_url".into(), json!(player_url.clone()));
                 }
                 if play_urls.is_empty() && status != "success" && status.is_empty() {
                     last_err = "响应无播放地址".into();
@@ -4101,6 +4287,7 @@ pub async fn chaoxing_get_video_status(
                     "data": out,
                     "play_url": play_urls.first().cloned().unwrap_or_default(),
                     "play_urls": play_urls,
+                    "player_url": player_url,
                 }));
             }
             Err(e) => last_err = e.to_string(),
@@ -4403,5 +4590,59 @@ mod catalog_and_video_tests {
             .iter()
             .any(|u| u.contains("s1.ananas.chaoxing.com/status/obj123")));
         assert!(urls.iter().all(|u| u.contains("_dc=99")));
+    }
+
+    #[test]
+    fn infer_attachment_kind_does_not_default_object_to_video() {
+        assert_eq!(infer_attachment_kind("video", "", ""), "video");
+        assert_eq!(infer_attachment_kind("document", "", ""), "document");
+        assert_eq!(
+            infer_attachment_kind("", "insertbook", "课件.pptx"),
+            "document"
+        );
+        assert_eq!(
+            infer_attachment_kind("", "", "第1章 绪论.pdf"),
+            "document"
+        );
+        assert_eq!(
+            infer_attachment_kind("", "insertvideo", "讲解.mp4"),
+            "video"
+        );
+        // 仅有 objectId 场景：att_type/module/name 皆空 → unknown，禁止 video
+        assert_eq!(infer_attachment_kind("", "", ""), "unknown");
+        assert_eq!(infer_attachment_kind("", "", "未命名资源"), "unknown");
+    }
+
+    #[test]
+    fn semester_from_date_str_covers_timestamp_and_ymd() {
+        assert!(semester_from_date_str("2024-09-01")
+            .unwrap_or_default()
+            .contains("第一学期"));
+        assert!(semester_from_date_str("2025-03-01")
+            .unwrap_or_default()
+            .contains("第二学期"));
+        // 2024-09-01 00:00 UTC 附近毫秒
+        let ms = "1725148800000";
+        assert!(semester_from_date_str(ms).is_some());
+    }
+
+    #[test]
+    fn guess_semester_label_avoids_fake_current_term() {
+        let content = json!({});
+        let item = json!({});
+        let label = guess_semester_label(&content, &item, None);
+        assert_eq!(label, "未分学期");
+
+        let content2 = json!({ "begindate": "2023-09-10" });
+        let label2 = guess_semester_label(&content2, &item, None);
+        assert!(label2.contains("2023") || label2.contains("学期"));
+    }
+
+    #[test]
+    fn extract_folder_array_nested() {
+        let v = json!({ "data": { "list": [{ "id": 1, "name": "2023-2024" }] } });
+        let arr = extract_folder_array(&v);
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], 1);
     }
 }

--- a/src/components/ChaoxingHubView.vue
+++ b/src/components/ChaoxingHubView.vue
@@ -31,7 +31,7 @@ const PIE_COLORS = ['#2563eb', '#7c3aed', '#06b6d4', '#f59e0b', '#ef4444', '#10b
 
 /**
  * 导航栈
- * list → course → section → knowledge → video | score
+ * list → course → section → knowledge → video | document | score
  */
 const stack = ref([{ level: 'list' }])
 
@@ -50,6 +50,8 @@ const breadcrumbs = computed(() => {
     else if (frame.level === 'score') items.push({ key: 'score', label: '成绩' })
     else if (frame.level === 'video')
       items.push({ key: 'video', label: frame.task?.title || '视频' })
+    else if (frame.level === 'document')
+      items.push({ key: 'document', label: frame.task?.title || '文档' })
   }
   return items
 })
@@ -62,6 +64,7 @@ const pageTitle = computed(() => {
   if (c.level === 'knowledge') return c.knowledge?.title || '任务'
   if (c.level === 'score') return '成绩组成'
   if (c.level === 'video') return c.task?.title || '视频'
+  if (c.level === 'document') return c.task?.title || '文档'
   return '课程中心'
 })
 
@@ -96,17 +99,26 @@ const normalizeCourse = (item = {}) => {
     ),
     pendingCount: safeNumber(raw.pending_count ?? raw.pendingCount ?? 0),
     courseUrl: safeText(raw.course_url || raw.courseUrl || raw.url || ''),
-    semester: safeText(raw.semester || raw.term || '本学期') || '本学期'
+    // 缺省用「未分学期」，避免全量标成「本学期」掩盖多学期问题
+    semester: safeText(raw.semester || raw.term || '未分学期') || '未分学期'
   }
 }
 
 const typeMetaOf = (typeRaw) => {
   const t = safeText(typeRaw).toLowerCase()
   if (t.includes('video') || t === '视频') return { text: '视频', type: 'info', kind: 'video' }
-  if (t.includes('doc') || t.includes('pdf') || t === 'document' || t === '文档')
+  if (
+    t.includes('doc') ||
+    t.includes('pdf') ||
+    t.includes('ppt') ||
+    t.includes('book') ||
+    t === 'document' ||
+    t === '文档'
+  )
     return { text: '文档', type: 'warning', kind: 'document' }
   if (t.includes('work') || t === '作业') return { text: '作业', type: 'danger', kind: 'work' }
   if (t === 'knowledge' || t === '章节') return { text: '小节', type: 'primary', kind: 'knowledge' }
+  if (t === 'unknown' || t === '未知') return { text: '未知类型', type: 'muted', kind: 'unknown' }
   return { text: safeText(typeRaw) || '任务', type: 'muted', kind: 'task' }
 }
 
@@ -135,21 +147,31 @@ const normalizeSection = (raw = {}) => {
 }
 
 const normalizeTaskItem = (raw = {}) => {
-  const typeRaw = raw.type || raw.task_type || ''
-  const meta = typeMetaOf(typeRaw)
+  // 类型以后端 type/task_type 为准，禁止仅凭 objectId 强制 video
+  const typeRaw = raw.type || raw.task_type || raw.module || ''
+  const title = safeText(raw.title || raw.name || '未命名任务')
+  let meta = typeMetaOf(typeRaw)
+  // 后端 unknown/task 时，用文件名扩展名再推断一次（仅前端展示）
+  if (meta.kind === 'task' || meta.kind === 'unknown') {
+    const lower = title.toLowerCase()
+    if (/\.(pdf|ppt|pptx|doc|docx|xls|xlsx|txt)$/i.test(lower) || /课件|讲义|幻灯/.test(title)) {
+      meta = { text: '文档', type: 'warning', kind: 'document' }
+    } else if (/\.(mp4|flv|m3u8|mov|avi|mkv|webm)$/i.test(lower)) {
+      meta = { text: '视频', type: 'info', kind: 'video' }
+    }
+  }
   const objectId = safeText(
     raw.objectId || raw.object_id || raw.property?.objectid || raw.property?.objectId
   )
-  // 有 objectId 且类型未知时按视频处理
-  const kind = meta.kind === 'task' && objectId ? 'video' : meta.kind
+  const kind = meta.kind
   return {
     id: safeText(raw.id || raw.jobid || raw.objectId || raw.object_id || Math.random()),
-    title: safeText(raw.title || raw.name || '未命名任务'),
+    title,
     objectId,
     jobid: safeText(raw.jobid || raw.jobId),
     completed: !!(raw.completed || raw.isPassed),
     status: safeText(raw.status || (raw.completed || raw.isPassed ? '已完成' : '未完成')),
-    typeMeta: kind === 'video' ? { text: '视频', type: 'info', kind: 'video' } : meta,
+    typeMeta: meta,
     kind,
     empty_hint: !!(raw.empty_hint || raw.emptyHint)
   }
@@ -301,16 +323,29 @@ const loadList = async ({ silent = false, force = false } = {}) => {
     for (const s of [...fromApi, ...fromCourses]) {
       if (!merged.includes(s)) merged.push(s)
     }
-    // 本学期优先
+    // 本学期优先，未分学期靠后
     merged.sort((a, b) => {
-      if (a === '本学期') return -1
-      if (b === '本学期') return 1
+      const rank = (s) => {
+        if (s === '本学期') return 0
+        if (String(s).includes('年') || String(s).includes('学期')) return 1
+        if (s === '历史课程') return 2
+        if (s === '未分学期') return 4
+        return 3
+      }
+      const d = rank(a) - rank(b)
+      if (d !== 0) return d
       return String(b).localeCompare(String(a), 'zh')
     })
     semesterTabs.value = ['全部', ...merged]
     if (!semesterTabs.value.includes(activeSemester.value)) {
       activeSemester.value = '全部'
     }
+    pushDebugLog(
+      'ChaoxingHub',
+      `学期列表 count=${merged.length} labels=${merged.join('|') || '(空)'} folder_extra=${courseRes?.folder_extra ?? 'n/a'}`,
+      merged.length <= 1 ? 'warn' : 'info',
+      { semesters: merged, from_api: fromApi, from_courses: fromCourses }
+    )
   } catch (e) {
     error.value = safeText(e?.message || e) || '加载失败'
   } finally {
@@ -512,6 +547,22 @@ const collectPlayUrls = (st = {}, top = {}) => {
   return list
 }
 
+const collectDocUrls = (st = {}, top = {}) => {
+  const list = []
+  const push = (u) => {
+    const https = preferHttps(u)
+    if (!https || !https.startsWith('http')) return
+    if (!list.includes(https)) list.push(https)
+  }
+  if (Array.isArray(top.play_urls)) top.play_urls.forEach(push)
+  if (Array.isArray(st.play_urls)) st.play_urls.forEach(push)
+  ;['https', 'http', 'download', 'pdf', 'url', 'preview', 'previewUrl', 'hd', 'sd'].forEach((k) => {
+    push(st[k])
+    push(top[k])
+  })
+  return list
+}
+
 const openVideo = async (course, section, knowledge, task, meta) => {
   if (!task.objectId) {
     showToast('该任务没有可播放资源')
@@ -528,7 +579,11 @@ const openVideo = async (course, section, knowledge, task, meta) => {
     if (res?.success === false) throw new Error(res?.error || '视频状态失败')
     const st = res?.data && typeof res.data === 'object' ? res.data : res
     const playUrls = collectPlayUrls(st, res || {})
-    if (!playUrls.length) {
+    const playerUrl = preferHttps(
+      safeText(res?.player_url || st.player_url || '') ||
+        `https://mooc1.chaoxing.com/ananas/modules/video/index.html?objectid=${encodeURIComponent(task.objectId)}&fid=${encodeURIComponent(meta?.fid || '0')}&isPhone=true`
+    )
+    if (!playUrls.length && !playerUrl) {
       throw new Error(
         st.status && st.status !== 'success'
           ? `视频不可用（${st.status}）`
@@ -541,8 +596,10 @@ const openVideo = async (course, section, knowledge, task, meta) => {
       section,
       knowledge,
       task,
-      src: playUrls[0],
+      src: playUrls[0] || '',
       playUrls,
+      playerUrl,
+      usePlayer: !playUrls.length,
       poster: preferHttps(safeText(st.screenshot || st.thumb || '')),
       filename: safeText(st.filename || task.title),
       duration: safeNumber(st.duration)
@@ -554,17 +611,86 @@ const openVideo = async (course, section, knowledge, task, meta) => {
   }
 }
 
-const onVideoError = () => {
-  const urls = current.value?.playUrls || []
-  if (videoSrcIndex.value + 1 < urls.length) {
-    videoSrcIndex.value += 1
-    videoError.value = `线路 ${videoSrcIndex.value} 失败，切换备用地址…`
+/** 文档/PPT：走 ananas status 取直链或官方预览页，禁止 openVideo */
+const openDocument = async (course, section, knowledge, task, meta) => {
+  if (!task.objectId) {
+    showToast(`文档「${task.title}」无可预览资源（缺少 objectId）`)
     return
   }
-  // 优先展示后端/播放器给出的具体原因，避免永远笼统「CDN/会话」
-  const detail = safeText(e?.message || e || '')
+  pageLoading.value = true
+  try {
+    const res = await cxInvoke('chaoxing_get_video_status', {
+      object_id: task.objectId,
+      fid: meta?.fid || '0'
+    })
+    if (res?.success === false) throw new Error(res?.error || '文档状态失败')
+    const st = res?.data && typeof res.data === 'object' ? res.data : res
+    const docUrls = collectDocUrls(st, res || {})
+    const filename = safeText(st.filename || task.title)
+    // 官方 PDF/文档模块页（无签名时仍可能依赖会话 cookie）
+    const officialPreview = preferHttps(
+      `https://mooc1.chaoxing.com/ananas/modules/pdf/index.html?objectid=${encodeURIComponent(task.objectId)}&fid=${encodeURIComponent(meta?.fid || '0')}`
+    )
+    const previewUrl = docUrls[0] || officialPreview
+    if (!previewUrl) {
+      showToast(`文档「${filename || task.title}」暂无预览地址，请在学习通网页端打开`)
+      return
+    }
+    push({
+      level: 'document',
+      course,
+      section,
+      knowledge,
+      task,
+      src: previewUrl,
+      candidates: docUrls.length ? docUrls : [officialPreview],
+      filename,
+      fileType: safeText(st.fileType || st.filetype || task.typeMeta?.text || '文档')
+    })
+  } catch (e) {
+    const msg = safeText(e?.message || e) || '文档打开失败'
+    showToast(`文档预览失败：${msg}`)
+  } finally {
+    pageLoading.value = false
+  }
+}
+
+const mediaErrorMessage = (ev) => {
+  try {
+    const el = ev?.target || ev?.currentTarget
+    const code = el?.error?.code
+    // MEDIA_ERR_*: 1=aborted 2=network 3=decode 4=src not supported
+    const map = {
+      1: '加载中止',
+      2: '网络错误（可能被 CDN 拒绝或会话失效）',
+      3: '解码失败',
+      4: '格式不支持或地址无效'
+    }
+    if (code && map[code]) return map[code]
+    if (el?.error?.message) return String(el.error.message)
+  } catch {
+    // ignore
+  }
+  return ''
+}
+
+const onVideoError = (ev) => {
+  const frame = current.value
+  const urls = frame?.playUrls || []
+  if (videoSrcIndex.value + 1 < urls.length) {
+    videoSrcIndex.value += 1
+    videoError.value = `线路 ${videoSrcIndex.value + 1}/${urls.length} 失败，切换备用地址…`
+    return
+  }
+  // 直链耗尽：尝试官方 ananas 播放器页
+  if (frame?.playerUrl && !frame.usePlayer) {
+    frame.usePlayer = true
+    videoError.value = '直链播放失败，已切换学习通官方播放器…'
+    return
+  }
+  const detail = mediaErrorMessage(ev)
   videoError.value = detail
-    ? `视频播放失败：${detail}`
+    ? `视频播放失败：${detail}。请重试、切换线路或重新登录学习通`
     : '视频播放失败：无法解析播放地址或被 CDN 拒绝。请重试，或重新登录学习通后再打开'
 }
 
@@ -588,11 +714,24 @@ const retryVideo = () => {
 
 const onTaskClick = (frame, task) => {
   if (task.empty_hint || task.status === '无可播放任务') {
-    showToast('该小节没有视频任务点')
+    showToast('该小节暂无任务点')
     return
   }
-  if (task.kind === 'video' || task.objectId) {
+  // 严格按 kind 分流：禁止 objectId 一律当视频
+  if (task.kind === 'video') {
     void openVideo(frame.course, frame.section, frame.knowledge, task, frame.meta)
+    return
+  }
+  if (task.kind === 'document') {
+    void openDocument(frame.course, frame.section, frame.knowledge, task, frame.meta)
+    return
+  }
+  if (task.kind === 'work') {
+    showToast(`作业「${task.title}」请在学习通网页端完成`)
+    return
+  }
+  if (task.kind === 'unknown' && task.objectId) {
+    showToast(`未知类型任务「${task.title}」，暂不按视频打开`)
     return
   }
   showToast(`${task.typeMeta?.text || '任务'}：${task.title}`)
@@ -673,7 +812,16 @@ onMounted(() => {
           <div class="hero-row">
             <div>
               <strong>我的课程</strong>
-              <p>{{ courses.length }} 门 · {{ semesterTabs.length > 1 ? semesterTabs.length - 1 + ' 个学期' : '本学期' }}</p>
+              <p>
+                {{ courses.length }} 门 ·
+                {{
+                  semesterTabs.length > 2
+                    ? semesterTabs.length - 1 + ' 个学期'
+                    : semesterTabs.length === 2
+                      ? semesterTabs[1]
+                      : '学期待同步'
+                }}
+              </p>
             </div>
             <TStatusBadge :type="badgeType" :text="badgeText" />
           </div>
@@ -959,13 +1107,23 @@ onMounted(() => {
         </section>
       </template>
 
-      <!-- 6. 应用内视频 -->
+      <!-- 6. 应用内视频（直链优先，失败切 ananas 官方播放器） -->
       <template v-else-if="current.level === 'video'">
         <section class="panel video-panel">
           <p class="crumb">{{ current.knowledge?.title }}</p>
           <h3 class="video-title">{{ current.filename || current.task?.title }}</h3>
           <p v-if="current.duration" class="hint">时长 {{ formatDuration(current.duration) }}</p>
+          <iframe
+            v-if="current.usePlayer && current.playerUrl"
+            :key="'player-' + current.playerUrl"
+            class="video-el doc-frame"
+            :src="current.playerUrl"
+            title="学习通视频播放器"
+            allow="autoplay; fullscreen"
+            referrerpolicy="no-referrer-when-downgrade"
+          />
           <video
+            v-else
             :key="activeVideoSrc"
             class="video-el"
             controls
@@ -983,7 +1141,7 @@ onMounted(() => {
               重新加载
             </button>
             <button
-              v-if="(current.playUrls || []).length > 1"
+              v-if="(current.playUrls || []).length > 1 && !current.usePlayer"
               type="button"
               class="chip-btn ghost light"
               @click="
@@ -993,8 +1151,56 @@ onMounted(() => {
             >
               切换线路 {{ videoSrcIndex + 1 }}/{{ current.playUrls.length }}
             </button>
+            <button
+              v-if="current.playerUrl && !current.usePlayer"
+              type="button"
+              class="chip-btn ghost light"
+              @click="
+                current.usePlayer = true;
+                videoError = ''
+              "
+            >
+              官方播放器
+            </button>
           </div>
-          <p class="hint">播放在应用内完成，不跳转浏览器</p>
+          <p class="hint">
+            {{ current.usePlayer ? '官方 ananas 播放器（应用内）' : '直链播放，失败可切换官方播放器' }}
+          </p>
+        </section>
+      </template>
+
+      <!-- 7. 文档/PPT 预览 -->
+      <template v-else-if="current.level === 'document'">
+        <section class="panel video-panel">
+          <p class="crumb">{{ current.knowledge?.title }}</p>
+          <h3 class="video-title">{{ current.filename || current.task?.title }}</h3>
+          <p class="hint">类型：{{ current.fileType || '文档' }}</p>
+          <iframe
+            v-if="current.src"
+            :key="current.src"
+            class="video-el doc-frame"
+            :src="current.src"
+            title="文档预览"
+            referrerpolicy="no-referrer-when-downgrade"
+          />
+          <p v-else class="video-err">暂无预览地址</p>
+          <div class="btn-row video-actions">
+            <button
+              v-if="(current.candidates || []).length > 1"
+              type="button"
+              class="chip-btn ghost light"
+              @click="
+                (() => {
+                  const list = current.candidates || []
+                  const i = Math.max(0, list.indexOf(current.src))
+                  current.src = list[(i + 1) % list.length]
+                })()
+              "
+            >
+              切换预览源
+            </button>
+          </div>
+          <p class="hint">文档在应用内预览；若空白请确认学习通会话有效</p>
         </section>
       </template>
     </div>
@@ -1627,6 +1833,12 @@ onMounted(() => {
   background: #000;
   max-height: 50vh;
   margin-top: 8px;
+}
+.doc-frame {
+  border: 0;
+  min-height: 55vh;
+  max-height: 70vh;
+  background: #fff;
 }
 .video-err {
   color: #fca5a5;


### PR DESCRIPTION
## Summary
- 修复文档/PPT 被误判为视频（前后端类型推断，未知不再默认 video）
- 视频线路失败后回落 ananas 官方播放器；修复 onVideoError 未定义变量
- 学期标签避免一律「本学期」；folder 解析与调试日志增强

## Test plan
- [x] cargo test --lib catalog_and_video_tests (8 passed)
- [x] Bridge: POST /debug/chaoxing/session connected；/debug/chaoxing/courses 返回课程
- [x] Bridge navigate chaoxing_hub + screenshot

Fixes #494