### PR TITLE
fix(#516): 个人信息页离线横幅误报——登录记录失败不再拖累整页离线状态

### DIFF
--- a/src/components/StudentInfoView.vue
+++ b/src/components/StudentInfoView.vue
@@ -30,6 +30,8 @@ const dorm = ref(null)
 const activeTab = ref('basic')
 const info = ref(null)
 const offline = ref(false)
+const accessOffline = ref(false)
+const accessSyncTime = ref('')
 const syncTime = ref('')
 
 const pageSizeOptions = [10, 20, 50]
@@ -225,7 +227,10 @@ const fetchLoginAccess = async (page = accessPage.value, pageSize = accessPageSi
     accessError.value = data?.error || '获取登录访问信息失败'
     return null
   } catch (e) {
-    accessError.value = e.response?.data?.error || '获取登录访问信息失败'
+    accessError.value =
+      e?.response?.data?.error ||
+      (typeof e === 'string' ? e : e?.message) ||
+      '获取登录访问信息失败'
     return null
   } finally {
     if (showLoading) {
@@ -316,15 +321,19 @@ const refreshData = async (options = {}) => {
 
   // 离线判定：仅当数据非缓存回源（本次请求确实失败且无可用缓存）时展示离线横幅，
   // 避免"每次进入都显示离线数据"的误报。
+  // 整页离线状态只由学生基本信息（basic）决定；登录访问记录（login_access）由独立的
+  // 融合门户会话提供，其失败不应把整页拖入"离线数据"状态（#516）。
   const basicOffline = !!basicRes?.offline && !basicRes?._fromCache && !basicRes?._stale
-  const accessOffline = !!accessRes?.offline
-  offline.value = basicOffline || accessOffline
+  const accessCached = !!accessRes?.offline
+  offline.value = basicOffline
+  accessOffline.value = accessCached
+  accessSyncTime.value = accessRes?.sync_time || ''
 
   // sync_time：离线时取离线数据自身的真实更新时间，避免被其他接口的"刚刚"覆盖
   if (offline.value) {
     if (basicOffline && basicRes?.sync_time) {
       syncTime.value = basicRes.sync_time
-    } else if (accessOffline && accessRes?.sync_time) {
+    } else if (accessCached && accessRes?.sync_time) {
       syncTime.value = accessRes.sync_time
     } else {
       syncTime.value = ''
@@ -607,6 +616,9 @@ onMounted(() => {
         <section v-show="activeTab === 'login'" class="info-card">
           <h3 class="card-section-title">联系方式 & 认证</h3>
           <div v-if="accessError" class="inline-error">{{ accessError }}</div>
+          <div v-if="accessOffline && !accessError" class="cache-hint">
+            登录记录暂不可用，当前显示缓存数据（更新于 {{ formatRelativeTime(accessSyncTime) }}）
+          </div>
 
           <div class="contact-list">
             <div class="contact-row">
@@ -650,6 +662,9 @@ onMounted(() => {
 
         <!-- Access Tab -->
         <section v-show="activeTab === 'access'" class="info-card">
+          <div v-if="accessOffline && !accessLoading" class="cache-hint">
+            登录记录暂不可用，当前显示缓存数据（更新于 {{ formatRelativeTime(accessSyncTime) }}）
+          </div>
           <div v-if="accessLoading" class="inline-loading">
             <div class="mini-spinner"></div>
             <span>正在加载访问记录...</span>
@@ -1138,6 +1153,16 @@ onMounted(() => {
   border-radius: 10px;
   background: rgba(239, 68, 68, 0.12);
   color: #b91c1c;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.cache-hint {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(245, 158, 11, 0.14);
+  color: #92610a;
   font-size: 13px;
   font-weight: 600;
 }

--- a/src/utils/student_info_offline_contract.spec.ts
+++ b/src/utils/student_info_offline_contract.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const readText = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+
+describe('student info offline banner contract (#516)', () => {
+  it('page-level offline banner is driven only by student basic info, not login-access block', () => {
+    const source = readText('src/components/StudentInfoView.vue')
+
+    const refreshBlock = source.match(/const refreshData = async \(options = \{\}\) => \{[\s\S]*?refreshing\.value = false\s*\n\}/)?.[0] || ''
+
+    // 整页离线状态只由学生基本信息决定（#516：login_access 失败不应拖累整页）
+    expect(refreshBlock).toContain('const basicOffline = !!basicRes?.offline && !basicRes?._fromCache && !basicRes?._stale')
+    expect(refreshBlock).toContain('offline.value = basicOffline')
+    // 登录访问记录独立标记，仅用于区块级提示
+    expect(refreshBlock).toContain('const accessCached = !!accessRes?.offline')
+    expect(refreshBlock).toContain('accessOffline.value = accessCached')
+    // 不允许再把 access 的 offline 并入整页离线判定
+    expect(refreshBlock).not.toContain('offline.value = basicOffline || accessOffline')
+    expect(refreshBlock).not.toContain('|| accessOffline')
+  })
+
+  it('shows block-level cache hint for login records while page stays online', () => {
+    const source = readText('src/components/StudentInfoView.vue')
+
+    expect(source).toContain('const accessOffline = ref(false)')
+    expect(source).toContain('const accessSyncTime = ref(\'\')')
+    expect(source).toContain('class="cache-hint"')
+    expect(source).toContain('登录记录暂不可用，当前显示缓存数据')
+    expect(source).toContain('formatRelativeTime(accessSyncTime)')
+    // 离线横幅保持原语义（仅整页离线时出现）
+    expect(source).toContain('当前显示离线数据，更新于 {{ formatRelativeTime(syncTime) }}')
+  })
+})


### PR DESCRIPTION
## 问题

个人信息页无论怎么刷新都显示「当前显示离线数据，更新于 43分钟前」，但后台日志显示学生基本信息请求实际成功（`source=remote, stale=false, error=""`，超星教务 200 OK）。

## 根因

- 页面离线状态由 `offline = basicOffline || accessOffline` 决定（StudentInfoView.vue refreshData）
- 登录访问记录（`fetch_personal_login_access_info`）依赖独立的融合门户会话（auth.hbut.edu.cn）：门户会话过期 → Rust 回退 43 分钟前缓存并返回 `offline=true, sync_time=旧时间`
- 辅助区块（登录记录）的失败把整页拖入「离线数据」状态，掩盖了学生基本信息实际成功的事实

## 修复

1. **整页离线状态只由学生基本信息决定**：`offline.value = basicOffline`（不再并入 login_access 的 offline）
2. **登录记录失败独立提示**：「当前登录」「登录信息」tab 显示区块级琥珀色提示「登录记录暂不可用，当前显示缓存数据（更新于 X）」，展示该区块缓存时间
3. **错误信息透传**：catch 时透传真实错误（Tauri invoke 拒绝字符串），用户能看到「融合门户会话已过期，请重新登录」等具体原因

## 验证

- 新增 contract 测试 `src/utils/student_info_offline_contract.spec.ts`（2 用例，断言整页离线不再由 access 决定）
- 全量 vitest：113/114 文件通过，唯一失败为预先存在的 `hbut_memory_match_game`（与本次无关）
- `npm run build` 成功
