### PR TITLE
fix(#528): iOS 课程中心加载瞬间崩溃——渲染渐进、封面缩略图、请求量收敛

### DIFF
--- a/src-tauri/src/modules/online_learning.rs
+++ b/src-tauri/src/modules/online_learning.rs
@@ -2436,7 +2436,9 @@ async fn chaoxing_node_completion(
     let mut total = 0usize;
     let mut passed = 0usize;
     let mut ok = true;
-    for num in 0..16u32 {
+    // 页数上限：单节点最多 6 页（附件满 30/页 ≈ 180 任务点），
+    // 防止异常超大节点发起十几页请求拖垮会话与触发风控
+    for num in 0..6u32 {
         let num_s = num.to_string();
         let url = format!(
             "https://mooc1.chaoxing.com/mooc-ans/knowledge/cards?clazzid={clazz_id}&courseid={course_id}&knowledgeid={knowledge_id}&num={num_s}&ut=s&cpi={cpi}&v=2025-0424-1038-3&mooc2=1&isMicroCourse=false&editorPreview=0"
@@ -2519,7 +2521,7 @@ async fn enrich_outline_with_task_completion(
         })
         .collect();
     let results: Vec<(usize, usize, bool)> =
-        futures::stream::iter(tasks).buffered(8).collect().await;
+        futures::stream::iter(tasks).buffered(6).collect().await;
 
     let mut completion: std::collections::HashMap<String, (usize, usize, bool)> =
         std::collections::HashMap::new();

--- a/src/components/ChaoxingHubView.vue
+++ b/src/components/ChaoxingHubView.vue
@@ -96,6 +96,17 @@ const preferHttps = (url) => {
   return u
 }
 
+/**
+ * 课程封面统一转缩略图：origin 原图 → 150x150c 缩略图
+ * 列表场景数百张卡片同时渲染时，原图（可能数 MB）会拖垮 WebView 内存
+ * （协议规则：https://p.ananas.chaoxing.com/star3/150_150c/{objectId}）
+ */
+const normalizeCourseCover = (url) => {
+  const u = safeText(url)
+  if (!u) return ''
+  return u.replace('/star3/origin/', '/star3/150_150c/')
+}
+
 const normalizeCourse = (item = {}) => {
   const raw = item && typeof item === 'object' ? item : {}
   const courseId = safeText(raw.course_id || raw.courseId || '')
@@ -108,7 +119,7 @@ const normalizeCourse = (item = {}) => {
     cpi,
     title: safeText(raw.title || raw.name || raw.course_name || '未命名课程'),
     teacher: safeText(raw.teacher || raw.teacher_name || raw.teacherfactor || ''),
-    imageUrl: safeText(raw.image_url || raw.imageUrl || raw.cover || ''),
+    imageUrl: normalizeCourseCover(raw.image_url || raw.imageUrl || raw.cover || ''),
     progressText: safeText(raw.progress_text || raw.progressText || ''),
     progressRate: safeNumber(
       raw.progress_rate ?? raw.progressRate ?? raw.progress_percent ?? raw.percent
@@ -118,6 +129,25 @@ const normalizeCourse = (item = {}) => {
     // 缺省用「未分学期」，避免全量标成「本学期」掩盖多学期问题
     semester: safeText(raw.semester || raw.term || '未分学期') || '未分学期'
   }
+}
+
+/** iOS 渐进渲染：首帧小批插入，rAF 逐批递增，平滑「列表加载完成瞬间」的渲染峰值 */
+let progressiveRenderRaf = 0
+const scheduleProgressiveCourseRender = () => {
+  if (progressiveRenderRaf) cancelAnimationFrame(progressiveRenderRaf)
+  const step = () => {
+    if (disposed) return
+    if (courseRenderLimit.value < IOS_SAFE_COURSE_BATCH) {
+      courseRenderLimit.value = Math.min(
+        IOS_SAFE_COURSE_BATCH,
+        courseRenderLimit.value + 3
+      )
+      progressiveRenderRaf = requestAnimationFrame(step)
+    } else {
+      progressiveRenderRaf = 0
+    }
+  }
+  progressiveRenderRaf = requestAnimationFrame(step)
 }
 
 const typeMetaOf = (typeRaw) => {
@@ -215,6 +245,10 @@ const hasMoreCourses = computed(() =>
 )
 
 const resetCourseRenderLimit = () => {
+  if (progressiveRenderRaf) {
+    cancelAnimationFrame(progressiveRenderRaf)
+    progressiveRenderRaf = 0
+  }
   courseRenderLimit.value = IOS_SAFE_COURSE_BATCH
 }
 
@@ -353,6 +387,11 @@ const loadList = async ({ silent = false, force = false } = {}) => {
       list = list.slice(0, MAX_COURSE_LIST_SIZE)
     }
     courses.value = list.map(normalizeCourse).filter((c) => c.courseId && c.clazzId)
+    // iOS：首帧小批渲染 + rAF 逐批递增，平滑「列表加载完成瞬间」的渲染峰值
+    if (isIOSLikeDevice) {
+      courseRenderLimit.value = Math.min(IOS_SAFE_COURSE_BATCH, 6)
+      scheduleProgressiveCourseRender()
+    }
     pushDebugLog(
       'ChaoxingHub',
       `课程列表完成 count=${courses.value.length} from_cache=${!!courseRes?.from_cache} (${Date.now() - t0}ms)`,
@@ -396,8 +435,17 @@ const loadList = async ({ silent = false, force = false } = {}) => {
     error.value = safeText(e?.message || e) || '加载失败'
   } finally {
     if (!disposed) {
-      loading.value = false
-      refreshing.value = false
+      // iOS：loading 退场延后一帧，避免「列表首渲染 + 移除加载动画」同帧峰值
+      if (isIOSLikeDevice) {
+        requestAnimationFrame(() => {
+          if (disposed) return
+          loading.value = false
+          refreshing.value = false
+        })
+      } else {
+        loading.value = false
+        refreshing.value = false
+      }
     }
   }
 }
@@ -867,6 +915,10 @@ watch([activeSemester, searchQuery], () => {
 
 /** iOS 原生层内存告警：立即收缩课程渲染批量，降低 DOM 与内存压力 */
 const onIosMemoryWarning = () => {
+  if (progressiveRenderRaf) {
+    cancelAnimationFrame(progressiveRenderRaf)
+    progressiveRenderRaf = 0
+  }
   courseRenderLimit.value = IOS_SAFE_COURSE_BATCH
   pushDebugLog('ChaoxingHub', '收到 iOS 内存告警，收缩课程渲染批量', 'warn')
 }
@@ -881,6 +933,10 @@ onMounted(() => {
 onUnmounted(() => {
   // 仅在组件卸载时置位；导航栈内 pop/jumpTo 切换不触发
   disposed = true
+  if (progressiveRenderRaf) {
+    cancelAnimationFrame(progressiveRenderRaf)
+    progressiveRenderRaf = 0
+  }
   window.removeEventListener('iosMemoryWarning', onIosMemoryWarning)
 })
 </script>

--- a/src/components/ChaoxingHubView.vue
+++ b/src/components/ChaoxingHubView.vue
@@ -237,7 +237,8 @@ const filteredCourses = computed(() => {
 
 const visibleCourses = computed(() => {
   if (!isIOSLikeDevice) return filteredCourses.value
-  return filteredCourses.value.slice(0, Math.max(IOS_SAFE_COURSE_BATCH, courseRenderLimit.value))
+  // 渐进渲染：以 courseRenderLimit 为准（loadList 首帧 6 → rAF 递增到 12）
+  return filteredCourses.value.slice(0, courseRenderLimit.value)
 })
 
 const hasMoreCourses = computed(() =>

--- a/src/components/chaoxing_hub_ios_contract.spec.ts
+++ b/src/components/chaoxing_hub_ios_contract.spec.ts
@@ -1,0 +1,38 @@
+// iOS 课程中心崩溃防护契约测试（#528）
+// 通过读取 ChaoxingHubView.vue 源码断言，验证防崩溃防护不回归：
+// 1) 封面缩略图转换（origin → 150_150c）
+// 2) iOS 渐进渲染真正生效（visibleCourses 以 courseRenderLimit 为准）
+// 3) iOS loading 退场延后一帧（与列表首渲染错帧）
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'ChaoxingHubView.vue'), 'utf8')
+
+describe('ChaoxingHubView iOS 崩溃防护契约', () => {
+  it('课程封面 origin 原图转 150x150c 缩略图', () => {
+    expect(source).toMatch(/\.replace\('\/star3\/origin\/', '\/star3\/150_150c\/'\)/)
+  })
+
+  it('渐进渲染真正生效：visibleCourses 以 courseRenderLimit 为准（非 max(batch, limit)）', () => {
+    // Math.max(batch, limit) 会使首帧 limit=6 被 max(12,6)=12 吞掉 → 渐进失效
+    expect(source).toMatch(/slice\(0, courseRenderLimit\.value\)/)
+    expect(source).not.toMatch(/Math\.max\(IOS_SAFE_COURSE_BATCH, courseRenderLimit\.value\)/)
+  })
+
+  it('首帧小批 + rAF 逐批递增', () => {
+    expect(source).toMatch(/courseRenderLimit\.value = Math\.min\(IOS_SAFE_COURSE_BATCH, 6\)/)
+    expect(source).toMatch(/requestAnimationFrame\(step\)/)
+    expect(source).toMatch(/courseRenderLimit\.value \+ 3/)
+  })
+
+  it('iOS loading 退场延后一帧（与列表首渲染错帧）', () => {
+    expect(source).toMatch(/isIOSLikeDevice\)\s*\{\s*requestAnimationFrame\(\(\) => \{/)
+  })
+
+  it('rAF 清理覆盖卸载/内存告警/重置', () => {
+    const cancelCount = (source.match(/cancelAnimationFrame\(progressiveRenderRaf\)/g) || []).length
+    expect(cancelCount).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/src/styles/home_dashboard_contract.spec.ts
+++ b/src/styles/home_dashboard_contract.spec.ts
@@ -119,7 +119,7 @@ describe('home dashboard interaction contract', () => {
     expect(source).toContain('HOME_SCROLL_STORAGE_KEY')
     expect(source).toContain('readStoredHomeScrollTop')
     expect(source).toContain('returningHome')
-    expect(source).toMatch(/goToView\('home', \{ restoreScroll: true(?:, direction: 'back')?\s*\}\)/)
+    expect(source).toContain("goToView('home', { restoreScroll: true })")
     expect(source).toContain('recoverViewportAfterTransition({ scrollToTop: false')
     // 系统返回键 / popstate：落地首页时必须 scrollToTop:false 并 restore，不可冲掉位置
     // （非首页落地仍可用 scrollToTop:true 校正视口，故不能用跨语句贪心正则一刀切）

--- a/src/styles/home_dashboard_contract.spec.ts
+++ b/src/styles/home_dashboard_contract.spec.ts
@@ -119,7 +119,7 @@ describe('home dashboard interaction contract', () => {
     expect(source).toContain('HOME_SCROLL_STORAGE_KEY')
     expect(source).toContain('readStoredHomeScrollTop')
     expect(source).toContain('returningHome')
-    expect(source).toContain("goToView('home', { restoreScroll: true })")
+    expect(source).toMatch(/goToView\('home', \{ restoreScroll: true(?:, direction: 'back')?\s*\}\)/)
     expect(source).toContain('recoverViewportAfterTransition({ scrollToTop: false')
     // 系统返回键 / popstate：落地首页时必须 scrollToTop:false 并 restore，不可冲掉位置
     // （非首页落地仍可用 scrollToTop:true 校正视口，故不能用跨语句贪心正则一刀切）


### PR DESCRIPTION
﻿## 概述

修复 iOS 课程中心列表加载完成瞬间崩溃闪退（关联 #528）。

## 崩溃机理

iOS WKWebView 在课程列表「加载完成的一瞬间」：一批卡片 DOM 插入 + 远程原图加载（`star3/origin` 数 MB/张）+ 多条 WebKit IPC 日志同帧叠加 → 内存/合成压力峰值 → 低内存设备闪退。

## 修复

**前端 `ChaoxingHubView.vue`：**
1. 课程封面 `star3/origin/` → `star3/150_150c/` 缩略图（全平台内存收益，幂等转换、空值安全）
2. iOS 渐进渲染：首帧 6 张 + `requestAnimationFrame` 逐批递增到 `IOS_SAFE_COURSE_BATCH(12)`，平滑渲染峰值
3. iOS loading 退场延后一帧，避免「列表首渲染 + 停动画」同帧合成压力
4. rAF 清理：`resetCourseRenderLimit`/`onIosMemoryWarning`/`onUnmounted` 取消未完成帧

**后端 `online_learning.rs`（详情页任务点统计请求量）：**
5. 分页上限 16→6 页、并发 8→6，防请求风暴/风控

## 验证

- `npm run build` ✅、`cargo check` ✅、`cargo test --lib modules::online_learning` 15 全绿 ✅
- 缩略图转换实测：`origin/x.jpg` → `150_150c/x.jpg`（幂等、空值安全）✅
- 待 iOS 真机回归（用户环境）
