### PR TITLE
fix(chaoxing): 降低 iOS 课程中心内存峰值

### DIFF
--- a/scripts/patch_tauri_ios_edge_to_edge.mjs
+++ b/scripts/patch_tauri_ios_edge_to_edge.mjs
@@ -102,6 +102,21 @@ private func configureMiniHbutEdgeToEdgeWebView(_ webview: WKWebView, _ viewCont
     webview.frame = viewController.view.bounds
   }
 }
+
+// 将 iOS 内存告警转发给 Web 层，使课程中心能收缩渲染批量。
+// 不替换 Tauri 的 navigationDelegate，避免影响其原有导航与插件回调。
+private func configureMiniHbutMemoryWarningBridge(_ webview: WKWebView) {
+  NotificationCenter.default.addObserver(
+    forName: UIApplication.didReceiveMemoryWarningNotification,
+    object: nil,
+    queue: .main
+  ) { [weak webview] _ in
+    webview?.evaluateJavaScript(
+      "window.dispatchEvent(new Event('iosMemoryWarning'))",
+      completionHandler: nil
+    )
+  }
+}
 `
 
   const callbackPattern = /(@_cdecl\("on_webview_created"\)\s*func\s+onWebviewCreated\s*\(\s*webview:\s*WKWebView,\s*viewController:\s*UIViewController\s*\)\s*\{)/
@@ -112,7 +127,10 @@ private func configureMiniHbutEdgeToEdgeWebView(_ webview: WKWebView, _ viewCont
     )
   }
 
-  source = source.replace(callbackPattern, `${helper}\n$1\n  configureMiniHbutEdgeToEdgeWebView(webview, viewController)`)
+  source = source.replace(
+    callbackPattern,
+    `${helper}\n$1\n  configureMiniHbutEdgeToEdgeWebView(webview, viewController)\n  configureMiniHbutMemoryWarningBridge(webview)`
+  )
 
   fs.writeFileSync(targetFile, source)
   console.log(`[tauri-ios-edge] 已补丁 Tauri iOS WebView: ${toPosix(path.relative(rootDir, targetFile))}`)

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -4600,10 +4600,7 @@ mod catalog_and_video_tests {
             infer_attachment_kind("", "insertbook", "课件.pptx"),
             "document"
         );
-        assert_eq!(
-            infer_attachment_kind("", "", "第1章 绪论.pdf"),
-            "document"
-        );
+        assert_eq!(infer_attachment_kind("", "", "第1章 绪论.pdf"), "document");
         assert_eq!(
             infer_attachment_kind("", "insertvideo", "讲解.mp4"),
             "video"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,4 @@
-﻿<script setup>
+<script setup>
 import { ref, onMounted, computed, watch, nextTick, onBeforeUnmount, defineAsyncComponent } from 'vue'
 import axios from 'axios'
 import UpdateDialog from './components/UpdateDialog.vue'
@@ -1003,6 +1003,7 @@ const VIEW_HEALTH_SELECTOR_MAP = Object.freeze({
   home: '.dashboard-root',
   schedule: '.schedule-view',
   classroom: '.classroom-view',
+  chaoxing_hub: '.cx-hub',
   more_module_host: '.more-module-host-view',
   school_website: '.school-website-view',
   more: '.more-view',

--- a/src/components/ChaoxingHubView.vue
+++ b/src/components/ChaoxingHubView.vue
@@ -4,7 +4,7 @@
  * 课程列表 → 章 → 小节 → 任务点 → 视频 / 成绩
  * 全部走 Tauri invoke，禁止外链
  */
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { invokeNative, isTauriRuntime } from '../platform/native'
 import { showToast } from '../utils/toast'
 import { pushDebugLog } from '../utils/debug_logger'
@@ -28,6 +28,22 @@ const videoError = ref('')
 const videoSrcIndex = ref(0)
 
 const PIE_COLORS = ['#2563eb', '#7c3aed', '#06b6d4', '#f59e0b', '#ef4444', '#10b981', '#8b5cf6', '#ec4899']
+const IOS_SAFE_COURSE_BATCH = 12
+// 课程列表上限：防止异常超大数据一次性 normalize/渲染导致 iOS 内存暴涨
+const MAX_COURSE_LIST_SIZE = 500
+const isIOSLikeDevice = (() => {
+  if (typeof navigator === 'undefined') return false
+  const ua = String(navigator.userAgent || '')
+  const platform = String(navigator.platform || '')
+  const maxTouchPoints = Number(navigator.maxTouchPoints || 0)
+  return /iPhone|iPad|iPod/i.test(ua) || (platform === 'MacIntel' && maxTouchPoints > 1)
+})()
+const courseRenderLimit = ref(IOS_SAFE_COURSE_BATCH)
+const shouldRenderRemoteCourseCovers = !isIOSLikeDevice
+
+// 卸载守卫：仅在组件卸载时置位（导航栈 pop/jumpTo 不置位），
+// 防止卸载后仍在途的异步回调继续写入响应式状态
+let disposed = false
 
 /**
  * 导航栈
@@ -189,6 +205,23 @@ const filteredCourses = computed(() => {
   )
 })
 
+const visibleCourses = computed(() => {
+  if (!isIOSLikeDevice) return filteredCourses.value
+  return filteredCourses.value.slice(0, Math.max(IOS_SAFE_COURSE_BATCH, courseRenderLimit.value))
+})
+
+const hasMoreCourses = computed(() =>
+  isIOSLikeDevice && visibleCourses.value.length < filteredCourses.value.length
+)
+
+const resetCourseRenderLimit = () => {
+  courseRenderLimit.value = IOS_SAFE_COURSE_BATCH
+}
+
+const loadMoreCourses = () => {
+  courseRenderLimit.value += IOS_SAFE_COURSE_BATCH
+}
+
 /** 成绩饼图切片（权重） */
 const scoreSlices = computed(() => {
   const score = current.value?.score
@@ -304,9 +337,21 @@ const loadList = async ({ silent = false, force = false } = {}) => {
       error: String(e?.message || e)
     }))
     const [courseRes, statusRes] = await Promise.all([coursePromise, statusPromise])
+    // 组件已卸载则放弃写入任何响应式状态
+    if (disposed) return
     if (courseRes?.success === false) throw new Error(courseRes?.error || '课程列表失败')
     statusMeta.value = statusRes || {}
-    const list = Array.isArray(courseRes?.courses) ? courseRes.courses : []
+    let list = Array.isArray(courseRes?.courses) ? courseRes.courses : []
+    // 数据规模防护：先记录数量摘要，超限截断，避免超大列表拖垮 iOS WebView
+    pushDebugLog('ChaoxingHub', `课程原始数据 count=${list.length}`, 'info')
+    if (list.length > MAX_COURSE_LIST_SIZE) {
+      pushDebugLog(
+        'ChaoxingHub',
+        `课程数量超限 raw=${list.length}，已截断至 ${MAX_COURSE_LIST_SIZE}`,
+        'warn'
+      )
+      list = list.slice(0, MAX_COURSE_LIST_SIZE)
+    }
     courses.value = list.map(normalizeCourse).filter((c) => c.courseId && c.clazzId)
     pushDebugLog(
       'ChaoxingHub',
@@ -347,10 +392,13 @@ const loadList = async ({ silent = false, force = false } = {}) => {
       { semesters: merged, from_api: fromApi, from_courses: fromCourses }
     )
   } catch (e) {
+    if (disposed) return
     error.value = safeText(e?.message || e) || '加载失败'
   } finally {
-    loading.value = false
-    refreshing.value = false
+    if (!disposed) {
+      loading.value = false
+      refreshing.value = false
+    }
   }
 }
 
@@ -377,11 +425,43 @@ const push = (frame) => {
   scrollModuleToTop()
 }
 
+/**
+ * 释放被移出栈帧关联的媒体资源（iOS 内存缓解）：
+ * video 清空 src 并 load()，文档/播放器 iframe 跳转空白页，
+ * 促使 WKWebView 尽快回收解码器与渲染内存
+ */
+const releaseMediaForFrames = (frames = []) => {
+  const needRelease = frames.some((f) => f?.level === 'video' || f?.level === 'document')
+  if (!needRelease) return
+  try {
+    document.querySelectorAll('.cx-hub video.video-el').forEach((v) => {
+      try {
+        v.pause()
+        v.src = ''
+        v.load()
+      } catch {
+        // 静默失败
+      }
+    })
+    document.querySelectorAll('.cx-hub iframe.doc-frame').forEach((f) => {
+      try {
+        f.src = 'about:blank'
+      } catch {
+        // 静默失败
+      }
+    })
+  } catch {
+    // 静默失败
+  }
+}
+
 const pop = () => {
   if (stack.value.length <= 1) {
     emit('back')
     return
   }
+  // 先释放即将被移出层级的媒体资源，再更新栈
+  releaseMediaForFrames([stack.value[stack.value.length - 1]])
   stack.value = stack.value.slice(0, -1)
   videoError.value = ''
   videoSrcIndex.value = 0
@@ -391,6 +471,8 @@ const pop = () => {
 /** 点面包屑跳到某一层 */
 const jumpTo = (index) => {
   if (index < 0 || index >= stack.value.length) return
+  // 先释放被移出层级（video/document）的媒体资源，再更新栈
+  releaseMediaForFrames(stack.value.slice(index + 1))
   stack.value = stack.value.slice(0, index + 1)
   videoError.value = ''
   videoSrcIndex.value = 0
@@ -408,6 +490,7 @@ const openCourse = async (course, { force = false } = {}) => {
       course_url: course.courseUrl || '',
       force: !!force
     })
+    if (disposed) return
     if (outlineRes?.success === false) throw new Error(outlineRes?.error || '大纲失败')
 
     let sectionList = Array.isArray(outlineRes?.sections) ? outlineRes.sections : []
@@ -439,6 +522,8 @@ const openCourse = async (course, { force = false } = {}) => {
       force: false
     })
       .then((progressRes) => {
+        // 组件已卸载则放弃后台进度回填
+        if (disposed) return
         const top = stack.value[stack.value.length - 1]
         if (top?.level === 'course' && top.course?.courseId === course.courseId) {
           top.progress = progressRes || {}
@@ -447,9 +532,10 @@ const openCourse = async (course, { force = false } = {}) => {
       })
       .catch(() => {})
   } catch (e) {
+    if (disposed) return
     showToast(safeText(e?.message || e) || '打开课程失败')
   } finally {
-    pageLoading.value = false
+    if (!disposed) pageLoading.value = false
   }
 }
 
@@ -471,6 +557,7 @@ const openKnowledge = async (course, section, knowledge) => {
       knowledge_id: kid,
       cpi
     })
+    if (disposed) return
     if (res?.success === false) throw new Error(res?.error || '任务点加载失败')
     const list = Array.isArray(res?.tasks)
       ? res.tasks
@@ -495,9 +582,10 @@ const openKnowledge = async (course, section, knowledge) => {
       }
     })
   } catch (e) {
+    if (disposed) return
     showToast(safeText(e?.message || e) || '打开小节失败')
   } finally {
-    pageLoading.value = false
+    if (!disposed) pageLoading.value = false
   }
 }
 
@@ -509,6 +597,7 @@ const openScore = async (course) => {
       clazz_id: course.clazzId,
       cpi: course.cpi || ''
     })
+    if (disposed) return
     if (res?.success === false) throw new Error(res?.error || res?.message || '成绩加载失败')
     // 若已在成绩页则替换，避免栈叠加
     if (current.value.level === 'score') {
@@ -518,6 +607,7 @@ const openScore = async (course) => {
       push({ level: 'score', course, score: res })
     }
   } catch (e) {
+    if (disposed) return
     const msg = safeText(e?.message || e) || '成绩加载失败'
     if (msg.includes('Unknown POST endpoint')) {
       showToast('成绩接口未就绪，请完全退出应用后重新打开')
@@ -527,7 +617,7 @@ const openScore = async (course) => {
       showToast(msg)
     }
   } finally {
-    pageLoading.value = false
+    if (!disposed) pageLoading.value = false
   }
 }
 
@@ -576,6 +666,7 @@ const openVideo = async (course, section, knowledge, task, meta) => {
       object_id: task.objectId,
       fid: meta?.fid || '0'
     })
+    if (disposed) return
     if (res?.success === false) throw new Error(res?.error || '视频状态失败')
     const st = res?.data && typeof res.data === 'object' ? res.data : res
     const playUrls = collectPlayUrls(st, res || {})
@@ -605,9 +696,10 @@ const openVideo = async (course, section, knowledge, task, meta) => {
       duration: safeNumber(st.duration)
     })
   } catch (e) {
+    if (disposed) return
     showToast(safeText(e?.message || e) || '视频打开失败')
   } finally {
-    pageLoading.value = false
+    if (!disposed) pageLoading.value = false
   }
 }
 
@@ -623,6 +715,7 @@ const openDocument = async (course, section, knowledge, task, meta) => {
       object_id: task.objectId,
       fid: meta?.fid || '0'
     })
+    if (disposed) return
     if (res?.success === false) throw new Error(res?.error || '文档状态失败')
     const st = res?.data && typeof res.data === 'object' ? res.data : res
     const docUrls = collectDocUrls(st, res || {})
@@ -648,10 +741,11 @@ const openDocument = async (course, section, knowledge, task, meta) => {
       fileType: safeText(st.fileType || st.filetype || task.typeMeta?.text || '文档')
     })
   } catch (e) {
+    if (disposed) return
     const msg = safeText(e?.message || e) || '文档打开失败'
     showToast(`文档预览失败：${msg}`)
   } finally {
-    pageLoading.value = false
+    if (!disposed) pageLoading.value = false
   }
 }
 
@@ -758,13 +852,32 @@ watch(
   () => props.studentId,
   () => {
     stack.value = [{ level: 'list' }]
+    resetCourseRenderLimit()
     void loadList()
   }
 )
 
+watch([activeSemester, searchQuery], () => {
+  resetCourseRenderLimit()
+})
+
+/** iOS 原生层内存告警：立即收缩课程渲染批量，降低 DOM 与内存压力 */
+const onIosMemoryWarning = () => {
+  courseRenderLimit.value = IOS_SAFE_COURSE_BATCH
+  pushDebugLog('ChaoxingHub', '收到 iOS 内存告警，收缩课程渲染批量', 'warn')
+}
+
 onMounted(() => {
   scrollModuleToTop()
+  // 事件名与原生层契约保持一致：iosMemoryWarning
+  window.addEventListener('iosMemoryWarning', onIosMemoryWarning)
   void loadList()
+})
+
+onUnmounted(() => {
+  // 仅在组件卸载时置位；导航栈内 pop/jumpTo 切换不触发
+  disposed = true
+  window.removeEventListener('iosMemoryWarning', onIosMemoryWarning)
 })
 </script>
 
@@ -830,6 +943,9 @@ onMounted(() => {
             <div class="stat"><span>待办</span><b>{{ totalPending }}</b></div>
           </div>
           <p v-if="error" class="err">{{ error }}</p>
+          <p v-if="isIOSLikeDevice && filteredCourses.length > visibleCourses.length" class="hint">
+            iOS 为降低进入课程中心时的闪退风险，首次仅渲染部分课程，可继续加载其余课程。
+          </p>
         </section>
 
         <div v-if="semesterTabs.length > 1" class="sem-scroll" role="tablist">
@@ -860,7 +976,7 @@ onMounted(() => {
         />
 
         <button
-          v-for="c in filteredCourses"
+          v-for="c in visibleCourses"
           :key="c.id"
           type="button"
           class="row-card course"
@@ -868,14 +984,17 @@ onMounted(() => {
         >
           <div class="cover">
             <img
-              v-if="c.imageUrl"
+              v-if="shouldRenderRemoteCourseCovers && c.imageUrl"
               :src="c.imageUrl"
               alt=""
               loading="lazy"
               referrerpolicy="no-referrer"
               @error="onCoverError"
             />
-            <div class="cover-fb" :style="c.imageUrl ? { display: 'none' } : undefined">
+            <div
+              class="cover-fb"
+              :style="shouldRenderRemoteCourseCovers && c.imageUrl ? { display: 'none' } : undefined"
+            >
               <span class="material-symbols-outlined">menu_book</span>
             </div>
           </div>
@@ -890,6 +1009,18 @@ onMounted(() => {
             </div>
           </div>
           <span class="material-symbols-outlined chev">chevron_right</span>
+        </button>
+        <button
+          v-if="hasMoreCourses"
+          type="button"
+          class="row-card course course-load-more"
+          @click="loadMoreCourses"
+        >
+          <div class="row-main">
+            <strong>继续加载更多课程</strong>
+            <p>剩余 {{ filteredCourses.length - visibleCourses.length }} 门未展示</p>
+          </div>
+          <span class="material-symbols-outlined chev">expand_more</span>
         </button>
       </template>
 
@@ -1529,6 +1660,9 @@ onMounted(() => {
 }
 .row-card:active {
   transform: scale(0.985);
+}
+.course-load-more {
+  justify-content: center;
 }
 .row-card.menu:hover {
   border-color: #93c5fd;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { initBackgroundFetchScheduler } from './utils/background_fetch'
 import { runNotificationCheck } from './utils/notify_center'
 import { runCampusNetworkAutoLogin } from './utils/campus_network_service'
 import { initDebugLogger, pushDebugLog } from './utils/debug_logger'
+import { installGlobalErrorCapture, attachVueErrorCapture } from './utils/crash_reporter'
 import { invokeNative, isTauriRuntime } from './platform/native'
 import { bootstrapWebsiteDemoIfNeeded } from './utils/website_demo_boot.js'
 import { ensureMaterialSymbolsFont, loadLocalIconFonts } from './utils/icon_fonts'
@@ -39,6 +40,8 @@ const removeNativeSplash = () => {
 
 const mountApp = () => {
   const app = createApp(App)
+  // 组件渲染 / 生命周期错误归因（写入调试日志，附组件名）
+  attachVueErrorCapture(app)
   app.component('IOSSelect', IOSSelect)
   app.mount('#app')
   // Vue 挂载后立刻清掉 index.html 原生启动页（若 mount 替换未生效也能兜底）
@@ -115,6 +118,8 @@ const bootstrap = () => {
   initThemeBridge()
 
   initDebugLogger()
+  // 尽早安装全局错误捕获（error / unhandledrejection），用于闪退前 JS 错误事后归因
+  installGlobalErrorCapture()
   pushDebugLog('Bootstrap', '开始初始化应用')
   initUiSettings()
   initAppSettings()

--- a/src/styles/bottom_tab_bar_safe_area.spec.ts
+++ b/src/styles/bottom_tab_bar_safe_area.spec.ts
@@ -79,6 +79,7 @@ describe('bottom tab bar safe area contract', () => {
   const tauriIosPatcher = () => readSource('scripts/patch_tauri_ios_edge_to_edge.mjs')
   const devWorkflow = () => readSource('.github/workflows/dev-build.yml')
   const releaseWorkflow = () => readSource('.github/workflows/release.yml')
+  const testFlightWorkflow = () => readSource('.github/workflows/ios-testflight.yml')
 
   const expectTauriIosWorkflowOrder = (workflow: string) => {
     const initIndex = workflow.search(/npm (run tauri|exec -- tauri) ios init/)
@@ -198,9 +199,10 @@ func onWebviewCreated(webview: WKWebView, viewController: UIViewController) {
     expect(patcher).toContain('DispatchQueue.main.asyncAfter')
   })
 
-  it('runs the Tauri iOS edge-to-edge patch after ios init and before xcodebuild', () => {
+  it('runs the Tauri iOS patch after ios init and before xcodebuild in every iOS workflow', () => {
     expectTauriIosWorkflowOrder(devWorkflow())
     expectTauriIosWorkflowOrder(releaseWorkflow())
+    expectTauriIosWorkflowOrder(testFlightWorkflow())
   })
 
   it('patches a generated Tauri iOS Swift bridge file idempotently', () => {
@@ -216,6 +218,9 @@ func onWebviewCreated(webview: WKWebView, viewController: UIViewController) {
       const patched = readFileSync(bridgePath, 'utf8')
       expect(patched.match(/Mini-HBUT iOS edge-to-edge WebView patch/g)).toHaveLength(1)
       expect(patched).toContain('configureMiniHbutEdgeToEdgeWebView(webview, viewController)')
+      expect(patched).toContain('configureMiniHbutMemoryWarningBridge(webview)')
+      expect(patched).toContain('UIApplication.didReceiveMemoryWarningNotification')
+      expect(patched).toContain("window.dispatchEvent(new Event('iosMemoryWarning'))")
       expect(patched).toContain('webview.frame = viewController.view.bounds')
     } finally {
       rmSync(tempRoot, { recursive: true, force: true })

--- a/src/utils/campus_guide_bridge_contract.spec.ts
+++ b/src/utils/campus_guide_bridge_contract.spec.ts
@@ -48,8 +48,10 @@ describe('campus guide bridge contract', () => {
     expect(home).toContain('PoiCard')
     expect(home).toContain('EntranceMenu')
     expect(home).toContain('NoticeBar')
-    expect(home).toContain('openYunyou')
-    expect(home).toContain('openPunch')
+    // #491 已从首页移除云游/打卡入口，避免历史函数重新出现在直达地图页。
+    expect(home).not.toContain('openYunyou')
+    expect(home).not.toContain('openPunch')
+    expect(home).toContain('@route="store.navigateTo(CAMPUS_GUIDE_VIEWS.route)')
     // #369：手绘层重试 + POI 暗色/安全区
     const core = read('src/features/campus-guide/map/campus-map-core.ts')
     expect(core).toContain('mountCustomLayer')

--- a/src/utils/crash_reporter.ts
+++ b/src/utils/crash_reporter.ts
@@ -1,0 +1,106 @@
+import { pushDebugLog } from './debug_logger'
+import type { App } from 'vue'
+
+/**
+ * 全局错误诊断（iOS 课程中心间歇性闪退归因）：
+ * - window 'error'：同步 JS 错误 / 资源加载错误
+ * - window 'unhandledrejection'：未处理的 Promise 拒绝
+ * - Vue app.config.errorHandler：组件渲染 / 生命周期错误（附组件上下文）
+ * 全部写入本地调试日志（debug_logger），不做任何网络上传。
+ */
+
+/** 单条摘要最大长度，避免日志过大 */
+const MAX_SNIPPET = 500
+
+let installed = false
+
+/** 脱敏：粗粒度抹掉 token / cookie / 密码等敏感键值，避免写入日志 */
+const redactSensitive = (text: string) =>
+  text.replace(
+    /((?:access|refresh|id)?[_-]?token|cookie|authorization|password|passwd|secret|session[_-]?id)\s*[=:]\s*[^\s;&"',}]+/gi,
+    '$1=[已脱敏]'
+  )
+
+/** 截断 + 脱敏，生成安全摘要 */
+const toSnippet = (input: unknown, max = MAX_SNIPPET) => {
+  let text = ''
+  if (typeof input === 'string') {
+    text = input
+  } else if (input instanceof Error) {
+    text = String(input.stack || input.message || input)
+  } else if (input === null || input === undefined) {
+    text = String(input)
+  } else {
+    try {
+      text = JSON.stringify(input)
+    } catch {
+      text = String(input)
+    }
+  }
+  text = redactSensitive(String(text || '').trim())
+  return text.length > max ? `${text.slice(0, max)}…(截断)` : text
+}
+
+const handleWindowError = (event: ErrorEvent) => {
+  try {
+    const stack = toSnippet(event.error?.stack || '')
+    const parts = [
+      `未捕获异常: ${toSnippet(event.message || '(无消息)', 200)}`,
+      `位置: ${toSnippet(event.filename || '(未知文件)', 160)}:${event.lineno || 0}:${event.colno || 0}`
+    ]
+    if (stack) parts.push(`堆栈: ${stack}`)
+    pushDebugLog('GlobalError', parts.join(' | '), 'error')
+  } catch {
+    // 诊断代码自身绝不能再抛错
+  }
+}
+
+const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+  try {
+    const reason = event.reason as { stack?: unknown } | undefined
+    const stack = toSnippet(reason?.stack || '')
+    const parts = [`未处理的 Promise 拒绝: ${toSnippet(String(event.reason), 200)}`]
+    if (stack) parts.push(`堆栈: ${stack}`)
+    pushDebugLog('GlobalError', parts.join(' | '), 'error')
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * 安装全局错误捕获（幂等，重复调用不会重复注册）。
+ * 应在应用入口尽早调用（initDebugLogger 之后）。
+ */
+export const installGlobalErrorCapture = () => {
+  if (installed || typeof window === 'undefined') return
+  window.addEventListener('error', handleWindowError)
+  window.addEventListener('unhandledrejection', handleUnhandledRejection)
+  installed = true
+  pushDebugLog('GlobalError', '全局错误捕获已安装（error / unhandledrejection）', 'info')
+}
+
+/**
+ * 为 Vue 应用挂接 errorHandler，补充组件名 / 生命周期钩子上下文。
+ * 记录后不吞错：继续 console.error，保持既有控制台行为。
+ */
+export const attachVueErrorCapture = (app: App) => {
+  const previous = app.config.errorHandler
+  app.config.errorHandler = (error, instance, info) => {
+    try {
+      const componentName =
+        (instance?.$options && (instance.$options.name || instance.$options.__name)) || '(匿名组件)'
+      pushDebugLog(
+        'GlobalError',
+        `Vue 错误 [${toSnippet(String(info), 80)}] 组件: ${toSnippet(String(componentName), 80)} | ${toSnippet(error)}`,
+        'error'
+      )
+    } catch {
+      // ignore
+    }
+    if (typeof previous === 'function') {
+      previous(error, instance, info)
+      return
+    }
+    console.error('[Vue] 组件错误:', error)
+  }
+}


### PR DESCRIPTION
课程中心在 iOS 上按批渲染并禁用远程封面；Tauri TestFlight 构建新增内存告警到 Web 层的桥接；补充发布链回归测试与既有 CI 契约修正。验证：Vitest 578/578、vue-tsc、Vite 生产构建、cargo fmt、cargo test 184/184。