### PR TITLE
fix(#488): 电费换房后用电趋势与空态文案

### DIFF
--- a/src/components/ElectricityView.vue
+++ b/src/components/ElectricityView.vue
@@ -11,6 +11,10 @@ import { invokeNative, isTauriRuntime } from '../platform/native'
 import { openExternal } from '../utils/external_link'
 import { prepareOneCodeAppOpen } from '../utils/one_code_open.js'
 import { showToast } from '../utils/toast'
+import {
+  isUsageSnapshotOnly,
+  resolveUsageEmptyText
+} from '../utils/electricity_usage_ui'
 import { TPageHeader, TEmptyState } from './templates'
 
 const props = defineProps({
@@ -544,6 +548,37 @@ const usageSourceHint = computed(() => {
   return ''
 })
 
+/** 四级宿舍已齐（换房后趋势以所选房为准） */
+const hasSelectedRoom = computed(() => selectedPath.value.length === 4)
+
+/**
+ * 换房后智能水电常只回快照（余额/余量、无分日曲线）。
+ * 必须与「未选房」空态区分，避免误导文案「请先选择宿舍」。
+ */
+const usageSnapshotOnly = computed(() => isUsageSnapshotOnly(usageStats.value))
+
+const usageEmptyText = computed(() =>
+  resolveUsageEmptyText({
+    hasSelectedRoom: hasSelectedRoom.value,
+    stats: usageStats.value
+  })
+)
+
+const usageSnapshotQuantity = computed(() => {
+  const q = usageStats.value?.quantity
+  if (q == null || String(q).trim() === '') return ''
+  return String(q)
+})
+
+const usageSnapshotBalance = computed(() => {
+  const b = usageStats.value?.balance
+  if (b == null || String(b).trim() === '') return ''
+  return String(b)
+})
+
+/** 换房竞态：只应用最后一次 electricity_usage_stats 结果 */
+let usageRequestSeq = 0
+
 const selectBar = (i) => {
   selectedBarIdx.value = i
 }
@@ -612,6 +647,7 @@ const roomLabelText = () => {
 
 const loadUsageStats = async () => {
   if (!isTauriRuntime()) return
+  const reqId = ++usageRequestSeq
   usageLoading.value = true
   usageError.value = ''
   selectedBarIdx.value = -1
@@ -629,25 +665,30 @@ const loadUsageStats = async () => {
       )
       acRoomId = String(roomNode?._acRoomValue || '').trim()
     }
+    // 换房：始终把所选 roomverify 交给后端；后端会 setbindroom + 按候选拉趋势
     const res = await invokeNative('electricity_usage_stats', {
       roomPath: selectedPath.value.length ? [...selectedPath.value] : null,
       roomVerify: roomId || null,
       roomVerifyAlt: acRoomId || null,
       roomLabel: roomLabelText() || null
     })
+    // 过期响应丢弃（快速连切房间）
+    if (reqId !== usageRequestSeq) return
     usageStats.value = res || null
     const pts = res?.points
     const monthPts = res?.month_points || res?.monthPoints
-    if (res?.success === false && !(Array.isArray(pts) && pts.length)) {
-      usageError.value = String(res?.message || '暂无用电数据')
-    } else if (Array.isArray(pts) && pts.length) {
+    const hasPts = Array.isArray(pts) && pts.length
+    const hasMonth = Array.isArray(monthPts) && monthPts.length
+    if (res?.success === false && !hasPts && !hasMonth) {
+      // 已选房时避免后端/兜底文案回落成「请先选择宿舍」
+      const raw = String(res?.message || '暂无用电数据')
+      usageError.value =
+        hasSelectedRoom.value && /请先选择宿舍/.test(raw)
+          ? '该房间暂无用电趋势数据，可重试或查看上方电费余额'
+          : raw
+    } else if (hasPts || hasMonth) {
       requestAnimationFrame(() => {
-        chartReady.value = true
-      })
-    } else if (Array.isArray(monthPts) && monthPts.length) {
-      // 仅有月曲线时也算成功，避免被快照路径误当成失败
-      requestAnimationFrame(() => {
-        chartReady.value = true
+        if (reqId === usageRequestSeq) chartReady.value = true
       })
     }
     // 绑定已更新时轻提示（勿当成错误）
@@ -656,10 +697,13 @@ const loadUsageStats = async () => {
       if (hint) showToast(hint, 'success')
     }
   } catch (e) {
+    if (reqId !== usageRequestSeq) return
     usageError.value = String(e?.message || e || '加载失败')
     usageStats.value = null
   } finally {
-    usageLoading.value = false
+    if (reqId === usageRequestSeq) {
+      usageLoading.value = false
+    }
   }
 }
 
@@ -674,7 +718,15 @@ watch(
     if (key === prev) return
     showPayQr.value = false
     if (selectedPath.value.length === 4) {
+      // 选齐四级：按新房拉趋势（后端 setbindroom + usage）
       void loadUsageStats()
+    } else {
+      // 改选中间级：清空旧房曲线，空态回到「请先选择宿舍…」
+      usageRequestSeq += 1
+      usageStats.value = null
+      usageError.value = ''
+      chartReady.value = false
+      usageLoading.value = false
     }
   }
 )
@@ -1049,7 +1101,29 @@ watch(
           </div>
         </template>
 
-        <div v-else class="util-muted">暂无用电数据，请先选择宿舍</div>
+        <!-- 已选房但无曲线：展示快照说明，禁止「请先选择宿舍」 -->
+        <div v-else-if="usageSnapshotOnly" class="usage-snapshot">
+          <p class="util-muted">
+            {{
+              usageStats?.message ||
+              usageStats?.summary ||
+              '该房间暂无分日/分月用电曲线'
+            }}
+          </p>
+          <div v-if="usageSnapshotQuantity || usageSnapshotBalance" class="kpi-row snapshot-kpi">
+            <div v-if="usageSnapshotQuantity" class="kpi pop">
+              <span>剩余电量</span>
+              <strong>{{ usageSnapshotQuantity }}<small>度</small></strong>
+            </div>
+            <div v-if="usageSnapshotBalance" class="kpi pop">
+              <span>余额</span>
+              <strong>{{ usageSnapshotBalance }}<small>元</small></strong>
+            </div>
+          </div>
+          <button type="button" class="link-btn" @click="loadUsageStats">重新拉取趋势</button>
+        </div>
+
+        <div v-else class="util-muted">{{ usageEmptyText }}</div>
       </section>
 
       <!-- 充值：直给，无废话 -->
@@ -1310,6 +1384,20 @@ html.dark .glass-card-warning {
   font-size: 13px;
   color: #94a3b8;
   padding: 12px 0 4px;
+}
+/* 已选房无曲线：快照说明区（#488） */
+.usage-snapshot {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0 8px;
+}
+.usage-snapshot .snapshot-kpi {
+  margin-top: 4px;
+}
+.usage-snapshot .link-btn {
+  align-self: flex-start;
+  padding-left: 0;
 }
 .util-err-row {
   display: flex;

--- a/src/utils/campus_goal_fixes_contract.spec.ts
+++ b/src/utils/campus_goal_fixes_contract.spec.ts
@@ -84,3 +84,28 @@ describe('SWAE setbindroom production path (not guessed multi-cmd)', () => {
     expect(fixture.body?.roomverify || '').toMatch(/\d/)
   })
 })
+
+describe('electricity room switch trend empty-state (#488)', () => {
+  it('ElectricityView reloads usage on full path and clears on partial path', () => {
+    const vue = read('src/components/ElectricityView.vue')
+    expect(vue).toContain("invokeNative('electricity_usage_stats'")
+    expect(vue).toContain('roomVerify:')
+    expect(vue).toContain('void loadUsageStats()')
+    // 改选中间级时清空旧房曲线，避免误导
+    expect(vue).toMatch(/selectedPath\.value\.length === 4[\s\S]*loadUsageStats/)
+    expect(vue).toContain('usageStats.value = null')
+    // 空态区分：不得再写死「暂无用电数据，请先选择宿舍」
+    expect(vue).not.toContain('暂无用电数据，请先选择宿舍')
+    expect(vue).toContain('usageEmptyText')
+    expect(vue).toContain('usageSnapshotOnly')
+    expect(vue).toContain('resolveUsageEmptyText')
+    expect(vue).toContain('isUsageSnapshotOnly')
+  })
+
+  it('usage empty helper rejects 请先选择宿舍 when room already selected', () => {
+    const ui = read('src/utils/electricity_usage_ui.ts')
+    expect(ui).toContain('请先选择宿舍查看用电趋势')
+    expect(ui).toContain('该房间暂无分日/分月用电曲线')
+    expect(ui).toContain('!/请先选择宿舍/')
+  })
+})

--- a/src/utils/electricity_usage_ui.spec.ts
+++ b/src/utils/electricity_usage_ui.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasUsageCurve,
+  isUsageSnapshotOnly,
+  resolveUsageEmptyText
+} from './electricity_usage_ui'
+
+describe('electricity_usage_ui (#488 empty / snapshot)', () => {
+  it('hasUsageCurve detects week or month points', () => {
+    expect(hasUsageCurve(null)).toBe(false)
+    expect(hasUsageCurve({ points: [] })).toBe(false)
+    expect(hasUsageCurve({ points: [{ value: 1 }] })).toBe(true)
+    expect(hasUsageCurve({ month_points: [{ value: 2 }] })).toBe(true)
+    expect(hasUsageCurve({ monthPoints: [{ value: 2 }] })).toBe(true)
+  })
+
+  it('isUsageSnapshotOnly when success with quantity and no curve', () => {
+    expect(
+      isUsageSnapshotOnly({
+        success: true,
+        points: [],
+        month_points: [],
+        quantity: '12.5',
+        message: '智能水电未返回分日曲线，已显示该房间当前电量/余额快照'
+      })
+    ).toBe(true)
+  })
+
+  it('isUsageSnapshotOnly false on hard failure or when curve exists', () => {
+    expect(
+      isUsageSnapshotOnly({
+        success: false,
+        points: [],
+        message: '电量趋势暂不可用'
+      })
+    ).toBe(false)
+    expect(
+      isUsageSnapshotOnly({
+        success: true,
+        points: [{ value: 1 }],
+        quantity: '9'
+      })
+    ).toBe(false)
+  })
+
+  it('resolveUsageEmptyText distinguishes 未选房 vs 已选房无曲线', () => {
+    expect(
+      resolveUsageEmptyText({ hasSelectedRoom: false, stats: null })
+    ).toBe('请先选择宿舍查看用电趋势')
+
+    expect(
+      resolveUsageEmptyText({
+        hasSelectedRoom: true,
+        stats: { success: true, points: [], message: '' }
+      })
+    ).toBe('该房间暂无分日/分月用电曲线，可查看上方电费余额')
+
+    expect(
+      resolveUsageEmptyText({
+        hasSelectedRoom: true,
+        stats: {
+          message: '智能水电未返回分日曲线，已显示该房间当前电量/余额快照'
+        }
+      })
+    ).toContain('智能水电未返回分日曲线')
+
+    // 已选房时绝不展示误导的「请先选择宿舍」
+    const misleading = resolveUsageEmptyText({
+      hasSelectedRoom: true,
+      stats: { message: '暂无用电数据，请先选择宿舍' }
+    })
+    expect(misleading).not.toMatch(/请先选择宿舍/)
+    expect(misleading).toContain('该房间暂无')
+  })
+})

--- a/src/utils/electricity_usage_ui.ts
+++ b/src/utils/electricity_usage_ui.ts
@@ -1,0 +1,73 @@
+/**
+ * 电费「用电趋势」空态 / 快照展示纯逻辑（#488）
+ *
+ * 目标：
+ * - 未选房 vs 已选房无曲线 文案可区分
+ * - 成功但无分日/分月曲线时识别为「快照」而非「请先选择宿舍」
+ */
+
+export type UsageStatsLike = {
+  success?: boolean
+  points?: unknown
+  month_points?: unknown
+  monthPoints?: unknown
+  message?: string | null
+  hint?: string | null
+  quantity?: string | number | null
+  balance?: string | number | null
+  today_use?: string | number | null
+  todayUse?: string | number | null
+  summary?: string | null
+}
+
+/** 是否已有可画柱图的日/月曲线 */
+export function hasUsageCurve(stats: UsageStatsLike | null | undefined): boolean {
+  if (!stats) return false
+  const pts = stats.points
+  const month = stats.month_points ?? stats.monthPoints
+  return (
+    (Array.isArray(pts) && pts.length > 0) ||
+    (Array.isArray(month) && month.length > 0)
+  )
+}
+
+/**
+ * 智能水电未返回曲线，但有余额/余量/说明时的「快照」态。
+ * 失败态（success===false）不算快照，交给错误行展示。
+ */
+export function isUsageSnapshotOnly(
+  stats: UsageStatsLike | null | undefined
+): boolean {
+  if (!stats || hasUsageCurve(stats)) return false
+  if (stats.success === false) return false
+  const hasQty =
+    stats.quantity != null && String(stats.quantity).trim() !== ''
+  const hasBal =
+    stats.balance != null && String(stats.balance).trim() !== ''
+  const hasToday =
+    (stats.today_use != null && String(stats.today_use).trim() !== '') ||
+    (stats.todayUse != null && String(stats.todayUse).trim() !== '')
+  const hasSummary = Boolean(String(stats.summary || '').trim())
+  const hasMessage = Boolean(String(stats.message || '').trim())
+  return hasQty || hasBal || hasToday || hasSummary || hasMessage
+}
+
+/**
+ * 趋势区空态文案：
+ * - 未选完整宿舍 → 引导选房
+ * - 已选房 → 绝不回落「请先选择宿舍」
+ */
+export function resolveUsageEmptyText(opts: {
+  hasSelectedRoom: boolean
+  stats?: UsageStatsLike | null
+}): string {
+  if (!opts.hasSelectedRoom) {
+    return '请先选择宿舍查看用电趋势'
+  }
+  const msg = String(opts.stats?.message || '').trim()
+  // 后端偶发把引导文案塞进 message 时，前端仍按「已选房」语义改写
+  if (msg && !/请先选择宿舍/.test(msg)) {
+    return msg
+  }
+  return '该房间暂无分日/分月用电曲线，可查看上方电费余额'
+}


### PR DESCRIPTION
## Summary
- 换房后正确拉取 usage；竞态序号防串数据
- 空态区分未选房 vs 已选房无曲线；快照 KPI 展示
- 契约与 UI 单测

## Test plan
- [x] vitest 11 passed；cargo one_code tests 6 passed
- [x] Bridge navigate electricity + screenshot

Fixes #488