### PR TITLE
fix(#491): 校园导览直达地图并移除打卡文化衫

### DIFF
--- a/src/composables/useGeolocation.ts
+++ b/src/composables/useGeolocation.ts
@@ -21,8 +21,13 @@ export function useGeolocation() {
    * 获取当前位置。
    * @param timeout 超时 ms
    * @param maximumAge 允许的缓存年龄 ms；0 表示强制刷新（校园导览 iOS 建议 0）
+   * @param enableHighAccuracy 是否启用高精度（部分机型室内高精度会直接失败）
    */
-  async function getCurrentPosition(timeout = 10000, maximumAge = 5000): Promise<GeoPosition> {
+  async function getCurrentPosition(
+    timeout = 10000,
+    maximumAge = 5000,
+    enableHighAccuracy = true
+  ): Promise<GeoPosition> {
     if (!available.value) {
       lastError.value = '当前设备不支持定位'
       pushDebugLog('Geo', lastError.value, 'warn', { available: false })
@@ -31,10 +36,12 @@ export function useGeolocation() {
 
     loading.value = true
     lastError.value = ''
-    pushDebugLog('Geo', `定位请求开始 timeout=${timeout}ms maximumAge=${maximumAge}`, 'debug', {
-      timeout,
-      maximumAge
-    })
+    pushDebugLog(
+      'Geo',
+      `定位请求开始 timeout=${timeout}ms maximumAge=${maximumAge} highAccuracy=${enableHighAccuracy}`,
+      'debug',
+      { timeout, maximumAge, enableHighAccuracy }
+    )
 
     return new Promise<GeoPosition>((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(
@@ -64,7 +71,7 @@ export function useGeolocation() {
           loading.value = false
           switch (err.code) {
             case err.PERMISSION_DENIED:
-              lastError.value = '定位权限被拒绝'
+              lastError.value = '定位权限被拒绝，请在系统设置中开启位置权限'
               break
             case err.POSITION_UNAVAILABLE:
               lastError.value = '无法获取位置信息'
@@ -77,12 +84,13 @@ export function useGeolocation() {
           }
           pushDebugLog('Geo', `定位失败: ${lastError.value}`, 'error', {
             code: err.code,
-            message: err.message
+            message: err.message,
+            enableHighAccuracy
           })
           reject(new Error(lastError.value))
         },
         {
-          enableHighAccuracy: true,
+          enableHighAccuracy: Boolean(enableHighAccuracy),
           timeout,
           maximumAge: Math.max(0, Number(maximumAge) || 0)
         }

--- a/src/features/campus-guide/components/EntranceMenu.vue
+++ b/src/features/campus-guide/components/EntranceMenu.vue
@@ -6,23 +6,17 @@ const emit = defineEmits<{
   activity: []
   bus: []
   mock: []
-  yunyou: []
-  punch: []
-  hub: []
   settings: []
 }>()
 </script>
 
 <template>
   <div class="campus-entrance-menu">
-    <button type="button" @click="emit('hub')">导览首页</button>
     <button type="button" @click="emit('about')">概况</button>
     <button type="button" @click="emit('route')">路线</button>
     <button type="button" @click="emit('collect')">收藏</button>
     <button type="button" @click="emit('activity')">活动</button>
     <button type="button" @click="emit('bus')">班车</button>
-    <button type="button" @click="emit('yunyou')">云游打卡</button>
-    <button type="button" @click="emit('punch')">校庆打卡</button>
     <button type="button" @click="emit('mock')">模拟定位</button>
     <button type="button" @click="emit('settings')">设置</button>
   </div>

--- a/src/features/campus-guide/config.ts
+++ b/src/features/campus-guide/config.ts
@@ -26,8 +26,9 @@ export const CAMPUS_GUIDE_CONFIG = Object.freeze({
   maxZoom: 20,
   defaultZoom: 16,
   useTencentGuide: true,
-  enableYunyou: true,
-  enablePunch: true,
+  /** #491：产品裁剪，入口层不再暴露云游/校庆打卡 */
+  enableYunyou: false,
+  enablePunch: false,
   /** 桌面端屏幕更大，默认展示全部 POI；小程序仍做点避让 */
   markerDodge: false,
   cdnBase: 'https://industry.map.qq.com/cloud/hugongda/2022/09/05'

--- a/src/features/campus-guide/map/campus-map-core.ts
+++ b/src/features/campus-guide/map/campus-map-core.ts
@@ -37,6 +37,8 @@ export class CampusMapCore {
   private lastSpots: CampusSpot[] = []
   private lastSelectedSpotId?: string | number
   private lastSpotSignature = ''
+  /** 最近一次成功写入 MultiMarker 的几何数量（用于 UI 提示有数无点） */
+  private lastPaintedMarkerCount = 0
   private zoomRefreshTimer: ReturnType<typeof setTimeout> | null = null
   private customLayerRetryTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -88,9 +90,21 @@ export class CampusMapCore {
     this.map?.on?.('zoom_changed', refresh)
   }
 
-  refreshMarkers() {
+  /**
+   * 强制刷新 marker。
+   * @param forceRecreate 为 true 时销毁重建 MultiMarker，避免 setStyles 残留导致有数无点
+   */
+  refreshMarkers(forceRecreate = false) {
     if (!this.lastSpots.length) return
+    if (forceRecreate) {
+      this.lastSpotSignature = ''
+      this.destroyMarkerLayer()
+    }
     this.renderSpots(this.lastSpots, this.lastSelectedSpotId)
+  }
+
+  getLastPaintedMarkerCount() {
+    return this.lastPaintedMarkerCount
   }
 
   private destroyMarkerLayer() {
@@ -261,39 +275,79 @@ export class CampusMapCore {
       visibleSpots,
       selected
     )
+    // 过滤掉 styles 中 undefined 条目，避免 MultiMarker 静默不可见
+    const safeStyles: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(styles)) {
+      if (value != null) safeStyles[key] = value
+    }
     const geometries = visibleSpots
       .map((spot, index) => {
         const geometry = spotToMarkerGeometry(spot, index, selected)
         if (!geometry) return null
+        // styleId 必须在 styles 中存在，否则 pin 不显示
+        if (!safeStyles[geometry.styleId]) return null
         const id = String(spot.spot_id || index)
         this.spotMap.set(id, spot)
-        return {
-          ...geometry,
-          position: toLatLng(this.TMap!, geometry.position as GeoPoint)
+        try {
+          return {
+            ...geometry,
+            position: toLatLng(this.TMap!, geometry.position as GeoPoint)
+          }
+        } catch {
+          return null
         }
       })
       .filter(Boolean)
+
+    this.lastPaintedMarkerCount = geometries.length
+    if (spots.length > 0 && geometries.length === 0) {
+      pushDebugLog(
+        'CampusGuide',
+        `renderSpots: ${spots.length} 个点位均无有效几何（坐标/样式失败）`,
+        'warn',
+        { spots: spots.length, visible: visibleSpots.length }
+      )
+    }
 
     const signature = this.buildSpotSignature(spots)
     const categoryChanged = signature !== this.lastSpotSignature
     this.lastSpotSignature = signature
 
-    // 始终写入 geometries（含空数组）以清掉上一分类残留；无有效坐标时不早退
+    // 有数无点常见于 setStyles 未生效：分类切换时强制重建；同分类尝试增量更新
     if (!categoryChanged && this.markerLayer) {
-      this.markerLayer.setStyles?.(styles)
-      this.markerLayer.setGeometries?.(geometries)
-      return
+      try {
+        this.markerLayer.setStyles?.(safeStyles)
+        this.markerLayer.setGeometries?.(geometries)
+        return
+      } catch (err) {
+        pushDebugLog(
+          'CampusGuide',
+          `setStyles/setGeometries 失败，重建 marker 层: ${(err as Error)?.message || err}`,
+          'warn'
+        )
+        this.destroyMarkerLayer()
+      }
     }
 
-    // 分类切换时销毁旧图层，否则残留上一分类标点
+    // 分类切换 / 更新失败时销毁旧图层再挂，避免残留或有数无点
     this.destroyMarkerLayer()
-    this.markerLayer = new this.TMap.MultiMarker({
-      map: this.map,
-      styles,
-      geometries,
-      zIndex: 120
-    })
-    this.bindMarkerClick()
+    try {
+      this.markerLayer = new this.TMap.MultiMarker({
+        map: this.map,
+        styles: safeStyles,
+        geometries,
+        zIndex: 120
+      })
+      this.bindMarkerClick()
+    } catch (err) {
+      this.lastPaintedMarkerCount = 0
+      pushDebugLog(
+        'CampusGuide',
+        `MultiMarker 创建失败: ${(err as Error)?.message || err}`,
+        'error',
+        { count: geometries.length }
+      )
+    }
   }
 
   renderLocation(point: GeoPoint) {
@@ -314,36 +368,68 @@ export class CampusMapCore {
 
   renderPolylines(segments: GeoPoint[][], color = CAMPUS_GUIDE_CONFIG.themeColor) {
     if (!this.TMap || !this.map) return
+    // 过滤非法点，避免 TMap 内部访问 undefined[n] 崩溃（#491 reading '4'）
     const geometries = segments
       .map((segment, index) => {
-        const paths = segment.map((point) => toLatLng(this.TMap!, point))
+        const paths = (segment || [])
+          .filter(
+            (point) =>
+              point &&
+              Number.isFinite(Number(point.latitude)) &&
+              Number.isFinite(Number(point.longitude))
+          )
+          .map((point) => toLatLng(this.TMap!, point))
         return paths.length >= 2 ? { id: `route-${index}`, paths } : null
       })
       .filter(Boolean)
-    const styles = {
-      route: {
-        color,
-        width: 6,
-        borderColor: '#ffffff',
-        borderWidth: 2,
-        lineCap: 'round'
+
+    // 必须用 PolylineStyle；纯对象在部分 GL 版本会触发内部 styles 索引崩溃
+    const styleOpts = {
+      color,
+      width: 6,
+      borderColor: '#ffffff',
+      borderWidth: 2,
+      lineCap: 'round' as const
+    }
+    const routeStyle =
+      typeof this.TMap.PolylineStyle === 'function'
+        ? new this.TMap.PolylineStyle(styleOpts)
+        : { ...styleOpts }
+    const styles = { route: routeStyle }
+    const mapped = geometries.map((item) => ({
+      id: item!.id,
+      styleId: 'route',
+      paths: item!.paths
+    }))
+
+    try {
+      if (!this.polylineLayer) {
+        this.polylineLayer = new this.TMap.MultiPolyline({
+          map: this.map,
+          styles,
+          geometries: mapped
+        })
+        return
       }
+      this.polylineLayer.setStyles?.(styles)
+      this.polylineLayer.setGeometries?.(mapped)
+    } catch (err) {
+      pushDebugLog(
+        'CampusGuide',
+        `renderPolylines 失败: ${(err as Error)?.message || err}`,
+        'error',
+        { segments: segments.length }
+      )
+      // 销毁坏层，避免后续 setGeometries 连环崩
+      try {
+        this.polylineLayer?.setMap?.(null)
+        this.polylineLayer?.destroy?.()
+      } catch {
+        // ignore
+      }
+      this.polylineLayer = null
+      throw err
     }
-    if (!this.polylineLayer) {
-      this.polylineLayer = new this.TMap.MultiPolyline({
-        map: this.map,
-        styles,
-        geometries: geometries.map((item) => ({
-          id: item!.id,
-          styleId: 'route',
-          paths: item!.paths
-        }))
-      })
-      return
-    }
-    this.polylineLayer.setGeometries?.(
-      geometries.map((item) => ({ id: item!.id, styleId: 'route', paths: item!.paths }))
-    )
   }
 
   clearPolylines() {
@@ -395,5 +481,6 @@ export class CampusMapCore {
     this.TMap = null
     this.spotMap.clear()
     this.lastSpotSignature = ''
+    this.lastPaintedMarkerCount = 0
   }
 }

--- a/src/features/campus-guide/map/marker-manager.ts
+++ b/src/features/campus-guide/map/marker-manager.ts
@@ -85,9 +85,16 @@ export const buildSpotMarkerStyles = (
     const id = String(spot.spot_id)
     const active = String(selectedId ?? '') === id
     const styleId = ensureSpotStyle(TMap, spot.name, size, active, spot.marker_type)
-    styles[styleId] = styleCache.get(styleId)
+    const style = styleCache.get(styleId)
+    // 禁止写入 undefined：MultiMarker 遇到缺失 style 会整层不显示
+    if (style != null) styles[styleId] = style
   }
   return styles
+}
+
+/** 测试/热重载时可清空样式缓存 */
+export const clearMarkerStyleCache = () => {
+  styleCache.clear()
 }
 
 export const spotToMarkerGeometry = (

--- a/src/features/campus-guide/map/polyline-decoder.spec.ts
+++ b/src/features/campus-guide/map/polyline-decoder.spec.ts
@@ -37,4 +37,14 @@ describe('campus guide polyline decoder', () => {
     expect(points.length).toBeGreaterThanOrEqual(1)
     expect(points[0].latitude).toBeCloseTo(30.48, 5)
   })
+
+  it('does not throw on sparse or short arrays (reading index crash guard)', () => {
+    const sparse = [] as Array<number | string>
+    sparse[0] = 30.48
+    // index 1 missing → should return empty, not throw
+    expect(() => decodeDeltaPolyline(sparse)).not.toThrow()
+    expect(decodeDeltaPolyline(sparse)).toEqual([])
+    expect(() => polylineToPoints([30.48] as unknown as Array<number | string>)).not.toThrow()
+    expect(polylineToPoints([30.48] as unknown as Array<number | string>)).toEqual([])
+  })
 })

--- a/src/features/campus-guide/map/polyline-decoder.ts
+++ b/src/features/campus-guide/map/polyline-decoder.ts
@@ -9,12 +9,21 @@ const isMicroDegreePolyline = (lat: number, lng: number) =>
 /** 解压腾讯步行路线坐标：兼容微度绝对坐标 + 增量，以及度坐标 + 增量（小程序 translateCoors） */
 export const decodeDeltaPolyline = (raw: Array<number | string>) => {
   if (!Array.isArray(raw) || raw.length < 2) return [] as number[]
-  const coors = raw.map((item) => Number(item))
+  // 防御稀疏数组 / 空洞导致 undefined[n] 类崩溃
+  const coors = raw.map((item) => {
+    const n = Number(item)
+    return Number.isFinite(n) ? n : NaN
+  })
+  if (coors.length < 2) return [] as number[]
 
-  if (isMicroDegreePolyline(coors[0], coors[1])) {
+  const firstLat = coors[0]
+  const firstLng = coors[1]
+  if (!Number.isFinite(firstLat) || !Number.isFinite(firstLng)) return [] as number[]
+
+  if (isMicroDegreePolyline(firstLat, firstLng)) {
     const values: number[] = []
-    let lat = coors[0] / 1_000_000
-    let lng = coors[1] / 1_000_000
+    let lat = firstLat / 1_000_000
+    let lng = firstLng / 1_000_000
     if (!Number.isFinite(lat) || !Number.isFinite(lng)) return []
     values.push(lat, lng)
     for (let index = 2; index + 1 < coors.length; index += 2) {
@@ -23,13 +32,13 @@ export const decodeDeltaPolyline = (raw: Array<number | string>) => {
       if (!Number.isFinite(deltaLat) || !Number.isFinite(deltaLng)) continue
       lat += deltaLat / 1_000_000
       lng += deltaLng / 1_000_000
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue
       values.push(lat, lng)
     }
     return values
   }
 
-  const values = [...coors]
-  if (!Number.isFinite(values[0]) || !Number.isFinite(values[1])) return []
+  const values = coors.slice()
   for (let index = 2; index < values.length; index += 1) {
     const base = values[index - 2]
     const delta = values[index]

--- a/src/features/campus-guide/map/tencent-map-loader.ts
+++ b/src/features/campus-guide/map/tencent-map-loader.ts
@@ -6,6 +6,7 @@ export type TencentMapNamespace = {
   MultiMarker: new (options: Record<string, unknown>) => TencentLayer
   MultiPolyline: new (options: Record<string, unknown>) => TencentLayer
   MarkerStyle: new (options: Record<string, unknown>) => unknown
+  PolylineStyle?: new (options: Record<string, unknown>) => unknown
   MultiPolygon: new (options: Record<string, unknown>) => TencentLayer
   ImageTileLayer: {
     createCustomLayer: (options: Record<string, unknown>) => Promise<TencentLayer | null>
@@ -23,6 +24,7 @@ export type TencentMapInstance = {
 export type TencentLayer = {
   setMap?: (map: TencentMapInstance | null) => void
   setGeometries?: (geometries: unknown[]) => void
+  setStyles?: (styles: Record<string, unknown>) => void
   on?: (event: string, handler: (...args: unknown[]) => void) => void
   destroy?: () => void
 }

--- a/src/features/campus-guide/services/location-service.ts
+++ b/src/features/campus-guide/services/location-service.ts
@@ -1,11 +1,27 @@
 import { useGeolocation } from '../../../composables/useGeolocation'
+import { isLiveLocationAllowed } from '../../../config/app_store_policy'
 import { pushDebugLog } from '../../../utils/debug_logger'
 import { HBUT_LOCATION, normalizePoint } from '../../../utils/towergo_map'
 import type { GeoPoint } from '../types'
 import { isPointInAoi } from '../utils/geo'
-import { isLiveLocationAllowed } from '../../../config/app_store_policy'
 
 const MOCK_LOC_KEY = 'campus_guide_mock_loc'
+
+export type LocationSource = 'mock' | 'system' | 'fallback' | 'policy'
+
+export type LocationResolveResult = {
+  point: GeoPoint
+  source: LocationSource
+  error?: string
+}
+
+/** 最近一次定位元信息，供 UI 区分「真定位 / 回退 / 合规禁用」 */
+let lastLocationMeta: LocationResolveResult = {
+  point: { ...HBUT_LOCATION, name: HBUT_LOCATION.name || '湖北工业大学' },
+  source: 'fallback'
+}
+
+export const getLastLocationMeta = (): LocationResolveResult => lastLocationMeta
 
 export const readMockLocation = (): GeoPoint | null => {
   try {
@@ -25,53 +41,99 @@ export const writeMockLocation = (point: GeoPoint | null) => {
   localStorage.setItem(MOCK_LOC_KEY, JSON.stringify(point))
 }
 
-export const resolveCampusLocation = async (): Promise<GeoPoint> => {
+const campusFallback = (): GeoPoint => ({
+  ...HBUT_LOCATION,
+  name: HBUT_LOCATION.name || '湖北工业大学'
+})
+
+/**
+ * 尝试系统定位：先高精度，失败再低精度（部分手机室内高精度会直接失败）。
+ */
+const trySystemLocation = async (): Promise<GeoPositionLike> => {
+  const geo = useGeolocation()
+  try {
+    return await geo.getCurrentPosition(12000, 0, true)
+  } catch (highAccErr) {
+    // 二次尝试：关闭高精度，拉长超时，允许短缓存
+    pushDebugLog(
+      'CampusGuide',
+      `高精度定位失败，尝试低精度: ${(highAccErr as Error)?.message || highAccErr}`,
+      'warn'
+    )
+    return geo.getCurrentPosition(16000, 3000, false)
+  }
+}
+
+type GeoPositionLike = {
+  latitude: number
+  longitude: number
+  accuracy: number
+}
+
+/** 详细解析定位来源；bootstrap / 显式定位共用 */
+export const resolveCampusLocationDetailed = async (): Promise<LocationResolveResult> => {
   const mock = readMockLocation()
   if (mock) {
     const point = { ...mock, name: mock.name || '模拟定位' }
+    const result: LocationResolveResult = { point, source: 'mock' }
+    lastLocationMeta = result
     pushDebugLog(
       'CampusGuide',
       `定位结果 source=mock lat=${point.latitude} lng=${point.longitude}`,
       'info',
       point
     )
-    return point
+    return result
   }
 
   // App Store 合规构建：不请求实时定位，回落校区默认点（POI 浏览仍可用）
   if (!isLiveLocationAllowed()) {
-    const fallback = { ...HBUT_LOCATION, name: HBUT_LOCATION.name || '校园中心' }
-    pushDebugLog('CampusGuide', 'App Store 构建跳过实时定位，使用默认点', 'info', fallback)
-    return fallback
+    const point = { ...campusFallback(), name: '校园中心' }
+    const result: LocationResolveResult = {
+      point,
+      source: 'policy',
+      error: '当前版本使用默认校区位置'
+    }
+    lastLocationMeta = result
+    pushDebugLog('CampusGuide', 'App Store 构建跳过实时定位，使用默认点', 'info', point)
+    return result
   }
 
-  const geo = useGeolocation()
   try {
-    // 缩短 maximumAge：避免 iOS 把缓存的旧坐标（校外）当成当前
-    const position = await geo.getCurrentPosition(12000, 0)
-    const point = {
+    const position = await trySystemLocation()
+    const point: GeoPoint = {
       latitude: position.latitude,
       longitude: position.longitude,
       accuracy: position.accuracy,
       name: '当前位置'
     }
+    const result: LocationResolveResult = { point, source: 'system' }
+    lastLocationMeta = result
     pushDebugLog(
       'CampusGuide',
       `定位结果 source=system lat=${point.latitude.toFixed(6)} lng=${point.longitude.toFixed(6)} ±${Math.round(point.accuracy || 0)}m`,
       'info',
       { ...point, source: 'system' }
     )
-    return point
+    return result
   } catch (err) {
-    const fallback = { ...HBUT_LOCATION, name: HBUT_LOCATION.name || '湖北工业大学' }
+    const message = (err as Error)?.message || '定位失败'
+    const point = campusFallback()
+    const result: LocationResolveResult = { point, source: 'fallback', error: message }
+    lastLocationMeta = result
     pushDebugLog(
       'CampusGuide',
-      `定位回退校区中心: ${(err as Error)?.message || err}`,
+      `定位回退校区中心: ${message}`,
       'warn',
-      { ...fallback, source: 'fallback' }
+      { ...point, source: 'fallback' }
     )
-    return fallback
+    return result
   }
+}
+
+export const resolveCampusLocation = async (): Promise<GeoPoint> => {
+  const result = await resolveCampusLocationDetailed()
+  return result.point
 }
 
 /**
@@ -92,7 +154,7 @@ export const resolveInsideScenic = (point: GeoPoint, aoiRings: GeoPoint[][]) => 
   // 与校区中心距离 < 2.5km 时，AOI 边界抖动也倾向判在校内
   const d = Math.hypot(
     (point.latitude - HBUT_LOCATION.latitude) * 111320,
-    (point.longitude - HBUT_LOCATION.longitude) * 111320 * Math.cos(point.latitude * Math.PI / 180)
+    (point.longitude - HBUT_LOCATION.longitude) * 111320 * Math.cos((point.latitude * Math.PI) / 180)
   )
   if (d < 2500) return true
   return false

--- a/src/features/campus-guide/services/navigation-service.spec.ts
+++ b/src/features/campus-guide/services/navigation-service.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { CAMPUS_GUIDE_CONFIG } from '../config'
 import {
   buildTencentWalkRouteUrl,
+  extractWalkPolyline,
   isValidGeoPoint,
   openExternalMapNavigation,
   resolveNavEndPoint
@@ -60,5 +61,21 @@ describe('campus guide navigation service', () => {
     await expect(
       openExternalMapNavigation({ latitude: 999, longitude: 114.31 }, '图书馆')
     ).resolves.toBe(false)
+  })
+
+  it('extractWalkPolyline handles nested and empty payloads without throwing', () => {
+    expect(extractWalkPolyline(null)).toBeNull()
+    expect(extractWalkPolyline([])).toBeNull()
+    expect(extractWalkPolyline(undefined)).toBeNull()
+    expect(extractWalkPolyline({ polyline: [30.48, 114.31, 100, 200] })).toEqual([
+      30.48, 114.31, 100, 200
+    ])
+    expect(
+      extractWalkPolyline({ routes: [{ polyline: [30.48, 114.31, 50, -100] }] })
+    ).toEqual([30.48, 114.31, 50, -100])
+    expect(extractWalkPolyline([{ polyline: [30.48, 114.31] }])).toEqual([30.48, 114.31])
+    expect(extractWalkPolyline({ polyline: [[30.48, 114.31], [30.49, 114.32]] })).toEqual([
+      30.48, 114.31, 30.49, 114.32
+    ])
   })
 })

--- a/src/features/campus-guide/services/navigation-service.ts
+++ b/src/features/campus-guide/services/navigation-service.ts
@@ -38,23 +38,108 @@ export const resolveNavEndPoint = (
   return isValidGeoPoint(point) ? point : null
 }
 
+/**
+ * 从步行路线 API 响应中提取 polyline 数组。
+ * 兼容：直接数组、{ polyline }、{ routes[0].polyline }、嵌套 list 等。
+ * 禁止对 undefined 做下标访问（历史崩溃 reading '4'）。
+ */
+export const extractWalkPolyline = (raw: unknown): Array<number | string> | null => {
+  if (raw == null) return null
+
+  const asPolylineArray = (value: unknown): Array<number | string> | null => {
+    if (!Array.isArray(value) || value.length < 2) return null
+    // 已是扁平 [lat,lng,delta...] 或微度
+    if (typeof value[0] === 'number' || typeof value[0] === 'string') {
+      return value as Array<number | string>
+    }
+    // [[lat,lng], ...] 展平
+    if (Array.isArray(value[0])) {
+      const flat: Array<number | string> = []
+      for (const pair of value) {
+        if (!Array.isArray(pair) || pair.length < 2) continue
+        flat.push(pair[0] as number | string, pair[1] as number | string)
+      }
+      return flat.length >= 2 ? flat : null
+    }
+    return null
+  }
+
+  const fromObject = (obj: Record<string, unknown>): Array<number | string> | null => {
+    const direct = asPolylineArray(obj.polyline)
+    if (direct) return direct
+
+    // routes / route / paths 等常见嵌套
+    const routes = obj.routes ?? obj.route ?? obj.list ?? obj.paths
+    if (Array.isArray(routes) && routes.length > 0) {
+      const first = routes[0]
+      if (first && typeof first === 'object') {
+        const nested = fromObject(first as Record<string, unknown>)
+        if (nested) return nested
+      }
+      const flat = asPolylineArray(routes)
+      if (flat) return flat
+    }
+
+    // 字符串 polyline："lat,lng;lat,lng" 或 "lat,lng,lat,lng"
+    if (typeof obj.polyline === 'string' && obj.polyline.trim()) {
+      const parts = obj.polyline
+        .split(/[;,\s]+/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+      if (parts.length >= 2) return parts
+    }
+    return null
+  }
+
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return null
+    // [ { polyline: [...] }, ... ]
+    if (raw[0] && typeof raw[0] === 'object' && !Array.isArray(raw[0])) {
+      return fromObject(raw[0] as Record<string, unknown>)
+    }
+    return asPolylineArray(raw)
+  }
+
+  if (typeof raw === 'object') {
+    return fromObject(raw as Record<string, unknown>)
+  }
+
+  return null
+}
+
 export const fetchCampusWalkRoute = async (start: GeoPoint, end: GeoPoint) => {
+  if (!isValidGeoPoint(start) || !isValidGeoPoint(end)) {
+    return {
+      points: [],
+      distance: undefined,
+      duration: undefined,
+      raw: undefined
+    } satisfies WalkNavigationResult
+  }
+
   const raw = await campusGuideApi.getWalkRoute({
     startLng: Number(start.longitude),
     startLat: Number(start.latitude),
     endLng: Number(end.longitude),
     endLat: Number(end.latitude)
   })
-  const data = (Array.isArray(raw) ? raw[0] : raw) as WalkRouteResult
-  const polyline = data?.polyline
+
+  // 兼容 data 为数组 / 单对象 / 再包一层
+  const dataCandidate = Array.isArray(raw) ? raw[0] : raw
+  const data = (dataCandidate && typeof dataCandidate === 'object'
+    ? dataCandidate
+    : {}) as WalkRouteResult & Record<string, unknown>
+
   let points: GeoPoint[] = []
-  if (Array.isArray(polyline)) {
-    try {
-      points = polylineToPoints(polyline)
-    } catch {
-      points = []
+  try {
+    const polyline = extractWalkPolyline(data) ?? extractWalkPolyline(raw)
+    if (polyline) {
+      points = polylineToPoints(polyline).filter(isValidGeoPoint)
     }
+  } catch {
+    points = []
   }
+
   return {
     points,
     distance: data?.distance,

--- a/src/features/campus-guide/store/campus-guide-store.ts
+++ b/src/features/campus-guide/store/campus-guide-store.ts
@@ -119,7 +119,8 @@ const createCampusGuideStore = (): CampusGuideStore => {
     activities: [] as CampusActivity[],
     notices: [] as ScenicNotice[],
     hotSearch: [] as string[],
-    currentView: CAMPUS_GUIDE_VIEWS.hub as CampusGuideViewId,
+    // #491：进入校园地图直达导览主地图，不再先出三选一 Hub
+    currentView: CAMPUS_GUIDE_VIEWS.home as CampusGuideViewId,
     navParams: {} as CampusGuideNavParams,
     viewStack: [] as CampusGuideViewId[]
   })

--- a/src/features/campus-guide/views/CampusGuideHome.vue
+++ b/src/features/campus-guide/views/CampusGuideHome.vue
@@ -9,8 +9,8 @@ import { CAMPUS_GUIDE_CONFIG } from '../config'
 import { CampusMapCore } from '../map/campus-map-core'
 import { CAMPUS_GUIDE_VIEWS } from '../navigation'
 import { playCampusSpeech } from '../services/audio-service'
+import { getLastLocationMeta } from '../services/location-service'
 import { resolveNavEndPoint } from '../services/navigation-service'
-import { hasSeenYunyouIntro, readYunyouUser } from '../services/phase2-storage'
 import { useCampusGuideStore } from '../store/campus-guide-store'
 import type { CampusSpot } from '../types'
 
@@ -89,7 +89,16 @@ const handleLocate = async () => {
     const point = await store.refreshLocation()
     mapCore.value?.setCenter(point, CAMPUS_GUIDE_CONFIG.defaultZoom)
     mapCore.value?.renderLocation(point)
-    showToast(store.insideScenic ? '已定位到校园内' : '已定位，当前在校外', 'success', 1800)
+    const meta = getLastLocationMeta()
+    if (meta.source === 'policy') {
+      showToast('当前版本使用默认校区位置', 'warning', 2200)
+    } else if (meta.source === 'fallback') {
+      showToast(meta.error || '定位失败，已使用校区中心', 'warning', 2400)
+    } else if (meta.source === 'mock') {
+      showToast('已使用模拟定位', 'success', 1600)
+    } else {
+      showToast(store.insideScenic ? '已定位到校园内' : '已定位，当前在校外', 'success', 1800)
+    }
   } catch (err) {
     showToast((err as Error)?.message || '定位失败', 'error', 2200)
   } finally {
@@ -103,10 +112,17 @@ const handleTagClick = async (tag: string) => {
     setActivePoi(null)
     const spots = await store.selectTag(tag)
     await refreshMapMarkers()
+    // 分类切换后强制重建 marker 层，避免 setStyles 残留导致有数无点
+    mapCore.value?.refreshMarkers(true)
     fitSpotsOnMap()
-    window.setTimeout(() => mapCore.value?.refreshMarkers(), 280)
+    window.setTimeout(() => {
+      mapCore.value?.resize()
+      mapCore.value?.refreshMarkers(true)
+    }, 280)
     if (!spots.length) {
       showToast('该分类下暂时没有点位', 'warning', 1800)
+    } else if ((mapCore.value?.getLastPaintedMarkerCount() ?? 0) === 0) {
+      showToast('点位数据缺少有效坐标，地图无法标注', 'warning', 2200)
     }
   } catch (err) {
     showToast((err as Error)?.message || '加载分类失败', 'error', 2200)
@@ -137,20 +153,6 @@ const handleFavorite = async () => {
   await store.toggleFavorite(activePoi.value)
   activePoi.value = store.selectedSpot
   showToast(activePoi.value?.is_saved ? '已收藏' : '已取消收藏', 'success', 1500)
-}
-
-const openYunyou = () => {
-  showEntrance.value = false
-  if (hasSeenYunyouIntro() && readYunyouUser()?.nickName) {
-    store.navigateTo(CAMPUS_GUIDE_VIEWS.yunyouDetail)
-    return
-  }
-  store.navigateTo(CAMPUS_GUIDE_VIEWS.yunyouIntro)
-}
-
-const openPunch = () => {
-  showEntrance.value = false
-  store.navigateTo(CAMPUS_GUIDE_VIEWS.punchHome)
 }
 
 const handleAudio = async () => {
@@ -279,14 +281,11 @@ onBeforeUnmount(() => {
         <EntranceMenu
           v-if="showEntrance"
           class="campus-guide-entrance-floating"
-          @hub="store.navigateTo(CAMPUS_GUIDE_VIEWS.hub); showEntrance = false"
           @about="store.navigateTo(CAMPUS_GUIDE_VIEWS.about); showEntrance = false"
           @route="store.navigateTo(CAMPUS_GUIDE_VIEWS.route); showEntrance = false"
           @collect="store.navigateTo(CAMPUS_GUIDE_VIEWS.collect); showEntrance = false"
           @activity="store.navigateTo(CAMPUS_GUIDE_VIEWS.activity); showEntrance = false"
           @bus="store.navigateTo(CAMPUS_GUIDE_VIEWS.bus); showEntrance = false"
-          @yunyou="openYunyou"
-          @punch="openPunch"
           @mock="store.navigateTo(CAMPUS_GUIDE_VIEWS.mockLocation); showEntrance = false"
           @settings="store.navigateTo(CAMPUS_GUIDE_VIEWS.settings); showEntrance = false"
         />

--- a/src/features/campus-guide/views/CampusGuideHub.vue
+++ b/src/features/campus-guide/views/CampusGuideHub.vue
@@ -2,25 +2,18 @@
 import { onMounted } from 'vue'
 import { TPageHeader } from '../../../components/templates'
 import { CAMPUS_GUIDE_VIEWS } from '../navigation'
-import { hasSeenYunyouIntro, readYunyouUser } from '../services/phase2-storage'
 import { useCampusGuideStore } from '../store/campus-guide-store'
 
 const emit = defineEmits(['back'])
 const store = useCampusGuideStore()
 
+// #491：Hub 仅保留导览入口（默认路径已直达 home，此处作兜底）
 const openGuide = () => store.navigateTo(CAMPUS_GUIDE_VIEWS.home)
-const openPunch = () => store.navigateTo(CAMPUS_GUIDE_VIEWS.punchHome)
+
 onMounted(() => {
+  // 默认路径已直达 home；Hub 仅作兜底页，点击进入导览
   if (!store.scenic) void store.bootstrap().catch(() => undefined)
 })
-
-const openYunyou = () => {
-  if (hasSeenYunyouIntro() && readYunyouUser()?.nickName) {
-    store.navigateTo(CAMPUS_GUIDE_VIEWS.yunyouDetail)
-    return
-  }
-  store.navigateTo(CAMPUS_GUIDE_VIEWS.yunyouIntro)
-}
 </script>
 
 <template>
@@ -33,19 +26,11 @@ const openYunyou = () => {
         :style="{ backgroundImage: `url(${store.scenic.screen_url})` }"
       />
       <h2 class="campus-guide-title">{{ store.scenic?.name || '湖北工业大学' }}</h2>
-      <p class="campus-guide-muted">选择导览模式，进入校园地图、校庆打卡或云游文化衫。</p>
+      <p class="campus-guide-muted">正在进入校园导览地图…</p>
       <div class="campus-guide-hub-actions">
         <button type="button" class="campus-guide-hub-card primary" @click="openGuide">
           <strong>校园导览</strong>
           <span>手绘地图 · POI · 导航</span>
-        </button>
-        <button type="button" class="campus-guide-hub-card" @click="openPunch">
-          <strong>校庆打卡</strong>
-          <span>地图打卡 · 明信片 · 校友卡</span>
-        </button>
-        <button type="button" class="campus-guide-hub-card" @click="openYunyou">
-          <strong>云游文化衫</strong>
-          <span>在线报名 · 签名定制</span>
         </button>
       </div>
     </div>

--- a/src/features/campus-guide/views/CampusGuideShell.vue
+++ b/src/features/campus-guide/views/CampusGuideShell.vue
@@ -43,12 +43,12 @@ const activeView = computed(() => store.currentView)
 const isUnknownView = computed(() => !isKnownCampusGuideView(activeView.value))
 
 const handleAppBack = () => {
-  if (activeView.value === CAMPUS_GUIDE_VIEWS.hub) {
+  // #491：主地图直接退出模块，不再回退到三选一 Hub
+  if (
+    activeView.value === CAMPUS_GUIDE_VIEWS.home ||
+    activeView.value === CAMPUS_GUIDE_VIEWS.hub
+  ) {
     emit('back')
-    return
-  }
-  if (activeView.value === CAMPUS_GUIDE_VIEWS.home) {
-    store.navigateTo(CAMPUS_GUIDE_VIEWS.hub)
     return
   }
   store.goBack()

--- a/src/features/campus-guide/views/CampusGuideWalkLine.vue
+++ b/src/features/campus-guide/views/CampusGuideWalkLine.vue
@@ -53,24 +53,43 @@ const init = async () => {
   requestAnimationFrame(() => mapCore.value?.resize())
 
   try {
+    if (!isValidGeoPoint(store.userLocation)) {
+      routeText.value = '起点坐标无效，请先定位或使用外部地图'
+      loadingRoute.value = false
+      return
+    }
     const result = await fetchCampusWalkRoute(store.userLocation, end)
-    if (result.points.length) {
-      core.renderPolylines([result.points])
-      core.fitPoints([store.userLocation, ...result.points, end])
-      const distanceText =
-        typeof result.distance === 'number'
-          ? `${Math.round(result.distance)}米`
-          : String(result.distance || '')
-      routeText.value = `${distanceText} ${formatWalkDuration(result.duration)}`.trim()
-      routeReady.value = true
+    if (result.points.length >= 2) {
+      try {
+        core.renderPolylines([result.points])
+        core.fitPoints([store.userLocation, ...result.points, end])
+        const distanceText =
+          typeof result.distance === 'number'
+            ? `${Math.round(result.distance)}米`
+            : String(result.distance || '')
+        routeText.value = `${distanceText} ${formatWalkDuration(result.duration)}`.trim()
+        routeReady.value = true
+      } catch {
+        // 画线崩溃（历史 reading '4'）时降级，不白屏
+        routeText.value = '路线绘制失败，可打开外部地图导航'
+        core.fitPoints([store.userLocation, end])
+        showToast('校内路线绘制失败，请使用外部地图', 'warning', 2400)
+      }
     } else if (store.insideScenic) {
       routeText.value = '未获取到校内步行路线，可尝试外部地图'
+      core.fitPoints([store.userLocation, end])
     } else {
       routeText.value = '当前在校外，建议使用外部地图导航'
+      core.fitPoints([store.userLocation, end])
     }
   } catch (err) {
     routeText.value = (err as Error)?.message || '路线规划失败'
     showToast(routeText.value, 'error', 2200)
+    try {
+      core.fitPoints([store.userLocation, end])
+    } catch {
+      // ignore
+    }
   } finally {
     loadingRoute.value = false
   }


### PR DESCRIPTION
## Summary
- 进入校园地图直接导览主图，去掉 Hub 三选一
- 移除校庆打卡 / 云游文化衫入口
- 修复 marker 刷新、定位提示、导航 polyline 崩溃

## Test plan
- [x] vitest campus-guide 26 passed
- [x] Bridge navigate campus_map + screenshot

Fixes #491