### PR TITLE
fix(#524): 学习通课程中心学期筛选、视频播放与进度统计修复

### DIFF
--- a/docs/chaoxing-protocol.md
+++ b/docs/chaoxing-protocol.md
@@ -25,6 +25,29 @@ Body: courseType=1&courseFolderId=0&superstarClass=0
 → HTML 片段（课程卡片）
 ```
 
+### 课程中心学期筛选（fyportal，2026-08-01 实测）
+
+湖工大定制平台（`fycourse.fanya.chaoxing.com`）的课程中心支持真实学期筛选，App 课程中心已对接：
+
+1. **学期列表**：`GET https://fycourse.fanya.chaoxing.com/fyportal/courselist/course?version=1&s=null`（带 `.chaoxing.com` cookie）返回的 HTML 中，`<select name="xq">` 服务端渲染全部学期：
+
+```html
+<select name="xq" class="dept_select">
+  <option value="0">全部</option>
+  <option value="43811" semesternum="20261" selected="true">2026-2027第一学期</option>
+  <option value="38370" semesternum="20252">2025-2026第二学期</option>
+  ...
+</select>
+```
+
+- `value` = sectionId（切换学期请求参数）
+- `semesternum` = 学年学期码（20261/20252/20251…）
+- `getFolderList?type=1` 接口返回 `{"data":[]}`，**不可用**，学期数据源是页面 HTML
+
+2. **切换学期**：`GET https://fycourse.fanya.chaoxing.com/fyportal/courselist/getStudyCourse?sectionId={sectionId}&semesterNum=&coursesource=0&coursename=&searchkkstatus=0&belongSchoolId=0` → HTML 课程卡片 `<li class="w_couritem" state="0|1" cid courseId classid clazzId personId=cpi ckenc cname>`；同一课程可出现在多个学期，归属由服务端按 sectionId 决定。
+
+Rust 实现：`online_learning.rs` `fetch_fyportal_semester_options` / `fetch_fyportal_courses_by_section` / `parse_fyportal_*`，在 `fetch_chaoxing_courses_remote` 中与 backclazzdata 结果按 `courseId:clazzId` 合并，返回 `semesters` + 每课 `semester`。
+
 ---
 
 ## Auth（门户 SSO，禁止二次登录）
@@ -166,6 +189,13 @@ Response JSON:
   1. `ananas/status/{objectId}` 返回的 `http(s)` 直链
   2. 带会话 cookie 下载 `downloadData` 转 `data:image/...;base64,...` 用 `<img>` 直显
   3. 勿对图片只塞黑底 iframe 加载 `objectshowpreview`
+
+### 视频播放（2026-08-01 实测修正）
+
+1. **状态接口**：`GET https://mooc1.chaoxing.com/ananas/status/{objectId}?k={fid}&flag=normal&ro=0&_dc={ts}`，返回 `http` 字段 = 带签名直链（`sd.mp4?at_=..&ak_=..&ad_=..`）+ `dtoken`（进度上报用）+ `download` 字段
+2. **⚠️ 直链有 Referer 防盗链**：cldisk CDN 无 chaoxing Referer 时返回 **403**。App WebView `<video>` 直链播放必失败 → 必须经 Rust 本地代理 `http_server.rs /proxy/video?url={直链}`（带学习通 cookie + `Referer: mooc1.chaoxing.com`，透传 Range）播放
+3. **⚠️ 官方 ananas 播放器带参 URL 已废弃**：`index.html?objectid=&fid=&isPhone=true` 在新版 JS（v2026-0710+）初始化即抛 TypeError、零请求、永久「正在为您加载文件」。网页端现在用**无参** `index.html?v=2026-0721-1025` + 父页 postMessage 传数据（`knowledge/cards` 页内嵌）。App 不再兜底官方播放器
+4. 播放中伴随请求：`richvideo/initdatawithviewerV2?mid=&cpi=&classid=&courseid=`（可能返回 `[]`）、`ananas/getpoints`、`richvideo/allsubtitle`、`multimedia/log`（进度上报，`dtoken` + `enc` 签名）
 - **SSO 缓存**：`chaoxing_sso` 进程内 TTL 与浏览器「关浏览器才丢 cookie」不同；cookie 仍有效时应探针复用，勿短 TTL 误杀
 
 可预览类型（JS `previewType`）：  

--- a/docs/chaoxing-semester-video-investigation-2026-08-01.md
+++ b/docs/chaoxing-semester-video-investigation-2026-08-01.md
@@ -1,0 +1,167 @@
+# 学习通课程中心 Bug 实况调查笔记（2026-08-01）
+
+> 对应 GitHub Issue: https://github.com/superdaobo/mini-hbut/issues/524
+> 调查方式：Playwright 实测（门户 SSO → 学习通课程中心 → 章节视频）
+> 账号：杨道博 2510231106（电气与电子工程学院 25通信1）
+
+## 一、Bug 1：学期筛选缺失
+
+### 网页端真实机制（实测）
+
+1. **课程中心页面**：`https://fycourse.fanya.chaoxing.com/fyportal/courselist/course?version=1&s=...&space_token=...`（在 i.chaoxing.com/base 的个人空间 iframe 内）
+2. **学期列表是服务端渲染在课程页 HTML 里的 `<select name="xq">`**，不是接口返回（`getFolderList?type=1` 返回 `{"data":[]}` 空数据，不可用）
+3. select 选项结构（当前账号实测 15 个学期）：
+
+```html
+<select name="xq" data-placeholder="全部" class="dept_select">
+  <option value="0">全部</option>
+  <option value="43811" semesternum="20261" selected="true">2026-2027第一学期</option>
+  <option value="38370" semesternum="20252">2025-2026第二学期</option>
+  <option value="35140" semesternum="20251">2025-2026第一学期</option>
+  <option value="27353" semesternum="20242">2024-2025第二学期</option>
+  <option value="24511" semesternum="20241">2024-2025第一学期</option>
+  <option value="19919" semesternum="20232">2023-2024第二学期</option>
+  <option value="15800" semesternum="20231">2023-2024第一学期</option>
+  ...（2022~2019 学期省略）
+</select>
+```
+
+   - `value` = sectionId（如 43811/38370/35140）
+   - `semesternum` 属性 = 学年学期码（20261/20252/20251）
+   - 文本 = 「2026-2027第一学期」等
+
+4. **切换学期请求**（切到 sectionId=24511 实测）：
+
+```
+GET https://fycourse.fanya.chaoxing.com/fyportal/courselist/getStudyCourse
+  ?sectionId=24511&semesterNum=&coursesource=0&coursename=&searchkkstatus=0&belongSchoolId=0&_=...
+```
+
+   - 注意 `semesterNum` 为空，学期完全由 `sectionId` 决定
+   - 响应：HTML 课程卡片列表（`<ul class="course-list"><li class="w_couritem" ...>`）
+
+5. **课程卡片 `<li>` 属性**（全部/单学期请求返回同构 HTML）：
+
+```
+<li class="w_couritem clearfix"
+    state="0"            # 0=进行中 1=已结课（封面显示「本课程已结课」）
+    kcenc="..."          # 课程加密
+    ckenc="..."          # 课程跳转加密（entercoursenewfy 用）
+    clazzenc="..."
+    personId="487811746" # = cpi
+    cid="254673763"      # courseId
+    classid="125938817"  # clazzId
+    cname="军事理论"     # 课程名
+    source="0">
+  <a href='/fyportal/courselist/entercoursenewfy?role=3&courseId=...&clazzId=...&cpi=...&ckenc=...'>
+  <img src="https://p.ananas.chaoxing.com/star3/origin/xxx.jpg">
+</li>
+```
+
+6. 实测结果：sectionId=0（全部）返回 23 门；sectionId=35140（20251）返回 7 门（军事理论、高数、思道法×2、劳育、安全教育、人工智能通识课[已结课]）；sectionId=24511（20241）返回空。**同一课程可出现在多个学期**（如军事理论 20251+当前），课程归属由服务端按 sectionId 决定。
+
+### 现有 App 实现差距
+
+- `src-tauri/src/modules/online_learning.rs`：
+  - `chaoxing_fetch_courses`（L2256）→ `fetch_chaoxing_courses_remote`（L1809）：用 `mooc1-api.chaoxing.com/mycourse/backclazzdata`（通用学习通接口），channelList **无学期字段** → `guess_semester_label`（L1435）猜不出就标「未分学期」
+  - `fetch_chaoxing_folder_courses`（L1541）：试探 `getCourseFolders` API + `visit/courselistdata`，folder 名当学期名（常是「历史课程」「课程夹 N」）——与网页端真实学期机制**完全不同**
+- 前端 `ChaoxingHubView.vue` 已有学期 tab 框架（semesterTabs + activeSemester 过滤 L196-200、L363-387），只需后端提供正确学期数据
+
+### 修复方向（Bug 1）
+
+Rust 端 `fetch_chaoxing_courses_remote` 增加 fyportal 数据源：
+1. `GET https://fycourse.fanya.chaoxing.com/fyportal/courselist/course?version=1&s=null`（带 .chaoxing.com cookie），正则/HTML 解析 `<select name="xq">` 选项 → 学期列表 `[{sectionId, semesterNum, label}]`
+2. 对 sectionId=0（全部）及各学期逐个 `GET getStudyCourse?sectionId=X&semesterNum=&coursesource=0&coursename=&searchkkstatus=0&belongSchoolId=0`，解析 `<li>` 课程卡片（cid/classid/personId/ckenc/cname/state）
+3. 返回 `semesters`（label 列表）+ 每门课 `semester` 归属；与 backclazzdata 结果按 courseId:clazzId 去重合并
+4. 前端 semesterTabs 直接可用；「本学期」由 semesternum 与当前日期推断（或取默认选中项）
+
+## 二、Bug 2：视频播放卡死
+
+### 网页端真实播放链路（实测）
+
+1. 进入章节：`mooc1.chaoxing.com/mycourse/studentstudy?chapterId=...&courseId=...&clazzid=...&cpi=...&enc=...`
+2. 知识卡片页 `mooc-ans/knowledge/cards` 内每个视频一个 iframe 播放器：**src = `https://mooc1.chaoxing.com/ananas/modules/video/index.html?v=2026-0721-1025`（无 objectid/fid 参数，数据经父页 postMessage 传入）**
+3. 播放器请求（带 cookie 会话 + `k=25368` fid）：
+
+```
+GET https://mooc1.chaoxing.com/ananas/status/{objectId}?k=25368&flag=normal&ro=0&_dc={ts}
+→ 200 JSON:
+{
+  "length": 34398924, "duration": 124,
+  "dtoken": "e88bb7eb...",
+  "http": "https://s2.cldisk.com/sv-s2/video/2d/d9/cf/{objectId}/sd.mp4?at_=...&ak_=...&ad_=...",
+  "download": "http://d0.cldisk.com/download/{objectId}?at_=...&ak_=...&ad_=...",
+  "mp3": "...", "screenshot": "...", "filename": "运动学习题1.mp4",
+  "status": "success"
+}
+```
+
+4. 直链 `http` 字段 = 带签名（at_/ak_/ad_）的 sd.mp4 地址
+5. 播放中额外请求：`richvideo/initdatawithviewerV2?mid=...&cpi=...&classid=...&courseid=...`（返回 []）、`ananas/getpoints`、`richvideo/viewpic`（缩略图）、`richvideo/allsubtitle`（字幕）、`multimedia/log`（进度上报）
+
+### 直链 403 根因（实测验证）
+
+对直链（带签名）做 fetch 对比：
+
+| 请求方式 | 结果 |
+|---|---|
+| 无 Referer（`referrer: ''`） | **403 Forbidden**（text/html 拦截页） |
+| Referer = `https://mooc1.chaoxing.com/` | **200 OK** `video/mp4`（7.7MB） |
+
+→ **cldisk.com 视频 CDN 有 Referer 防盗链**。App 内 `<video>` 直接播直链时 Referer 是 App 自身 origin（`tauri://localhost` / `capacitor://localhost` 等）→ 403 → 直链播放失败 → 触发 `onVideoError` 切官方播放器。
+
+补充：UA 不影响（ChaoXingStudy UA vs Chrome UA 返回相同直链）；`k=0` vs `k=25368` 不影响直链字段。
+
+### 官方播放器卡死根因（实测复现）
+
+`https://mooc1.chaoxing.com/ananas/modules/video/index.html?objectid=...&fid=25368&isPhone=true`（App 当前拼的 URL）直接打开：
+
+- 页面停留「正在为您加载文件...」**永不加载**
+- Console 报错：`TypeError: Cannot read properties of null (reading 'getAttribute')` at `index.js?v=2026-0710-1840:1:4207` (config → loadVideo)
+- **没有任何 ananas/status 网络请求发出**
+
+→ 新版官方播放器 JS（v=2026-0710-1840+）**不再支持 URL query 传参模式**（objectid/fid/isPhone），必须用 `index.html?v=2026-0721-1025`（无参数）+ 父页 postMessage 传数据。App 拼的旧式带参 URL 直接初始化失败，永远卡在「正在为您加载文件」。
+
+### 现有 App 实现差距
+
+- `ChaoxingHubView.vue` `openVideo`（L656-697）：`playerUrl` = `index.html?objectid=...&fid=...&isPhone=true`（L673-676）→ 必卡死
+- `onVideoError`（L771-789）：直链耗尽切 usePlayer=true → iframe 加载上述死 URL
+- `online_learning.rs` `chaoxing_get_video_status`（L4191-4297）：能拿到直链（http 字段），但直链在 App WebView 被 Referer 防盗链拦截
+- docs/chaoxing-protocol.md L165 已记录「WebView iframe 不共享 Rust reqwest CookieJar」——官方播放器兜底即使 URL 正确也会因无 cookie 失效
+
+### 修复方向（Bug 2，待对齐后定稿）
+
+**方案 A（推荐）：Rust 端本地流式代理**
+- `http_server.rs` 新增路由 `GET /proxy/video?url={直链}`：reqwest 带 `Referer: https://mooc1.chaoxing.com/` + 学习通 cookie 拉直链，`stream` 响应体转发（支持 Range，`<video>` 拖动需要）
+- 前端 `openVideo` 拿直链后把 `<video src>` 指向 `http://127.0.0.1:4399/proxy/video?url=...`（Web/远程模式经 HTTP Bridge 同构）
+- 优点：确定性绕开 Referer 防盗链 + cookie 不共享；支持 Range 拖动；不暴露签名 URL
+- 缺点：视频流经本地端口转发（性能可接受，局域网/本机）
+
+**方案 B：前端 fetch+blob 播放**
+- 前端 `fetch(direct, { referrer: 'https://mooc1.chaoxing.com/' })` → blob → `<video src=blobURL>`
+- 风险：跨域 CORS 头实测为空（浏览器环境无 ACAO 仍成功，Tauri WebView 行为可能不同）；大视频全量下载内存占用高；不支持拖动 Range（需 fetch Range 分片，复杂）
+- 不推荐作为主方案，可作 Web 端备选
+
+**方案 C：修官方播放器 URL + postMessage 协议**
+- 需要逆向 index.js 的 postMessage 协议（objectid/fid/mid 等字段），脆弱且依赖学习通前端
+- 不推荐
+
+## 三、验证标准（对齐网页端）
+
+- [ ] 课程中心「全部」+ 真实学期 tab（2026-2027第一学期 … 2019-2020），课程正确归属，无「未分学期」
+- [ ] 视频直链可播（本地代理），官方播放器兜底不再卡「正在为您加载文件」
+- [ ] 拖动进度、播放进度上报（multimedia/log）不回归
+
+## 四、附：关键请求清单（Playwright 抓包索引）
+
+| # | 请求 | 用途 |
+|---|---|---|
+| 218 | GET fycourse.fanya.chaoxing.com/fyportal/courselist/getFolderList?type=1 | 学期文件夹（data 为空，废弃） |
+| 219 | GET .../getStudyCourse?sectionId=0&semesterNum=... | 全部课程（23 门） |
+| 241 | GET .../getStudyCourse?sectionId=24511 | 2024-2025 第一学期（空） |
+| 242 | GET .../getStudyCourse?sectionId=35140 | 2025-2026 第一学期（7 门） |
+| 1298 | GET mooc1.chaoxing.com/ananas/status/1f397c...?k=25368&flag=normal&ro=0 | 视频状态+签名直链 |
+| 1392 | GET .../richvideo/initdatawithviewerV2?mid=... | 播放器数据（返回 []） |
+| 1957 | GET .../multimedia/log/... | 播放进度上报 |
+
+截图：`.playwright-mcp/evidence-player-stuck.png`（官方播放器卡「正在为您加载文件」）

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -4418,7 +4418,8 @@ async fn chaoxing_video_proxy(
 
 async fn campus_map_direction_proxy(
     RawQuery(query): RawQuery,
-) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {    let query_text = query.unwrap_or_default();
+) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
+    let query_text = query.unwrap_or_default();
     if query_text.trim().is_empty() {
         return Err(err(
             StatusCode::BAD_REQUEST,

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1011,6 +1011,8 @@ async fn run_http_server(
         .route("/school-website/*path", any(school_website_proxy))
         .route("/resource_share/direct_url", get(resource_share_direct_url))
         .route("/resource_share/proxy", get(resource_share_proxy))
+        // 学习通视频直链本地代理（绕过 cldisk Referer 防盗链 + WebView cookie 不共享）
+        .route("/proxy/video", get(chaoxing_video_proxy))
         .route(
             "/electricity_query_location",
             post(electricity_query_location),
@@ -4304,10 +4306,109 @@ async fn towergo_proxy(
     Ok(response)
 }
 
+/// 学习通视频直链本地代理：
+/// 绕过 cldisk 视频 CDN 的 Referer 防盗链（App WebView 播直链会被 403 拒绝），
+/// 以及 WebView 与 Rust reqwest CookieJar 不共享导致的官方播放器失效问题。
+///
+/// GET /proxy/video?url={encodeURIComponent(ananas/status 返回的签名直链)}
+/// - 用主会话 client（自带 .chaoxing.com cookie jar）请求直链
+/// - 强制 Referer/Origin 为 mooc1.chaoxing.com 通过防盗链校验
+/// - 透传 Range / Content-Range / Accept-Ranges，支持 `<video>` 进度拖动
+/// - 域名白名单（chaoxing.com / cldisk.com）防 SSRF
+async fn chaoxing_video_proxy(
+    State(state): State<HttpState>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
+    let target_raw = query
+        .as_deref()
+        .unwrap_or("")
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("url="))
+        .unwrap_or("")
+        .to_string();
+    if target_raw.is_empty() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "参数错误",
+            "缺少 url 参数".to_string(),
+        ));
+    }
+    let target = urlencoding::decode(&target_raw)
+        .map(|s| s.into_owned())
+        .unwrap_or(target_raw);
+    // 安全白名单：仅允许学习通视频 CDN 域名（防 SSRF 拉取内网/任意地址）
+    let lower = target.to_ascii_lowercase();
+    let host_ok = ["cldisk.com", "chaoxing.com"]
+        .iter()
+        .any(|d| lower.contains(d));
+    if !host_ok || !(lower.starts_with("http://") || lower.starts_with("https://")) {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "参数错误",
+            "代理目标不在允许的域名内".to_string(),
+        ));
+    }
+
+    let client = state.client.read().await;
+    let mut builder = client
+        .client
+        .get(&target)
+        .header("Referer", "https://mooc1.chaoxing.com/")
+        .header("Origin", "https://mooc1.chaoxing.com");
+    if let Some(range) = headers.get("range") {
+        builder = builder.header("Range", range.clone());
+    }
+    let upstream = match builder.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return Err(err(
+                StatusCode::BAD_GATEWAY,
+                "代理错误",
+                format!("视频代理请求失败: {e}"),
+            ));
+        }
+    };
+
+    let status = upstream.status();
+    let upstream_headers = upstream.headers().clone();
+    // 2xx 流式透传（<video> 边下边播）；非 2xx 收集响应体原样回放
+    let mut response = if status.is_success() {
+        let stream = upstream
+            .bytes_stream()
+            .map(|chunk| chunk.map_err(|e| std::io::Error::new(ErrorKind::Other, e.to_string())));
+        let mut resp = Response::new(Body::from_stream(stream));
+        *resp.status_mut() = status;
+        resp
+    } else {
+        let body_bytes = upstream.bytes().await.unwrap_or_default();
+        let mut resp = Response::new(Body::from(body_bytes));
+        *resp.status_mut() = status;
+        resp
+    };
+    // 透传媒体相关响应头（Range 拖动、类型、长度）
+    for (name, value) in upstream_headers.iter() {
+        let lower = name.as_str().to_ascii_lowercase();
+        if matches!(
+            lower.as_str(),
+            "content-type"
+                | "content-length"
+                | "accept-ranges"
+                | "content-range"
+                | "content-disposition"
+                | "etag"
+                | "last-modified"
+                | "cache-control"
+        ) {
+            response.headers_mut().insert(name.clone(), value.clone());
+        }
+    }
+    Ok(response)
+}
+
 async fn campus_map_direction_proxy(
     RawQuery(query): RawQuery,
-) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
-    let query_text = query.unwrap_or_default();
+) -> Result<Response, (StatusCode, Json<ApiResponse<serde_json::Value>>)> {    let query_text = query.unwrap_or_default();
     if query_text.trim().is_empty() {
         return Err(err(
             StatusCode::BAD_REQUEST,

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -4338,11 +4338,21 @@ async fn chaoxing_video_proxy(
         .map(|s| s.into_owned())
         .unwrap_or(target_raw);
     // 安全白名单：仅允许学习通视频 CDN 域名（防 SSRF 拉取内网/任意地址）
-    let lower = target.to_ascii_lowercase();
-    let host_ok = ["cldisk.com", "chaoxing.com"]
-        .iter()
-        .any(|d| lower.contains(d));
-    if !host_ok || !(lower.starts_with("http://") || lower.starts_with("https://")) {
+    // 精确 host 匹配（拒绝 userinfo 混淆、子串伪域如 evilchaoxing.com）
+    let host_ok = match reqwest::Url::parse(&target) {
+        Ok(u) => {
+            let has_userinfo = !u.username().is_empty() || u.password().is_some();
+            let host = u.host_str().unwrap_or("");
+            let scheme_ok = matches!(u.scheme(), "http" | "https");
+            let host_ok = host == "cldisk.com"
+                || host.ends_with(".cldisk.com")
+                || host == "chaoxing.com"
+                || host.ends_with(".chaoxing.com");
+            !has_userinfo && scheme_ok && host_ok
+        }
+        Err(_) => false,
+    };
+    if !host_ok {
         return Err(err(
             StatusCode::BAD_REQUEST,
             "参数错误",

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -5335,4 +5335,17 @@ mod catalog_and_video_tests {
         assert!(parse_cards_attachments("<html>mArg = {};</html>").is_empty());
         assert!(parse_cards_attachments("").is_empty());
     }
+
+    #[test]
+    fn parse_cards_attachments_handles_nested_arrays() {
+        // 附件含内嵌数组字段（如 jumpTimePointList:[]），不得提前截断
+        let html = r#"<html>mArg = {"attachments":[
+            {"otherInfo":"n1","isPassed":false,"jumpTimePointList":[],"randomFaceCaptureTimeList":[],"type":"video"},
+            {"otherInfo":"n2","isPassed":true,"type":"document"}
+        ]};</html>"#;
+        let atts = parse_cards_attachments(html);
+        assert_eq!(atts.len(), 2, "内嵌数组不应导致提前截断: {:?}", atts);
+        assert!(!atts[0]["isPassed"].as_bool().unwrap_or(true));
+        assert!(atts[1]["isPassed"].as_bool().unwrap_or(false));
+    }
 }

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -1104,7 +1104,7 @@ fn write_chaoxing_course_progress_fallback(
     let message = if role_type == 1 {
         "教师视角课程，暂不统计学习进度"
     } else {
-        "官方进度暂不可用"
+        "暂无章节任务点"
     };
     if let Some(map) = course.as_object_mut() {
         map.insert("progress_text".to_string(), json!(message));
@@ -1806,6 +1806,201 @@ fn extract_folder_array(v: &Value) -> Vec<Value> {
     Vec::new()
 }
 
+/// 解析课程中心页 HTML 中的学期下拉（<select name="xq">，服务端渲染）
+/// 返回 (section_id, semester_num, label)，如 ("43811", "20261", "2026-2027第一学期")
+/// 对应网页端真实学期筛选：切换学期即 getStudyCourse?sectionId={section_id}
+/// 注意：
+/// - 必须限定 name="xq" 的 select，页面还有院系/部门等多个下拉（否则混入噪声 label）
+/// - 真实 HTML 属性名是驼峰 `semesterNum`（部分场景小写），需两者兼容
+/// - 排除 value=0 的「全部」占位项（前端会自行提供「全部」tab）
+fn parse_fyportal_semester_options(html: &str) -> Vec<(String, String, String)> {
+    let re_select = regex::Regex::new(
+        r#"(?is)<select\s+name=["']xq["'][^>]*>(.*?)</select>"#,
+    )
+    .expect("fyportal xq select regex");
+    let re_option = regex::Regex::new(
+        r#"(?i)<option\s+value="(\d+)"(?:\s+semesternum="(\d+)")?[^>]*>([^<]{2,40})</option>"#,
+    )
+    .expect("fyportal semester option regex");
+    let mut out = Vec::new();
+    for cap in re_select.captures_iter(html) {
+        let inner = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        for opt in re_option.captures_iter(inner) {
+            let value = match opt.get(1) {
+                Some(m) => m.as_str().to_string(),
+                None => continue,
+            };
+            let sem = opt
+                .get(2)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            let label = opt
+                .get(3)
+                .map(|m| m.as_str().trim().to_string())
+                .unwrap_or_default();
+            // 排除「全部」(value=0) 与占位文本，避免污染学期 tab
+            if value == "0" || label == "全部" || label.contains("请选择") {
+                continue;
+            }
+            if label.is_empty() {
+                continue;
+            }
+            out.push((value, sem, label));
+        }
+    }
+    out
+}
+
+/// 解析 fyportal 课程卡片 HTML（<ul class="course-list"><li class="w_couritem ...">）
+/// 每张卡片属性：state(0进行中/1已结课)、cid、classid、personId(=cpi)、ckenc、cname、封面图
+fn parse_fyportal_course_cards(html: &str, semester_label: &str) -> Vec<Value> {
+    let re_li = regex::Regex::new(
+        r#"(?is)<li\s+class="[^"]*w_couritem[^"]*"([^>]*)>(.*?)</li>"#,
+    )
+    .expect("fyportal course li regex");
+    let re_attr = regex::Regex::new(
+        r#"(?i)(cid|classid|personid|ckenc|kcenc|clazzenc|cname|state|source)="([^"]*)""#,
+    )
+    .expect("fyportal course attr regex");
+    let re_img = regex::Regex::new(r#"(?i)<img\s+src="([^"]*)""#).expect("fyportal img regex");
+    let mut out = Vec::new();
+    for cap in re_li.captures_iter(html) {
+        // capture(1) = li 开标签属性段（cid/classid/cname 等），capture(2) = inner HTML（封面图）
+        let attrs_html = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let inner = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+        let mut attrs = std::collections::HashMap::new();
+        for a in re_attr.captures_iter(attrs_html) {
+            if let (Some(k), Some(v)) = (a.get(1), a.get(2)) {
+                attrs.insert(
+                    k.as_str().to_ascii_lowercase(),
+                    v.as_str().trim().to_string(),
+                );
+            }
+        }
+        let course_id = attrs.get("cid").cloned().unwrap_or_default();
+        let clazz_id = attrs.get("classid").cloned().unwrap_or_default();
+        if course_id.is_empty() || clazz_id.is_empty() {
+            continue;
+        }
+        let cname = attrs
+            .get("cname")
+            .cloned()
+            .unwrap_or_else(|| format!("课程 {course_id}"));
+        let cpi = attrs.get("personid").cloned().unwrap_or_default();
+        let state = attrs.get("state").cloned().unwrap_or_default();
+        let image_url = re_img
+            .captures(inner)
+            .and_then(|m| m.get(1))
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        let course_url = format!(
+            "https://mooc1.chaoxing.com/mooc-ans/mycourse/studentstudycourselist?courseId={course_id}&chapterId=0&clazzid={clazz_id}&cpi={cpi}&mooc2=1&isMicroCourse=false"
+        );
+        out.push(json!({
+            "id": format!("{course_id}:{clazz_id}"),
+            "course_id": course_id,
+            "clazz_id": clazz_id,
+            "cpi": cpi,
+            "name": cname,
+            "title": cname,
+            "teacher": "",
+            "image_url": image_url,
+            "course_url": course_url,
+            "role_type": 3,
+            "role_label": "student",
+            "auto_supported": true,
+            "semester": semester_label,
+            "state": state,
+            "source": "fyportal",
+        }));
+    }
+    out
+}
+
+/// 从 fyportal 课程中心页面拉取学期下拉（服务端渲染在 HTML 里）
+async fn fetch_fyportal_semester_options(client: &HbutClient) -> Vec<(String, String, String)> {
+    let url = "https://fycourse.fanya.chaoxing.com/fyportal/courselist/course?version=1&s=null";
+    let resp = match client
+        .client
+        .get(url)
+        .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        .header("Referer", "https://i.chaoxing.com/base")
+        .timeout(Duration::from_secs(12))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            crate::hbut_session_log!("ChaoxingCourses", "fyportal 学期页请求失败: {}", e);
+            return Vec::new();
+        }
+    };
+    let final_url = resp.url().to_string();
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    let opts = parse_fyportal_semester_options(&text);
+    crate::hbut_session_log!(
+        "ChaoxingCourses",
+        "fyportal 学期页 status={} final={} len={} options={}",
+        status.as_u16(),
+        final_url,
+        text.len(),
+        opts.len()
+    );
+    opts
+}
+
+/// 按学期（sectionId）拉取 fyportal 课程卡片（返回 HTML 课程列表）
+async fn fetch_fyportal_courses_by_section(
+    client: &HbutClient,
+    section_id: &str,
+    semester_label: &str,
+) -> Vec<Value> {
+    let url = format!(
+        "https://fycourse.fanya.chaoxing.com/fyportal/courselist/getStudyCourse?sectionId={}&semesterNum=&coursesource=0&coursename=&searchkkstatus=0&belongSchoolId=0",
+        section_id
+    );
+    let resp = match client
+        .client
+        .get(&url)
+        .header("Accept", "text/html, */*")
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header(
+            "Referer",
+            "https://fycourse.fanya.chaoxing.com/fyportal/courselist/course?version=1&s=null",
+        )
+        .timeout(Duration::from_secs(15))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            crate::hbut_session_log!(
+                "ChaoxingCourses",
+                "fyportal 学期课程页请求失败 section={} err={}",
+                section_id,
+                e
+            );
+            return Vec::new();
+        }
+    };
+    let final_url = resp.url().to_string();
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    let cards = parse_fyportal_course_cards(&text, semester_label);
+    crate::hbut_session_log!(
+        "ChaoxingCourses",
+        "fyportal 学期课程 section={} label={} status={} final={} len={} cards={}",
+        section_id,
+        semester_label,
+        status.as_u16(),
+        final_url,
+        text.len(),
+        cards.len()
+    );
+    cards
+}
+
 async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, DynError> {
     let url = "https://mooc1-api.chaoxing.com/mycourse/backclazzdata?view=json&rss=1";
     let resp = client
@@ -1996,28 +2191,86 @@ async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, Dyn
                 courses.len()
             );
 
-            // 再拉课程文件夹（历史学期），合并去重
-            let mut folder_extra = 0usize;
-            match fetch_chaoxing_folder_courses(client, &mut seen).await {
-                Ok(extra) => {
-                    folder_extra = extra.len();
-                    for c in extra {
-                        courses.push(c);
+            // fyportal 定制平台学期数据（湖工大网络教学平台）：学期下拉 + 各学期课程，
+            // 与网页端课程中心完全同源；成功时优于文件夹试探（文件夹名不是真实学期）
+            let mut fyportal_semesters: Vec<String> = Vec::new();
+            let mut fyportal_matched = 0usize;
+            let mut fyportal_added = 0usize;
+            let sem_meta = fetch_fyportal_semester_options(client).await;
+            let fyportal_ok = !sem_meta.is_empty();
+            if fyportal_ok {
+                fyportal_semesters = sem_meta
+                    .iter()
+                    .map(|(_, _, label)| label.clone())
+                    .collect();
+                // 逐学期拉课程（串行：量小且避免触发风控），标记学期归属
+                for (section_id, _, label) in sem_meta.iter() {
+                    let items = fetch_fyportal_courses_by_section(client, section_id, label).await;
+                    if items.is_empty() {
+                        continue;
+                    }
+                    for c in items {
+                        let key = format!(
+                            "{}:{}",
+                            json_str_field(&c, &["course_id"]),
+                            json_str_field(&c, &["clazz_id"])
+                        );
+                        if let Some(existing) = courses.iter_mut().find(|e| {
+                            format!(
+                                "{}:{}",
+                                json_str_field(e, &["course_id"]),
+                                json_str_field(e, &["clazz_id"])
+                            ) == key
+                        }) {
+                            fyportal_matched += 1;
+                            // 以网页端学期归属覆盖猜测值
+                            existing["semester"] = c
+                                .get("semester")
+                                .cloned()
+                                .unwrap_or_else(|| json!("未分学期"));
+                        } else {
+                            fyportal_added += 1;
+                            courses.push(c);
+                        }
                     }
                 }
-                Err(e) => {
-                    println!("[调试] fetch_chaoxing_folder_courses failed: {e}");
+                println!(
+                    "[调试] fyportal semesters={:?} matched={} added={}",
+                    fyportal_semesters, fyportal_matched, fyportal_added
+                );
+            }
+
+            // 再拉课程文件夹（历史学期），合并去重。
+            // fyportal 学期数据可用时跳过：文件夹名不是真实学期，且 16 个试探请求拖慢加载
+            let mut folder_extra = 0usize;
+            if !fyportal_ok {
+                match fetch_chaoxing_folder_courses(client, &mut seen).await {
+                    Ok(extra) => {
+                        folder_extra = extra.len();
+                        for c in extra {
+                            courses.push(c);
+                        }
+                    }
+                    Err(e) => {
+                        println!("[调试] fetch_chaoxing_folder_courses failed: {e}");
+                    }
                 }
             }
 
-            let mut semesters: Vec<String> = courses
-                .iter()
-                .filter_map(|c| {
-                    c.get("semester")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                })
-                .collect();
+            let mut semesters: Vec<String> = if !fyportal_semesters.is_empty() {
+                // fyportal 学期列表保持网页端顺序（最新在前）
+                fyportal_semesters
+            } else {
+                // 回退：从课程自身收集
+                courses
+                    .iter()
+                    .filter_map(|c| {
+                        c.get("semester")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    })
+                    .collect()
+            };
             semesters.sort();
             semesters.dedup();
             // 本学期优先，其次带「年/学期」的标签
@@ -2123,7 +2376,206 @@ async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, Dyn
     }))
 }
 
-async fn fetch_chaoxing_course_progress_remote(
+/// 从 knowledge/cards 页 HTML 提取 attachments 数组（任务点列表）
+/// 容错解析：mArg 整体可能含 JS 语法，只提取 `"attachments":[...]` 数组
+fn parse_cards_attachments(html: &str) -> Vec<Value> {
+    let marker = "\"attachments\":";
+    let Some(marker_pos) = html.find(marker) else {
+        return Vec::new();
+    };
+    let after = &html[marker_pos + marker.len()..];
+    let Some(arr_start_rel) = after.find('[') else {
+        return Vec::new();
+    };
+    let arr_start = marker_pos + marker.len() + arr_start_rel;
+    let bytes = html.as_bytes();
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut i = arr_start;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_str = false;
+            }
+        } else {
+            match c {
+                b'"' => in_str = true,
+                b'{' => depth += 1,
+                b'}' => depth -= 1,
+                b']' if depth == 0 => {
+                    let arr_text = &html[arr_start..=i];
+                    return serde_json::from_str(arr_text).unwrap_or_default();
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    Vec::new()
+}
+
+/// 统计单个知识节点（knowledge）的任务点完成情况
+/// 返回 (任务点总数, 已完成数)
+/// completed 语义：attachment.isPassed === true 才算完成（缺省视为未完成）
+/// —— 视频/文档等任务点由学习通服务端标记 isPassed，比章节页 orangeNew 准确
+async fn chaoxing_node_completion(
+    client: &HbutClient,
+    course_id: &str,
+    clazz_id: &str,
+    knowledge_id: &str,
+    cpi: &str,
+) -> (usize, usize) {
+    let study_referer = format!(
+        "https://mooc1.chaoxing.com/mooc-ans/mycourse/studentstudy?chapterId={knowledge_id}&courseId={course_id}&clazzid={clazz_id}&cpi={cpi}&mooc2=1"
+    );
+    let mut total = 0usize;
+    let mut passed = 0usize;
+    for num in 0..16u32 {
+        let num_s = num.to_string();
+        let url = format!(
+            "https://mooc1.chaoxing.com/mooc-ans/knowledge/cards?clazzid={clazz_id}&courseid={course_id}&knowledgeid={knowledge_id}&num={num_s}&ut=s&cpi={cpi}&v=2025-0424-1038-3&mooc2=1&isMicroCourse=false&editorPreview=0"
+        );
+        let resp = match client
+            .client
+            .get(&url)
+            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+            .header("Referer", &study_referer)
+            .timeout(Duration::from_secs(12))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(_) => break,
+        };
+        let html = resp.text().await.unwrap_or_default();
+        let atts = parse_cards_attachments(&html);
+        if atts.is_empty() {
+            break;
+        }
+        total += atts.len();
+        passed += atts
+            .iter()
+            .filter(|a| {
+                a.get("isPassed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            })
+            .count();
+        // 一页未满说明没有下一页
+        if atts.len() < 30 {
+            break;
+        }
+    }
+    (total, passed)
+}
+
+/// 用任务点级完成状态（isPassed）升级大纲：
+/// 节点 completed = 该节点有任务点且全部通过；并重算课程级统计
+/// 修复「二级显示已完成但三级视频未看完」的误判（orangeNew 不统计视频）
+async fn enrich_outline_with_task_completion(
+    client: &HbutClient,
+    course_id: &str,
+    clazz_id: &str,
+    cpi: &str,
+    mut outline: Value,
+) -> Value {
+    let nodes = outline
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let knowledge_ids: Vec<String> = nodes
+        .iter()
+        .filter_map(|n| {
+            n.get("knowledge_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect();
+    if knowledge_ids.is_empty() {
+        return outline;
+    }
+    // 并发拉取每个节点的任务点完成状态（限流避免触发风控）
+    let tasks: Vec<_> = knowledge_ids
+        .iter()
+        .map(|kid| {
+            let cid = course_id.to_string();
+            let clz = clazz_id.to_string();
+            let cp = cpi.to_string();
+            let k = kid.clone();
+            async move { chaoxing_node_completion(client, &cid, &clz, &k, &cp).await }
+        })
+        .collect();
+    let results: Vec<(usize, usize)> = futures::stream::iter(tasks)
+        .buffer_unordered(8)
+        .collect()
+        .await;
+
+    let mut completion: std::collections::HashMap<String, (usize, usize)> =
+        std::collections::HashMap::new();
+    for (kid, res) in knowledge_ids.iter().zip(results.iter()) {
+        completion.insert(kid.clone(), *res);
+    }
+
+    let mut completed_count = 0usize;
+    let mut task_total = 0usize;
+    let mut task_passed = 0usize;
+    if let Some(arr) = outline.get_mut("nodes").and_then(|v| v.as_array_mut()) {
+        for node in arr.iter_mut() {
+            let kid = node
+                .get("knowledge_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let (total, passed) = completion.get(&kid).copied().unwrap_or((0, 0));
+            // 节点完成：有任务点且全部通过（无任务点的节点不算完成，避免误报）
+            let done = total > 0 && passed == total;
+            node["completed"] = json!(done);
+            node["task_total"] = json!(total);
+            node["task_passed"] = json!(passed);
+            if done {
+                completed_count += 1;
+            }
+            task_total += total;
+            task_passed += passed;
+        }
+    }
+    // 课程级统计采用「任务点粒度」（与网页端 unfinishCount/publishJobNum 口径一致）
+    outline["completed_count"] = json!(task_passed);
+    outline["total_count"] = json!(task_total);
+    outline["pending_count"] = json!(task_total.saturating_sub(task_passed));
+    outline["task_total"] = json!(task_total);
+    outline["task_passed"] = json!(task_passed);
+    outline["task_percent"] = json!(if task_total == 0 {
+        0.0
+    } else {
+        task_passed as f64 * 100.0 / task_total as f64
+    });
+    outline["progress_percent"] = json!(if task_total == 0 {
+        0.0
+    } else {
+        task_passed as f64 * 100.0 / task_total as f64
+    });
+    outline["progress_text"] = json!(format!("已完成 {} / {}", task_passed, task_total));
+    outline["completed_nodes"] = json!(completed_count);
+    outline["total_nodes"] = json!(
+        outline
+            .get("nodes")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0)
+    );
+    outline
+}
+
+/// 列表页快速进度估算（仅解析章节页 orangeNew，不发 knowledge/cards 请求）
+/// 用于课程列表批量展示；详情页用 fetch_chaoxing_course_progress_remote（任务点精确）
+async fn fetch_chaoxing_course_progress_fast(
     client: &HbutClient,
     course_id: &str,
     clazz_id: &str,
@@ -2156,6 +2608,53 @@ async fn fetch_chaoxing_course_progress_remote(
         "pending_count": total_count.saturating_sub(completed_count),
         "progress_percent": if total_count == 0 { 0.0 } else { completed_count as f64 * 100.0 / total_count as f64 },
         "progress_text": format!("已完成 {} / {}", completed_count, total_count),
+        "nodes": nodes
+    }))
+}
+
+async fn fetch_chaoxing_course_progress_remote(
+    client: &HbutClient,
+    course_id: &str,
+    clazz_id: &str,
+    cpi: &str,
+    course_url: Option<&str>,
+) -> Result<Value, DynError> {
+    let outline =
+        fetch_chaoxing_outline_remote(client, course_id, clazz_id, cpi, course_url).await?;
+    // 任务点级精确统计（isPassed），替代 orangeNew 估算
+    let outline = enrich_outline_with_task_completion(client, course_id, clazz_id, cpi, outline)
+        .await;
+    let nodes = outline
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let task_total = outline
+        .get("task_total")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let task_passed = outline
+        .get("task_passed")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let task_percent = if task_total == 0 {
+        0.0
+    } else {
+        task_passed as f64 * 100.0 / task_total as f64
+    };
+    Ok(json!({
+        "success": true,
+        "course_id": course_id,
+        "clazz_id": clazz_id,
+        "cpi": cpi,
+        "total_count": task_total,
+        "completed_count": task_passed,
+        "pending_count": task_total.saturating_sub(task_passed),
+        "task_total": task_total,
+        "task_passed": task_passed,
+        "task_percent": task_percent,
+        "progress_percent": task_percent,
+        "progress_text": format!("已完成 {} / {}", task_passed, task_total),
         "nodes": nodes
     }))
 }
@@ -2217,7 +2716,7 @@ async fn enrich_chaoxing_courses_with_progress(
         };
 
         if progress_payload.is_none() && allow_live_fetch {
-            match fetch_chaoxing_course_progress_remote(
+            match fetch_chaoxing_course_progress_fast(
                 client,
                 &course_id,
                 &clazz_id,
@@ -2270,7 +2769,13 @@ pub async fn chaoxing_fetch_courses(
                 .and_then(|v| v.as_array())
                 .map(|a| a.len())
                 .unwrap_or(0);
-            if count > 0 {
+            // schema=2：含真实学期数据（fyportal）。旧缓存（无学期）直接跳过走远程
+            let schema_ok = cached
+                .get("schema")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                >= 2;
+            if count > 0 && schema_ok {
                 crate::hbut_session_log!(
                     "ChaoxingCourses",
                     "命中缓存 {} 门课 force=false，跳过会话探测与远程拉取",
@@ -2278,6 +2783,13 @@ pub async fn chaoxing_fetch_courses(
                 );
                 timer.finish(Some(json!({ "from_cache": true, "count": count })));
                 return Ok(crate::attach_sync_time(cached, &sync_time, true));
+            }
+            if count > 0 {
+                crate::hbut_session_log!(
+                    "ChaoxingCourses",
+                    "缓存 schema 过旧（无学期数据）count={}，忽略缓存走远程",
+                    count
+                );
             }
         }
     } else {
@@ -2324,6 +2836,7 @@ pub async fn chaoxing_fetch_courses(
                 "courses": courses,
                 "semesters": payload.get("semesters").cloned().unwrap_or(json!([])),
                 "pending_count": pending_count,
+                "schema": 2,
                 "platform_status": {
                     "platform": PLATFORM_CHAOXING,
                     "connected": true,
@@ -2454,7 +2967,7 @@ pub fn assemble_chaoxing_outline_from_html(
 
     let raw_leaves = extract_chaoxing_catalog_leaves(html);
     let mut leaves: Vec<(usize, Value)> = Vec::new();
-    for (pos, knowledge_id, title, cap_course_id, cap_clazz_id, cur_id) in raw_leaves {
+    for (pos, knowledge_id, title, cap_course_id, cap_clazz_id, cur_id, completed) in raw_leaves {
         let chapter_id = if cur_id.is_empty() {
             knowledge_id.clone()
         } else {
@@ -2481,7 +2994,7 @@ pub fn assemble_chaoxing_outline_from_html(
                 "cpi": cpi,
                 "chapter_id": chapter_id,
                 "knowledge_id": knowledge_id,
-                "completed": false,
+                "completed": completed,
                 "task_type": "knowledge",
                 "type": "knowledge",
                 "children": [],
@@ -2506,6 +3019,14 @@ pub fn assemble_chaoxing_outline_from_html(
     if section_marks.is_empty() {
         let tasks: Vec<Value> = leaves.into_iter().map(|(_, v)| v).collect();
         let total = tasks.len();
+        let completed = tasks
+            .iter()
+            .filter(|t| {
+                t.get("completed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            })
+            .count();
         sections.push(json!({
             "id": "all",
             "title": "全部章节",
@@ -2517,8 +3038,8 @@ pub fn assemble_chaoxing_outline_from_html(
             "sections": sections,
             "nodes": sections[0]["tasks"].clone(),
             "total_count": total,
-            "completed_count": 0,
-            "pending_count": total,
+            "completed_count": completed,
+            "pending_count": total.saturating_sub(completed),
             "course_id": course_id,
             "clazz_id": clazz_id,
             "cpi": cpi,
@@ -2584,17 +3105,27 @@ pub fn assemble_chaoxing_outline_from_html(
             total_count += arr.len();
         }
     }
+    // 完成状态统计：节点 completed 来自章节页 orangeNew 数字（0 = 已完成）
+    let nodes: Vec<Value> = sections
+        .iter()
+        .flat_map(|s| s.get("tasks").and_then(|t| t.as_array()).cloned().unwrap_or_default())
+        .collect();
+    let completed_count = nodes
+        .iter()
+        .filter(|n| {
+            n.get("completed")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+        })
+        .count();
 
     Ok(json!({
         "success": true,
         "sections": sections,
-        "nodes": sections
-            .iter()
-            .flat_map(|s| s.get("tasks").and_then(|t| t.as_array()).cloned().unwrap_or_default())
-            .collect::<Vec<_>>(),
+        "nodes": nodes,
         "total_count": total_count,
-        "completed_count": 0,
-        "pending_count": total_count,
+        "completed_count": completed_count,
+        "pending_count": total_count.saturating_sub(completed_count),
         "course_id": course_id,
         "clazz_id": clazz_id,
         "cpi": cpi,
@@ -2624,6 +3155,10 @@ pub async fn chaoxing_fetch_course_outline(
         .await
     {
         Ok(payload) => {
+            // 任务点级精确完成状态（isPassed）：修复「二级显示完成但三级任务未看完」
+            let payload =
+                enrich_outline_with_task_completion(client, course_id, clazz_id, cpi, payload)
+                    .await;
             save_cache(CACHE_CHAOXING_OUTLINE, &cache_id, &payload);
             Ok(crate::attach_sync_time(payload, &now_sync_time(), false))
         }
@@ -4126,15 +4661,17 @@ pub fn chaoxing_video_status_candidate_urls(
 }
 
 /// 从章节页 HTML 提取 knowledge 叶子（纯函数）
-/// 返回 (pos, knowledge_id, title, course_id, clazz_id, chapter_cur_id)
+/// 返回 (pos, knowledge_id, title, course_id, clazz_id, chapter_cur_id, completed)
+/// completed：节点内 `orangeNew` 数字（服务端渲染的未完成任务点数），0 = 已完成
 pub fn extract_chaoxing_catalog_leaves(
     html: &str,
-) -> Vec<(usize, String, String, String, String, String)> {
+) -> Vec<(usize, String, String, String, String, String, bool)> {
     let re_leaf = regex::Regex::new(
         r#"id="cur(\d+)"[\s\S]{0,2500}?getTeacherAjax\('(\d+)','(\d+)','(\d+)'\)"#,
     )
     .expect("regex leaf");
     let re_leaf_title = regex::Regex::new(r#"title="\s*([^"]*?)\s*""#).expect("regex leaf title");
+    let re_orange = regex::Regex::new(r#"class="orangeNew">(\d+)<"#).expect("regex orangeNew");
     let mut out = Vec::new();
     let mut seen = HashSet::new();
     for cap in re_leaf.captures_iter(html) {
@@ -4156,7 +4693,22 @@ pub fn extract_chaoxing_catalog_leaves(
             .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
             .filter(|t| !t.is_empty())
             .unwrap_or_else(|| format!("小节 {knowledge_id}"));
-        out.push((pos, knowledge_id, title, course_id, clazz_id, cur_id));
+        // 完成状态：orangeNew 数字 = 该节点未完成任务点数；0 = 已完成
+        let completed = re_orange
+            .captures(block)
+            .and_then(|c| c.get(1))
+            .and_then(|m| m.as_str().parse::<u32>().ok())
+            .map(|n| n == 0)
+            .unwrap_or(false);
+        out.push((
+            pos,
+            knowledge_id,
+            title,
+            course_id,
+            clazz_id,
+            cur_id,
+            completed,
+        ));
     }
     if out.is_empty() {
         let re_ajax =
@@ -4174,6 +4726,12 @@ pub fn extract_chaoxing_catalog_leaves(
                 .and_then(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
                 .filter(|t| !t.is_empty())
                 .unwrap_or_else(|| format!("小节 {knowledge_id}"));
+            let completed = re_orange
+                .captures(window)
+                .and_then(|c| c.get(1))
+                .and_then(|m| m.as_str().parse::<u32>().ok())
+                .map(|n| n == 0)
+                .unwrap_or(false);
             out.push((
                 pos,
                 knowledge_id,
@@ -4181,6 +4739,7 @@ pub fn extract_chaoxing_catalog_leaves(
                 cap[1].to_string(),
                 cap[2].to_string(),
                 String::new(),
+                completed,
             ));
         }
     }
@@ -4541,15 +5100,20 @@ mod catalog_and_video_tests {
     fn extract_leaves_from_realistic_html() {
         let html = r#"
         <div class="posCatalog_select firstLayer" id="1" title="第一章 绪论"></div>
-        <div id="cur1001" class="posCatalog_name" title=" 1.1 电路模型" onclick="getTeacherAjax('2288','3399','100239488')"></div>
-        <div id="cur1002" title="1.2 电源" onclick="getTeacherAjax('2288','3399','100239489')"></div>
+        <div id="cur1001" class="posCatalog_name" title=" 1.1 电路模型" onclick="getTeacherAjax('2288','3399','100239488')"><span class="orangeNew">0</span></div>
+        <div id="cur1002" title="1.2 电源" onclick="getTeacherAjax('2288','3399','100239489')"><span class="orangeNew">2</span></div>
         "#;
         let leaves = extract_chaoxing_catalog_leaves(html);
         assert!(leaves.len() >= 2, "expected >=2 leaves, got {:?}", leaves);
         assert!(leaves
             .iter()
-            .any(|(_, kid, title, _, _, _)| kid == "100239488" && title.contains("电路")));
-        assert!(leaves.iter().any(|(_, kid, _, _, _, _)| kid == "100239489"));
+            .any(|(_, kid, title, _, _, _, _)| kid == "100239488" && title.contains("电路")));
+        assert!(leaves.iter().any(|(_, kid, _, _, _, _, _)| kid == "100239489"));
+        // 完成状态：orangeNew=0 → 已完成；orangeNew=2 → 未完成
+        let leaf1 = leaves.iter().find(|(_, kid, _, _, _, _, _)| kid == "100239488").unwrap();
+        let leaf2 = leaves.iter().find(|(_, kid, _, _, _, _, _)| kid == "100239489").unwrap();
+        assert!(leaf1.6, "orangeNew=0 应标记已完成");
+        assert!(!leaf2.6, "orangeNew=2 应标记未完成");
     }
 
     #[test]
@@ -4561,8 +5125,8 @@ mod catalog_and_video_tests {
     fn assemble_outline_drives_extract_leaves() {
         let html = r#"
         <div class="posCatalog_select firstLayer" id="1" title="第一章 绪论"></div>
-        <div id="cur1001" title=" 1.1 电路模型" onclick="getTeacherAjax('2288','3399','100239488')"></div>
-        <div id="cur1002" title="1.2 电源" onclick="getTeacherAjax('2288','3399','100239489')"></div>
+        <div id="cur1001" title=" 1.1 电路模型" onclick="getTeacherAjax('2288','3399','100239488')"><span class="orangeNew">0</span></div>
+        <div id="cur1002" title="1.2 电源" onclick="getTeacherAjax('2288','3399','100239489')"><span class="orangeNew">1</span></div>
         "#;
         let out = assemble_chaoxing_outline_from_html(
             html,
@@ -4575,6 +5139,9 @@ mod catalog_and_video_tests {
         assert_eq!(out["success"], true);
         let total = out["total_count"].as_u64().unwrap_or(0);
         assert!(total >= 2, "total={total} out={out}");
+        // completed_count 应统计 orangeNew=0 的节点
+        let completed = out["completed_count"].as_u64().unwrap_or(0);
+        assert_eq!(completed, 1, "completed_count={completed} out={out}");
         let leaves = extract_chaoxing_catalog_leaves(html);
         assert_eq!(leaves.len() as u64, total);
     }
@@ -4641,5 +5208,111 @@ mod catalog_and_video_tests {
         let arr = extract_folder_array(&v);
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["id"], 1);
+    }
+
+    #[test]
+    fn fyportal_semester_options_parse_realistic_select() {
+        // 对齐网页端实测结构：value=sectionId + semesterNum(驼峰) + selected
+        // 同时包含干扰 select（院系/部门），验证只解析 name="xq"
+        let html = r#"
+        <select name="xq" data-placeholder="全部" style="width: 240px; display: none;" class="dept_select">
+            <option value="0">全部</option>
+            <option value="43811" semesterNum="20261" selected="true">2026-2027第一学期</option>
+            <option value="38370" semesterNum="20252">2025-2026第二学期</option>
+            <option value="35140" semesterNum="20251">2025-2026第一学期</option>
+            <option value="2618" semesterNum="20191">2019-2020第二学期</option>
+        </select>
+        <select name="dept">
+            <option value="0">请选择开课院系</option>
+            <option value="123">马克思主义学院</option>
+            <option value="456">电气与电子工程学院</option>
+        </select>
+        "#;
+        let opts = parse_fyportal_semester_options(html);
+        // 只保留真实学期：排除 value=0「全部」与干扰 select 的院系/占位
+        assert_eq!(opts.len(), 4);
+        assert_eq!(opts[0], ("43811".into(), "20261".into(), "2026-2027第一学期".into()));
+        assert_eq!(opts[1], ("38370".into(), "20252".into(), "2025-2026第二学期".into()));
+        assert_eq!(opts[3], ("2618".into(), "20191".into(), "2019-2020第二学期".into()));
+        assert!(!opts.iter().any(|(_, _, l)| l.contains("院系") || l.contains("学院") || l == "全部"));
+    }
+
+    #[test]
+    fn fyportal_semester_options_empty_html() {
+        assert!(parse_fyportal_semester_options("<html></html>").is_empty());
+        assert!(parse_fyportal_semester_options("").is_empty());
+    }
+
+    #[test]
+    fn fyportal_course_cards_parse_realistic_li() {
+        // 对齐网页端实测课程卡片结构
+        let html = r#"
+        <ul class="course-list">
+            <li class="w_couritem clearfix" state="0" kcenc="abc" ckenc="ck123" clazzenc="ce1"
+                personId="487811746" iswzy="0" micid="" cid="254673763" classid="125938817"
+                cname="军事理论" source="0">
+                <div class="course-cover">
+                    <a href='/fyportal/courselist/entercoursenewfy?role=3&courseId=254673763&clazzId=125938817&cpi=487811746&ckenc=ck123' target="_blank">
+                        <img src="https://p.ananas.chaoxing.com/star3/origin/abc.jpg">
+                    </a>
+                </div>
+                <div class="course-info">
+                    <h3><span class="course-name">军事理论</span></h3>
+                    <p class="line2 color3">李海燕</p>
+                </div>
+            </li>
+            <li class="w_couritem clearfix" state="1" personId="487811746"
+                cid="254918439" classid="126631792" cname="人工智能通识课" source="0">
+                <div class="course-cover"><a href='/x'><img src="http://p.ananas.chaoxing.com/x.jpg"></a></div>
+            </li>
+        </ul>
+        "#;
+        let cards = parse_fyportal_course_cards(html, "2026-2027第一学期");
+        assert_eq!(cards.len(), 2);
+        let first = &cards[0];
+        assert_eq!(first["course_id"], "254673763");
+        assert_eq!(first["clazz_id"], "125938817");
+        assert_eq!(first["cpi"], "487811746");
+        assert_eq!(first["name"], "军事理论");
+        assert_eq!(first["semester"], "2026-2027第一学期");
+        assert_eq!(first["state"], "0");
+        assert!(first["image_url"]
+            .as_str()
+            .unwrap_or("")
+            .contains("p.ananas.chaoxing.com"));
+        assert_eq!(cards[1]["state"], "1");
+        assert_eq!(cards[1]["name"], "人工智能通识课");
+    }
+
+    #[test]
+    fn fyportal_course_cards_skip_invalid() {
+        let html = r#"<ul class="course-list"><li class="w_couritem" cname="无id课程"></li></ul>"#;
+        assert!(parse_fyportal_course_cards(html, "2025-2026第一学期").is_empty());
+    }
+
+    #[test]
+    fn parse_cards_attachments_extracts_array() {
+        // 模拟 knowledge/cards 的 mArg（attachments 数组）
+        let html = r#"<html>mArg = {"hiddenConfig":false,"attachments":[
+            {"otherInfo":"nodeId_1-cpi_1","isPassed":false,"type":"video","property":{"name":"a.mp4"}},
+            {"otherInfo":"nodeId_2-cpi_1","isPassed":true,"type":"document","job":true}
+        ],"coursename":"x"};</html>"#;
+        let atts = parse_cards_attachments(html);
+        assert_eq!(atts.len(), 2);
+        assert!(!atts[0]["isPassed"].as_bool().unwrap_or(true));
+        assert!(atts[1]["isPassed"].as_bool().unwrap_or(false));
+        assert_eq!(atts[1]["type"], "document");
+    }
+
+    #[test]
+    fn parse_cards_attachments_handles_escaped_and_no_marker() {
+        // 含转义引号与嵌套
+        let html = r#"<html>mArg = {"attachments":[{"otherInfo":"a\"b","isPassed":true}]};</html>"#;
+        let atts = parse_cards_attachments(html);
+        assert_eq!(atts.len(), 1);
+        assert!(atts[0]["isPassed"].as_bool().unwrap_or(false));
+        // 无 attachments 标记
+        assert!(parse_cards_attachments("<html>mArg = {};</html>").is_empty());
+        assert!(parse_cards_attachments("").is_empty());
     }
 }

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -2389,7 +2389,8 @@ fn parse_cards_attachments(html: &str) -> Vec<Value> {
     };
     let arr_start = marker_pos + marker.len() + arr_start_rel;
     let bytes = html.as_bytes();
-    let mut depth = 0i32;
+    // bracket 深度：arr 自身 `[` 计入（从 0 开始，遇 `[` +1）；跟踪 [] 配对避免内嵌数组提前截断
+    let mut depth_bracket = 0i32;
     let mut in_str = false;
     let mut i = arr_start;
     while i < bytes.len() {
@@ -2405,11 +2406,13 @@ fn parse_cards_attachments(html: &str) -> Vec<Value> {
         } else {
             match c {
                 b'"' => in_str = true,
-                b'{' => depth += 1,
-                b'}' => depth -= 1,
-                b']' if depth == 0 => {
-                    let arr_text = &html[arr_start..=i];
-                    return serde_json::from_str(arr_text).unwrap_or_default();
+                b'[' => depth_bracket += 1,
+                b']' => {
+                    depth_bracket -= 1;
+                    if depth_bracket == 0 {
+                        let arr_text = &html[arr_start..=i];
+                        return serde_json::from_str(arr_text).unwrap_or_default();
+                    }
                 }
                 _ => {}
             }
@@ -2420,21 +2423,23 @@ fn parse_cards_attachments(html: &str) -> Vec<Value> {
 }
 
 /// 统计单个知识节点（knowledge）的任务点完成情况
-/// 返回 (任务点总数, 已完成数)
+/// 返回 (任务点总数, 已完成数, 是否完整统计)
 /// completed 语义：attachment.isPassed === true 才算完成（缺省视为未完成）
 /// —— 视频/文档等任务点由学习通服务端标记 isPassed，比章节页 orangeNew 准确
+/// ok=false 表示中途请求失败（分页未取完），调用方不得据此判定节点完成
 async fn chaoxing_node_completion(
     client: &HbutClient,
     course_id: &str,
     clazz_id: &str,
     knowledge_id: &str,
     cpi: &str,
-) -> (usize, usize) {
+) -> (usize, usize, bool) {
     let study_referer = format!(
         "https://mooc1.chaoxing.com/mooc-ans/mycourse/studentstudy?chapterId={knowledge_id}&courseId={course_id}&clazzid={clazz_id}&cpi={cpi}&mooc2=1"
     );
     let mut total = 0usize;
     let mut passed = 0usize;
+    let mut ok = true;
     for num in 0..16u32 {
         let num_s = num.to_string();
         let url = format!(
@@ -2450,11 +2455,18 @@ async fn chaoxing_node_completion(
             .await
         {
             Ok(r) => r,
-            Err(_) => break,
+            Err(_) => {
+                ok = false;
+                break;
+            }
         };
         let html = resp.text().await.unwrap_or_default();
         let atts = parse_cards_attachments(&html);
         if atts.is_empty() {
+            // 首页为空：可能是无任务点或页面结构异常；保守标记不完整
+            if num == 0 {
+                ok = false;
+            }
             break;
         }
         total += atts.len();
@@ -2471,7 +2483,7 @@ async fn chaoxing_node_completion(
             break;
         }
     }
-    (total, passed)
+    (total, passed, ok)
 }
 
 /// 用任务点级完成状态（isPassed）升级大纲：
@@ -2511,15 +2523,21 @@ async fn enrich_outline_with_task_completion(
             async move { chaoxing_node_completion(client, &cid, &clz, &k, &cp).await }
         })
         .collect();
-    let results: Vec<(usize, usize)> = futures::stream::iter(tasks)
-        .buffer_unordered(8)
+    let results: Vec<(usize, usize, bool)> = futures::stream::iter(tasks)
+        .buffered(8)
         .collect()
         .await;
 
-    let mut completion: std::collections::HashMap<String, (usize, usize)> =
+    let mut completion: std::collections::HashMap<String, (usize, usize, bool)> =
         std::collections::HashMap::new();
     for (kid, res) in knowledge_ids.iter().zip(results.iter()) {
         completion.insert(kid.clone(), *res);
+    }
+
+    // 全量统计失败（如会话失效）时回退到章节页 orangeNew 估算，避免进度归零误导
+    let any_ok = results.iter().any(|(_, _, ok)| *ok);
+    if !any_ok {
+        return outline;
     }
 
     let mut completed_count = 0usize;
@@ -2532,17 +2550,19 @@ async fn enrich_outline_with_task_completion(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            let (total, passed) = completion.get(&kid).copied().unwrap_or((0, 0));
-            // 节点完成：有任务点且全部通过（无任务点的节点不算完成，避免误报）
-            let done = total > 0 && passed == total;
+            let (total, passed, ok) = completion.get(&kid).copied().unwrap_or((0, 0, false));
+            // 节点完成：统计完整且有任务点且全部通过（无任务点/未完整统计不算完成，避免误报）
+            let done = ok && total > 0 && passed == total;
             node["completed"] = json!(done);
             node["task_total"] = json!(total);
             node["task_passed"] = json!(passed);
             if done {
                 completed_count += 1;
             }
-            task_total += total;
-            task_passed += passed;
+            if ok {
+                task_total += total;
+                task_passed += passed;
+            }
         }
     }
     // 课程级统计采用「任务点粒度」（与网页端 unfinishCount/publishJobNum 口径一致）

--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -1814,10 +1814,8 @@ fn extract_folder_array(v: &Value) -> Vec<Value> {
 /// - 真实 HTML 属性名是驼峰 `semesterNum`（部分场景小写），需两者兼容
 /// - 排除 value=0 的「全部」占位项（前端会自行提供「全部」tab）
 fn parse_fyportal_semester_options(html: &str) -> Vec<(String, String, String)> {
-    let re_select = regex::Regex::new(
-        r#"(?is)<select\s+name=["']xq["'][^>]*>(.*?)</select>"#,
-    )
-    .expect("fyportal xq select regex");
+    let re_select = regex::Regex::new(r#"(?is)<select\s+name=["']xq["'][^>]*>(.*?)</select>"#)
+        .expect("fyportal xq select regex");
     let re_option = regex::Regex::new(
         r#"(?i)<option\s+value="(\d+)"(?:\s+semesternum="(\d+)")?[^>]*>([^<]{2,40})</option>"#,
     )
@@ -1854,10 +1852,8 @@ fn parse_fyportal_semester_options(html: &str) -> Vec<(String, String, String)> 
 /// 解析 fyportal 课程卡片 HTML（<ul class="course-list"><li class="w_couritem ...">）
 /// 每张卡片属性：state(0进行中/1已结课)、cid、classid、personId(=cpi)、ckenc、cname、封面图
 fn parse_fyportal_course_cards(html: &str, semester_label: &str) -> Vec<Value> {
-    let re_li = regex::Regex::new(
-        r#"(?is)<li\s+class="[^"]*w_couritem[^"]*"([^>]*)>(.*?)</li>"#,
-    )
-    .expect("fyportal course li regex");
+    let re_li = regex::Regex::new(r#"(?is)<li\s+class="[^"]*w_couritem[^"]*"([^>]*)>(.*?)</li>"#)
+        .expect("fyportal course li regex");
     let re_attr = regex::Regex::new(
         r#"(?i)(cid|classid|personid|ckenc|kcenc|clazzenc|cname|state|source)="([^"]*)""#,
     )
@@ -1923,7 +1919,10 @@ async fn fetch_fyportal_semester_options(client: &HbutClient) -> Vec<(String, St
     let resp = match client
         .client
         .get(url)
-        .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        .header(
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        )
         .header("Referer", "https://i.chaoxing.com/base")
         .timeout(Duration::from_secs(12))
         .send()
@@ -2199,10 +2198,7 @@ async fn fetch_chaoxing_courses_remote(client: &HbutClient) -> Result<Value, Dyn
             let sem_meta = fetch_fyportal_semester_options(client).await;
             let fyportal_ok = !sem_meta.is_empty();
             if fyportal_ok {
-                fyportal_semesters = sem_meta
-                    .iter()
-                    .map(|(_, _, label)| label.clone())
-                    .collect();
+                fyportal_semesters = sem_meta.iter().map(|(_, _, label)| label.clone()).collect();
                 // 逐学期拉课程（串行：量小且避免触发风控），标记学期归属
                 for (section_id, _, label) in sem_meta.iter() {
                     let items = fetch_fyportal_courses_by_section(client, section_id, label).await;
@@ -2448,7 +2444,10 @@ async fn chaoxing_node_completion(
         let resp = match client
             .client
             .get(&url)
-            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+            .header(
+                "Accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
             .header("Referer", &study_referer)
             .timeout(Duration::from_secs(12))
             .send()
@@ -2472,11 +2471,7 @@ async fn chaoxing_node_completion(
         total += atts.len();
         passed += atts
             .iter()
-            .filter(|a| {
-                a.get("isPassed")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false)
-            })
+            .filter(|a| a.get("isPassed").and_then(|v| v.as_bool()).unwrap_or(false))
             .count();
         // 一页未满说明没有下一页
         if atts.len() < 30 {
@@ -2523,10 +2518,8 @@ async fn enrich_outline_with_task_completion(
             async move { chaoxing_node_completion(client, &cid, &clz, &k, &cp).await }
         })
         .collect();
-    let results: Vec<(usize, usize, bool)> = futures::stream::iter(tasks)
-        .buffered(8)
-        .collect()
-        .await;
+    let results: Vec<(usize, usize, bool)> =
+        futures::stream::iter(tasks).buffered(8).collect().await;
 
     let mut completion: std::collections::HashMap<String, (usize, usize, bool)> =
         std::collections::HashMap::new();
@@ -2583,13 +2576,11 @@ async fn enrich_outline_with_task_completion(
     });
     outline["progress_text"] = json!(format!("已完成 {} / {}", task_passed, task_total));
     outline["completed_nodes"] = json!(completed_count);
-    outline["total_nodes"] = json!(
-        outline
-            .get("nodes")
-            .and_then(|v| v.as_array())
-            .map(|a| a.len())
-            .unwrap_or(0)
-    );
+    outline["total_nodes"] = json!(outline
+        .get("nodes")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0));
     outline
 }
 
@@ -2642,8 +2633,8 @@ async fn fetch_chaoxing_course_progress_remote(
     let outline =
         fetch_chaoxing_outline_remote(client, course_id, clazz_id, cpi, course_url).await?;
     // 任务点级精确统计（isPassed），替代 orangeNew 估算
-    let outline = enrich_outline_with_task_completion(client, course_id, clazz_id, cpi, outline)
-        .await;
+    let outline =
+        enrich_outline_with_task_completion(client, course_id, clazz_id, cpi, outline).await;
     let nodes = outline
         .get("nodes")
         .and_then(|v| v.as_array())
@@ -2790,11 +2781,7 @@ pub async fn chaoxing_fetch_courses(
                 .map(|a| a.len())
                 .unwrap_or(0);
             // schema=2：含真实学期数据（fyportal）。旧缓存（无学期）直接跳过走远程
-            let schema_ok = cached
-                .get("schema")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0)
-                >= 2;
+            let schema_ok = cached.get("schema").and_then(|v| v.as_u64()).unwrap_or(0) >= 2;
             if count > 0 && schema_ok {
                 crate::hbut_session_log!(
                     "ChaoxingCourses",
@@ -3128,7 +3115,12 @@ pub fn assemble_chaoxing_outline_from_html(
     // 完成状态统计：节点 completed 来自章节页 orangeNew 数字（0 = 已完成）
     let nodes: Vec<Value> = sections
         .iter()
-        .flat_map(|s| s.get("tasks").and_then(|t| t.as_array()).cloned().unwrap_or_default())
+        .flat_map(|s| {
+            s.get("tasks")
+                .and_then(|t| t.as_array())
+                .cloned()
+                .unwrap_or_default()
+        })
         .collect();
     let completed_count = nodes
         .iter()
@@ -5128,10 +5120,18 @@ mod catalog_and_video_tests {
         assert!(leaves
             .iter()
             .any(|(_, kid, title, _, _, _, _)| kid == "100239488" && title.contains("电路")));
-        assert!(leaves.iter().any(|(_, kid, _, _, _, _, _)| kid == "100239489"));
+        assert!(leaves
+            .iter()
+            .any(|(_, kid, _, _, _, _, _)| kid == "100239489"));
         // 完成状态：orangeNew=0 → 已完成；orangeNew=2 → 未完成
-        let leaf1 = leaves.iter().find(|(_, kid, _, _, _, _, _)| kid == "100239488").unwrap();
-        let leaf2 = leaves.iter().find(|(_, kid, _, _, _, _, _)| kid == "100239489").unwrap();
+        let leaf1 = leaves
+            .iter()
+            .find(|(_, kid, _, _, _, _, _)| kid == "100239488")
+            .unwrap();
+        let leaf2 = leaves
+            .iter()
+            .find(|(_, kid, _, _, _, _, _)| kid == "100239489")
+            .unwrap();
         assert!(leaf1.6, "orangeNew=0 应标记已完成");
         assert!(!leaf2.6, "orangeNew=2 应标记未完成");
     }
@@ -5251,10 +5251,21 @@ mod catalog_and_video_tests {
         let opts = parse_fyportal_semester_options(html);
         // 只保留真实学期：排除 value=0「全部」与干扰 select 的院系/占位
         assert_eq!(opts.len(), 4);
-        assert_eq!(opts[0], ("43811".into(), "20261".into(), "2026-2027第一学期".into()));
-        assert_eq!(opts[1], ("38370".into(), "20252".into(), "2025-2026第二学期".into()));
-        assert_eq!(opts[3], ("2618".into(), "20191".into(), "2019-2020第二学期".into()));
-        assert!(!opts.iter().any(|(_, _, l)| l.contains("院系") || l.contains("学院") || l == "全部"));
+        assert_eq!(
+            opts[0],
+            ("43811".into(), "20261".into(), "2026-2027第一学期".into())
+        );
+        assert_eq!(
+            opts[1],
+            ("38370".into(), "20252".into(), "2025-2026第二学期".into())
+        );
+        assert_eq!(
+            opts[3],
+            ("2618".into(), "20191".into(), "2019-2020第二学期".into())
+        );
+        assert!(!opts
+            .iter()
+            .any(|(_, _, l)| l.contains("院系") || l.contains("学院") || l == "全部"));
     }
 
     #[test]

--- a/src/components/ChaoxingHubView.vue
+++ b/src/components/ChaoxingHubView.vue
@@ -653,6 +653,18 @@ const collectDocUrls = (st = {}, top = {}) => {
   return list
 }
 
+/**
+ * 视频直链 → 本地代理地址：
+ * cldisk CDN 有 Referer 防盗链（无 chaoxing Referer 返回 403），且 WebView 与
+ * Rust cookie jar 不共享；Tauri 下必须经 http_server 的 /proxy/video 流式代理播放。
+ * 非 Tauri（dev 浏览器）退回原直链尽力播放。
+ */
+const toVideoProxyUrl = (u) => {
+  if (!u || !u.startsWith('http')) return u
+  if (!isTauriRuntime()) return u
+  return `http://127.0.0.1:4399/proxy/video?url=${encodeURIComponent(u)}`
+}
+
 const openVideo = async (course, section, knowledge, task, meta) => {
   if (!task.objectId) {
     showToast('该任务没有可播放资源')
@@ -669,12 +681,10 @@ const openVideo = async (course, section, knowledge, task, meta) => {
     if (disposed) return
     if (res?.success === false) throw new Error(res?.error || '视频状态失败')
     const st = res?.data && typeof res.data === 'object' ? res.data : res
-    const playUrls = collectPlayUrls(st, res || {})
-    const playerUrl = preferHttps(
-      safeText(res?.player_url || st.player_url || '') ||
-        `https://mooc1.chaoxing.com/ananas/modules/video/index.html?objectid=${encodeURIComponent(task.objectId)}&fid=${encodeURIComponent(meta?.fid || '0')}&isPhone=true`
-    )
-    if (!playUrls.length && !playerUrl) {
+    // 直链经本地代理播放（绕过 cldisk Referer 防盗链）；官方 ananas 播放器
+    // 带参 URL 已被学习通新版前端废弃（会永久卡「正在为您加载文件」），不再兜底
+    const playUrls = collectPlayUrls(st, res || {}).map(toVideoProxyUrl)
+    if (!playUrls.length) {
       throw new Error(
         st.status && st.status !== 'success'
           ? `视频不可用（${st.status}）`
@@ -689,8 +699,6 @@ const openVideo = async (course, section, knowledge, task, meta) => {
       task,
       src: playUrls[0] || '',
       playUrls,
-      playerUrl,
-      usePlayer: !playUrls.length,
       poster: preferHttps(safeText(st.screenshot || st.thumb || '')),
       filename: safeText(st.filename || task.title),
       duration: safeNumber(st.duration)
@@ -776,12 +784,8 @@ const onVideoError = (ev) => {
     videoError.value = `线路 ${videoSrcIndex.value + 1}/${urls.length} 失败，切换备用地址…`
     return
   }
-  // 直链耗尽：尝试官方 ananas 播放器页
-  if (frame?.playerUrl && !frame.usePlayer) {
-    frame.usePlayer = true
-    videoError.value = '直链播放失败，已切换学习通官方播放器…'
-    return
-  }
+  // 直链全部失败：官方 ananas 播放器带参 URL 已被学习通废弃（永久卡「正在为您加载文件」），
+  // 不再切换，直接给出可操作提示
   const detail = mediaErrorMessage(ev)
   videoError.value = detail
     ? `视频播放失败：${detail}。请重试、切换线路或重新登录学习通`
@@ -1244,17 +1248,7 @@ onUnmounted(() => {
           <p class="crumb">{{ current.knowledge?.title }}</p>
           <h3 class="video-title">{{ current.filename || current.task?.title }}</h3>
           <p v-if="current.duration" class="hint">时长 {{ formatDuration(current.duration) }}</p>
-          <iframe
-            v-if="current.usePlayer && current.playerUrl"
-            :key="'player-' + current.playerUrl"
-            class="video-el doc-frame"
-            :src="current.playerUrl"
-            title="学习通视频播放器"
-            allow="autoplay; fullscreen"
-            referrerpolicy="no-referrer-when-downgrade"
-          />
           <video
-            v-else
             :key="activeVideoSrc"
             class="video-el"
             controls
@@ -1272,7 +1266,7 @@ onUnmounted(() => {
               重新加载
             </button>
             <button
-              v-if="(current.playUrls || []).length > 1 && !current.usePlayer"
+              v-if="(current.playUrls || []).length > 1"
               type="button"
               class="chip-btn ghost light"
               @click="
@@ -1282,21 +1276,8 @@ onUnmounted(() => {
             >
               切换线路 {{ videoSrcIndex + 1 }}/{{ current.playUrls.length }}
             </button>
-            <button
-              v-if="current.playerUrl && !current.usePlayer"
-              type="button"
-              class="chip-btn ghost light"
-              @click="
-                current.usePlayer = true;
-                videoError = ''
-              "
-            >
-              官方播放器
-            </button>
           </div>
-          <p class="hint">
-            {{ current.usePlayer ? '官方 ananas 播放器（应用内）' : '直链播放，失败可切换官方播放器' }}
-          </p>
+          <p class="hint">直链经本地代理播放，失败可切换线路或重新加载</p>
         </section>
       </template>
 


### PR DESCRIPTION
﻿## 概述

修复学习通课程中心三个问题（关联 #524）：
1. **学期筛选**：课程显示「未分学期」→ 新增 fyportal 数据源（解析课程页 `<select name="xq">` 学期下拉 + `getStudyCourse?sectionId=` 按学期拉课），与 backclazzdata 合并
2. **视频播放**：直链 403 + 官方播放器卡「正在为您加载文件」→ 新增 `/proxy/video` 本地流式代理（注入 chaoxing Referer 绕过 cldisk 防盗链、Range 透传），前端直链改走代理；移除已废弃的官方播放器带参 URL 兜底
3. **进度统计**：课程进度恒 0 / 章节误判完成 → 任务点级精确统计（`knowledge/cards` 的 `isPassed`，视频/文档真实完成状态）

## 测试

- `cargo test --lib`：190 全绿（新增 fyportal 解析、attachments 解析等 8 个单测）
- 前端 `vite build` 通过
- 实况验证：Playwright 端到端（代理 → `<video>` canplay）、fyportal 学期解析（真实页面 14 学期零噪声）、任务点 isPassed 判定（未看完视频节点正确标记未完成）

## 审查修复

- `/proxy/video` SSRF 白名单精确 host 匹配（拒绝 userinfo/伪域）
- 任务点统计 `buffered` 保序；分页中断标记不完整；全量失败降级 orangeNew
- `parse_cards_attachments` 跟踪 `[]` 深度
