### PR TITLE
chore(release): bump version to 1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-hbut",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Mini-HBUT - 湖北工业大学教务助手",
   "license": "GPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "hbut-helper"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "aes",
  "async-stream",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hbut-helper"
-version = "1.4.4"
+version = "1.4.5"
 edition = "2021"
 description = "湖北工业大学教务助手 - Tauri 桌面应用"
 authors = ["HBUT Helper Team"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Mini-HBUT",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "identifier": "com.hbut.mini",
   "build": {
     "beforeDevCommand": "node scripts/ensure_dist.mjs && npm run dev",


### PR DESCRIPTION
## 背景

TestFlight 拒绝 1.4.4，因为该营销版本已获批且预发布 train 已关闭。

## 变更

- 将 package、Tauri 与 Cargo 版本统一为 1.4.5
- 同步 Cargo.lock 根包版本

## 验证

- npm test -- --run src/utils/ios_testflight_workflow_contract.spec.ts
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1