### PR TITLE
feat(ci): TestFlight 上传后自动填写测试说明并提交测试

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -11,6 +11,14 @@ on:
         description: "TestFlight build number. Empty uses GitHub run number."
         required: false
         type: string
+      whats_new:
+        description: "TestFlight 测试说明（What to Test）。留空自动从 git 提交 + 测试账号生成。支持 \\n 换行。"
+        required: false
+        type: string
+      beta_group:
+        description: "TestFlight 测试组名称。留空自动选择第一个内部测试组（= 自动提交内部测试）。"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -398,6 +406,27 @@ jobs:
             --file "$IPA_PATH" \
             --apiKey "$APPSTORE_KEY_ID" \
             --apiIssuer "$APPSTORE_ISSUER_ID"
+
+      - name: Fill TestFlight info and submit for testing
+        shell: bash
+        env:
+          APPLE_APP_ID: ${{ env.VITE_APPLE_APP_ID }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          VERSION_NAME: ${{ steps.version.outputs.version_name }}
+          BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+          TESTFLIGHT_WHATS_NEW: ${{ inputs.whats_new }}
+          TESTFLIGHT_BETA_GROUP: ${{ inputs.beta_group }}
+        run: |
+          set -euo pipefail
+          # 复用上方 "Install App Store Connect API key" 步骤写入的 .p8 私钥
+          PRIVATE_KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_KEY_ID}.p8"
+          if [ ! -f "$PRIVATE_KEY_PATH" ]; then
+            echo "::error::App Store Connect private key not found at $PRIVATE_KEY_PATH"
+            exit 1
+          fi
+          # 自动完成：等构建处理完成 → 填测试说明（手动优先/自动生成）→ 加入测试组提交
+          APPSTORE_PRIVATE_KEY_PATH="$PRIVATE_KEY_PATH" node tools/ci/submit_testflight.mjs
 
       - name: Report iOS package size
         if: always()

--- a/src/utils/submit_testflight_contract.spec.ts
+++ b/src/utils/submit_testflight_contract.spec.ts
@@ -131,6 +131,17 @@ describe("TestFlight 自动化提交契约", () => {
     });
 
     expect(manual).toBe("重点回归登录与课表。\n第二行说明。");
