### PR TITLE
fix(#493): 审核 guest/demo 隐藏学习通一码通与敏感模块

### DIFF
--- a/src/components/Dashboard.spec.ts
+++ b/src/components/Dashboard.spec.ts
@@ -26,4 +26,14 @@ describe('Dashboard quick entry defaults', () => {
     expect(darkCss).toContain('html.dark .bg-blue-50')
     expect(darkCss).toContain('html.dark .quick-entry-editor-item--selected')
   })
+
+  it('App Store guest/demo: drops empty feature categories and filters quick entries', () => {
+    const vue = source()
+    // 空分组（学习通/一码通被滤空后）不得残留 tab 标题
+    expect(vue).toContain('return cats.filter((c) => Array.isArray(c.modules) && c.modules.length > 0)')
+    // 快捷入口与编辑器均走 isModuleAllowed
+    expect(vue).toContain('isModuleAllowed(item.id, appStoreSessionOpts())')
+    expect(vue).toContain('editableQuickEntryMeta')
+    expect(vue).toContain('v-for="(meta, id) in editableQuickEntryMeta"')
+  })
 })

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -543,12 +543,48 @@ const homeWidgetOrder = computed(() => isHomeLayoutEditing.value ? draftHomeWidg
 const isChaoxingLogin = computed(() => isChaoxingMethod(loginMethod.value))
 const homeCollisionFx = ref([])
 
-const moduleCategories = computed(() => [
-  { title: '教务服务', modules: modules.value.filter(m => ['grades', 'exams', 'ranking', 'academic', 'qxzkb', 'course_selection', 'training', 'teaching_eval', 'classroom', 'calendar', 'school_inbox'].includes(m.id)) },
-  { title: '学习通', modules: modules.value.filter(m => ['chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class'].includes(m.id)) },
-  { title: '一码通', modules: modules.value.filter(m => ['campus_code', 'electricity', 'transactions', 'broadband', 'sports_venue'].includes(m.id)) },
-  { title: '资源', modules: modules.value.filter(m => ['library', 'campus_map', 'resource_share', 'towergo', 'ai'].includes(m.id)) }
-])
+// 合规 guest/demo 下学习通、一码通等整组会被滤空：不渲染空分组标题，避免误导审核员
+const moduleCategories = computed(() => {
+  const cats = [
+    {
+      title: '教务服务',
+      modules: modules.value.filter((m) =>
+        [
+          'grades',
+          'exams',
+          'ranking',
+          'academic',
+          'qxzkb',
+          'course_selection',
+          'training',
+          'teaching_eval',
+          'classroom',
+          'calendar',
+          'school_inbox'
+        ].includes(m.id)
+      )
+    },
+    {
+      title: '学习通',
+      modules: modules.value.filter((m) =>
+        ['chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class'].includes(m.id)
+      )
+    },
+    {
+      title: '一码通',
+      modules: modules.value.filter((m) =>
+        ['campus_code', 'electricity', 'transactions', 'broadband', 'sports_venue'].includes(m.id)
+      )
+    },
+    {
+      title: '资源',
+      modules: modules.value.filter((m) =>
+        ['library', 'campus_map', 'resource_share', 'towergo', 'ai'].includes(m.id)
+      )
+    }
+  ]
+  return cats.filter((c) => Array.isArray(c.modules) && c.modules.length > 0)
+})
 
 const handleCategoryModuleClick = (moduleId) => { showAllModules.value = false; navigateTo(moduleId) }
 
@@ -872,6 +908,12 @@ const QUICK_ENTRY_KEY = 'hbu_quick_entry_modules'
 const HOME_FEATURE_TAB_KEY = 'hbu_home_feature_tab'
 const defaultQuickEntries = ['grades', 'exams', 'classroom', 'electricity', 'ranking']
 
+/** 合规策略会话参数：与 modules / navigateTo 保持一致 */
+const appStoreSessionOpts = () => ({
+  isLoggedIn: props.isLoggedIn,
+  isDemoSession: isTestAccountSession()
+})
+
 const quickEntryIds = ref([...defaultQuickEntries])
 const showQuickEntryEditor = ref(false)
 const draftQuickEntries = ref([...defaultQuickEntries])
@@ -888,18 +930,27 @@ const loadQuickEntries = () => {
 }
 
 const saveQuickEntries = () => {
-  quickEntryIds.value = [...draftQuickEntries.value]
+  const session = appStoreSessionOpts()
+  // 再次过滤：防止草稿残留被禁 id
+  const next = draftQuickEntries.value.filter((id) => isModuleAllowed(id, session))
+  if (next.length !== 5) {
+    showToast('请选择 5 个可用模块')
+    return
+  }
+  quickEntryIds.value = next
   localStorage.setItem(QUICK_ENTRY_KEY, JSON.stringify(quickEntryIds.value))
   showQuickEntryEditor.value = false
   showToast('快捷入口已更新', 'success')
 }
 
 const openQuickEntryEditor = () => {
-  draftQuickEntries.value = [...quickEntryIds.value]
+  const session = appStoreSessionOpts()
+  draftQuickEntries.value = quickEntryIds.value.filter((id) => isModuleAllowed(id, session))
   showQuickEntryEditor.value = true
 }
 
 const toggleDraftEntry = (id) => {
+  if (!isModuleAllowed(id, appStoreSessionOpts())) return
   const idx = draftQuickEntries.value.indexOf(id)
   if (idx >= 0) { draftQuickEntries.value.splice(idx, 1) }
   else if (draftQuickEntries.value.length < 5) { draftQuickEntries.value.push(id) }
@@ -935,8 +986,19 @@ const quickEntryMeta = {
   ai: { name: '校园助手', icon: 'fa-robot', color: 'bg-gray-50', iconColor: 'text-gray-500' }
 }
 
+// 快捷入口也走策略过滤：默认含 electricity/ranking，guest/demo 不得展示被禁模块
 const quickEntryItems = computed(() => {
-  return quickEntryIds.value.map(id => ({ id, ...quickEntryMeta[id] })).filter(item => item.name)
+  return quickEntryIds.value
+    .map((id) => ({ id, ...quickEntryMeta[id] }))
+    .filter((item) => item.name && isModuleAllowed(item.id, appStoreSessionOpts()))
+})
+
+/** 编辑器可选模块：同样隐藏合规收紧会话下的被禁入口 */
+const editableQuickEntryMeta = computed(() => {
+  const session = appStoreSessionOpts()
+  return Object.fromEntries(
+    Object.entries(quickEntryMeta).filter(([id]) => isModuleAllowed(id, session))
+  )
 })
 
 const handleQuickEntryClick = (id) => {
@@ -962,6 +1024,19 @@ const persistHomeFeatureTab = () => {
     // ignore storage failure
   }
 }
+
+// 空分组被滤掉后，若缓存 tab 指向「学习通/一码通」等，回落到首个可见分类
+watch(
+  moduleCategories,
+  (cats) => {
+    if (!cats.length) return
+    if (!cats.some((c) => c.title === activeFeatureTab.value)) {
+      activeFeatureTab.value = cats[0].title
+      persistHomeFeatureTab()
+    }
+  },
+  { immediate: true }
+)
 /** 所有功能宫格列数（与 template grid-cols-4 一致） */
 const FEATURE_GRID_COLS = 4
 
@@ -1797,7 +1872,7 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
           <p class="text-xs text-gray-500 mb-4">选择 5 个模块作为快捷入口（已选 {{ draftQuickEntries.length }}/5）</p>
           <div class="grid grid-cols-4 gap-3 mb-6">
             <div
-              v-for="(meta, id) in quickEntryMeta"
+              v-for="(meta, id) in editableQuickEntryMeta"
               :key="id"
               class="quick-entry-editor-item flex flex-col items-center p-2 rounded-xl cursor-pointer border-2 transition-all"
               :class="draftQuickEntries.includes(id) ? 'quick-entry-editor-item--selected' : 'border-transparent'"

--- a/src/config/accessible_view.spec.ts
+++ b/src/config/accessible_view.spec.ts
@@ -4,11 +4,15 @@ import {
   resolvePolicySafeSnapshotView,
   resolvePolicySafeView
 } from './accessible_view'
-import { setAppStoreBuildOverrideForTests } from './app_store_policy'
+import {
+  setAppStoreBuildOverrideForTests,
+  setAppStoreSessionOverrideForTests
+} from './app_store_policy'
 
 describe('accessible_view (hash / history / resume path)', () => {
   afterEach(() => {
     setAppStoreBuildOverrideForTests(null)
+    setAppStoreSessionOverrideForTests(null)
   })
 
   it('flag off: hash campus_code stays campus_code', () => {
@@ -20,23 +24,54 @@ describe('accessible_view (hash / history / resume path)', () => {
 
   it('flag on: hash #/{sid}/campus_code cannot open blocked view', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     const route = resolvePolicySafeHashRoute('#/2026000001/campus_code')
     expect(route).not.toBeNull()
     expect(route!.sid).toBe('2026000001')
     expect(route!.view).toBe('home')
   })
 
+  it('flag on + guest: deep link into 学习通/一码通 extensions falls back to home', () => {
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
+    for (const view of [
+      'chaoxing_hub',
+      'chaoxing_inbox',
+      'chaoxing_class',
+      'broadband',
+      'sports_venue',
+      'teaching_eval',
+      'electricity',
+      'transactions'
+    ]) {
+      expect(resolvePolicySafeView(view), view).toBe('home')
+      expect(resolvePolicySafeHashRoute(`#/2026000001/${view}`)?.view, view).toBe('home')
+    }
+  })
+
+  it('flag on + demo session: deep link into blocked modules falls back to home', () => {
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: true, isDemoSession: true })
+    expect(resolvePolicySafeView('chaoxing_hub')).toBe('home')
+    expect(resolvePolicySafeView('broadband')).toBe('home')
+    expect(resolvePolicySafeHashRoute('#/2026000001/sports_venue')?.view).toBe('home')
+    expect(resolvePolicySafeSnapshotView({ view: 'teaching_eval' }, 'me')).toBe('home')
+  })
+
   it('flag on: history/resume snapshot cannot restore more_module_host or electricity', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     expect(
       resolvePolicySafeSnapshotView({ view: 'more_module_host', module: 'jump_out' }, 'me')
     ).toBe('home')
     expect(resolvePolicySafeSnapshotView({ view: 'electricity' }, 'home')).toBe('home')
+    expect(resolvePolicySafeSnapshotView({ view: 'chaoxing_hub' }, 'home')).toBe('home')
     expect(resolvePolicySafeSnapshotView({ tab: 'schedule' }, 'home')).toBe('schedule')
   })
 
   it('flag on: allowed core views still resolve', () => {
     setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
     expect(resolvePolicySafeHashRoute('#/2026000001/grades')?.view).toBe('grades')
     expect(resolvePolicySafeHashRoute('#/2026000001/schedule')?.view).toBe('schedule')
     expect(resolvePolicySafeView('privacy_data')).toBe('privacy_data')

--- a/src/config/app_store_policy.spec.ts
+++ b/src/config/app_store_policy.spec.ts
@@ -68,6 +68,12 @@ describe('app_store_policy', () => {
       'transactions',
       'resource_share',
       'chaoxing_class',
+      // 学习通 / 一码通扩展入口（#493 显式黑名单）
+      'chaoxing_hub',
+      'chaoxing_inbox',
+      'broadband',
+      'sports_venue',
+      'teaching_eval',
       'ai',
       'more',
       'more_module_host',
@@ -93,6 +99,40 @@ describe('app_store_policy', () => {
     expect(isModuleAllowed('course_selection')).toBe(false)
     expect(isViewAllowed('more_module_host')).toBe(false)
     expect(getFeaturePolicy().remoteCode).toBe(false)
+    // 演示账号 reviewer：学习通 / 一码通扩展模块同样不可用
+    for (const id of [
+      'chaoxing_hub',
+      'chaoxing_inbox',
+      'chaoxing_class',
+      'broadband',
+      'sports_venue',
+      'teaching_eval',
+      'electricity',
+      'transactions'
+    ]) {
+      expect(isModuleAllowed(id), id).toBe(false)
+      expect(isDeepLinkAllowed(id), id).toBe(false)
+    }
+  })
+
+  it('flag on + guest: explicit blacklist covers 学习通/一码通 extension ids', () => {
+    setAppStoreBuildOverrideForTests(true)
+    setAppStoreSessionOverrideForTests({ isLoggedIn: false, isDemoSession: false })
+    // 即便未走默认拒绝路径，黑名单也必须显式命中（审核清单可核对）
+    for (const id of [
+      'chaoxing_hub',
+      'chaoxing_inbox',
+      'broadband',
+      'sports_venue',
+      'teaching_eval'
+    ]) {
+      expect(isModuleAllowed(id), `module ${id}`).toBe(false)
+      expect(isViewAllowed(id), `view ${id}`).toBe(false)
+      expect(isDeepLinkAllowed(id), `deeplink ${id}`).toBe(false)
+    }
+    // 默认拒绝边界：完全未知 id 同样 false
+    expect(isModuleAllowed('future_sensitive_module_xyz')).toBe(false)
+    expect(isViewAllowed('future_sensitive_module_xyz')).toBe(false)
   })
 
   it('flag on + real logged-in: unlocks full feature tree', () => {

--- a/src/config/app_store_policy.ts
+++ b/src/config/app_store_policy.ts
@@ -226,30 +226,43 @@ export function getFeaturePolicy(session?: {
   return shouldApplyAppStoreRestrictions(session) ? APP_STORE_POLICY : FULL_POLICY
 }
 
-/** 合规构建下禁止的 module / view id（与 Dashboard / App 路由对齐） */
+/**
+ * 合规构建下禁止的 module / view id（与 Dashboard / App 路由对齐）。
+ * 未列入白名单的 id 默认也会拒绝；此处显式列出学习通 / 一码通 / 敏感能力，
+ * 避免新增入口漏过滤，并保证单测与审核清单可逐项核对。
+ */
 export const APP_STORE_BLOCKED_MODULE_IDS: ReadonlySet<string> = Object.freeze(
   new Set([
+    // 教务写入 / 敏感学业
     'course_selection',
     'ranking',
     'qxzkb',
     'school_inbox',
+    'teaching_eval',
+    // 一码通与校园生活写操作
     'campus_code',
     'electricity',
     'transactions',
-    'resource_share',
+    'broadband',
+    'sports_venue',
+    'campus_network',
+    // 学习通（含签到与资料）
+    'chaoxing_hub',
+    'chaoxing_inbox',
     'chaoxing_class',
+    'more_chaoxing_checkin',
+    // 远程代码 / 出行 / 其它高风险
+    'resource_share',
     'towergo',
     'smart_orientation',
     'ai',
     'forum',
     'more',
     'more_module_host',
-    'more_chaoxing_checkin',
     'service_stats',
     'config',
     'school_website',
-    'quick_links',
-    'campus_network'
+    'quick_links'
   ])
 )
 


### PR DESCRIPTION
## Summary
- 合规包下 guest/demo 显式屏蔽 chaoxing_hub/inbox、broadband、sports_venue、teaching_eval 等
- Dashboard 空分组（学习通/一码通）不再残留
- 深链回落与单测补齐

## Test plan
- [x] vitest app_store / accessible_view / Dashboard 相关 31 passed

Fixes #493