### PR TITLE
fix(#522): 官网 App Store 下载链接补齐 /cn/app/mini-hbut 路径

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4156,7 +4156,8 @@ async fn auto_relogin_from_stored(
         Some(""),
     );
     let _ = credential_store::save_password(&session_key, &password);
-    let _ = credential_store::save_remembered_credential(&format!("hbut:{}", session_key), &password);
+    let _ =
+        credential_store::save_remembered_credential(&format!("hbut:{}", session_key), &password);
     Ok(user_info)
 }
 

--- a/src/utils/website_appstore_cta_contract.spec.ts
+++ b/src/utils/website_appstore_cta_contract.spec.ts
@@ -17,8 +17,9 @@ describe('website App Store dual CTA (#466)', () => {
   it('centralizes store links and anchors in home-content', () => {
     const content = read('data/home-content.ts')
     expect(content).toMatch(/export const APP_STORE_APP_ID\s*=\s*['"]6787857278['"]/)
-    expect(content).toMatch(/itms-apps:\/\/apps\.apple\.com\/app\/id\$\{APP_STORE_APP_ID\}/)
-    expect(content).toMatch(/https:\/\/apps\.apple\.com\/app\/id\$\{APP_STORE_APP_ID\}/)
+    expect(content).toMatch(/itms-apps:\/\/apps\.apple\.com\/\$\{APP_STORE_PAGE_PATH\}/)
+    expect(content).toMatch(/https:\/\/apps\.apple\.com\/\$\{APP_STORE_PAGE_PATH\}/)
+    expect(content).toMatch(/APP_STORE_PAGE_PATH\s*=\s*`cn\/app\/mini-hbut\/id\$\{APP_STORE_APP_ID\}`/)
     expect(content).toMatch(/DOWNLOAD_ANDROID_ANCHOR/)
     expect(content).toMatch(/export function resolveAppStoreOpenUrl/)
   })
@@ -51,8 +52,8 @@ describe('website App Store dual CTA (#466)', () => {
     expect(idMatch?.[1]).toBe('6787857278')
     const APP_STORE_APP_ID = idMatch![1]
     const APP_STORE_LINKS = {
-      itmsApps: `itms-apps://apps.apple.com/app/id${APP_STORE_APP_ID}`,
-      https: `https://apps.apple.com/app/id${APP_STORE_APP_ID}`,
+      itmsApps: `itms-apps://apps.apple.com/cn/app/mini-hbut/id${APP_STORE_APP_ID}`,
+      https: `https://apps.apple.com/cn/app/mini-hbut/id${APP_STORE_APP_ID}`,
     }
     // 与源文件 resolveAppStoreOpenUrl 同构的最小实现：若源文件改了分支，合同字符串也会失败
     expect(src).toContain('/iPhone|iPad|iPod/i')
@@ -63,9 +64,9 @@ describe('website App Store dual CTA (#466)', () => {
     }
     const iphone =
       'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15'
-    expect(resolve(iphone)).toBe('itms-apps://apps.apple.com/app/id6787857278')
+    expect(resolve(iphone)).toBe('itms-apps://apps.apple.com/cn/app/mini-hbut/id6787857278')
     expect(resolve('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe(
-      'https://apps.apple.com/app/id6787857278',
+      'https://apps.apple.com/cn/app/mini-hbut/id6787857278',
     )
   })
 })

--- a/website/src/data/home-content.appstore.spec.ts
+++ b/website/src/data/home-content.appstore.spec.ts
@@ -10,8 +10,12 @@ import {
 describe('App Store download links (#466)', () => {
   it('centralizes App Store id and official URLs', () => {
     expect(APP_STORE_APP_ID).toBe('6787857278')
-    expect(APP_STORE_LINKS.itmsApps).toBe('itms-apps://apps.apple.com/app/id6787857278')
-    expect(APP_STORE_LINKS.https).toBe('https://apps.apple.com/app/id6787857278')
+    expect(APP_STORE_LINKS.itmsApps).toBe(
+      'itms-apps://apps.apple.com/cn/app/mini-hbut/id6787857278',
+    )
+    expect(APP_STORE_LINKS.https).toBe(
+      'https://apps.apple.com/cn/app/mini-hbut/id6787857278',
+    )
     expect(APP_STORE_LINKS.testFlight).toContain(APP_STORE_APP_ID)
     expect(DOWNLOAD_ANDROID_ANCHOR).toBe('download-android')
     expect(DOWNLOAD_IOS_ANCHOR).toBe('download-ios')

--- a/website/src/data/home-content.ts
+++ b/website/src/data/home-content.ts
@@ -22,11 +22,13 @@ export const SITE_URL = 'https://hbut.6661111.xyz';
 
 /** App Store / TestFlight 集中配置（#466）— 避免 Hero/Download 散落魔法字符串 */
 export const APP_STORE_APP_ID = '6787857278';
+/** App Store 商店页完整路径（#522）：带国家区 + App 名称，避免无路径重定向异常 */
+export const APP_STORE_PAGE_PATH = `cn/app/mini-hbut/id${APP_STORE_APP_ID}`;
 export const APP_STORE_LINKS = {
   /** iOS 系统优先打开的 App Store 深链 */
-  itmsApps: `itms-apps://apps.apple.com/app/id${APP_STORE_APP_ID}`,
+  itmsApps: `itms-apps://apps.apple.com/${APP_STORE_PAGE_PATH}`,
   /** 桌面/失败回退的网页商店页 */
-  https: `https://apps.apple.com/app/id${APP_STORE_APP_ID}`,
+  https: `https://apps.apple.com/${APP_STORE_PAGE_PATH}`,
   /** 次要：TestFlight（非首页主 CTA） */
   testFlight: `itms-beta://beta.itunes.apple.com/v1/app/${APP_STORE_APP_ID}`,
 } as const;


### PR DESCRIPTION
## 问题

关联 issue #522：官网 App Store 下载链接缺少国家区与 App 名称路径。

- 旧：`https://apps.apple.com/app/id6787857278` / `itms-apps://apps.apple.com/app/id6787857278`
- 新：`https://apps.apple.com/cn/app/mini-hbut/id6787857278` / `itms-apps://apps.apple.com/cn/app/mini-hbut/id6787857278`

## 变更

- `website/src/data/home-content.ts`：新增 `APP_STORE_PAGE_PATH`（`cn/app/mini-hbut/id{APP_ID}`），`APP_STORE_LINKS.https` 与 `.itmsApps` 均使用完整路径
- `website/src/data/home-content.appstore.spec.ts`：断言同步
- `src/utils/website_appstore_cta_contract.spec.ts`：契约断言同步

## 验证

- website spec：3/3 通过
- 根目录 vitest：593 通过 / 3 失败（均为预先存在的 hbut_memory_match_game，与基线一致）
- `website npm run build` 通过