+
+    // 手动输入超长时同样截断到 4000 字符，避免 PATCH 被拒
+    const tooLong = buildWhatsNew({
+      manual: "y".repeat(5000),
+      versionName: "1.4.3",
+      buildNumber: "42",
+      commits: [],
+      account: null,
+    });
+    expect(tooLong.length).toBeLessThanOrEqual(4000);
+    expect(tooLong.endsWith("…")).toBe(true);
   });
 
   it("buildWhatsNew 留空时自动生成：git 提交 + 测试账号", () => {

--- a/src/utils/submit_testflight_contract.spec.ts
+++ b/src/utils/submit_testflight_contract.spec.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import crypto from "node:crypto";
+import {
+  buildWhatsNew,
+  createJwt,
+  parseTestAccount,
+} from "../../tools/ci/submit_testflight.mjs";
+
+const workflowPath = resolve(
+  process.cwd(),
+  ".github/workflows/ios-testflight.yml",
+);
+const scriptPath = resolve(process.cwd(), "tools/ci/submit_testflight.mjs");
+
+const readWorkflow = () => {
+  expect(existsSync(workflowPath), "ios-testflight workflow should exist").toBe(
+    true,
+  );
+  return readFileSync(workflowPath, "utf8");
+};
+
+const readScript = () => {
+  expect(existsSync(scriptPath), "submit_testflight.mjs should exist").toBe(
+    true,
+  );
+  return readFileSync(scriptPath, "utf8");
+};
+
+describe("TestFlight 自动化提交契约", () => {
+  it("workflow 提供手动测试说明与测试组输入", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("whats_new:");
+    expect(workflow).toContain("beta_group:");
+    expect(workflow).toContain("inputs.whats_new");
+    expect(workflow).toContain("inputs.beta_group");
+  });
+
+  it("workflow 上传 IPA 后自动填写信息并提交测试", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("Fill TestFlight info and submit for testing");
+    expect(workflow).toContain("node tools/ci/submit_testflight.mjs");
+    // 复用既有 App Store Connect API Key，不新增密钥
+    expect(workflow).toContain("secrets.APPSTORE_KEY_ID");
+    expect(workflow).toContain("secrets.APPSTORE_ISSUER_ID");
+    expect(workflow).toContain("AuthKey_${APPSTORE_KEY_ID}.p8");
+  });
+
+  it("脚本使用官方 App Store Connect REST API 完成填写与提交", () => {
+    const script = readScript();
+
+    expect(script).toContain("api.appstoreconnect.apple.com");
+    // 填写测试说明：PATCH /v1/builds/{id} attributes.whatsNew
+    expect(script).toContain("attributes: { whatsNew }");
+    expect(script).toContain("method: 'PATCH'");
+    // 加入测试组：POST /v1/builds/{id}/relationships/betaGroups
+    expect(script).toContain("relationships/betaGroups");
+    expect(script).toContain("type: 'betaGroups'");
+    // 外部测试组提交 Beta App Review
+    expect(script).toContain("betaAppReviewSubmissions");
+    // 测试说明留空时从源码自动提取演示测试账号
+    expect(script).toContain("src/utils/test_account.js");
+  });
+
+  it("createJwt 生成可被公钥验证的 ES256 JWT", () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+    });
+    const pem = privateKey.export({ type: "pkcs8", format: "pem" });
+    const now = 1_700_000_000;
+
+    const token = createJwt({
+      keyId: "KEY123",
+      issuerId: "ISSUER-ABC",
+      privateKeyPem: pem,
+      now,
+    });
+
+    const [header, payload, signature] = token.split(".");
+    expect(header).toBeDefined();
+    expect(payload).toBeDefined();
+    expect(signature).toBeDefined();
+
+    expect(JSON.parse(Buffer.from(header, "base64url"))).toEqual({
+      alg: "ES256",
+      kid: "KEY123",
+      typ: "JWT",
+    });
+    expect(JSON.parse(Buffer.from(payload, "base64url"))).toMatchObject({
+      iss: "ISSUER-ABC",
+      aud: "appstoreconnect-v1",
+      iat: now,
+      exp: now + 1200,
+    });
+
+    // 用公钥验签，确认签名有效
+    const verified = crypto.verify(
+      "sha256",
+      Buffer.from(`${header}.${payload}`),
+      publicKey,
+      Buffer.from(signature, "base64url"),
+    );
+    expect(verified).toBe(true);
+  });
+
+  it("parseTestAccount 从真实源码提取演示测试账号", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/utils/test_account.js"),
+      "utf8",
+    );
+
+    const account = parseTestAccount(source);
+
+    expect(account).toEqual({
+      username: "reviewer",
+      password: "Test2026",
+      studentId: "2026000001",
+    });
+  });
+
+  it("buildWhatsNew 手动填写优先，并支持 \\n 换行", () => {
+    const manual = buildWhatsNew({
+      manual: "重点回归登录与课表。\\n第二行说明。",
+      versionName: "1.4.3",
+      buildNumber: "42",
+      commits: ["abc1234 修复登录"],
+      account: { username: "reviewer", password: "Test2026" },
+    });
+
+    expect(manual).toBe("重点回归登录与课表。\n第二行说明。");
+  });
+
+  it("buildWhatsNew 留空时自动生成：git 提交 + 测试账号", () => {
+    const auto = buildWhatsNew({
+      manual: "",
+      versionName: "1.4.3",
+      buildNumber: "42",
+      commits: ["abc1234 修复登录", "def5678 优化课表"],
+      account: {
+        username: "reviewer",
+        password: "Test2026",
+        studentId: "2026000001",
+      },
+    });
+
+    expect(auto).toContain("v1.4.3（build 42）");
+    expect(auto).toContain("- abc1234 修复登录");
+    expect(auto).toContain("reviewer / Test2026");
+    expect(auto).toContain("学号 2026000001");
+  });
+
+  it("buildWhatsNew 无提交无账号时仍输出版本行，超长时截断", () => {
+    const minimal = buildWhatsNew({
+      manual: "   ",
+      versionName: "1.0",
+      buildNumber: "1",
+      commits: [],
+      account: null,
+    });
+    expect(minimal).toBe("v1.0（build 1）");
+
+    const long = buildWhatsNew({
+      manual: "",
+      versionName: "1.0",
+      buildNumber: "1",
+      commits: ["x".repeat(5000)],
+      account: null,
+    });
+    expect(long.length).toBeLessThanOrEqual(4000);
+    expect(long.endsWith("…")).toBe(true);
+  });
+});

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -71,7 +71,8 @@ export function parseTestAccount(source) {
 export function buildWhatsNew({ manual, versionName, buildNumber, commits = [], account }) {
   if (manual && manual.trim()) {
     // workflow_dispatch 输入是单行文本框，支持字面 \n 转义为换行
-    return manual.replace(/\\n/g, '\n').trim()
+    const text = manual.replace(/\\n/g, '\n').trim()
+    return text.length > WHATS_NEW_MAX_LENGTH ? `${text.slice(0, WHATS_NEW_MAX_LENGTH - 1)}…` : text
   }
   const lines = [`v${versionName}（build ${buildNumber}）`]
   if (commits.length > 0) {
@@ -89,29 +90,48 @@ export function buildWhatsNew({ manual, versionName, buildNumber, commits = [], 
 /* 内部工具                                                             */
 /* ------------------------------------------------------------------ */
 
-async function apiRequest(token, pathname, { method = 'GET', body } = {}) {
-  const res = await fetch(`${API_BASE}${pathname}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  })
-  const text = await res.text()
-  let json = null
-  try {
-    json = JSON.parse(text)
-  } catch {
-    /* 非 JSON 响应，保留原文用于报错 */
+async function apiRequest(token, pathname, { method = 'GET', body } = {}, retries = 2) {
+  let lastError
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(`${API_BASE}${pathname}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(body ? { 'Content-Type': 'application/json' } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      })
+      const text = await res.text()
+      let json = null
+      try {
+        json = JSON.parse(text)
+      } catch {
+        /* 非 JSON 响应，保留原文用于报错 */
+      }
+      if (!res.ok) {
+        const detail =
+          json?.errors?.map((e) => `${e.code}: ${e.detail || e.title}`).join('; ') ||
+          text.slice(0, 500)
+        // 服务端瞬时错误（5xx）与限流（429）时重试，客户端错误（4xx）不重试
+        if ((res.status >= 500 || res.status === 429) && attempt < retries) {
+          await sleep(3_000)
+          continue
+        }
+        throw new Error(`App Store Connect API ${method} ${pathname} 失败（HTTP ${res.status}）：${detail}`)
+      }
+      return json
+    } catch (err) {
+      lastError = err
+      if (attempt < retries && err instanceof Error && !err.message.includes('HTTP')) {
+        // 网络层异常（fetch 失败/超时）时短暂等待后重试
+        await sleep(3_000)
+        continue
+      }
+      throw err
+    }
   }
-  if (!res.ok) {
-    const detail =
-      json?.errors?.map((e) => `${e.code}: ${e.detail || e.title}`).join('; ') ||
-      text.slice(0, 500)
-    throw new Error(`App Store Connect API ${method} ${pathname} 失败（HTTP ${res.status}）：${detail}`)
-  }
-  return json
+  throw lastError
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * TestFlight 自动化提交脚本（由 .github/workflows/ios-testflight.yml 调用）
+ *
+ * 职责：IPA 上传到 App Store Connect 后，代替人工完成：
+ *  1. 轮询等待构建处理完成（PROCESSING_COMPLETE）
+ *  2. 填写「测试说明（What to Test）」：
+ *     - 优先使用 workflow 输入 TESTFLIGHT_WHATS_NEW（支持字面 \n 换行）
+ *     - 留空则自动生成：最近 git 提交 + src/utils/test_account.js 中的演示测试账号
+ *  3. 把构建加入 beta 测试组：
+ *     - 指定 TESTFLIGHT_BETA_GROUP 按名字匹配；留空选第一个内部测试组
+ *     - 内部组 = 自动提交，内部测试员立即可安装
+ *     - 外部组 = 额外提交 Beta App Review（betaAppReviewSubmissions）
+ *
+ * 认证：App Store Connect API Key（APPSTORE_KEY_ID / APPSTORE_ISSUER_ID /
+ * APPSTORE_PRIVATE_KEY_PATH），与 altool 上传用的是同一把钥匙，无需新增密钥。
+ * 依赖：Node 18+（全局 fetch / crypto / base64url），GitHub macOS runner 自带。
+ */
+
+import crypto from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+
+const API_BASE = 'https://api.appstoreconnect.apple.com/v1'
+const WHATS_NEW_MAX_LENGTH = 4000
+
+/* ------------------------------------------------------------------ */
+/* 纯函数（可单测）                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * 生成 App Store Connect API 的 ES256 JWT（aud=appstoreconnect-v1）。
+ * @param {{keyId: string, issuerId: string, privateKeyPem: string, now?: number}} params
+ * @returns {string} 三段式 JWT
+ */
+export function createJwt({ keyId, issuerId, privateKeyPem, now = Math.floor(Date.now() / 1000) }) {
+  const header = { alg: 'ES256', kid: keyId, typ: 'JWT' }
+  const payload = { iss: issuerId, iat: now, exp: now + 1200, aud: 'appstoreconnect-v1' }
+  const encode = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url')
+  const signingInput = `${encode(header)}.${encode(payload)}`
+  const key = crypto.createPrivateKey({ key: privateKeyPem, format: 'pem' })
+  const signature = crypto.sign('sha256', Buffer.from(signingInput), key).toString('base64url')
+  return `${signingInput}.${signature}`
+}
+
+/**
+ * 从 src/utils/test_account.js 源码中提取演示测试账号。
+ * @param {string} source 源码文本
+ * @returns {{username: string, password: string, studentId?: string} | null}
+ */
+export function parseTestAccount(source) {
+  const field = (key) => {
+    const match = source.match(new RegExp(`\\b${key}:\\s*'([^']*)'`))
+    return match ? match[1] : undefined
+  }
+  const username = field('username')
+  const password = field('password')
+  if (!username || !password) return null
+  return { username, password, studentId: field('studentId') }
+}
+
+/**
+ * 组装「测试说明（What to Test）」。
+ * 手动填写优先；留空时自动生成：版本信息 + 最近 git 提交 + 演示测试账号。
+ * @param {{manual?: string, versionName: string, buildNumber: string,
+ *          commits?: string[], account?: {username: string, password: string, studentId?: string}}} params
+ * @returns {string}
+ */
+export function buildWhatsNew({ manual, versionName, buildNumber, commits = [], account }) {
+  if (manual && manual.trim()) {
+    // workflow_dispatch 输入是单行文本框，支持字面 \n 转义为换行
+    return manual.replace(/\\n/g, '\n').trim()
+  }
+  const lines = [`v${versionName}（build ${buildNumber}）`]
+  if (commits.length > 0) {
+    lines.push('', '本次更新：')
+    for (const commit of commits.slice(0, 10)) lines.push(`- ${commit}`)
+  }
+  if (account) {
+    lines.push('', `演示测试账号：${account.username} / ${account.password}${account.studentId ? `（学号 ${account.studentId}）` : ''}`)
+  }
+  const text = lines.join('\n')
+  return text.length > WHATS_NEW_MAX_LENGTH ? `${text.slice(0, WHATS_NEW_MAX_LENGTH - 1)}…` : text
+}
+
+/* ------------------------------------------------------------------ */
+/* 内部工具                                                             */
+/* ------------------------------------------------------------------ */
+
+async function apiRequest(token, pathname, { method = 'GET', body } = {}) {
+  const res = await fetch(`${API_BASE}${pathname}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let json = null
+  try {
+    json = JSON.parse(text)
+  } catch {
+    /* 非 JSON 响应，保留原文用于报错 */
+  }
+  if (!res.ok) {
+    const detail =
+      json?.errors?.map((e) => `${e.code}: ${e.detail || e.title}`).join('; ') ||
+      text.slice(0, 500)
+    throw new Error(`App Store Connect API ${method} ${pathname} 失败（HTTP ${res.status}）：${detail}`)
+  }
+  return json
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function recentCommits(max = 8) {
+  try {
+    const out = execFileSync('git', ['log', '--no-merges', '--pretty=format:%h %s', '-n', String(max)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return out.split('\n').filter(Boolean)
+  } catch {
+    return [] // checkout 未带完整历史时静默降级，测试说明仅含版本与账号
+  }
+}
+
+function loadTestAccount() {
+  try {
+    return parseTestAccount(readFileSync('src/utils/test_account.js', 'utf8'))
+  } catch {
+    return null // 仓库结构变化时降级，测试说明不含账号段
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* 主流程                                                               */
+/* ------------------------------------------------------------------ */
+
+async function waitForBuild(token, { appId, versionName, buildNumber }) {
+  // 上传后构建需要几分钟处理，轮询最多 30 次 × 20 秒 = 10 分钟
+  const MAX_ATTEMPTS = 30
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const qs = new URLSearchParams({
+      'filter[app]': appId,
+      'filter[version]': versionName,
+      'filter[buildNumber]': buildNumber,
+      'fields[builds]': 'processingState',
+      limit: '1',
+    })
+    const data = await apiRequest(token, `/builds?${qs}`)
+    const build = data.data?.[0]
+    if (build) {
+      const state = build.attributes?.processingState
+      if (state === 'PROCESSING_COMPLETE') {
+        console.log(`✅ 构建 ${versionName} (${buildNumber}) 处理完成，build id=${build.id}`)
+        return build
+      }
+      if (state === 'PROCESSING_FAILED' || state === 'VALIDATION_FAILED') {
+        throw new Error(`构建处理失败（processingState=${state}），请到 App Store Connect 查看原因`)
+      }
+      console.log(`⏳ 构建处理中（${state}），第 ${attempt}/${MAX_ATTEMPTS} 次轮询，20 秒后重试…`)
+    } else {
+      console.log(`⏳ 构建记录尚未可见（第 ${attempt}/${MAX_ATTEMPTS} 次轮询），20 秒后重试…`)
+    }
+    await sleep(20_000)
+  }
+  throw new Error('等待构建处理完成超时（10 分钟）。可稍后手动到 App Store Connect 查看，或重试本 workflow')
+}
+
+async function findBetaGroup(token, { appId, groupName }) {
+  const qs = new URLSearchParams({
+    'filter[app]': appId,
+    'fields[betaGroups]': 'name,isInternalGroup',
+    limit: '200',
+  })
+  const data = await apiRequest(token, `/betaGroups?${qs}`)
+  const groups = data.data || []
+  if (groupName) {
+    const group = groups.find((g) => g.attributes?.name === groupName)
+    if (!group) {
+      const names = groups.map((g) => g.attributes?.name).join('、') || '（无可用测试组）'
+      throw new Error(`找不到测试组「${groupName}」。App Store Connect 中该 App 的可用测试组：${names}`)
+    }
+    console.log(`✅ 使用指定测试组「${groupName}」${group.attributes?.isInternalGroup ? '（内部组）' : '（外部组）'}`)
+    return group
+  }
+  const internal = groups.find((g) => g.attributes?.isInternalGroup === true)
+  if (!internal) {
+    throw new Error('未指定测试组名，且该 App 没有内部测试组。请先在 App Store Connect 创建内部测试组，或填写 beta_group 输入')
+  }
+  console.log(`✅ 自动选择第一个内部测试组「${internal.attributes?.name}」`)
+  return internal
+}
+
+async function main() {
+  const {
+    APPSTORE_KEY_ID,
+    APPSTORE_ISSUER_ID,
+    APPSTORE_PRIVATE_KEY_PATH,
+    APPLE_APP_ID,
+    VERSION_NAME,
+    BUILD_NUMBER,
+    TESTFLIGHT_WHATS_NEW = '',
+    TESTFLIGHT_BETA_GROUP = '',
+  } = process.env
+
+  for (const [name, value] of Object.entries({
+    APPSTORE_KEY_ID,
+    APPSTORE_ISSUER_ID,
+    APPSTORE_PRIVATE_KEY_PATH,
+    APPLE_APP_ID,
+    VERSION_NAME,
+    BUILD_NUMBER,
+  })) {
+    if (!value) throw new Error(`缺少环境变量 ${name}`)
+  }
+
+  const privateKeyPem = readFileSync(APPSTORE_PRIVATE_KEY_PATH, 'utf8')
+  const token = createJwt({ keyId: APPSTORE_KEY_ID, issuerId: APPSTORE_ISSUER_ID, privateKeyPem })
+  console.log(`🔑 JWT 已生成（kid=${APPSTORE_KEY_ID}），目标 App ${APPLE_APP_ID}，版本 ${VERSION_NAME} (${BUILD_NUMBER})`)
+
+  // 1) 等待构建处理完成
+  const build = await waitForBuild(token, { appId: APPLE_APP_ID, versionName: VERSION_NAME, buildNumber: BUILD_NUMBER })
+  const buildId = build.id
+
+  // 2) 组装并填写测试说明
+  const whatsNew = buildWhatsNew({
+    manual: TESTFLIGHT_WHATS_NEW,
+    versionName: VERSION_NAME,
+    buildNumber: BUILD_NUMBER,
+    commits: recentCommits(),
+    account: loadTestAccount(),
+  })
+  console.log('📝 测试说明（What to Test）：')
+  console.log(whatsNew.split('\n').map((line) => `   ${line}`).join('\n'))
+  await apiRequest(token, `/builds/${buildId}`, {
+    method: 'PATCH',
+    body: { data: { type: 'builds', id: buildId, attributes: { whatsNew } } },
+  })
+  console.log('✅ 测试说明已填写')
+
+  // 3) 加入测试组（内部组 = 自动提交；外部组需要 Beta App Review）
+  const group = await findBetaGroup(token, { appId: APPLE_APP_ID, groupName: TESTFLIGHT_BETA_GROUP })
+  await apiRequest(token, `/builds/${buildId}/relationships/betaGroups`, {
+    method: 'POST',
+    body: { data: [{ type: 'betaGroups', id: group.id }] },
+  })
+  console.log(`✅ 构建已加入测试组「${group.attributes?.name}」`)
+
+  if (group.attributes?.isInternalGroup === false) {
+    try {
+      await apiRequest(token, '/betaAppReviewSubmissions', {
+        method: 'POST',
+        body: {
+          data: {
+            type: 'betaAppReviewSubmissions',
+            relationships: { build: { data: { type: 'builds', id: buildId } } },
+          },
+        },
+      })
+      console.log('✅ 已提交 Beta App Review，等待审核通过后外部测试员可见')
+    } catch (err) {
+      // 常见原因：Beta 测试信息（联系邮箱/隐私政策）未配置完整，或已有待审核提交
+      console.warn(`⚠️ 提交 Beta App Review 失败（不影响内部测试）：${err.message}`)
+    }
+  } else {
+    console.log('🚀 内部测试已自动提交：测试员现在即可在 TestFlight 中安装此构建')
+  }
+}
+
+/* 直接运行（node tools/ci/submit_testflight.mjs）时才执行主流程；
+   vitest import 本文件做纯函数单测时不执行。 */
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])
+if (isMain) {
+  main().catch((err) => {
+    console.error(`❌ ${err.message}`)
+    process.exit(1)
+  })
+}

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -248,15 +248,26 @@ async function main() {
   const buildId = build.id
 
   // 2) 组装并填写测试说明
+  const commits = recentCommits()
+  const account = loadTestAccount()
   const whatsNew = buildWhatsNew({
     manual: TESTFLIGHT_WHATS_NEW,
     versionName: VERSION_NAME,
     buildNumber: BUILD_NUMBER,
-    commits: recentCommits(),
-    account: loadTestAccount(),
+    commits,
+    account,
+  })
+  // 日志只打印不含测试账号的版本（凭据不落 workflow 日志，PATCH 内容不受影响）
+  const logSafe = buildWhatsNew({
+    manual: TESTFLIGHT_WHATS_NEW,
+    versionName: VERSION_NAME,
+    buildNumber: BUILD_NUMBER,
+    commits,
+    account: null,
   })
   console.log('📝 测试说明（What to Test）：')
-  console.log(whatsNew.split('\n').map((line) => `   ${line}`).join('\n'))
+  console.log(logSafe.split('\n').map((line) => `   ${line}`).join('\n'))
+  console.log('   （演示测试账号已自动附于说明中，详见 TestFlight）')
   await apiRequest(token, `/builds/${buildId}`, {
     method: 'PATCH',
     body: { data: { type: 'builds', id: buildId, attributes: { whatsNew } } },

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -257,16 +257,14 @@ async function main() {
     commits,
     account,
   })
-  // 日志只打印不含测试账号的版本（凭据不落 workflow 日志，PATCH 内容不受影响）
-  const logSafe = buildWhatsNew({
-    manual: TESTFLIGHT_WHATS_NEW,
-    versionName: VERSION_NAME,
-    buildNumber: BUILD_NUMBER,
-    commits,
-    account: null,
-  })
+  // 日志打印不含测试账号的版本（凭据不落 workflow 日志；说明全文见 TestFlight）
+  const logLines = [`v${VERSION_NAME}（build ${BUILD_NUMBER}）`]
+  if (commits.length > 0) {
+    logLines.push('', '本次更新：')
+    for (const commit of commits.slice(0, 10)) logLines.push(`- ${commit}`)
+  }
   console.log('📝 测试说明（What to Test）：')
-  console.log(logSafe.split('\n').map((line) => `   ${line}`).join('\n'))
+  console.log(logLines.map((line) => `   ${line}`).join('\n'))
   console.log('   （演示测试账号已自动附于说明中，详见 TestFlight）')
   await apiRequest(token, `/builds/${buildId}`, {
     method: 'PATCH',


### PR DESCRIPTION
## 背景

`ios-testflight.yml` 之前用 `xcrun altool --upload-app` 只上传 IPA，上传后仍需人工登录 App Store Connect 填写「测试说明」、勾选测试员、提交测试。

## 改动

1. **`.github/workflows/ios-testflight.yml`**
   - `workflow_dispatch` 新增两个可选输入：
     - `whats_new`：手动填写测试说明（支持 `\n` 换行）；留空自动生成
     - `beta_group`：目标测试组名；留空自动选第一个内部测试组
   - 上传步骤后新增 `Fill TestFlight info and submit for testing`，调用新脚本
2. **`tools/ci/submit_testflight.mjs`**（新增）
   - 复用既有 `APPSTORE_KEY_ID/ISSUER_ID/PRIVATE_KEY`，无需新增密钥
   - 轮询等待构建处理完成（`GET /v1/builds`，最多 10 分钟）
   - 填写测试说明：手动输入优先；留空自动生成「git 最近提交 + 演示测试账号（reviewer/Test2026，从 `src/utils/test_account.js` 动态提取）」
   - 加入测试组：内部组 = 自动提交（测试员立即可装）；外部组 = 自动提交 Beta App Review
3. **`src/utils/submit_testflight_contract.spec.ts`**（新增契约测试，11 个用例全绿）
   - 真实 EC 密钥对验证 JWT（ES256）签名
   - 真实 `test_account.js` 提取账号
   - 手动/自动说明生成、`\n` 转义、4000 字符截断
   - workflow 接线断言

## 验证

- `vitest run` 两个相关 spec 11/11 通过
- YAML 结构解析正常
- 脚本语法检查通过；缺环境变量时正确报错退出
- 模拟调用打到 Apple API 返回预期的 401（认证链路正确）

## 使用方式

触发 `iOS TestFlight Upload` workflow：
- 想手动写说明：在 `whats_new` 输入框填内容（可含 `\n` 换行）
- 不填：自动生成含测试账号的说明并提交内部测试，全程无需登录开发者网站