### PR TITLE
fix(#520): 会话过期红灯凭据判定改走后端 DB，未勾记住密码也可自动重登

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4112,10 +4112,9 @@ fn resolve_stored_portal_password(student_id: &str) -> Option<String> {
 /// 查询本地是否存在可恢复的门户凭据（DB 密码 / 密钥环），供前端消除「未保存密码」误报。
 #[tauri::command]
 async fn has_restorable_credentials(
-    state: State<'_, AppState>,
+    _state: State<'_, AppState>,
     student_id: String,
 ) -> Result<bool, String> {
-    let _ = state.client.read().await;
     Ok(resolve_stored_portal_password(&student_id).is_some())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4081,6 +4081,86 @@ async fn restore_latest_session(state: State<'_, AppState>) -> Result<UserInfo, 
     Ok(user_info)
 }
 
+/// 解析本地可恢复的门户凭据（DB 会话密码 + 密钥环双键），供自动重登判定。
+/// 说明：login 命令无条件把密码写入 SQLite user_sessions（与前端「记住密码」勾选无关），
+/// 因此前端 localStorage 标志为 false 时后端仍可能具备恢复能力，需以本函数为准。
+fn resolve_stored_portal_password(student_id: &str) -> Option<String> {
+    let sid = student_id.trim();
+    if sid.is_empty() {
+        return None;
+    }
+    // 1) DB 会话密码（login 时无条件保存，密钥环可用时存 __keyring__ 标记）
+    if let Ok(Some(session)) = db::get_user_session(DB_FILENAME, sid) {
+        if !session.password.is_empty() {
+            return Some(session.password);
+        }
+    }
+    // 2) 密钥环：学号键（旧键）/ hbut: 学号键（记住密码键）
+    if let Some(p) = credential_store::load_session_password(sid) {
+        if !p.is_empty() {
+            return Some(p);
+        }
+    }
+    if let Some(p) = credential_store::load_remembered_credential(&format!("hbut:{}", sid)) {
+        if !p.is_empty() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// 查询本地是否存在可恢复的门户凭据（DB 密码 / 密钥环），供前端消除「未保存密码」误报。
+#[tauri::command]
+async fn has_restorable_credentials(
+    state: State<'_, AppState>,
+    student_id: String,
+) -> Result<bool, String> {
+    let _ = state.client.read().await;
+    Ok(resolve_stored_portal_password(&student_id).is_some())
+}
+
+/// 使用本地存储的门户凭据自动重登（DB 密码走完整 CAS 登录），恢复教务会话。
+/// 与手动 login 命令一致：成功后写会话 DB、密钥环双写、持久化 cookies。
+#[tauri::command]
+async fn auto_relogin_from_stored(
+    state: State<'_, AppState>,
+    student_id: String,
+) -> Result<UserInfo, String> {
+    let sid = student_id.trim().to_string();
+    if sid.is_empty() {
+        return Err("学号为空，无法自动重登".to_string());
+    }
+    let password = resolve_stored_portal_password(&sid)
+        .ok_or_else(|| "本地未找到可用的门户密码，无法自动重登".to_string())?;
+
+    let mut client = state.client.write().await;
+    client.set_credentials(sid.clone(), password.clone());
+    let user_info = client
+        .login(&sid, &password, "", "", "")
+        .await
+        .map_err(|e| e.to_string())?;
+    client.set_chaoxing_login_mode(false);
+
+    let session_key = if user_info.student_id.trim().is_empty() {
+        sid.clone()
+    } else {
+        user_info.student_id.clone()
+    };
+    client.persist_session_cookies(&session_key);
+    let _ = db::save_user_session(
+        DB_FILENAME,
+        &session_key,
+        &client.get_cookies(),
+        &password,
+        "",
+        Some(""),
+        Some(""),
+    );
+    let _ = credential_store::save_password(&session_key, &password);
+    let _ = credential_store::save_remembered_credential(&format!("hbut:{}", session_key), &password);
+    Ok(user_info)
+}
+
 #[tauri::command]
 async fn set_offline_user_context(
     state: State<'_, AppState>,
@@ -7114,6 +7194,8 @@ pub fn run() {
             commands::campus_network::campus_network_logout,
             restore_session,
             restore_latest_session,
+            has_restorable_credentials,
+            auto_relogin_from_stored,
             set_offline_user_context,
             get_cookies,
             refresh_session,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1825,6 +1825,14 @@ const handleLoginSuccess = (data) => {
   }
   clearJwxtMaintenance()
   stopJwxtRecoveryPolling()
+  // #520：登录成功后主动探测教务会话是否真正恢复（刷新学习通短票/CAS 桥接）。
+  // 若探测失败，refreshSessionSilently 内部会自动进入后台重登 + 定时重试，
+  // 避免用户重新登录后仍长期停留在「会话已过期」状态。
+  if (!isTestAccountSession() && hasTauri) {
+    window.setTimeout(() => {
+      refreshSessionSilently()
+    }, 2500)
+  }
   recoverViewportAfterTransition()
 }
 
@@ -2909,6 +2917,29 @@ const attemptAutoRelogin = async () => {
   if (!creds) {
     jwxtSessionLastError.value = '本地未找到融合门户记住密码'
     return false
+  }
+
+  // #520：前端密钥环无凭据但后端 DB 无条件保存过密码（未勾记住密码也落库），
+  // 直接调用后端 auto_relogin_from_stored 走完整 CAS 登录，立即恢复而非等轮询。
+  if (creds.backendRestorable) {
+    try {
+      const userInfo = await invokeNative('auto_relogin_from_stored', {
+        studentId: creds.username
+      })
+      await persistSessionCookies()
+      const sid = String(
+        userInfo?.student_id || userInfo?.studentId || creds.username || ''
+      ).trim()
+      if (sid) {
+        studentId.value = sid
+        localStorage.setItem('hbu_username', sid)
+      }
+      return true
+    } catch (e) {
+      jwxtSessionLastError.value = formatSessionError(e)
+      console.warn('[Session] 后端存储凭据自动登录失败:', e)
+      return false
+    }
   }
 
   const doLogin = async () => {

--- a/src/composables/useSessionCredentials.js
+++ b/src/composables/useSessionCredentials.js
@@ -4,6 +4,7 @@ import {
   loadChaoxingRememberedPassword,
   loadPortalRememberedPassword
 } from '../utils/credential_storage.js'
+import { invokeNative, isTauriRuntime } from '../platform/native'
 
 const CHAOXING_REMEMBER_KEY = 'hbu_cx_remember'
 const CHAOXING_ACCOUNT_KEY = 'hbu_cx_account'
@@ -11,16 +12,35 @@ const CHAOXING_PASSWORD_KEY = 'hbu_cx_password'
 
 /**
  * 从安全存储加载门户账号密码（Tauri 密钥环 / Web 设备密钥加密）。
+ *
+ * 注意：即使前端未勾选「记住密码」（hbu_remember === 'false'），
+ * 后端 login 命令仍无条件把密码写入 SQLite user_sessions（密钥环可用时写
+ * __keyring__ 标记）。因此前端判定为「未保存」时还需查询后端
+ * has_restorable_credentials，避免误报红灯（#520）。
  */
 export async function loadPortalStoredPassword() {
+  const username = String(localStorage.getItem('hbu_username') || '').trim()
+  if (!username) return null
   const remember = localStorage.getItem('hbu_remember')
-  const username = localStorage.getItem('hbu_username')
-  if (remember === 'false' || !username) {
-    return null
+  // 勾选过「记住密码」：优先走密钥环 / 本地加密备份
+  if (remember !== 'false') {
+    const password = await loadPortalRememberedPassword(username)
+    if (password) return { username, password, backendRestorable: false }
   }
-  const password = await loadPortalRememberedPassword(username)
-  if (!password) return null
-  return { username, password }
+  // 未勾选或密钥环缺失：后端 DB 仍无条件保存密码，可静默重登
+  if (isTauriRuntime()) {
+    try {
+      const restorable = await invokeNative('has_restorable_credentials', {
+        studentId: username
+      })
+      if (restorable) {
+        return { username, password: '', backendRestorable: true }
+      }
+    } catch {
+      // 旧版二进制可能未注册该命令，忽略并走原有判定
+    }
+  }
+  return null
 }
 
 /**

--- a/src/utils/session_credential_detection_contract.spec.ts
+++ b/src/utils/session_credential_detection_contract.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const readText = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+
+describe('session credential detection contract (#520)', () => {
+  it('backend registers has_restorable_credentials and auto_relogin_from_stored commands', () => {
+    const lib = readText('src-tauri/src/lib.rs')
+    const handlerBlock = lib.match(/invoke_handler\(tauri::generate_handler!\[[\s\S]*?\]\)/)?.[0] || ''
+
+    // 命令必须注册给前端调用
+    expect(handlerBlock).toContain('has_restorable_credentials')
+    expect(handlerBlock).toContain('auto_relogin_from_stored')
+  })
+
+  it('has_restorable_credentials resolves from db user_sessions and keyring', () => {
+    const lib = readText('src-tauri/src/lib.rs')
+    const fnBlock = lib.match(/fn resolve_stored_portal_password\(student_id: &str\) -> Option<String> \{[\s\S]*?\n\}/)?.[0] || ''
+
+    // DB 会话密码（login 时无条件保存）优先
+    expect(fnBlock).toContain('db::get_user_session(DB_FILENAME, sid)')
+    expect(fnBlock).toContain('!session.password.is_empty()')
+    // 密钥环双键兜底：学号键 + hbut: 记住密码键
+    expect(fnBlock).toContain('credential_store::load_session_password(sid)')
+    expect(fnBlock).toContain('load_remembered_credential(&format!("hbut:{}", sid))')
+  })
+
+  it('auto_relogin_from_stored performs full CAS login and persists credentials', () => {
+    const lib = readText('src-tauri/src/lib.rs')
+    const cmdBlock = lib.match(/async fn auto_relogin_from_stored\([\s\S]*?\n\}/)?.[0] || ''
+
+    expect(cmdBlock).toContain('resolve_stored_portal_password(&sid)')
+    expect(cmdBlock).toContain('client.set_credentials(sid.clone(), password.clone())')
+    expect(cmdBlock).toContain('.login(&sid, &password, "", "", "")')
+    expect(cmdBlock).toContain('client.set_chaoxing_login_mode(false)')
+    expect(cmdBlock).toContain('client.persist_session_cookies(&session_key)')
+    expect(cmdBlock).toContain('db::save_user_session(')
+    expect(cmdBlock).toContain('credential_store::save_password(&session_key, &password)')
+  })
+
+  it('frontend probes backend credentials when remember flag is false', () => {
+    const source = readText('src/composables/useSessionCredentials.js')
+
+    // 未勾记住密码时仍会向后端查询可恢复凭据（#520：login 时后端无条件落库）
+    expect(source).toContain('isTauriRuntime()')
+    expect(source).toContain("invokeNative('has_restorable_credentials',")
+    expect(source).toContain('backendRestorable: true')
+  })
+
+  it('attemptAutoRelogin calls auto_relogin_from_stored for backend-restorable credentials', () => {
+    const app = readText('src/App.vue')
+    const autoReloginBlock = app.match(/const attemptAutoRelogin = async \(\) => \{[\s\S]*?\n\}/)?.[0] || ''
+
+    expect(autoReloginBlock).toContain('creds.backendRestorable')
+    expect(autoReloginBlock).toContain("invokeNative('auto_relogin_from_stored', {")
+  })
+
+  it('login success triggers proactive session probe to avoid stale expired banner', () => {
+    const app = readText('src/App.vue')
+    const loginBlock = app.match(/const handleLoginSuccess = \(data\) => \{[\s\S]*?\n\}/)?.[0] || ''
+
+    expect(loginBlock).toContain('refreshSessionSilently()')
+    expect(loginBlock).toContain('#520')
+  })
+})


### PR DESCRIPTION
## 问题

关联 issue #520：会话过期后首页红灯误报「本地未保存密码」，且重新登录后仍提示「会话已过期」。

## 根因

1. **红灯误报**：前端判定「是否有密码」只看 localStorage 记住标志（`hbu_remember` / `hbu_cx_remember`）+ 密钥环；但后端 `login` 命令**无条件**把密码写入 SQLite `user_sessions`（密钥环标记或 base64），与前端「记住密码」勾选无关。未勾「记住密码」→ 前端误判无密码 → 红灯；后端 DB 实际有密码 → 65s 轮询或 SSO 模块从 DB 回填后静默续期成功 → 红灯消失。
2. **重新登录仍过期**：`login` 仅刷新 CAS TGT + 教务短票，20min keep-alive 再命中登录页时前端 `attemptAutoRelogin` 又因凭据探测失败返回 false → 红灯循环；最终恢复依赖后端 SSO 后台续期，与「重新登录」动作无关。

## 变更

- **后端**（`src-tauri/src/lib.rs`）：
  - 新增 `has_restorable_credentials(student_id)`：查询 DB `user_sessions` 密码 + 密钥环双键，返回是否可恢复
  - 新增 `auto_relogin_from_stored(student_id)`：取 DB 密码走完整 CAS 登录（`client.login`），成功后写会话 DB、密钥环双写、持久化 cookies
- **前端**（`src/composables/useSessionCredentials.js`、`src/App.vue`）：
  - `loadPortalStoredPassword` 未勾记住密码 / 密钥环缺失时，向后端查询可恢复凭据（`backendRestorable`），消除误报
  - `attemptAutoRelogin` 支持 `backendRestorable`：后端有密码立即重登，不等 65s 轮询
  - 登录成功后 2.5s 主动探测教务会话，失败自动进入后台恢复，避免长期停留在「会话已过期」
- **测试**：新增 `session_credential_detection_contract.spec.ts`（6 用例）

## 验证

- `cargo check` 通过
- `vitest run`：593 通过 / 3 失败（均为预先存在的 hbut_memory_match_game，与基线一致）
- `npm run build` 通过
