### PR TITLE
feat: 移除首页资源区智慧迎新入口（内容已并入个人信息页）

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -158,8 +158,7 @@ const LOGIN_METHOD_KEY = 'hbu_login_method'
 const JWXT_MODULE_ALLOWLIST = new Set([
   'grades', 'classroom', 'exams', 'ranking', 'calendar', 'school_inbox', 'academic',
   'qxzkb', 'course_selection', 'training', 'teaching_eval', 'library', 'campus_map', 'resource_share',
-  'chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class', 'broadband', 'sports_venue', 'towergo',
-  'smart_orientation'
+  'chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class', 'broadband', 'sports_venue', 'towergo'
 ])
 const loginMethod = ref('')
 const isChaoxingMethod = (value) => String(value || '').trim().startsWith('chaoxing')
@@ -504,7 +503,6 @@ const baseModules = [
   { id: 'campus_map', name: '校园地图', iconKey: 'campus_map', color: '#14b8a6', desc: '校园地图查看', available: true, requiresLogin: false },
   { id: 'resource_share', name: '资源网盘', iconKey: 'resource_share', color: '#0ea5e9', desc: 'WebDAV 资料浏览与下载', available: true, requiresLogin: false },
   { id: 'towergo', name: '小塔出行', iconKey: 'towergo', color: '#22c55e', desc: '校园电单车与骑行服务', available: true, requiresLogin: false },
-  { id: 'smart_orientation', name: '智慧迎新', iconKey: 'smart_orientation', color: '#f59e0b', desc: '迎新消息与班导师宿舍等只读信息', available: true, requiresLogin: true },
   { id: 'ai', name: '校园助手', iconKey: 'ai', color: '#94a3b8', desc: '暂不可用', available: true, requiresLogin: true }
 ]
 
@@ -546,7 +544,6 @@ const isChaoxingLogin = computed(() => isChaoxingMethod(loginMethod.value))
 const homeCollisionFx = ref([])
 
 // 合规 guest/demo 下学习通、一码通等整组会被滤空：不渲染空分组标题，避免误导审核员
