### PR TITLE
feat(#527): 动效优化——统一动效 token、视图切换方向感知、弹窗过渡

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -466,18 +466,38 @@ const currentView = ref(initialView)
 const activeTab = ref(initialTab)
 // 视图切换方向（iOS 风格：前进 slide-up / 返回 slide-down / replace 淡入）
 const navDirection = ref('forward')
-// 视图过渡 class：按方向切换（保留 name="module-fade" 兼容健康检查类名）
+// 视图过渡 class：按方向切换
+// - back → module-fade-back-*（下滑返回）
+// - forward → module-fade-fwd-*（上滑前进）
+// - none（replace/tab）→ 不传自定义类，回落 name="module-fade" 的纯淡入，
+//   同时保证 module-fade-* 类出现在 DOM 供 isCurrentViewDomHealthy 识别过渡态
 const viewTransitionEnterActive = computed(() =>
-  navDirection.value === 'back' ? 'module-fade-back-enter-active' : 'module-fade-fwd-enter-active'
+  navDirection.value === 'back'
+    ? 'module-fade-back-enter-active'
+    : navDirection.value === 'forward'
+      ? 'module-fade-fwd-enter-active'
+      : undefined
 )
 const viewTransitionLeaveActive = computed(() =>
-  navDirection.value === 'back' ? 'module-fade-back-leave-active' : 'module-fade-fwd-leave-active'
+  navDirection.value === 'back'
+    ? 'module-fade-back-leave-active'
+    : navDirection.value === 'forward'
+      ? 'module-fade-fwd-leave-active'
+      : undefined
 )
 const viewTransitionEnterFrom = computed(() =>
-  navDirection.value === 'back' ? 'module-fade-back-enter-from' : 'module-fade-fwd-enter-from'
+  navDirection.value === 'back'
+    ? 'module-fade-back-enter-from'
+    : navDirection.value === 'forward'
+      ? 'module-fade-fwd-enter-from'
+      : undefined
 )
 const viewTransitionLeaveTo = computed(() =>
-  navDirection.value === 'back' ? 'module-fade-back-leave-to' : 'module-fade-fwd-leave-to'
+  navDirection.value === 'back'
+    ? 'module-fade-back-leave-to'
+    : navDirection.value === 'forward'
+      ? 'module-fade-fwd-leave-to'
+      : undefined
 )
 const gradeData = ref([])
 const studentId = ref(String(initialRouteSnapshot?.sid || '').trim())
@@ -1040,7 +1060,10 @@ const isCurrentViewDomHealthy = (view = currentView.value) => {
     if (!transitionRoot) return false
 
     // leave/enter 过渡中子树可能短暂为空，勿判死
-    const leaving = transitionRoot.querySelector('.v-leave-active, .v-enter-active, .module-fade-leave-active, .module-fade-enter-active')
+    // 兼容三套过渡类：name 兜底（module-fade-*）、方向类（module-fade-fwd/back-*）、Vue 基础 v-*
+    const leaving = transitionRoot.querySelector(
+      '.v-leave-active, .v-enter-active, .module-fade-leave-active, .module-fade-enter-active, .module-fade-fwd-leave-active, .module-fade-fwd-enter-active, .module-fade-back-leave-active, .module-fade-back-enter-active'
+    )
     if (leaving) return true
 
     const expectedSelector = VIEW_HEALTH_SELECTOR_MAP[normalizeViewName(view)]
@@ -1715,8 +1738,11 @@ const resolveParentView = (view) => {
 const goToParentView = () => {
   const parentView = resolveParentView(currentView.value)
   if (!parentView) return false
-  navDirection.value = 'back'
-  goToViewInternal(parentView, { push: false, restoreScroll: parentView === 'home' })
+  goToViewInternal(parentView, {
+    push: false,
+    restoreScroll: parentView === 'home',
+    direction: 'back'
+  })
   return true
 }
 
@@ -1912,7 +1938,6 @@ const handleNavigate = async (target) => {
 
 // 处理返回仪表盘
 const handleBackToDashboard = () => {
-  navDirection.value = 'back'
   goToView('home', { restoreScroll: true, direction: 'back' })
 }
 
@@ -3148,8 +3173,7 @@ const handlePopState = async () => {
     const handled = goToParentView()
     if (!handled) {
       // 无父级时回首页并恢复滚动
-      navDirection.value = 'back'
-      goToViewInternal('home', { push: false, restoreScroll: true })
+      goToViewInternal('home', { push: false, restoreScroll: true, direction: 'back' })
       return
     }
     // goToParentView 已处理首页恢复；勿再 forceScrollTop 冲掉位置

--- a/src/App.vue
+++ b/src/App.vue
@@ -464,6 +464,21 @@ const repairModuleHostSession = async (payload) => {
 // 视图状态: home, schedule, me, grades...
 const currentView = ref(initialView)
 const activeTab = ref(initialTab)
+// 视图切换方向（iOS 风格：前进 slide-up / 返回 slide-down / replace 淡入）
+const navDirection = ref('forward')
+// 视图过渡 class：按方向切换（保留 name="module-fade" 兼容健康检查类名）
+const viewTransitionEnterActive = computed(() =>
+  navDirection.value === 'back' ? 'module-fade-back-enter-active' : 'module-fade-fwd-enter-active'
+)
+const viewTransitionLeaveActive = computed(() =>
+  navDirection.value === 'back' ? 'module-fade-back-leave-active' : 'module-fade-fwd-leave-active'
+)
+const viewTransitionEnterFrom = computed(() =>
+  navDirection.value === 'back' ? 'module-fade-back-enter-from' : 'module-fade-fwd-enter-from'
+)
+const viewTransitionLeaveTo = computed(() =>
+  navDirection.value === 'back' ? 'module-fade-back-leave-to' : 'module-fade-fwd-leave-to'
+)
 const gradeData = ref([])
 const studentId = ref(String(initialRouteSnapshot?.sid || '').trim())
 const userUuid = ref('')
@@ -1622,9 +1637,11 @@ const ensureLoginRequiredViewAccess = (view) => {
   return false
 }
 
-const goToViewInternal = (view, { push = true, restoreScroll = false, scrollToTop } = {}) => {
+const goToViewInternal = (view, { push = true, restoreScroll = false, scrollToTop, direction } = {}) => {
   const normalized = normalizeViewName(view)
   const fromView = currentView.value
+  // 视图切换方向：显式指定优先（返回链传 'back'）；否则 push 视为前进、replace 视为无方向淡入
+  navDirection.value = direction || (push ? 'forward' : 'none')
   // 离开首页前记住滚动位置
   if (fromView === 'home' && normalized !== 'home') {
     rememberHomeScrollPosition()
@@ -1651,7 +1668,7 @@ const goToViewInternal = (view, { push = true, restoreScroll = false, scrollToTo
   void trackViewNavigation(fromView, normalized)
 }
 
-const goToView = (view, { push = true, restoreScroll = false } = {}) => {
+const goToView = (view, { push = true, restoreScroll = false, direction } = {}) => {
   const normalized = normalizeViewName(view)
   // App Store 合规：统一拒绝已禁用 view（宫格/深链/通知/历史恢复共用）
   if (!isViewAllowed(normalized)) {
@@ -1679,7 +1696,7 @@ const goToView = (view, { push = true, restoreScroll = false } = {}) => {
   if (!ensureProtectedViewAccess(normalized, { push, fallbackView: currentView.value })) {
     return false
   }
-  goToViewInternal(normalized, { push, restoreScroll })
+  goToViewInternal(normalized, { push, restoreScroll, direction })
   return true
 }
 
@@ -1698,6 +1715,7 @@ const resolveParentView = (view) => {
 const goToParentView = () => {
   const parentView = resolveParentView(currentView.value)
   if (!parentView) return false
+  navDirection.value = 'back'
   goToViewInternal(parentView, { push: false, restoreScroll: parentView === 'home' })
   return true
 }
@@ -1894,7 +1912,8 @@ const handleNavigate = async (target) => {
 
 // 处理返回仪表盘
 const handleBackToDashboard = () => {
-  goToView('home', { restoreScroll: true })
+  navDirection.value = 'back'
+  goToView('home', { restoreScroll: true, direction: 'back' })
 }
 
 const isTemporaryLoginSession = () => {
@@ -3129,6 +3148,7 @@ const handlePopState = async () => {
     const handled = goToParentView()
     if (!handled) {
       // 无父级时回首页并恢复滚动
+      navDirection.value = 'back'
       goToViewInternal('home', { push: false, restoreScroll: true })
       return
     }
@@ -3146,6 +3166,7 @@ const handlePopState = async () => {
   }
 
   const prev = currentView.value
+  navDirection.value = 'back'
   await syncFromHash({ scrollToTop: false })
   if (currentView.value === 'home' && prev !== 'home') {
     recoverViewportAfterTransition({ scrollToTop: false, blurActive: true })
@@ -3166,9 +3187,10 @@ const installCloseInterceptor = async () => {
       if (currentView.value !== 'home') {
         event.preventDefault()
         if ((window.history.length > 1) && (window.location.hash || '#/') !== '#/') {
+          navDirection.value = 'back'
           window.history.back()
         } else {
-          goToView('home', { restoreScroll: true })
+          goToView('home', { restoreScroll: true, direction: 'back' })
         }
         return
       }
@@ -3610,7 +3632,14 @@ onBeforeUnmount(() => {
     ref="appShellRef"
   >
     <DemoModeBanner v-if="isLoggedIn && isTestAccountSession()" />
-    <Transition name="module-fade" mode="out-in">
+    <Transition
+      name="module-fade"
+      mode="out-in"
+      :enter-active-class="viewTransitionEnterActive"
+      :leave-active-class="viewTransitionLeaveActive"
+      :enter-from-class="viewTransitionEnterFrom"
+      :leave-to-class="viewTransitionLeaveTo"
+    >
       <div :key="`${currentView}:${viewRenderNonce}`" class="view-transition-root">
       <!-- 首页 -->
       <Dashboard 
@@ -4033,12 +4062,15 @@ onBeforeUnmount(() => {
     />
   </section>
 
+  <Transition name="modal-pop">
   <div v-if="showLoginPrompt" class="login-mask">
-    <div class="login-mask-card">请先在个人中心登录</div>
+    <div class="login-mask-card modal-pop-card">请先在个人中心登录</div>
   </div>
+  </Transition>
 
+  <Transition name="modal-pop">
   <div v-if="showDailyAccessDialog" class="daily-access-overlay">
-    <div class="daily-access-card">
+    <div class="daily-access-card modal-pop-card">
       <h3>输入今日秘钥</h3>
       <p class="daily-access-desc">
         {{ protectedViewPromptTitle }} 已启用访问门禁，请输入根据当天日期生成的秘钥后再进入。
@@ -4065,9 +4097,11 @@ onBeforeUnmount(() => {
       </form>
     </div>
   </div>
+  </Transition>
 
+  <Transition name="modal-pop">
   <div v-if="showExitDialog" class="exit-dialog-overlay">
-    <div class="exit-dialog-card">
+    <div class="exit-dialog-card modal-pop-card">
       <h3>退出应用</h3>
       <p>是否退出 Mini-HBUT？</p>
       <div class="exit-dialog-actions">
@@ -4078,6 +4112,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
   </div>
+  </Transition>
 
   <!-- 版本更新对话框 -->
   <UpdateDialog 
@@ -4086,8 +4121,9 @@ onBeforeUnmount(() => {
   />
 
   <!-- 强制更新覆盖层 -->
+  <Transition name="modal-pop">
   <div v-if="showForceUpdate" class="force-update-overlay">
-    <div class="force-update-card">
+    <div class="force-update-card modal-pop-card">
       <h3>需要更新</h3>
       <p class="force-update-message">
         {{ forceUpdateInfo?.message || '当前版本过低，请更新后继续使用。' }}
@@ -4102,10 +4138,12 @@ onBeforeUnmount(() => {
       </div>
     </div>
   </div>
+  </Transition>
 
   <!-- 公告详情弹窗 -->
+  <Transition name="modal-pop">
   <div v-if="showAnnouncementModal" class="notice-modal-overlay" @click.self="closeAnnouncement">
-    <div class="notice-modal">
+    <div class="notice-modal modal-pop-card">
       <div class="notice-modal-header">
         <h3>{{ activeAnnouncement?.title }}</h3>
         <button class="notice-close" @click="closeAnnouncement">×</button>
@@ -4128,10 +4166,12 @@ onBeforeUnmount(() => {
       </a>
     </div>
   </div>
+  </Transition>
 
   <!-- 确认公告弹窗 -->
+  <Transition name="modal-pop">
   <div v-if="showBlockingAnnouncement" class="notice-confirm-overlay">
-    <div class="notice-confirm-card">
+    <div class="notice-confirm-card modal-pop-card">
       <h3>重要公告</h3>
       <p class="notice-confirm-title">{{ blockingAnnouncement?.title }}</p>
       <div class="notice-confirm-content" v-html="blockingAnnouncementHtml"></div>
@@ -4141,6 +4181,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
   </div>
+  </Transition>
     
   <!-- 全局提示 -->
   <WorkspaceLayoutEditor
@@ -4219,6 +4260,40 @@ onBeforeUnmount(() => {
   min-height: 100%;
 }
 
+/* 视图切换动效（iOS 风格方向感知）：
+   - 前进（push）：内容从下方滑入，离开时轻微上移淡出
+   - 返回（back）：内容从上方滑入，离开时轻微下移淡出
+   保留 name="module-fade" 类名（Vue 自动生成），兼容 isCurrentViewDomHealthy 检查 */
+.module-fade-fwd-enter-active,
+.module-fade-fwd-leave-active,
+.module-fade-back-enter-active,
+.module-fade-back-leave-active {
+  transition:
+    opacity calc(var(--ui-duration-normal) * var(--ui-motion-scale)) var(--ui-ease-out),
+    transform calc(var(--ui-duration-normal) * var(--ui-motion-scale)) var(--ui-ease-out);
+}
+
+.module-fade-fwd-enter-from {
+  opacity: 0;
+  transform: translateY(14px);
+}
+
+.module-fade-fwd-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.module-fade-back-enter-from {
+  opacity: 0;
+  transform: translateY(-14px);
+}
+
+.module-fade-back-leave-to {
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+/* 兜底：无方向（replace/tab 切换）保持原纯淡入，避免 class 未覆盖时硬切 */
 .module-fade-enter-active,
 .module-fade-leave-active {
   transition:
@@ -4233,6 +4308,10 @@ onBeforeUnmount(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .module-fade-fwd-enter-active,
+  .module-fade-fwd-leave-active,
+  .module-fade-back-enter-active,
+  .module-fade-back-leave-active,
   .module-fade-enter-active,
   .module-fade-leave-active {
     transition: none;

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1861,8 +1861,9 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
 
     <!-- Quick Entry Editor Modal -->
     <Teleport to="body">
-      <div v-if="showQuickEntryEditor" class="quick-entry-editor-overlay fixed inset-0 z-[200] flex items-end justify-center bg-black/40" @click.self="showQuickEntryEditor = false">
-        <div class="quick-entry-editor-panel w-full max-w-md bg-white rounded-t-3xl p-6 animate-slide-up max-h-[80vh] overflow-y-auto">
+      <Transition name="modal-pop">
+        <div v-if="showQuickEntryEditor" class="quick-entry-editor-overlay fixed inset-0 z-[200] flex items-end justify-center bg-black/40" @click.self="showQuickEntryEditor = false">
+          <div class="quick-entry-editor-panel modal-pop-card w-full max-w-md bg-white rounded-t-3xl p-6 max-h-[80vh] overflow-y-auto">
           <div class="flex items-center justify-between mb-4">
             <h3 class="font-bold text-lg text-gray-800">编辑快捷入口</h3>
             <button class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center" @click="showQuickEntryEditor = false">
@@ -1901,6 +1902,7 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
           </button>
         </div>
       </div>
+      </Transition>
     </Teleport>
   </div>
 </template>
@@ -2012,17 +2014,8 @@ watch(() => [uiSettings.workspaceLayout.home.widgetsOrder.join('|'), uiSettings.
   to { transform: scale(1); opacity: 1; }
 }
 
-@keyframes slide-up {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
-}
-
 .animate-scale-in {
   animation: scale-in 0.25s ease-out;
-}
-
-.animate-slide-up {
-  animation: slide-up 0.3s ease-out;
 }
 
 .scrollbar-hide {

--- a/src/components/GradeView.vue
+++ b/src/components/GradeView.vue
@@ -575,8 +575,9 @@ watch(
 
     <!-- 详情弹窗 -->
     <Teleport to="body">
-      <div v-if="showDetail" class="modal-overlay" @click="closeDetail">
-        <div class="modal-content" @click.stop>
+      <Transition name="modal-pop">
+        <div v-if="showDetail" class="modal-overlay" @click="closeDetail">
+          <div class="modal-content modal-pop-card" @click.stop>
           <button class="modal-close" @click="closeDetail">×</button>
           
           <div class="detail-header">
@@ -658,6 +659,7 @@ watch(
           </div>
         </div>
       </div>
+      </Transition>
     </Teleport>
       </template>
     </main>
@@ -1150,20 +1152,8 @@ watch(
   max-height: min(80vh, 680px);
   overflow: auto;
   position: relative;
-  animation: slideUp 0.3s ease;
   border: 1px solid var(--ui-surface-border);
   box-shadow: var(--ui-shadow-strong);
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 .modal-close {

--- a/src/components/MeView.vue
+++ b/src/components/MeView.vue
@@ -403,9 +403,10 @@ const handleShowLegal = async (tab) => {
     </footer>
 
     <!-- 开源说明弹窗 -->
-    <div v-if="showOpenSourceModal" class="modal-mask" @click="showOpenSourceModal = false">
-      <div class="modal-card" @click.stop>
-        <h3><span class="material-symbols-outlined opensource-title-icon">menu_book</span> 开源说明</h3>
+    <Transition name="modal-pop">
+      <div v-if="showOpenSourceModal" class="modal-mask" @click="showOpenSourceModal = false">
+        <div class="modal-card modal-pop-card" @click.stop>
+          <h3><span class="material-symbols-outlined opensource-title-icon">menu_book</span> 开源说明</h3>
         <p class="intro">Mini-HBUT 是一个开源项目，致力于提供更好的校园信息查询体验。</p>
         <div class="section">
           <p class="label">项目地址</p>
@@ -433,15 +434,17 @@ const handleShowLegal = async (tab) => {
           <button class="btn-primary" @click="showOpenSourceModal = false">知道了</button>
         </div>
       </div>
-    </div>
+      </div>
+    </Transition>
 
     <!-- 赞助弹窗（合规包 guest/demo 不挂载） -->
-    <div
-      v-if="showSponsorModal && showSponsorEntry"
-      class="modal-mask"
-      @click="showSponsorModal = false"
-    >
-      <div class="modal-card sponsor-modal" @click.stop>
+    <Transition name="modal-pop">
+      <div
+        v-if="showSponsorModal && showSponsorEntry"
+        class="modal-mask"
+        @click="showSponsorModal = false"
+      >
+        <div class="modal-card sponsor-modal modal-pop-card" @click.stop>
         <h3>❤️ 赞助支持</h3>
         <p class="intro">如果 Mini-HBUT 对你有帮助，欢迎请作者喝杯咖啡 ☕</p>
         <div class="sponsor-qr-container">
@@ -458,7 +461,8 @@ const handleShowLegal = async (tab) => {
           <button class="btn-primary" @click="showSponsorModal = false">关闭</button>
         </div>
       </div>
-    </div>
+      </div>
+    </Transition>
   </div>
 </template>
 

--- a/src/components/templates/TModal.vue
+++ b/src/components/templates/TModal.vue
@@ -101,22 +101,36 @@ const onOverlayClick = () => {
   border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 
+/* 弹窗过渡（iOS 风格：遮罩淡入 + 内容轻微回弹缩放上滑，含离场） */
 .t-modal-enter-active,
 .t-modal-leave-active {
-  transition: opacity calc(0.2s * var(--ui-motion-scale)) ease;
+  transition: opacity calc(var(--ui-duration-normal) * var(--ui-motion-scale)) var(--ui-ease-out);
 }
 .t-modal-enter-active .t-modal__container,
 .t-modal-leave-active .t-modal__container {
-  transition: transform calc(0.2s * var(--ui-motion-scale)) ease;
+  transition:
+    transform calc(var(--ui-duration-normal) * var(--ui-motion-scale)) var(--ui-ease-spring),
+    opacity calc(var(--ui-duration-fast) * var(--ui-motion-scale)) var(--ui-ease-out);
 }
 .t-modal-enter-from,
 .t-modal-leave-to {
   opacity: 0;
 }
 .t-modal-enter-from .t-modal__container {
-  transform: scale(0.92) translateY(12px);
+  transform: scale(0.94) translateY(14px);
+  opacity: 0;
 }
 .t-modal-leave-to .t-modal__container {
-  transform: scale(0.95) translateY(6px);
+  transform: scale(0.97) translateY(8px);
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-modal-enter-active,
+  .t-modal-leave-active,
+  .t-modal-enter-active .t-modal__container,
+  .t-modal-leave-active .t-modal__container {
+    transition: none;
+  }
 }
 </style>

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,13 @@
   --ui-font-scale: 1;
   --ui-space-scale: 1;
   --ui-motion-scale: 1;
+  /* 动效规范（iOS 风格：温和缓入 + 轻微弹性） */
+  --ui-duration-fast: 0.15s;
+  --ui-duration-normal: 0.24s;
+  --ui-duration-slow: 0.35s;
+  --ui-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ui-ease-spring: cubic-bezier(0.34, 1.3, 0.5, 1);
+  --ui-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ui-danger: #ef4444;
   --ui-success: #10b981;
   --ui-shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.12);
@@ -67,7 +74,41 @@
   }
 }
 
-/* shadcn-vue theme variables */
+/* ============================================================
+   通用模态过渡（iOS 风格：遮罩淡入 + 内容轻微回弹缩放上滑）
+   用法：<Transition name="modal-pop"> 包裹 v-if 弹窗根节点；
+   卡片层加 .modal-pop-card 标记以命中内容动画
+   ============================================================ */
+.modal-pop-enter-active,
+.modal-pop-leave-active {
+  transition: opacity calc(var(--ui-duration-normal) * var(--ui-motion-scale)) var(--ui-ease-out);
+}
+.modal-pop-enter-active .modal-pop-card,
+.modal-pop-leave-active .modal-pop-card {
+  transition:
+    transform calc(var(--ui-duration-normal) * var(--ui-motion-scale)) var(--ui-ease-spring),
+    opacity calc(var(--ui-duration-fast) * var(--ui-motion-scale)) var(--ui-ease-out);
+}
+.modal-pop-enter-from,
+.modal-pop-leave-to {
+  opacity: 0;
+}
+.modal-pop-enter-from .modal-pop-card {
+  transform: scale(0.94) translateY(16px);
+  opacity: 0;
+}
+.modal-pop-leave-to .modal-pop-card {
+  transform: scale(0.97) translateY(8px);
+  opacity: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .modal-pop-enter-active,
+  .modal-pop-leave-active,
+  .modal-pop-enter-active .modal-pop-card,
+  .modal-pop-leave-active .modal-pop-card {
+    transition: none !important;
+  }
+}
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/style.css
+++ b/src/style.css
@@ -15,6 +15,13 @@
   --ui-font-scale: 1;
   --ui-space-scale: 1;
   --ui-motion-scale: 1;
+  /* 动效规范（iOS 风格：温和缓入 + 轻微弹性） */
+  --ui-duration-fast: 0.15s;
+  --ui-duration-normal: 0.24s;
+  --ui-duration-slow: 0.35s;
+  --ui-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ui-ease-spring: cubic-bezier(0.34, 1.3, 0.5, 1);
+  --ui-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ui-danger: #ef4444;
   --ui-success: #10b981;
   --ui-shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.12);

--- a/src/styles/home_dashboard_contract.spec.ts
+++ b/src/styles/home_dashboard_contract.spec.ts
@@ -119,7 +119,7 @@ describe('home dashboard interaction contract', () => {
     expect(source).toContain('HOME_SCROLL_STORAGE_KEY')
     expect(source).toContain('readStoredHomeScrollTop')
     expect(source).toContain('returningHome')
-    expect(source).toContain("goToView('home', { restoreScroll: true })")
+    expect(source).toMatch(/goToView\('home', \{ restoreScroll: true(?:, direction: 'back')?\s*\}\)/)
     expect(source).toContain('recoverViewportAfterTransition({ scrollToTop: false')
     // 系统返回键 / popstate：落地首页时必须 scrollToTop:false 并 restore，不可冲掉位置
     // （非首页落地仍可用 scrollToTop:true 校正视口，故不能用跨语句贪心正则一刀切）

--- a/src/utils/app_motion_contract.spec.ts
+++ b/src/utils/app_motion_contract.spec.ts
@@ -1,0 +1,36 @@
+// 动效方向契约测试：防止导航方向逻辑回归（#527）
+// 通过读取 App.vue 源码做字符串断言，验证：
+// 1) 返回链（goToParentView / popstate fallback / 返回首页）显式传 direction: 'back'
+// 2) 视图过渡 computed 在 'none'（replace/tab）时不传自定义类（回落 name 纯淡入）
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const appVue = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'App.vue'), 'utf8')
+
+describe('App.vue 视图切换方向契约', () => {
+  it('goToParentView 显式传 direction: back（不被 goToViewInternal 覆盖）', () => {
+    // goToViewInternal 内会无条件 navDirection = direction || (push ? 'forward' : 'none')
+    // 因此返回链必须显式传 direction:'back'，前置赋值是无效且误导的
+    expect(appVue).toMatch(/goToViewInternal\(parentView,\s*\{\s*push: false,\s*restoreScroll: parentView === 'home',\s*direction: 'back'\s*\}/)
+  })
+
+  it('popstate 无父级回退首页显式传 direction: back', () => {
+    expect(appVue).toMatch(/goToViewInternal\('home', \{ push: false, restoreScroll: true, direction: 'back' \}\)/)
+  })
+
+  it('返回仪表盘显式传 direction: back', () => {
+    expect(appVue).toMatch(/goToView\('home', \{ restoreScroll: true, direction: 'back' \}\)/)
+  })
+
+  it('replace（none 方向）不传自定义过渡类，回落 name=module-fade', () => {
+    // navDirection==='none' 时 computed 返回 undefined
+    expect(appVue).toMatch(/\? 'module-fade-fwd-enter-active'\s*: undefined/)
+  })
+
+  it('isCurrentViewDomHealthy 过渡短路覆盖 fwd/back 方向类', () => {
+    expect(appVue).toMatch(/module-fade-fwd-leave-active, \.module-fade-fwd-enter-active/)
+    expect(appVue).toMatch(/module-fade-back-leave-active, \.module-fade-back-enter-active/)
+  })
+})


### PR DESCRIPTION
﻿## 概述

动效优化核心轮（关联 #527）：参考 iOS 设计风格，为视图切换与弹层补充过渡动画。

## 内容

1. **统一动效 token**：`--ui-duration-fast/normal/slow`（0.15/0.24/0.35s）+ `--ui-ease-out/spring/in-out`（Toast 同款弹性曲线）
2. **视图切换方向感知**：前进 slide-up / 返回 slide-down / Tab 淡入，时长 token 化；保留 `module-fade` 类名与 `.view-transition-root` 兼容 `isCurrentViewDomHealthy`
3. **通用弹窗过渡** `.modal-pop`：遮罩 fade + 卡片 `scale(0.94) translateY(16px)` spring 缓入 + 完整离场；`TModal` 同步升级
4. **高频弹窗接入 8 处**：开源协议/赞助/登录遮罩/每日秘钥/退出确认/强制更新/公告详情/重要公告
5. **清理只入场无离场**：GradeView/Dashboard，删除死代码
6. **低动效尊重**：全部乘 `--ui-motion-scale` + `prefers-reduced-motion` 禁用

## 验证

- `npm run build` 通过
- Playwright 实测：弹窗离场类序列（leave-from→leave-active→leave-to→移除）、课表 Tab `module-fade-fwd` 序列、低动效 `--ui-motion-scale=0.2` → 0.048s、reduced-motion 生效
- `isCurrentViewDomHealthy` 类名兼容确认

## Backlog（后续轮次，见 #527）

- CampusGuideShell 25+ 子视图过渡、shadcn 动画接线/清理、其余约 10 处弹窗、重复 keyframes 收敛
