### PR TITLE
feat(#481): 智慧迎新只读模块前后端与入口

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -155,6 +155,7 @@ const loadTeachingEvalView = () => import('./components/TeachingEvalView.vue')
 const loadBroadbandView = () => import('./components/BroadbandView.vue')
 const loadSportsVenueView = () => import('./components/SportsVenueView.vue')
 const loadTowerGoView = () => import('./components/TowerGoView.vue')
+const loadSmartOrientationView = () => import('./components/SmartOrientationView.vue')
 
 const Dashboard = createAsyncPage(loadDashboardView)
 const GradeView = createAsyncPage(loadGradeView)
@@ -199,6 +200,7 @@ const TeachingEvalView = createAsyncPage(loadTeachingEvalView)
 const BroadbandView = createAsyncPage(loadBroadbandView)
 const SportsVenueView = createAsyncPage(loadSportsVenueView)
 const TowerGoView = createAsyncPage(loadTowerGoView)
+const SmartOrientationView = createAsyncPage(loadSmartOrientationView)
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 const GRADE_CACHE_REFRESH_RETRY_MS = 8000
@@ -293,7 +295,8 @@ const VIEW_PREFETCHERS = Object.freeze({
   teaching_eval: loadTeachingEvalView,
   broadband: loadBroadbandView,
   sports_venue: loadSportsVenueView,
-  towergo: loadTowerGoView
+  towergo: loadTowerGoView,
+  smart_orientation: loadSmartOrientationView
 })
 
 const prefetchViewComponent = (view) => {
@@ -3914,6 +3917,14 @@ onBeforeUnmount(() => {
         v-else-if="currentView === 'towergo'"
         :student-id="studentId"
         @back="handleBackToDashboard"
+      />
+
+      <!-- 智慧迎新 -->
+      <SmartOrientationView
+        v-else-if="currentView === 'smart_orientation'"
+        :student-id="studentId"
+        @back="handleBackToDashboard"
+        @logout="handleLogout"
       />
       
       <!-- 其他模块占位 -->

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -158,7 +158,8 @@ const LOGIN_METHOD_KEY = 'hbu_login_method'
 const JWXT_MODULE_ALLOWLIST = new Set([
   'grades', 'classroom', 'exams', 'ranking', 'calendar', 'school_inbox', 'academic',
   'qxzkb', 'course_selection', 'training', 'teaching_eval', 'library', 'campus_map', 'resource_share',
-  'chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class', 'broadband', 'sports_venue', 'towergo'
+  'chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class', 'broadband', 'sports_venue', 'towergo',
+  'smart_orientation'
 ])
 const loginMethod = ref('')
 const isChaoxingMethod = (value) => String(value || '').trim().startsWith('chaoxing')
@@ -503,6 +504,7 @@ const baseModules = [
   { id: 'campus_map', name: '校园地图', iconKey: 'campus_map', color: '#14b8a6', desc: '校园地图查看', available: true, requiresLogin: false },
   { id: 'resource_share', name: '资源网盘', iconKey: 'resource_share', color: '#0ea5e9', desc: 'WebDAV 资料浏览与下载', available: true, requiresLogin: false },
   { id: 'towergo', name: '小塔出行', iconKey: 'towergo', color: '#22c55e', desc: '校园电单车与骑行服务', available: true, requiresLogin: false },
+  { id: 'smart_orientation', name: '智慧迎新', iconKey: 'smart_orientation', color: '#f59e0b', desc: '迎新消息与班导师宿舍等只读信息', available: true, requiresLogin: true },
   { id: 'ai', name: '校园助手', iconKey: 'ai', color: '#94a3b8', desc: '暂不可用', available: true, requiresLogin: true }
 ]
 
@@ -544,6 +546,7 @@ const isChaoxingLogin = computed(() => isChaoxingMethod(loginMethod.value))
 const homeCollisionFx = ref([])
 
 // 合规 guest/demo 下学习通、一码通等整组会被滤空：不渲染空分组标题，避免误导审核员
+// 资源组含 smart_orientation（#481）；合规收紧会话下会被 policy 滤掉且整组可能变空
 const moduleCategories = computed(() => {
   const cats = [
     {
@@ -579,7 +582,7 @@ const moduleCategories = computed(() => {
     {
       title: '资源',
       modules: modules.value.filter((m) =>
-        ['library', 'campus_map', 'resource_share', 'towergo', 'ai'].includes(m.id)
+        ['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai'].includes(m.id)
       )
     }
   ]
@@ -983,6 +986,7 @@ const quickEntryMeta = {
   campus_map: { name: '校园地图', icon: 'fa-map-marked-alt', color: 'bg-teal-50', iconColor: 'text-teal-600' },
   resource_share: { name: '资料分享', icon: 'fa-folder-open', color: 'bg-blue-50', iconColor: 'text-blue-600' },
   towergo: { name: '小塔出行', icon: 'fa-bicycle', color: 'bg-emerald-50', iconColor: 'text-emerald-600' },
+  smart_orientation: { name: '智慧迎新', icon: 'fa-user-graduate', color: 'bg-amber-50', iconColor: 'text-amber-600' },
   ai: { name: '校园助手', icon: 'fa-robot', color: 'bg-gray-50', iconColor: 'text-gray-500' }
 }
 
@@ -1122,7 +1126,7 @@ const featureIconColors = {
   chaoxing_hub: 'bg-blue-600', chaoxing_inbox: 'bg-indigo-600', chaoxing_class: 'bg-sky-500',
   broadband: 'bg-cyan-600', sports_venue: 'bg-green-600',
   library: 'bg-emerald-600', campus_map: 'bg-teal-500', resource_share: 'bg-blue-500',
-  towergo: 'bg-emerald-500',
+  towergo: 'bg-emerald-500', smart_orientation: 'bg-amber-500',
   ai: 'bg-gray-400'
 }
 
@@ -1134,7 +1138,7 @@ const featureIcons = {
   chaoxing_hub: 'fa-graduation-cap', chaoxing_inbox: 'fa-inbox', chaoxing_class: 'fa-folder-open',
   broadband: 'fa-wifi', sports_venue: 'fa-futbol',
   library: 'fa-book', campus_map: 'fa-map-marked-alt', resource_share: 'fa-cloud',
-  towergo: 'fa-bicycle',
+  towergo: 'fa-bicycle', smart_orientation: 'fa-user-graduate',
   ai: 'fa-robot'
 }
 

--- a/src/components/SmartOrientationView.spec.ts
+++ b/src/components/SmartOrientationView.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const viewPath = resolve(__dirname, 'SmartOrientationView.vue')
+const source = readFileSync(viewPath, 'utf8')
+
+describe('SmartOrientationView contract (#459)', () => {
+  it('registers five readonly tabs', () => {
+    for (const id of ['messages', 'mentor', 'counselor', 'dorm', 'profile']) {
+      expect(source).toContain(`id: '${id}'`)
+    }
+  })
+
+  it('calls only readonly smart_orientation invokes', () => {
+    expect(source).toContain("smart_orientation_list_panels")
+    expect(source).toContain("smart_orientation_list_messages")
+    expect(source).toContain("smart_orientation_profile_blocks")
+    expect(source).not.toMatch(/smart_orientation_.*(submit|save|upload|confirm)/i)
+  })
+
+  it('uses grade-style building blocks and theme tokens', () => {
+    expect(source).toContain('TPageHeader')
+    expect(source).toContain('TEmptyState')
+    expect(source).toContain('var(--ui-')
+    expect(source).toMatch(/loading|TEmptyState type="loading"/)
+    expect(source).toMatch(/type="empty"/)
+    expect(source).toMatch(/type="error"/)
+  })
+
+  it('does not render submit/write form actions', () => {
+    expect(source).not.toMatch(/type=["']submit["']/)
+    expect(source).not.toMatch(/@click="[^"]*(submit|upload|confirmSave)/i)
+    expect(source).toContain('只读展示')
+    expect(source).toContain('填报请前往官方门户')
+  })
+})

--- a/src/components/SmartOrientationView.vue
+++ b/src/components/SmartOrientationView.vue
@@ -1,0 +1,689 @@
+<script setup>
+/**
+ * 智慧迎新只读页（#459）
+ * - 布局对齐成绩查询：TPageHeader / 卡片 / Tab / token
+ * - 数据：smart_orientation_* 只读 invoke；无填报提交
+ */
+import { ref, computed, onMounted } from 'vue'
+import { invokeNative, isTauriRuntime } from '../platform/native'
+import { formatRelativeTime } from '../utils/time.js'
+import { TPageHeader, TEmptyState } from './templates'
+
+const props = defineProps({
+  studentId: { type: String, default: '' }
+})
+
+const emit = defineEmits(['back', 'logout'])
+
+const TABS = [
+  { id: 'messages', label: '消息', icon: 'mail' },
+  { id: 'mentor', label: '班导师', icon: 'person' },
+  { id: 'counselor', label: '辅导员', icon: 'support_agent' },
+  { id: 'dorm', label: '宿舍', icon: 'apartment' },
+  { id: 'profile', label: '个人信息', icon: 'badge' }
+]
+
+const activeTab = ref('messages')
+const loading = ref(false)
+const refreshing = ref(false)
+const error = ref('')
+const notice = ref('')
+const source = ref('')
+const demo = ref(false)
+const fetchedAt = ref('')
+
+const panels = ref([])
+const messages = ref([])
+const mentor = ref(null)
+const counselor = ref(null)
+const dorm = ref(null)
+const profile = ref(null)
+const selectedMessage = ref(null)
+
+const isInitialLoading = computed(() => loading.value && !fetchedAt.value)
+const unreadCount = computed(() => messages.value.filter((m) => !m.isRead).length)
+
+const sourceLabel = computed(() => {
+  if (source.value === 'live') return '在线'
+  if (source.value === 'mixed') return '部分在线'
+  if (source.value === 'fixture') return '协议样例'
+  return source.value || '智慧迎新'
+})
+
+const personFields = (person) => {
+  if (!person) return []
+  return [
+    { label: '姓名', value: person.name },
+    { label: '工号', value: person.staffId },
+    { label: '学院', value: person.college },
+    { label: '手机', value: person.phone },
+    { label: '邮箱', value: person.email },
+    { label: '办公地点', value: person.office },
+    { label: '备注', value: person.remark }
+  ].filter((row) => String(row.value || '').trim())
+}
+
+const dormFields = computed(() => {
+  const d = dorm.value
+  if (!d) return []
+  return [
+    { label: '校区', value: d.campus },
+    { label: '楼栋', value: d.building },
+    { label: '房间', value: d.room },
+    { label: '床位', value: d.bed },
+    { label: '状态', value: d.status },
+    { label: '备注', value: d.remark }
+  ].filter((row) => String(row.value || '').trim())
+})
+
+const profileFields = computed(() => {
+  const p = profile.value
+  if (!p) return []
+  return [
+    { label: '学号', value: p.studentId },
+    { label: '姓名', value: p.name },
+    { label: '性别', value: p.gender },
+    { label: '学院', value: p.college },
+    { label: '专业', value: p.major },
+    { label: '班级', value: p.className },
+    { label: '年级', value: p.grade },
+    { label: '培养层次', value: p.educationLevel },
+    { label: '身份证号', value: p.idNumber },
+    { label: '手机', value: p.phone },
+    { label: '迎新状态', value: p.orientationStatus }
+  ].filter((row) => String(row.value || '').trim())
+})
+
+const normalizeMessage = (item) => ({
+  id: String(item?.id || ''),
+  title: String(item?.title || '无标题'),
+  summary: String(item?.summary || ''),
+  body: String(item?.body || item?.summary || ''),
+  publishedAt: String(item?.publishedAt || item?.published_at || ''),
+  isRead: !!(item?.isRead ?? item?.is_read),
+  category: String(item?.category || '')
+})
+
+const normalizePerson = (raw) => {
+  if (!raw || typeof raw !== 'object') return null
+  return {
+    name: String(raw.name || ''),
+    staffId: String(raw.staffId || raw.staff_id || ''),
+    college: String(raw.college || ''),
+    phone: String(raw.phone || ''),
+    email: String(raw.email || ''),
+    office: String(raw.office || ''),
+    remark: String(raw.remark || '')
+  }
+}
+
+const formatTime = (value) => {
+  const text = String(value || '').trim()
+  if (!text) return '未知时间'
+  const parsed = Date.parse(text.replace(/-/g, '/'))
+  if (!Number.isFinite(parsed)) return text
+  return formatRelativeTime(new Date(parsed).toISOString()) || text
+}
+
+const applyMeta = (payload) => {
+  if (!payload || typeof payload !== 'object') return
+  source.value = String(payload.source || source.value || '')
+  demo.value = !!(payload.demo ?? demo.value)
+  notice.value = String(payload.notice || notice.value || '')
+  fetchedAt.value = String(payload.fetchedAt || payload.fetched_at || fetchedAt.value || '')
+  if (payload.error) {
+    error.value = String(payload.error)
+  }
+}
+
+const fetchAll = async ({ force = false } = {}) => {
+  if (!isTauriRuntime()) {
+    error.value = '智慧迎新仅支持 Tauri 桌面端'
+    return
+  }
+
+  if (force) {
+    refreshing.value = true
+  } else {
+    loading.value = true
+  }
+  error.value = ''
+  notice.value = ''
+
+  try {
+    const [panelsRes, messagesRes, blocksRes] = await Promise.all([
+      invokeNative('smart_orientation_list_panels').catch((e) => ({
+        panels: [],
+        error: e?.message || String(e),
+        source: 'fixture',
+        demo: true
+      })),
+      invokeNative('smart_orientation_list_messages').catch((e) => ({
+        items: [],
+        error: e?.message || String(e),
+        source: 'fixture',
+        demo: true
+      })),
+      invokeNative('smart_orientation_profile_blocks').catch((e) => ({
+        error: e?.message || String(e),
+        source: 'fixture',
+        demo: true
+      }))
+    ])
+
+    panels.value = Array.isArray(panelsRes?.panels) ? panelsRes.panels : []
+    applyMeta(panelsRes)
+
+    const list = Array.isArray(messagesRes?.items) ? messagesRes.items : []
+    messages.value = list.map(normalizeMessage).filter((m) => m.id)
+    applyMeta(messagesRes)
+
+    mentor.value = normalizePerson(blocksRes?.mentor)
+    counselor.value = normalizePerson(blocksRes?.counselor)
+    dorm.value = blocksRes?.dorm && typeof blocksRes.dorm === 'object' ? blocksRes.dorm : null
+    profile.value =
+      blocksRes?.profile && typeof blocksRes.profile === 'object' ? blocksRes.profile : null
+    applyMeta(blocksRes)
+
+    if (!fetchedAt.value) {
+      fetchedAt.value = new Date().toISOString()
+    }
+  } catch (err) {
+    error.value = err?.message || String(err) || '获取智慧迎新数据失败'
+  } finally {
+    loading.value = false
+    refreshing.value = false
+  }
+}
+
+const openMessage = (item) => {
+  selectedMessage.value = item
+}
+
+const closeMessage = () => {
+  selectedMessage.value = null
+}
+
+const handleBack = () => {
+  if (selectedMessage.value) {
+    closeMessage()
+    return
+  }
+  emit('back')
+}
+
+const switchTab = (id) => {
+  selectedMessage.value = null
+  activeTab.value = id
+}
+
+onMounted(() => {
+  void fetchAll()
+})
+</script>
+
+<template>
+  <div class="so-page min-h-screen flex flex-col mx-auto max-w-[448px] relative pb-24">
+    <TPageHeader
+      :title="selectedMessage ? '消息详情' : '智慧迎新'"
+      icon="waving_hand"
+      @back="handleBack"
+    >
+      <template #actions>
+        <button
+          class="so-icon-btn"
+          type="button"
+          :aria-busy="refreshing || loading"
+          aria-label="刷新"
+          @click="fetchAll({ force: true })"
+        >
+          <span class="material-symbols-outlined" :class="{ spinning: refreshing || loading }">
+            refresh
+          </span>
+        </button>
+      </template>
+    </TPageHeader>
+
+    <div v-if="!isTauriRuntime()" class="p-4">
+      <TEmptyState type="empty" message="智慧迎新仅支持 Tauri 桌面端，请在桌面应用中使用。" />
+    </div>
+
+    <template v-else-if="selectedMessage">
+      <main class="flex-1 flex flex-col gap-4 p-4">
+        <article class="so-card">
+          <h2 class="so-card-title">{{ selectedMessage.title }}</h2>
+          <div class="so-meta-row">
+            <span v-if="selectedMessage.category" class="so-badge">{{ selectedMessage.category }}</span>
+            <span>{{ selectedMessage.publishedAt || '未知时间' }}</span>
+          </div>
+          <p class="so-body whitespace-pre-wrap">{{ selectedMessage.body }}</p>
+        </article>
+      </main>
+    </template>
+
+    <template v-else>
+      <div v-if="fetchedAt || notice || demo" class="so-banner mx-4 mt-2">
+        <span>来源：{{ sourceLabel }}</span>
+        <span v-if="fetchedAt"> · 更新于 {{ formatRelativeTime(fetchedAt) || fetchedAt }}</span>
+        <span v-if="demo" class="so-badge so-badge--demo">样例</span>
+        <p v-if="notice" class="so-banner-notice">{{ notice }}</p>
+      </div>
+
+      <nav class="so-tabs" aria-label="智慧迎新分区">
+        <button
+          v-for="tab in TABS"
+          :key="tab.id"
+          type="button"
+          class="so-tab"
+          :class="{ 'so-tab--active': activeTab === tab.id }"
+          @click="switchTab(tab.id)"
+        >
+          <span class="material-symbols-outlined text-base">{{ tab.icon }}</span>
+          <span>{{ tab.label }}</span>
+          <span v-if="tab.id === 'messages' && unreadCount > 0" class="so-tab-dot">{{ unreadCount }}</span>
+        </button>
+      </nav>
+
+      <main class="flex-1 flex flex-col gap-3 p-4">
+        <TEmptyState v-if="isInitialLoading" type="loading" message="正在加载智慧迎新..." />
+
+        <TEmptyState
+          v-else-if="error && !messages.length && !mentor && !counselor && !dorm && !profile"
+          type="error"
+          :message="error"
+        >
+          <button class="so-primary-btn mt-3" type="button" @click="fetchAll({ force: true })">
+            重试
+          </button>
+        </TEmptyState>
+
+        <template v-else-if="activeTab === 'messages'">
+          <div v-if="messages.length" class="so-stats">
+            <div class="so-stat so-stat--primary">
+              <span class="so-stat-label">全部</span>
+              <span class="so-stat-value">{{ messages.length }}</span>
+            </div>
+            <div class="so-stat">
+              <span class="so-stat-label">未读</span>
+              <span class="so-stat-value">{{ unreadCount }}</span>
+            </div>
+          </div>
+          <TEmptyState v-if="!messages.length" type="empty" message="暂无迎新消息" />
+          <ul v-else class="flex flex-col gap-2">
+            <li v-for="item in messages" :key="item.id">
+              <button
+                type="button"
+                class="so-msg-item"
+                :class="{ 'so-msg-item--unread': !item.isRead }"
+                @click="openMessage(item)"
+              >
+                <div class="flex items-start gap-3">
+                  <span
+                    class="so-dot"
+                    :class="item.isRead ? 'so-dot--read' : 'so-dot--unread'"
+                    aria-hidden="true"
+                  />
+                  <div class="flex-1 min-w-0 text-left">
+                    <div class="flex items-start justify-between gap-2">
+                      <h3 class="so-msg-title">{{ item.title }}</h3>
+                      <span class="material-symbols-outlined text-base so-chevron">chevron_right</span>
+                    </div>
+                    <p v-if="item.summary" class="so-msg-summary">{{ item.summary }}</p>
+                    <div class="so-msg-time">{{ formatTime(item.publishedAt) }}</div>
+                  </div>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </template>
+
+        <template v-else-if="activeTab === 'mentor'">
+          <TEmptyState v-if="!mentor?.name" type="empty" message="暂无班导师信息" />
+          <article v-else class="so-card">
+            <h2 class="so-card-title">班导师</h2>
+            <dl class="so-field-list">
+              <div v-for="row in personFields(mentor)" :key="row.label" class="so-field">
+                <dt>{{ row.label }}</dt>
+                <dd>{{ row.value }}</dd>
+              </div>
+            </dl>
+          </article>
+        </template>
+
+        <template v-else-if="activeTab === 'counselor'">
+          <TEmptyState v-if="!counselor?.name" type="empty" message="暂无辅导员信息" />
+          <article v-else class="so-card">
+            <h2 class="so-card-title">辅导员</h2>
+            <dl class="so-field-list">
+              <div v-for="row in personFields(counselor)" :key="row.label" class="so-field">
+                <dt>{{ row.label }}</dt>
+                <dd>{{ row.value }}</dd>
+              </div>
+            </dl>
+          </article>
+        </template>
+
+        <template v-else-if="activeTab === 'dorm'">
+          <TEmptyState v-if="!dormFields.length" type="empty" message="暂无宿舍信息" />
+          <article v-else class="so-card">
+            <h2 class="so-card-title">宿舍信息</h2>
+            <dl class="so-field-list">
+              <div v-for="row in dormFields" :key="row.label" class="so-field">
+                <dt>{{ row.label }}</dt>
+                <dd>{{ row.value }}</dd>
+              </div>
+            </dl>
+          </article>
+        </template>
+
+        <template v-else-if="activeTab === 'profile'">
+          <TEmptyState v-if="!profileFields.length" type="empty" message="暂无个人信息" />
+          <article v-else class="so-card">
+            <h2 class="so-card-title">个人信息</h2>
+            <p class="so-readonly-hint">只读展示 · 填报请前往官方门户</p>
+            <dl class="so-field-list">
+              <div v-for="row in profileFields" :key="row.label" class="so-field">
+                <dt>{{ row.label }}</dt>
+                <dd>{{ row.value }}</dd>
+              </div>
+            </dl>
+          </article>
+        </template>
+
+        <p v-if="error && (messages.length || mentor || counselor || dorm || profile)" class="so-soft-error">
+          {{ error }}
+        </p>
+      </main>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.so-page {
+  background: var(--ui-bg, var(--md-sys-color-surface, #0f172a));
+  color: var(--ui-text, var(--md-sys-color-on-surface, #e2e8f0));
+}
+
+.so-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  color: inherit;
+  transition: background-color 0.2s ease;
+}
+
+.so-icon-btn:active {
+  background: color-mix(in srgb, var(--ui-text, #111) 8%, transparent);
+}
+
+.spinning {
+  animation: so-spin 0.8s linear infinite;
+}
+
+@keyframes so-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.so-banner {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+  background: var(--ui-surface, var(--md-sys-color-surface-container-low, #1e293b));
+  border: 1px solid var(--ui-surface-border, var(--md-sys-color-outline-variant, transparent));
+}
+
+.so-banner-notice {
+  margin-top: 0.25rem;
+  opacity: 0.9;
+}
+
+.so-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.35rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 9999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  background: var(--ui-primary-soft, var(--md-sys-color-primary-container, #312e81));
+  color: var(--ui-text, var(--md-sys-color-on-primary-container, #e0e7ff));
+}
+
+.so-badge--demo {
+  background: color-mix(in srgb, #f59e0b 28%, transparent);
+  color: var(--ui-text, #fde68a);
+}
+
+.so-tabs {
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem 0.25rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.so-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  padding: 0.45rem 0.7rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+  background: var(--ui-surface, var(--md-sys-color-surface-container-lowest, #1e293b));
+  border: 1px solid var(--ui-surface-border, var(--md-sys-color-outline-variant, transparent));
+  transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+}
+
+.so-tab--active {
+  color: var(--ui-text, var(--md-sys-color-on-primary-container, #e0e7ff));
+  background: var(--ui-primary-soft, var(--md-sys-color-primary-container, #312e81));
+  border-color: color-mix(
+    in srgb,
+    var(--ui-primary-soft, var(--md-sys-color-primary, #6366f1)) 55%,
+    transparent
+  );
+}
+
+.so-tab-dot {
+  min-width: 1.1rem;
+  height: 1.1rem;
+  padding: 0 0.3rem;
+  border-radius: 9999px;
+  font-size: 0.65rem;
+  line-height: 1.1rem;
+  text-align: center;
+  background: color-mix(in srgb, #ef4444 85%, transparent);
+  color: #fff;
+}
+
+.so-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.so-stat {
+  border-radius: 1rem;
+  padding: 1rem;
+  background: var(--ui-surface, var(--md-sys-color-surface-container-lowest, #1e293b));
+  border: 1px solid var(--ui-surface-border, var(--md-sys-color-outline-variant, transparent));
+  box-shadow: var(--ui-shadow-strong, none);
+}
+
+.so-stat--primary {
+  background: var(--ui-primary-soft, var(--md-sys-color-primary-container, #312e81));
+  border-color: transparent;
+}
+
+.so-stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+}
+
+.so-stat-value {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--ui-text, inherit);
+}
+
+.so-card {
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+  background: var(--ui-surface, var(--md-sys-color-surface-container-lowest, #1e293b));
+  border: 1px solid var(--ui-surface-border, var(--md-sys-color-outline-variant, transparent));
+  box-shadow: var(--ui-shadow-strong, none);
+}
+
+.so-card-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ui-text, inherit);
+  line-height: 1.35;
+}
+
+.so-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+}
+
+.so-body {
+  margin-top: 0.85rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--ui-text, inherit);
+}
+
+.so-readonly-hint {
+  margin-top: 0.35rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.7rem;
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+}
+
+.so-field-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  margin-top: 0.75rem;
+}
+
+.so-field {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.so-field dt {
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+}
+
+.so-field dd {
+  color: var(--ui-text, inherit);
+  word-break: break-word;
+}
+
+.so-msg-item {
+  width: 100%;
+  border-radius: 1rem;
+  padding: 0.875rem 1rem;
+  text-align: left;
+  background: var(--ui-surface, var(--md-sys-color-surface-container-lowest, #1e293b));
+  border: 1px solid var(--ui-surface-border, var(--md-sys-color-outline-variant, transparent));
+  transition: transform 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.so-msg-item:active {
+  transform: scale(0.985);
+}
+
+.so-msg-item--unread {
+  border-color: color-mix(
+    in srgb,
+    var(--ui-primary-soft, var(--md-sys-color-primary, #6366f1)) 45%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--ui-primary-soft, var(--md-sys-color-primary-container, #312e81)) 28%,
+    var(--ui-surface, #1e293b)
+  );
+}
+
+.so-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-top: 0.4rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+.so-dot--unread {
+  background: var(--md-sys-color-primary, #6366f1);
+}
+
+.so-dot--read {
+  background: color-mix(in srgb, var(--ui-muted, #94a3b8) 50%, transparent);
+}
+
+.so-msg-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ui-text, inherit);
+  line-height: 1.35;
+}
+
+.so-msg-summary {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--ui-muted, var(--md-sys-color-on-surface-variant, #94a3b8));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.so-msg-time {
+  margin-top: 0.4rem;
+  font-size: 0.7rem;
+  color: var(--ui-muted, var(--md-sys-color-outline, #64748b));
+}
+
+.so-chevron {
+  color: var(--ui-muted, var(--md-sys-color-outline, #64748b));
+}
+
+.so-primary-btn {
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  background: var(--md-sys-color-primary, #6366f1);
+  color: var(--md-sys-color-on-primary, #fff);
+}
+
+.so-soft-error {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--md-sys-color-error, #f87171);
+}
+</style>

--- a/src/components/icons/ThemeModuleIcon.vue
+++ b/src/components/icons/ThemeModuleIcon.vue
@@ -33,6 +33,7 @@ const iconMap = {
   broadband: 'wifi',
   sports_venue: 'sports_soccer',
   towergo: 'electric_bike',
+  smart_orientation: 'school',
   ai: 'smart_toy',
   more: 'apps',
   home: 'home',

--- a/src/config/ui_settings.ts
+++ b/src/config/ui_settings.ts
@@ -31,6 +31,7 @@ export type HomeModuleKey =
   | 'broadband'
   | 'sports_venue'
   | 'towergo'
+  | 'smart_orientation'
   | 'ai'
 export type NotificationCardKey = 'class_reminder' | 'electricity' | 'grades' | 'exams' | 'school_inbox'
 
@@ -99,6 +100,7 @@ export const HOME_MODULE_ORDER_DEFAULT = [
   'campus_map',
   'resource_share',
   'towergo',
+  'smart_orientation',
   'ai'
 ] as const satisfies readonly HomeModuleKey[]
 export const NOTIFICATION_CARD_ORDER_DEFAULT = [

--- a/src/navigation/app_navigation.ts
+++ b/src/navigation/app_navigation.ts
@@ -45,7 +45,8 @@ export const HIERARCHICAL_PARENT_VIEW_MAP: Readonly<Record<string, string>> = Ob
   campus_network: 'me',
   more: 'me',
   more_module_host: 'more',
-  more_chaoxing_checkin: 'more'
+  more_chaoxing_checkin: 'more',
+  smart_orientation: 'home'
 })
 
 export type MainTab = (typeof MAIN_TABS)[number]

--- a/src/utils/home_search.js
+++ b/src/utils/home_search.js
@@ -17,6 +17,7 @@ const SERVICE_ALIASES = Object.freeze({
   resource_share: ['资料', '文件', '分享', '下载'],
   chaoxing_class: ['学习通', '超星', '邀请码', '入班', '班级资料', '课件'],
   towergo: ['小塔', '小塔出行', '出行', '电动车', '电单车', '骑行', '骑车', '单车', '扫码用车'],
+  smart_orientation: ['智慧迎新', '迎新', '班导师', '辅导员', '宿舍', '报到'],
   ai: ['AI', '助手', '校园助手']
 })
 

--- a/src/utils/smart_orientation_entry_contract.spec.ts
+++ b/src/utils/smart_orientation_entry_contract.spec.ts
@@ -7,46 +7,99 @@ const root = resolve(__dirname, '..')
 const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8')
 
 /**
- * #485：班导师/辅导员/宿舍并入个人信息，移除首页智慧迎新独立入口与独立页。
- * 后端 `smart_orientation_profile_blocks` 仍保留。
+ * #481：智慧迎新只读完整能力
+ * - 首页资源分组入口（需登录）
+ * - SmartOrientationView 成绩风格只读页
+ * - 个人信息仍可读取 profile_blocks（#485 并入保留）
+ * - 后端仅只读命令
  */
-describe('orientation blocks in student info (#485)', () => {
-  it('Dashboard 资源区不再挂 smart_orientation 入口', () => {
+describe('smart_orientation entry + readonly wiring (#481)', () => {
+  it('Dashboard 资源区挂 smart_orientation 入口且 requiresLogin', () => {
     const dash = read('components/Dashboard.vue')
-    expect(dash).not.toContain("id: 'smart_orientation'")
-    expect(dash).not.toMatch(/title:\s*'资源'[\s\S]{0,220}smart_orientation/)
+    expect(dash).toContain("id: 'smart_orientation'")
+    expect(dash).toMatch(/id:\s*'smart_orientation'[\s\S]{0,260}requiresLogin:\s*true/)
+    expect(dash).toMatch(/title:\s*'资源'[\s\S]{0,220}smart_orientation/)
+    expect(dash).toContain(
+      "['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai']"
+    )
   })
 
-  it('App.vue 不再懒加载 SmartOrientationView', () => {
+  it('App.vue 懒加载 SmartOrientationView', () => {
     const app = read('App.vue')
-    expect(app).not.toContain("import('./components/SmartOrientationView.vue')")
-    expect(app).not.toContain('loadSmartOrientationView')
-    expect(app).not.toContain("currentView === 'smart_orientation'")
-    expect(app).not.toContain('<SmartOrientationView')
+    expect(app).toContain("import('./components/SmartOrientationView.vue')")
+    expect(app).toContain('loadSmartOrientationView')
+    expect(app).toContain('smart_orientation: loadSmartOrientationView')
+    expect(app).toContain("currentView === 'smart_orientation'")
+    expect(app).toContain('<SmartOrientationView')
   })
 
-  it('navigation 无 smart_orientation 映射', () => {
+  it('navigation 映射到 home', () => {
     const nav = read('navigation/app_navigation.ts')
-    expect(nav).not.toContain('smart_orientation')
+    expect(nav).toContain("smart_orientation: 'home'")
   })
 
-  it('ui_settings 默认模块序无 smart_orientation', () => {
+  it('ui_settings / policy 注册模块 id', () => {
     const ui = read('config/ui_settings.ts')
-    expect(ui).not.toContain("'smart_orientation'")
+    const policy = read('config/app_store_policy.ts')
+    expect(ui).toContain("'smart_orientation'")
+    expect(policy).toContain("'smart_orientation'")
+    expect(policy).toContain('smartOrientation')
   })
 
-  it('StudentInfoView 拉取 profile_blocks 并展示三项', () => {
+  it('ThemeModuleIcon 含 smart_orientation 图标', () => {
+    const icon = read('components/icons/ThemeModuleIcon.vue')
+    expect(icon).toContain('smart_orientation:')
+  })
+
+  it('SmartOrientationView 只读三命令 + 成绩风格 token', () => {
+    const view = read('components/SmartOrientationView.vue')
+    expect(view).toContain("invokeNative('smart_orientation_list_panels'")
+    expect(view).toContain("invokeNative('smart_orientation_list_messages'")
+    expect(view).toContain("invokeNative('smart_orientation_profile_blocks'")
+    expect(view).not.toMatch(/smart_orientation_.*(submit|save|upload|confirm)/i)
+    expect(view).toContain('TPageHeader')
+    expect(view).toContain('TEmptyState')
+    expect(view).toContain('var(--ui-')
+    expect(view).toContain('只读展示')
+    expect(view).toContain('填报请前往官方门户')
+  })
+
+  it('StudentInfoView 仍可读 profile_blocks（#485 并入保留）', () => {
     const view = read('components/StudentInfoView.vue')
     expect(view).toContain("invokeNative('smart_orientation_profile_blocks'")
     expect(view).toContain('班导师')
     expect(view).toContain('辅导员')
-    expect(view).toContain('宿舍信息')
     expect(view).not.toMatch(/smart_orientation_.*(submit|save|upload)/)
   })
 
-  it('后端仍注册 profile_blocks 只读命令', () => {
+  it('后端注册只读命令且无 submit', () => {
     const lib = read('../src-tauri/src/lib.rs')
+    const modrs = read('../src-tauri/src/modules/mod.rs')
+    const rs = read('../src-tauri/src/modules/smart_orientation.rs')
+    expect(modrs).toContain('smart_orientation')
+    expect(lib).toContain('smart_orientation_list_panels')
+    expect(lib).toContain('smart_orientation_list_messages')
     expect(lib).toContain('smart_orientation_profile_blocks')
     expect(lib).not.toContain('smart_orientation_submit')
+    expect(rs).toContain('list_panels')
+    expect(rs).toContain('list_messages')
+    expect(rs).toContain('profile_blocks')
+    const prod = rs.split('mod tests')[0] || rs
+    expect(prod).not.toContain('smart_orientation_submit')
+    expect(rs).toContain('orientation_demo_allowed')
+    expect(rs).toContain('MINI_HBUT_ORIENTATION_DEMO')
+  })
+
+  it('协议文档与脱敏 fixtures 存在', () => {
+    const doc = read('../docs/protocol/smart-orientation.md')
+    expect(doc).toContain('智慧迎新')
+    expect(doc).toContain('只读')
+    expect(doc.length).toBeGreaterThan(200)
+    const overview = read('../src-tauri/tests/fixtures/smart-orientation/overview.json')
+    expect(overview).toContain('panels')
+    const messages = read('../src-tauri/tests/fixtures/smart-orientation/messages.json')
+    expect(messages).toContain('title')
+    const blocks = read('../src-tauri/tests/fixtures/smart-orientation/profile_blocks.json')
+    expect(blocks).toMatch(/mentor|counselor|dorm|profile/)
   })
 })

--- a/src/utils/towergo_home_contract.spec.ts
+++ b/src/utils/towergo_home_contract.spec.ts
@@ -13,9 +13,11 @@ describe('towergo home integration contract', () => {
 
     expect(HOME_MODULE_ORDER_DEFAULT).toContain('towergo')
     expect(dashboard).toContain("{ id: 'towergo', name: '小塔出行'")
-    // 资料分享 (chaoxing_class) 归入「学习通」分类；资源区保留网盘 / 小塔 / AI（#485 已移除智慧迎新独立入口）
-    expect(dashboard).toContain("['library', 'campus_map', 'resource_share', 'towergo', 'ai']")
-    expect(dashboard).not.toContain("id: 'smart_orientation'")
+    // 资料分享 (chaoxing_class) 归入「学习通」分类；资源区含网盘 / 小塔 / 智慧迎新 / AI（#481）
+    expect(dashboard).toContain(
+      "['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai']"
+    )
+    expect(dashboard).toContain("id: 'smart_orientation'")
     expect(dashboard).toContain("id: 'towergo'")
     expect(dashboard).toContain("['chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class']")
     expect(app).toContain("const loadTowerGoView = () => import('./components/TowerGoView.vue')")


### PR DESCRIPTION
## Summary
- 恢复智慧迎新只读页 + 首页资源入口（需登录）
- 复用 main 后端 smart_orientation_*；无会话不注入假 PII
- 保留 #485 个人信息 profile_blocks 并入

## Test plan
- [x] vitest entry/view/contract 15+；cargo smart_orientation 7 passed
- [x] Bridge navigate smart_orientation

Fixes #481
Closes #457