-// 资源组含 smart_orientation（#481）；合规收紧会话下会被 policy 滤掉且整组可能变空
 const moduleCategories = computed(() => {
   const cats = [
     {
@@ -582,7 +579,7 @@ const moduleCategories = computed(() => {
     {
       title: '资源',
       modules: modules.value.filter((m) =>
-        ['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai'].includes(m.id)
+        ['library', 'campus_map', 'resource_share', 'towergo', 'ai'].includes(m.id)
       )
     }
   ]
@@ -986,7 +983,6 @@ const quickEntryMeta = {
   campus_map: { name: '校园地图', icon: 'fa-map-marked-alt', color: 'bg-teal-50', iconColor: 'text-teal-600' },
   resource_share: { name: '资料分享', icon: 'fa-folder-open', color: 'bg-blue-50', iconColor: 'text-blue-600' },
   towergo: { name: '小塔出行', icon: 'fa-bicycle', color: 'bg-emerald-50', iconColor: 'text-emerald-600' },
-  smart_orientation: { name: '智慧迎新', icon: 'fa-user-graduate', color: 'bg-amber-50', iconColor: 'text-amber-600' },
   ai: { name: '校园助手', icon: 'fa-robot', color: 'bg-gray-50', iconColor: 'text-gray-500' }
 }
 
@@ -1126,7 +1122,7 @@ const featureIconColors = {
   chaoxing_hub: 'bg-blue-600', chaoxing_inbox: 'bg-indigo-600', chaoxing_class: 'bg-sky-500',
   broadband: 'bg-cyan-600', sports_venue: 'bg-green-600',
   library: 'bg-emerald-600', campus_map: 'bg-teal-500', resource_share: 'bg-blue-500',
-  towergo: 'bg-emerald-500', smart_orientation: 'bg-amber-500',
+  towergo: 'bg-emerald-500',
   ai: 'bg-gray-400'
 }
 
@@ -1138,7 +1134,7 @@ const featureIcons = {
   chaoxing_hub: 'fa-graduation-cap', chaoxing_inbox: 'fa-inbox', chaoxing_class: 'fa-folder-open',
   broadband: 'fa-wifi', sports_venue: 'fa-futbol',
   library: 'fa-book', campus_map: 'fa-map-marked-alt', resource_share: 'fa-cloud',
-  towergo: 'fa-bicycle', smart_orientation: 'fa-user-graduate',
+  towergo: 'fa-bicycle',
   ai: 'fa-robot'
 }
 

--- a/src/utils/home_search.js
+++ b/src/utils/home_search.js
@@ -17,7 +17,6 @@ const SERVICE_ALIASES = Object.freeze({
   resource_share: ['资料', '文件', '分享', '下载'],
   chaoxing_class: ['学习通', '超星', '邀请码', '入班', '班级资料', '课件'],
   towergo: ['小塔', '小塔出行', '出行', '电动车', '电单车', '骑行', '骑车', '单车', '扫码用车'],
-  smart_orientation: ['智慧迎新', '迎新', '班导师', '辅导员', '宿舍', '报到'],
   ai: ['AI', '助手', '校园助手']
 })
 

--- a/src/utils/smart_orientation_entry_contract.spec.ts
+++ b/src/utils/smart_orientation_entry_contract.spec.ts
@@ -8,20 +8,21 @@ const read = (rel: string) => readFileSync(resolve(root, rel), 'utf8')
 
 /**
  * #481：智慧迎新只读完整能力
- * - 首页资源分组入口（需登录）
- * - SmartOrientationView 成绩风格只读页
+ * - 首页资源分组入口已移除（内容并入个人信息页 #485/#516，避免重复入口）
+ * - SmartOrientationView 成绩风格只读页（保留，仍可通过页面路由访问）
  * - 个人信息仍可读取 profile_blocks（#485 并入保留）
  * - 后端仅只读命令
  */
 describe('smart_orientation entry + readonly wiring (#481)', () => {
-  it('Dashboard 资源区挂 smart_orientation 入口且 requiresLogin', () => {
+  it('Dashboard 资源区不再挂 smart_orientation 入口（内容已并入个人信息页）', () => {
     const dash = read('components/Dashboard.vue')
-    expect(dash).toContain("id: 'smart_orientation'")
-    expect(dash).toMatch(/id:\s*'smart_orientation'[\s\S]{0,260}requiresLogin:\s*true/)
-    expect(dash).toMatch(/title:\s*'资源'[\s\S]{0,220}smart_orientation/)
-    expect(dash).toContain(
+    expect(dash).not.toContain("id: 'smart_orientation'")
+    expect(dash).not.toContain(
       "['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai']"
     )
+    // 个人信息页保留 profile_blocks 读取能力（#485）
+    const view = read('components/StudentInfoView.vue')
+    expect(view).toContain("invokeNative('smart_orientation_profile_blocks'")
   })
 
   it('App.vue 懒加载 SmartOrientationView', () => {

--- a/src/utils/towergo_home_contract.spec.ts
+++ b/src/utils/towergo_home_contract.spec.ts
@@ -13,11 +13,11 @@ describe('towergo home integration contract', () => {
 
     expect(HOME_MODULE_ORDER_DEFAULT).toContain('towergo')
     expect(dashboard).toContain("{ id: 'towergo', name: '小塔出行'")
-    // 资料分享 (chaoxing_class) 归入「学习通」分类；资源区含网盘 / 小塔 / 智慧迎新 / AI（#481）
+    // 资料分享 (chaoxing_class) 归入「学习通」分类；资源区含网盘 / 小塔 / AI（智慧迎新已并入个人信息页）
     expect(dashboard).toContain(
-      "['library', 'campus_map', 'resource_share', 'towergo', 'smart_orientation', 'ai']"
+      "['library', 'campus_map', 'resource_share', 'towergo', 'ai']"
     )
-    expect(dashboard).toContain("id: 'smart_orientation'")
+    expect(dashboard).not.toContain("id: 'smart_orientation'")
     expect(dashboard).toContain("id: 'towergo'")
     expect(dashboard).toContain("['chaoxing_hub', 'chaoxing_inbox', 'chaoxing_class']")
     expect(app).toContain("const loadTowerGoView = () => import('./components/TowerGoView.vue')")


### PR DESCRIPTION
## 变更内容

移除首页「资源」分组中的「智慧迎新」模块入口。该模块内容（班导师 / 辅导员 / 宿舍信息）已在 #485 并入个人信息页（学工附属信息区块），首页保留独立入口属于重复展示。

## 修改文件

### src/components/Dashboard.vue（6 处）
- `baseModules`：删除 smart_orientation 模块条目
- `moduleCategories` 资源组白名单：移除 'smart_orientation'
- `JWXT_MODULE_ALLOWLIST`（学习通登录白名单）：移除
- 图标映射：quickEntryMeta / featureIconColors / featureIcons 三处删除 smart_orientation
- 同步删除 #481 相关注释

### src/utils/home_search.js
- 移除 smart_orientation 搜索关键词（智慧迎新/迎新/班导师/辅导员/宿舍/报到），搜索不再返回该入口

### 保留项（不删）
- `SmartOrientationView.vue` 组件与路由（App.vue 懒加载、navigation、ui_settings、app_store_policy 均保留）
- 后端只读命令（smart_orientation_list_panels / list_messages / profile_blocks）——**个人信息页学工附属信息仍依赖 profile_blocks**
- StudentInfoView 的 profile_blocks 读取逻辑

## 验证

- contract 测试更新并新增断言：Dashboard 资源区**不再**包含 smart_orientation（`smart_orientation_entry_contract.spec.ts`、`towergo_home_contract.spec.ts`）
- 全量 vitest：113/114 文件通过，唯一失败为预先存在的 `hbut_memory_match_game`（与本次无关）
- `npm run build` 成功（7.1s）
