### PR TITLE
security: 阶段一安全收口

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ node scripts/check-design-tokens.mjs
 
 - 业务逻辑优先放在 `http_client/`、`modules/`，避免继续膨胀 `lib.rs`
 - 数据库访问集中在 `db.rs`；密码走 `credential_store.rs`
-- 新增 HTTP Bridge 路由必须评估鉴权（`HBUT_BRIDGE_TOKEN`）
+- 新增 HTTP Bridge 路由必须登记访问级别（PublicHealth / PublicEmbed / Protected / DebugOnly），默认按 Protected 处理
 - `cargo fmt` 后再提交；Clippy 全绿为长期目标，勿在未修复存量告警时强行 `-D warnings`
 
 ### 前端（`src/`）
@@ -65,7 +65,8 @@ node scripts/check-design-tokens.mjs
 | 变量 | 用途 |
 |------|------|
 | `HBUT_HTTP_BRIDGE_ENABLED=1` | 桌面 Release 下启动本地 Bridge；Tauri iOS Release 默认已开启 |
-| `HBUT_BRIDGE_TOKEN` | Bridge 敏感 API Bearer 令牌 |
+| `HBUT_BRIDGE_TOKEN` | CLI/自动化访问 Protected Bridge 路由时使用的兼容 Bearer 令牌；应用内 WebView 走可信 Origin |
+| `HBUT_HTTP_BRIDGE_PORT` | 调整 Loopback Bridge 端口；监听地址始终固定为 `127.0.0.1` |
 | `MINI_HBUT_INSECURE_TLS=1` | 禁用 TLS 校验（仅排障） |
 
 详见 [SECURITY.md](./SECURITY.md)。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,8 +21,10 @@
 
 - **密码存储**：用户密码保存在操作系统密钥环（`keyring`），SQLite 不保存可逆密码。
 - **TLS**：Release 构建默认校验证书；仅 Debug 或显式设置 `MINI_HBUT_INSECURE_TLS=1` 时放宽。
-- **本地 HTTP Bridge（:4399）**：桌面 Release 默认不启动，启用需 `HBUT_HTTP_BRIDGE_ENABLED=1`；**Tauri iOS Release 为内嵌小游戏/学校官网默认开启** loopback Bridge。敏感路由需 `HBUT_BRIDGE_TOKEN`。
-- **调试接口**：`debug.enable_bridge_tools` 等能力仅在受控调试环境使用，勿在生产分发包中开启。
+- **本地 HTTP Bridge（:4399）**：固定绑定 `127.0.0.1`，忽略外部 Host 配置；桌面 Release 默认不启动，Tauri iOS Release 因内嵌页面依赖可启用。除健康检查和受控的只读嵌入资源外，请求必须来自可信 Tauri/Capacitor/Loopback Origin，或携带有效 Bridge Bearer 令牌。
+- **Bridge CORS**：仅回显 `tauri://localhost`、`capacitor://localhost` 和 Loopback 开发 Origin；任意公网、局域网和 `null` Origin 均被拒绝。
+- **调试接口**：`/debug/*` 与 `/campus-guide-debug/*` 只在 Debug Router 中注册，Release Router 不包含这些路由；抓包文件和 `rust_backend_session.json` 也只允许 Debug 构建读取。
+- **WebView 安全**：Tauri CSP 明确限制脚本、连接、Frame、对象和表单来源；Capability 仅授予主窗口实际使用的通知、外链和子 WebView 权限。
 - **签名密钥**：Android 发布密钥仅通过 CI Secrets 注入，勿提交 `.jks` / `keystore-base64.txt`。
 
 ## 质量门禁（DevSecOps）

--- a/scripts/test_more_module_bridge.mjs
+++ b/scripts/test_more_module_bridge.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 
 const bridgeBase = process.env.BRIDGE_BASE || 'http://127.0.0.1:4399'
+const bridgeToken = String(process.env.HBUT_BRIDGE_TOKEN || process.env.DEBUG_TOKEN || '').trim()
 const moduleBase = process.env.MODULE_CDN_BASE || 'https://hbut.6661111.xyz/modules'
 const channel = process.env.MODULE_CHANNEL || 'latest'
 const moduleId = process.env.MODULE_ID || 'hecheng_hugongda'
@@ -112,6 +113,10 @@ const resolvePackageUrl = (manifestUrl, manifest) => {
 }
 
 const main = async () => {
+  assert.ok(
+    bridgeToken,
+    '受保护 Bridge 接口需要 HBUT_BRIDGE_TOKEN（或兼容的 DEBUG_TOKEN）'
+  )
   const catalogPayload = await fetchJson(`${moduleCatalogUrl}?ts=${Date.now()}`)
   const modules = Array.isArray(catalogPayload?.modules) ? catalogPayload.modules : []
   const target = modules.find((item) => item?.id === moduleId)
@@ -124,7 +129,10 @@ const main = async () => {
 
   const preparePayload = await fetchJson(`${bridgeBase}/module_bundle/prepare`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bridgeToken}`
+    },
     body: JSON.stringify({
       channel,
       moduleId,

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main-capability",
-  "description": "Main capability for Mini-HBUT window",
-  "windows": ["main"],
+  "description": "Least-privilege capability for the Mini-HBUT main window",
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
     "core:webview:allow-create-webview",
@@ -12,12 +14,12 @@
     "core:webview:allow-set-webview-position",
     "core:webview:allow-set-webview-size",
     "core:webview:allow-set-webview-auto-resize",
-    "notification:default",
     "notification:allow-request-permission",
     "notification:allow-is-permission-granted",
     "notification:allow-notify",
     "notification:allow-create-channel",
     "notification:allow-list-channels",
+    "notification:allow-register-listener",
     "shell:default",
     "window-state:default"
   ]

--- a/src-tauri/docs/http_bridge_security.md
+++ b/src-tauri/docs/http_bridge_security.md
@@ -1,0 +1,68 @@
+# 本地 HTTP Bridge 安全边界
+
+阶段一安全收口对应 GitHub Issues #532–#538。
+
+## 监听与启用
+
+- Bridge 始终绑定 IPv4 Loopback：`127.0.0.1`。
+- `HBUT_HTTP_BRIDGE_HOST` 不再生效，避免误暴露到局域网或公网。
+- `HBUT_HTTP_BRIDGE_PORT` 仅可修改端口。
+- Debug 构建默认启用；Tauri iOS 因内嵌页面依赖默认启用；桌面 Release 仅在显式配置后启用。
+
+## 路由访问级别
+
+| 级别 | 示例 | 要求 |
+| --- | --- | --- |
+| `PublicHealth` | `GET /health` | 仅用于进程健康探测，不返回凭证 |
+| `PublicEmbed` | 模块包静态内容、学校官网只读嵌入 | 仅 `GET/HEAD`；显式不可信 Origin 仍拒绝 |
+| `Protected` | 登录、成绩、课表、选课、学习、AI、代理和写操作 | 可信 WebView/Loopback Origin，或有效 Bearer / `X-Local-Token` |
+| `DebugOnly` | `/debug/*`、`/campus-guide-debug/*` | 仅 Debug Router 注册，并继续要求运行时调试开关和统一访问控制 |
+
+所有未知路由默认归入 `Protected`，新增路由不能因为遗漏登记而自动变成公开接口。
+
+## Origin 白名单
+
+允许：
+
+- `tauri://localhost`
+- `capacitor://localhost`
+- `http(s)://localhost[:port]`
+- `http(s)://127.0.0.1[:port]`
+- `http(s)://[::1][:port]`
+- `https://tauri.localhost`
+
+拒绝公网、局域网 IP、`file:` 和 `null` Origin。CORS 不再使用 `Any`。
+
+## 令牌
+
+每次 Bridge 启动都会生成随机会话令牌，服务端仅在内存中保存。CLI 与自动化脚本可继续通过 `HBUT_BRIDGE_TOKEN` 提供受控兼容令牌。令牌比较会同时检查长度和全部字节。
+
+## Release 隔离
+
+- Release Router 不合并 Debug Router。
+- `rust_backend_session.json`、`captured_requests.json` 和 `captured_requests1.json` 仅在 Debug 构建读取。
+- Release 即使开启普通 Bridge，也无法通过运行时配置重新注册调试路由。
+
+## Capability 最小权限审查
+
+| 权限组 | 结论 | 原因 |
+| --- | --- | --- |
+| `core:default` | 保留 | 主窗口生命周期与基础事件能力 |
+| 子 WebView create/show/hide/close/position/size/auto-resize | 保留显式条目 | 学校官网、模块预览等现有子 WebView 流程依赖 |
+| `notification:*` | 移除 `notification:default`，改用显式权限 | 仅保留通知、权限查询/申请、Channel 和 Action Listener 实际调用 |
+| `shell:default` | 保留 | Tauri 生成的默认 scope 仅允许 `http(s)`、`tel`、`mailto` 外链打开，不授予任意命令执行 |
+| `window-state:default` | 保留 | 桌面窗口尺寸与位置恢复依赖 |
+| `fs` | 不向前端授予 | 文件能力由受控 Rust command 处理，主窗口 Capability 中没有文件系统权限 |
+
+新增插件或前端命令时，必须先补充此矩阵并证明现有显式权限不足，不能直接恢复插件 `default` 全权限集合。
+
+## 变更检查
+
+```powershell
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --release --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+npm run test:ci
+npm run build
+```

--- a/src-tauri/src/http_client/ai.rs
+++ b/src-tauri/src/http_client/ai.rs
@@ -20,6 +20,7 @@ impl HbutClient {
             "https%3A%2F%2Fhub.17wanxiao.com%2Fbsacs%2Fdklight.action%3Fstate%3Dbjdk_hbgy_dk_echar",
         ];
 
+        #[cfg(debug_assertions)]
         fn find_entry_url_in_text(text: &str) -> Option<String> {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(text) {
                 if let Some(arr) = json.as_array() {
@@ -70,11 +71,14 @@ impl HbutClient {
         fn load_entry_url_template() -> Option<String> {
             let mut dir = std::env::current_dir().ok()?;
             for _ in 0..=6 {
-                let candidate = dir.join("captured_requests.json");
-                if candidate.exists() {
-                    if let Ok(text) = std::fs::read_to_string(candidate) {
-                        if let Some(url) = find_entry_url_in_text(&text) {
-                            return Some(url);
+                #[cfg(debug_assertions)]
+                {
+                    let candidate = dir.join("captured_requests.json");
+                    if candidate.exists() {
+                        if let Ok(text) = std::fs::read_to_string(candidate) {
+                            if let Some(url) = find_entry_url_in_text(&text) {
+                                return Some(url);
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -10,7 +10,9 @@
 //! - 返回体固定为 { success, data, error, time }
 
 use axum::body::{Body, Bytes};
+use axum::extract::Request;
 use axum::http::header::{CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_TYPE};
+use axum::middleware::{self, Next};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::{
@@ -148,43 +150,28 @@ fn ensure_debug_bridge_enabled(
 }
 
 /// 登录、cookie 导出等敏感 Bridge 路由鉴权。
+///
+/// Router 中间件会先执行同一套策略；这里保留二次校验，避免未来将敏感 handler
+/// 挂载到未受保护的 Router 时静默失守。
 fn ensure_sensitive_bridge_auth(
     headers: &HeaderMap,
     state: &HttpState,
 ) -> Result<(), (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
-    if cfg!(debug_assertions) && debug_bridge::is_bridge_tools_enabled(&state.app) {
+    if has_explicit_untrusted_origin(headers) {
+        return Err(bridge_auth_error(
+            StatusCode::FORBIDDEN,
+            "请求 Origin 不在 Bridge 白名单",
+        ));
+    }
+
+    if has_trusted_bridge_context(headers) || bridge_token_matches(headers, state) {
         return Ok(());
     }
 
-    let expected = std::env::var("HBUT_BRIDGE_TOKEN")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-
-    let Some(expected) = expected else {
-        return Err(err(
-            StatusCode::FORBIDDEN,
-            "权限不足",
-            "敏感桥接 API 已禁用：请设置 HBUT_BRIDGE_TOKEN".to_string(),
-        ));
-    };
-
-    let token = extract_bearer(headers).ok_or_else(|| {
-        err(
-            StatusCode::UNAUTHORIZED,
-            "权限不足",
-            "缺少桥接令牌（Authorization: Bearer … 或 X-Local-Token）".to_string(),
-        )
-    })?;
-
-    if token != expected {
-        return Err(err(
-            StatusCode::UNAUTHORIZED,
-            "权限不足",
-            "桥接令牌无效".to_string(),
-        ));
-    }
-    Ok(())
+    Err(bridge_auth_error(
+        StatusCode::UNAUTHORIZED,
+        "缺少可信 WebView Origin 或有效 Bridge 令牌",
+    ))
 }
 
 fn is_allowed_cache_table(table: &str) -> bool {
@@ -272,23 +259,224 @@ use futures::FutureExt;
 use futures::Stream;
 use futures::StreamExt;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-use rand::Rng;
+use rand::{Rng, RngCore};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::io::ErrorKind;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tauri::{path::BaseDirectory, AppHandle, Emitter, Manager};
 use tokio::sync::{Mutex, RwLock};
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
 
 #[derive(Clone)]
 struct HttpState {
     client: Arc<RwLock<HbutClient>>,
     local_api_key: Option<DecodingKey>,
+    bridge_token: Arc<str>,
     app: AppHandle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BridgeRoutePolicy {
+    PublicHealth,
+    PublicEmbed,
+    Protected,
+    DebugOnly,
+}
+
+fn bridge_route_policy(path: &str) -> BridgeRoutePolicy {
+    if path == "/health" {
+        BridgeRoutePolicy::PublicHealth
+    } else if path.starts_with("/module_bundle/content/")
+        || path == "/school-website"
+        || path == "/school-website/"
+        || path.starts_with("/school-website/")
+    {
+        // 这些 URL 会作为子 WebView 的顶层导航地址，请求可能没有 Origin。
+        // 仅允许 GET/HEAD，且不得携带显式不可信 Origin。
+        BridgeRoutePolicy::PublicEmbed
+    } else if path.starts_with("/debug/") || path.starts_with("/campus-guide-debug/") {
+        BridgeRoutePolicy::DebugOnly
+    } else {
+        BridgeRoutePolicy::Protected
+    }
+}
+
+fn generate_bridge_session_token() -> Arc<str> {
+    let mut bytes = [0_u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    Arc::<str>::from(general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn tokens_equal(left: &str, right: &str) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .fold(0_u8, |diff, (a, b)| diff | (a ^ b))
+        == 0
+}
+
+fn configured_bridge_token() -> Option<String> {
+    std::env::var("HBUT_BRIDGE_TOKEN")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn is_trusted_bridge_origin(raw: &str) -> bool {
+    let value = raw.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("null") {
+        return false;
+    }
+
+    let Ok(url) = url::Url::parse(value) else {
+        return false;
+    };
+    let scheme = url.scheme().to_ascii_lowercase();
+    let host = url.host_str().unwrap_or_default().to_ascii_lowercase();
+
+    match scheme.as_str() {
+        "tauri" | "capacitor" => host == "localhost",
+        "http" | "https" => matches!(
+            host.as_str(),
+            "localhost" | "127.0.0.1" | "::1" | "tauri.localhost"
+        ),
+        _ => false,
+    }
+}
+
+fn has_explicit_untrusted_origin(headers: &HeaderMap) -> bool {
+    headers
+        .get("origin")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|origin| !is_trusted_bridge_origin(origin))
+}
+
+fn has_trusted_bridge_context(headers: &HeaderMap) -> bool {
+    if let Some(origin) = headers.get("origin").and_then(|value| value.to_str().ok()) {
+        return is_trusted_bridge_origin(origin);
+    }
+
+    headers
+        .get("referer")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(is_trusted_bridge_origin)
+}
+
+fn bridge_token_matches(headers: &HeaderMap, state: &HttpState) -> bool {
+    let Some(provided) = extract_bearer(headers) else {
+        return false;
+    };
+
+    tokens_equal(&provided, state.bridge_token.as_ref())
+        || configured_bridge_token()
+            .as_deref()
+            .is_some_and(|expected| tokens_equal(&provided, expected))
+}
+
+fn bridge_auth_error(
+    status: StatusCode,
+    message: &str,
+) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
+    err(status, "权限不足", message.to_string())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BridgeAccessDecision {
+    Allow,
+    Unauthorized,
+    ForbiddenOrigin,
+    DebugRouteUnavailable,
+}
+
+fn decide_bridge_access(
+    policy: BridgeRoutePolicy,
+    method: &Method,
+    headers: &HeaderMap,
+    token_valid: bool,
+    debug_build: bool,
+) -> BridgeAccessDecision {
+    if policy == BridgeRoutePolicy::PublicHealth && matches!(*method, Method::GET | Method::HEAD) {
+        return BridgeAccessDecision::Allow;
+    }
+
+    if policy == BridgeRoutePolicy::DebugOnly && !debug_build {
+        return BridgeAccessDecision::DebugRouteUnavailable;
+    }
+
+    if has_explicit_untrusted_origin(headers) {
+        return BridgeAccessDecision::ForbiddenOrigin;
+    }
+
+    if policy == BridgeRoutePolicy::PublicEmbed && matches!(*method, Method::GET | Method::HEAD) {
+        return BridgeAccessDecision::Allow;
+    }
+
+    if has_trusted_bridge_context(headers) || token_valid {
+        BridgeAccessDecision::Allow
+    } else {
+        BridgeAccessDecision::Unauthorized
+    }
+}
+
+async fn bridge_access_middleware(
+    State(state): State<HttpState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let path = request.uri().path().to_string();
+    let method = request.method().clone();
+    let policy = bridge_route_policy(&path);
+
+    let token_valid = bridge_token_matches(request.headers(), &state);
+    match decide_bridge_access(
+        policy,
+        &method,
+        request.headers(),
+        token_valid,
+        cfg!(debug_assertions),
+    ) {
+        BridgeAccessDecision::Allow => next.run(request).await,
+        BridgeAccessDecision::Unauthorized => bridge_auth_error(
+            StatusCode::UNAUTHORIZED,
+            "缺少可信 WebView Origin 或有效 Bridge 令牌",
+        )
+        .into_response(),
+        BridgeAccessDecision::ForbiddenOrigin => {
+            bridge_auth_error(StatusCode::FORBIDDEN, "请求 Origin 不在 Bridge 白名单")
+                .into_response()
+        }
+        BridgeAccessDecision::DebugRouteUnavailable => {
+            bridge_auth_error(StatusCode::NOT_FOUND, "调试路由在 Release 构建中不存在")
+                .into_response()
+        }
+    }
+}
+
+fn bridge_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(|origin: &HeaderValue, _| {
+            origin
+                .to_str()
+                .map(is_trusted_bridge_origin)
+                .unwrap_or(false)
+        }))
+        .allow_methods([
+            Method::GET,
+            Method::HEAD,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers(AllowHeaders::mirror_request())
 }
 
 #[derive(Debug, Deserialize)]
@@ -556,17 +744,17 @@ pub fn is_http_bridge_enabled() -> bool {
             .unwrap_or(false)
 }
 
-/// 解析 Bridge 监听地址（默认 `127.0.0.1:4399`）。
+/// 解析 Bridge 监听地址（固定 Loopback，端口默认 `4399`）。
+///
+/// `HBUT_HTTP_BRIDGE_HOST` 已被有意忽略，避免 Release 或误配置将 Bridge 暴露到
+/// 局域网/公网。端口仍可通过 `HBUT_HTTP_BRIDGE_PORT` 调整。
 pub fn bridge_listen_addr() -> SocketAddr {
     let port = std::env::var("HBUT_HTTP_BRIDGE_PORT")
         .ok()
-        .and_then(|v| v.parse::<u16>().ok())
+        .and_then(|value| value.parse::<u16>().ok())
+        .filter(|port| *port != 0)
         .unwrap_or(4399);
-    let host = std::env::var("HBUT_HTTP_BRIDGE_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
-    let ip: IpAddr = host
-        .parse()
-        .unwrap_or_else(|_| IpAddr::from([127, 0, 0, 1]));
-    SocketAddr::from((ip, port))
+    SocketAddr::from(([127, 0, 0, 1], port))
 }
 
 /// `ensure_http_bridge` / 前端 resume 探测共用的状态字段。
@@ -657,6 +845,7 @@ pub fn spawn_http_server(client: Arc<RwLock<HbutClient>>, app: AppHandle) {
     let state = HttpState {
         client,
         local_api_key: load_local_api_public_key(),
+        bridge_token: generate_bridge_session_token(),
         app,
     };
     let gen = life
@@ -771,6 +960,35 @@ pub async fn ensure_http_bridge(
     })
 }
 
+#[cfg(debug_assertions)]
+fn debug_routes() -> Router<HttpState> {
+    Router::new()
+        .route(
+            "/debug/custom_schedule/upsert",
+            post(debug_custom_schedule_upsert),
+        )
+        .route("/debug/navigate", post(debug_navigate))
+        .route("/debug/open_module", post(debug_open_module))
+        .route("/debug/reset_more_modules", post(debug_reset_more_modules))
+        .route("/debug/screenshot", post(debug_screenshot))
+        .route("/debug/dom_screenshot", post(debug_dom_screenshot))
+        .route("/debug/state", get(debug_state))
+        .route("/debug/save_export_file", post(debug_save_export_file))
+        .route("/debug/logs", get(debug_logs_get).delete(debug_logs_clear))
+        .route("/debug/logs/query", post(debug_logs_query))
+        .route("/debug/logs/push", post(debug_logs_push))
+        .route("/debug/diag", get(debug_diag))
+        .route("/debug/routes", get(debug_routes_list))
+        .route("/debug/chaoxing/session", post(debug_chaoxing_session))
+        .route("/debug/chaoxing/courses", post(debug_chaoxing_courses))
+        .route("/debug/inbox", post(debug_inbox_fetch))
+        .route("/campus-guide-debug/probe", post(campus_guide_debug_probe))
+        .route(
+            "/campus-guide-debug/field-matrix",
+            get(campus_guide_debug_field_matrix),
+        )
+}
+
 async fn run_http_server(
     state: HttpState,
     generation: u64,
@@ -778,7 +996,7 @@ async fn run_http_server(
     let addr = bridge_listen_addr();
     let life = bridge_lifecycle();
 
-    let app = Router::new()
+    let app: Router<HttpState> = Router::new()
         .route("/health", get(health))
         .route("/login", post(login))
         .route("/restore_session", post(restore_session))
@@ -791,26 +1009,6 @@ async fn run_http_server(
         .route("/schedule/custom/add", post(schedule_custom_add))
         .route("/schedule/custom/delete", post(schedule_custom_delete))
         .route("/schedule/custom/update", post(schedule_custom_update))
-        .route(
-            "/debug/custom_schedule/upsert",
-            post(debug_custom_schedule_upsert),
-        )
-        .route("/debug/navigate", post(debug_navigate))
-        .route("/debug/open_module", post(debug_open_module))
-        .route("/debug/reset_more_modules", post(debug_reset_more_modules))
-        .route("/debug/screenshot", post(debug_screenshot))
-        .route("/debug/dom_screenshot", post(debug_dom_screenshot))
-        .route("/debug/state", get(debug_state))
-        .route("/debug/save_export_file", post(debug_save_export_file))
-        // 运行时调试日志 / 诊断（本机 agent / curl 直接拉）
-        .route("/debug/logs", get(debug_logs_get).delete(debug_logs_clear))
-        .route("/debug/logs/query", post(debug_logs_query))
-        .route("/debug/logs/push", post(debug_logs_push))
-        .route("/debug/diag", get(debug_diag))
-        .route("/debug/routes", get(debug_routes_list))
-        .route("/debug/chaoxing/session", post(debug_chaoxing_session))
-        .route("/debug/chaoxing/courses", post(debug_chaoxing_courses))
-        .route("/debug/inbox", post(debug_inbox_fetch))
         .route("/module_bundle/prepare", post(module_bundle_prepare))
         .route("/module_bundle/open", post(module_bundle_open))
         .route(
@@ -1001,11 +1199,6 @@ async fn run_http_server(
         .route("/towergo/*path", any(towergo_proxy))
         .route("/campus-map/direction", get(campus_map_direction_proxy))
         .route("/campus-guide/*path", any(campus_guide_proxy))
-        .route("/campus-guide-debug/probe", post(campus_guide_debug_probe))
-        .route(
-            "/campus-guide-debug/field-matrix",
-            get(campus_guide_debug_field_matrix),
-        )
         .route("/school-website", any(school_website_proxy_root))
         .route("/school-website/", any(school_website_proxy_root))
         .route("/school-website/*path", any(school_website_proxy))
@@ -1036,14 +1229,18 @@ async fn run_http_server(
         .route("/ai_chat_session/new", post(ai_chat_session_new))
         .route("/ai_chat_session/history", post(ai_chat_session_history))
         .route("/ai_chat_session/messages", post(ai_chat_session_messages))
-        .route("/ai_chat_session/delete", post(ai_chat_session_delete))
-        .with_state(state)
-        .layer(
-            CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
-        );
+        .route("/ai_chat_session/delete", post(ai_chat_session_delete));
+
+    #[cfg(debug_assertions)]
+    let app = app.merge(debug_routes());
+
+    let app = app
+        .with_state(state.clone())
+        .layer(middleware::from_fn_with_state(
+            state,
+            bridge_access_middleware,
+        ))
+        .layer(bridge_cors_layer());
 
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(listener) => listener,
@@ -1087,18 +1284,155 @@ async fn run_http_server(
 
 #[cfg(test)]
 mod ensure_http_bridge_tests {
-    use super::{bridge_listen_addr, is_http_bridge_enabled, EnsureHttpBridgeResult};
+    use super::{
+        bridge_listen_addr, bridge_route_policy, decide_bridge_access, is_http_bridge_enabled,
+        is_trusted_bridge_origin, tokens_equal, BridgeAccessDecision, BridgeRoutePolicy,
+        EnsureHttpBridgeResult,
+    };
+    use axum::http::Method;
+    use reqwest::header::{HeaderMap, HeaderValue};
 
     #[test]
     fn bridge_listen_addr_defaults_to_loopback_4399() {
         let addr = bridge_listen_addr();
         assert!(addr.port() > 0, "bridge port must be non-zero");
-        let _ = addr.ip();
+        assert!(addr.ip().is_loopback(), "bridge must stay on loopback");
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
     }
 
     #[test]
     fn is_http_bridge_enabled_is_deterministic_bool() {
         let _ = is_http_bridge_enabled();
+    }
+
+    #[test]
+    fn trusted_origins_are_limited_to_app_and_loopback_contexts() {
+        for origin in [
+            "tauri://localhost",
+            "capacitor://localhost",
+            "http://localhost:5173",
+            "http://127.0.0.1:4399",
+            "https://tauri.localhost",
+        ] {
+            assert!(
+                is_trusted_bridge_origin(origin),
+                "expected trusted: {origin}"
+            );
+        }
+        for origin in [
+            "null",
+            "https://example.com",
+            "http://192.168.1.10:5173",
+            "file:///tmp/index.html",
+        ] {
+            assert!(
+                !is_trusted_bridge_origin(origin),
+                "expected rejected: {origin}"
+            );
+        }
+    }
+
+    #[test]
+    fn route_policy_protects_data_and_marks_debug_routes() {
+        assert_eq!(
+            bridge_route_policy("/health"),
+            BridgeRoutePolicy::PublicHealth
+        );
+        assert_eq!(
+            bridge_route_policy("/module_bundle/content/stable/demo/1/index.html"),
+            BridgeRoutePolicy::PublicEmbed
+        );
+        assert_eq!(
+            bridge_route_policy("/sync_grades"),
+            BridgeRoutePolicy::Protected
+        );
+        assert_eq!(
+            bridge_route_policy("/course_selection/select"),
+            BridgeRoutePolicy::Protected
+        );
+        assert_eq!(
+            bridge_route_policy("/debug/state"),
+            BridgeRoutePolicy::DebugOnly
+        );
+    }
+
+    #[test]
+    fn access_decision_rejects_unauthorized_and_untrusted_requests() {
+        let empty = HeaderMap::new();
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::Protected,
+                &Method::POST,
+                &empty,
+                false,
+                true,
+            ),
+            BridgeAccessDecision::Unauthorized
+        );
+
+        let mut hostile = HeaderMap::new();
+        hostile.insert(
+            "origin",
+            HeaderValue::from_static("https://attacker.example"),
+        );
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::Protected,
+                &Method::POST,
+                &hostile,
+                true,
+                true,
+            ),
+            BridgeAccessDecision::ForbiddenOrigin
+        );
+    }
+
+    #[test]
+    fn access_decision_accepts_trusted_origin_or_valid_token() {
+        let mut trusted = HeaderMap::new();
+        trusted.insert("origin", HeaderValue::from_static("tauri://localhost"));
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::Protected,
+                &Method::POST,
+                &trusted,
+                false,
+                true,
+            ),
+            BridgeAccessDecision::Allow
+        );
+
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::Protected,
+                &Method::POST,
+                &HeaderMap::new(),
+                true,
+                true,
+            ),
+            BridgeAccessDecision::Allow
+        );
+    }
+
+    #[test]
+    fn access_decision_hides_debug_routes_in_release() {
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::DebugOnly,
+                &Method::GET,
+                &HeaderMap::new(),
+                true,
+                false,
+            ),
+            BridgeAccessDecision::DebugRouteUnavailable
+        );
+    }
+
+    #[test]
+    fn bridge_token_comparison_checks_length_and_content() {
+        assert!(tokens_equal("same-token", "same-token"));
+        assert!(!tokens_equal("same-token", "other-token"));
+        assert!(!tokens_equal("short", "longer"));
     }
 
     #[test]
@@ -2180,11 +2514,7 @@ async fn debug_open_module(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!("[DebugBridge] debug_open_module skipped auth: local_api_key not configured");
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
     match debug_bridge::request_debug_open_module(&state.app, req, 12_000).await {
         Ok(()) => Ok(ok(serde_json::json!({
             "opened": true
@@ -2212,11 +2542,7 @@ async fn debug_screenshot(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!("[DebugBridge] debug_screenshot skipped auth: local_api_key not configured");
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
 
     match debug_bridge::capture_native_debug_screenshot(&state.app, req) {
         Ok(result) => Ok(ok(serde_json::json!({
@@ -2238,11 +2564,7 @@ async fn debug_dom_screenshot(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!("[DebugBridge] debug_screenshot skipped auth: local_api_key not configured");
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
     match debug_bridge::request_debug_screenshot(&state.app, req, 15_000).await {
         Ok(result) => {
             eprintln!(
@@ -2287,12 +2609,16 @@ struct DebugLogsQuery {
     q: Option<String>,
 }
 
-/// 调试接口：默认在 debug 构建可用；release 仍要求 enable_bridge_tools
+/// 调试接口只会在 debug 构建的 Router 中注册。
 fn ensure_debug_or_dev(
     state: &HttpState,
 ) -> Result<(), (StatusCode, Json<ApiResponse<serde_json::Value>>)> {
-    if cfg!(debug_assertions) {
-        return Ok(());
+    if !cfg!(debug_assertions) {
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            "调试接口不可用",
+            "Debug routes are not compiled into the Release router".to_string(),
+        ));
     }
     ensure_debug_bridge_enabled(state)
 }
@@ -2519,11 +2845,7 @@ async fn debug_state(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!("[DebugBridge] debug_state skipped auth: local_api_key not configured");
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
 
     match debug_bridge::request_debug_state(&state.app, DebugStateRequest::default(), 8_000).await {
         Ok(result) => Ok(ok(result.state)),
@@ -2552,13 +2874,7 @@ async fn debug_reset_more_modules(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!(
-            "[DebugBridge] debug_reset_more_modules skipped auth: local_api_key not configured"
-        );
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
 
     let request = payload
         .map(|json| json.0)
@@ -2623,11 +2939,7 @@ async fn debug_navigate(
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!("[DebugBridge] debug_navigate skipped auth: local_api_key not configured");
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
 
     let view = req.view.trim().to_string();
     if view.is_empty() {
@@ -2677,13 +2989,7 @@ async fn debug_save_export_file(
     (StatusCode, Json<ApiResponse<serde_json::Value>>),
 > {
     ensure_debug_bridge_enabled(&state)?;
-    if state.local_api_key.is_some() {
-        ensure_local_cache_auth(&headers, &state)?;
-    } else {
-        eprintln!(
-            "[DebugBridge] debug_save_export_file skipped auth: local_api_key not configured"
-        );
-    }
+    ensure_sensitive_bridge_auth(&headers, &state)?;
 
     crate::save_export_file_impl(state.app.clone(), req)
         .map(ok)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6900,6 +6900,7 @@ pub fn run() {
                 eprintln!("初始化数据库失败: {}", e);
             }
 
+            #[cfg(debug_assertions)]
             fn find_file_in_parents(
                 file_name: &str,
                 max_depth: usize,
@@ -6929,6 +6930,7 @@ pub fn run() {
                 }
             }
 
+            #[cfg(debug_assertions)]
             fn clean_cookie_string(raw: &str) -> String {
                 raw.replace("Code:", "")
                     .replace("Auth:", "")
@@ -6938,6 +6940,7 @@ pub fn run() {
                     .to_string()
             }
 
+            #[cfg(debug_assertions)]
             fn read_access_token_from_capture(paths: &[std::path::PathBuf]) -> Option<String> {
                 let token_re = regex::Regex::new(r#"\"accessToken\"\s*:\s*\"([^\"]+)\""#).ok()?;
                 let auth_re = regex::Regex::new(r#"\"authorization\"\s*:\s*\"([^\"]+)\""#).ok()?;
@@ -7042,6 +7045,7 @@ pub fn run() {
                     client.hydrate_session_cookies_from_store(None);
                 });
             }
+            #[cfg(debug_assertions)]
             if !restored_any {
                 if let Some(path) = find_file_in_parents("rust_backend_session.json", 6) {
                     if let Ok(text) = std::fs::read_to_string(path) {
@@ -7108,6 +7112,7 @@ pub fn run() {
                     }
                 }
             }
+            #[cfg(debug_assertions)]
             if !token_loaded {
                 let mut capture_paths: Vec<std::path::PathBuf> = Vec::new();
                 if let Some(path) = find_file_in_parents("captured_requests1.json", 6) {
@@ -7124,7 +7129,10 @@ pub fn run() {
                     });
                 }
             }
-            // 启动本地 HTTP 测试桥接服务（用于外部 Python 验证脚本）
+            #[cfg(not(debug_assertions))]
+            let _ = (restored_any, token_loaded);
+
+            // 启动本地 HTTP Bridge 服务；具体平台/构建开关由 http_server 统一判断。
             let client = app.state::<AppState>().client.clone();
             crate::http_server::spawn_http_server(client, app.handle().clone());
             Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self' customprotocol: asset:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: blob: https: http://127.0.0.1:4399; font-src 'self' data: https:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:4399 https: wss:; media-src 'self' blob: data: http://127.0.0.1:4399 https:; frame-src 'self' http://127.0.0.1:4399 https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self' https:; frame-ancestors 'none'"
     }
   },
   "bundle": {

--- a/src/utils/phase1_security_contract.spec.ts
+++ b/src/utils/phase1_security_contract.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (relativePath: string) => readFileSync(path.join(process.cwd(), relativePath), 'utf8')
+const readJson = <T>(relativePath: string): T => JSON.parse(read(relativePath)) as T
+
+describe('phase one security boundaries', () => {
+  it('protects Bridge routes with a central policy and trusted-origin CORS', () => {
+    const bridge = read('src-tauri/src/http_server.rs')
+
+    expect(bridge).toContain('enum BridgeRoutePolicy')
+    expect(bridge).toContain('async fn bridge_access_middleware')
+    expect(bridge).toContain('middleware::from_fn_with_state')
+    expect(bridge).toContain('AllowOrigin::predicate')
+    expect(bridge).toContain('AllowHeaders::mirror_request()')
+    expect(bridge).not.toContain('.allow_origin(Any)')
+    expect(bridge).not.toContain('.allow_methods(Any)')
+    expect(bridge).not.toContain('.allow_headers(Any)')
+  })
+
+  it('keeps the Bridge on loopback and excludes debug routes from the Release router', () => {
+    const bridge = read('src-tauri/src/http_server.rs')
+
+    expect(bridge).toContain('SocketAddr::from(([127, 0, 0, 1], port))')
+    expect(bridge).not.toContain('std::env::var("HBUT_HTTP_BRIDGE_HOST")')
+    expect(bridge).toMatch(/#\[cfg\(debug_assertions\)\]\s+fn debug_routes\(\)/)
+    expect(bridge).toMatch(/#\[cfg\(debug_assertions\)\]\s+let app = app\.merge\(debug_routes\(\)\)/)
+  })
+
+  it('does not restore capture files in Release builds', () => {
+    const lib = read('src-tauri/src/lib.rs')
+    const ai = read('src-tauri/src/http_client/ai.rs')
+
+    expect(lib).toMatch(/#\[cfg\(debug_assertions\)\]\s+if !restored_any/)
+    expect(lib).toMatch(/#\[cfg\(debug_assertions\)\]\s+if !token_loaded/)
+    expect(lib).toContain('find_file_in_parents("rust_backend_session.json", 6)')
+    expect(lib).toContain('find_file_in_parents("captured_requests.json", 6)')
+    expect(ai).toMatch(/#\[cfg\(debug_assertions\)\]\s+fn find_entry_url_in_text/)
+    expect(ai).toMatch(/#\[cfg\(debug_assertions\)\]\s+\{\s+let candidate = dir\.join\("captured_requests\.json"\)/)
+  })
+
+  it('requires external automation and public docs to use Bridge tokens', () => {
+    const script = read('scripts/test_more_module_bridge.mjs')
+    const nonebotDocs = read('website/src/views/docs/Nonebot.tsx')
+    const moreDocs = read('website/src/views/docs/More.tsx')
+    const apiDocs = read('website/src/views/docs/TauriApi.tsx')
+
+    expect(script).toContain('process.env.HBUT_BRIDGE_TOKEN')
+    expect(script).toContain('Authorization: `Bearer ${bridgeToken}`')
+    expect(nonebotDocs).toContain('Authorization: Bearer $HBUT_BRIDGE_TOKEN')
+    expect(moreDocs).toContain('Authorization: Bearer $HBUT_BRIDGE_TOKEN')
+    expect(apiDocs).toContain('Authorization: Bearer $HBUT_BRIDGE_TOKEN')
+    expect(nonebotDocs).not.toContain('/fetch_grades')
+    expect(moreDocs).not.toContain('/fetch_schedule')
+  })
+
+  it('enables CSP and uses an explicit notification capability set', () => {
+    const tauri = readJson<{ app: { security: { csp: string | null } } }>('src-tauri/tauri.conf.json')
+    const capability = readJson<{ permissions: string[] }>('src-tauri/capabilities/main.json')
+
+    expect(tauri.app.security.csp).toBeTypeOf('string')
+    expect(tauri.app.security.csp).toContain("object-src 'none'")
+    expect(tauri.app.security.csp).toContain('http://127.0.0.1:4399')
+    expect(capability.permissions).not.toContain('notification:default')
+    expect(capability.permissions).toContain('notification:allow-notify')
+    expect(capability.permissions).toContain('notification:allow-register-listener')
+    expect(capability.permissions).toContain('shell:default')
+  })
+})

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * TestFlight 自动化提交脚本（由 .github/workflows/ios-testflight.yml 调用）
  *

--- a/website/src/views/docs/More.tsx
+++ b/website/src/views/docs/More.tsx
@@ -127,15 +127,15 @@ npm run tauri ios build`}</code>
                         </div>
                     </div>
                     <p className="text-sm text-gray-400 mt-2">
-                        Bridge 仅监听本机，若需跨设备访问请通过安全通道转发并增加鉴权。
+                        Bridge 固定监听本机；除健康检查外，外部程序必须配置并发送 HBUT_BRIDGE_TOKEN。
                     </p>
 
                     <h3 className="text-lg font-bold text-white mt-4">常用接口</h3>
                     <pre className="bg-black/60 rounded-lg p-4 text-xs text-gray-300 overflow-x-auto">
                         <code>{`GET  /health          — 检查 Bridge 是否在线
 POST /login           — 触发登录
-POST /fetch_grades    — 获取最新成绩
-POST /fetch_schedule  — 获取课表
+POST /sync_grades     — 获取最新成绩
+POST /sync_schedule   — 获取课表
 POST /fetch_exams     — 获取考试安排
 POST /fetch_ranking   — 获取绩点排名`}</code>
                     </pre>
@@ -145,18 +145,24 @@ POST /fetch_ranking   — 获取绩点排名`}</code>
                         NoneBot 调用示例
                     </h3>
                     <pre className="bg-black/60 rounded-lg p-4 text-xs text-gray-300 overflow-x-auto">
-                        <code>{`import httpx
+                        <code>{`import os
+import httpx
 from nonebot import on_command
 
 cmd = on_command("成绩")
+token = os.environ["HBUT_BRIDGE_TOKEN"]
 
 @cmd.handle()
 async def handle():
+    headers = {"Authorization": f"Bearer {token}"}
     async with httpx.AsyncClient() as client:
-        resp = await client.get("http://127.0.0.1:4399/fetch_grades")
-        if resp.status_code == 200:
-            data = resp.json()
-            await cmd.finish(f"GPA: {data.get('data', {}).get('gpa', '-')}")`}</code>
+        resp = await client.post(
+            "http://127.0.0.1:4399/sync_grades",
+            headers=headers,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        await cmd.finish(f"课程数: {len(data.get('data', {}).get('grades', []))}")`}</code>
                     </pre>
 
                     <h3 className="text-lg font-bold text-white mt-4">
@@ -167,11 +173,12 @@ async def handle():
                         <code>{`# 检查服务状态
 curl http://127.0.0.1:4399/health
 
-# 获取成绩
-curl -X POST http://127.0.0.1:4399/fetch_grades
+# 受保护接口：应用启动前需配置同值 HBUT_BRIDGE_TOKEN
+curl -X POST http://127.0.0.1:4399/sync_grades \
+  -H "Authorization: Bearer $HBUT_BRIDGE_TOKEN"
 
-# 获取课表
-curl -X POST http://127.0.0.1:4399/fetch_schedule`}</code>
+curl -X POST http://127.0.0.1:4399/sync_schedule \
+  -H "Authorization: Bearer $HBUT_BRIDGE_TOKEN"`}</code>
                     </pre>
 
                     <h3 className="text-lg font-bold text-white mt-4">
@@ -179,8 +186,9 @@ curl -X POST http://127.0.0.1:4399/fetch_schedule`}</code>
                         安全与限频
                     </h3>
                     <ul className="list-disc list-inside text-gray-300 space-y-1 text-sm">
-                        <li>Bridge 端口仅监听 127.0.0.1，外网访问需自行转发。</li>
-                        <li>涉及缓存读取的接口需要 JWT 或本地信任策略。</li>
+                        <li>Bridge 固定监听 127.0.0.1，不接受局域网或公网绑定。</li>
+                        <li>除 /health 和只读嵌入资源外，脚本必须携带 HBUT_BRIDGE_TOKEN。</li>
+                        <li>缓存 API 还会按接口要求校验 JWT scope。</li>
                         <li>高频任务建议加本地缓存，避免触发登录频率限制。</li>
                     </ul>
                 </div>

--- a/website/src/views/docs/Nonebot.tsx
+++ b/website/src/views/docs/Nonebot.tsx
@@ -1,4 +1,4 @@
-﻿import { Plug, Terminal, Shield, Send } from 'lucide-react';
+import { Plug, Terminal, Shield, Send } from 'lucide-react';
 
 const Nonebot = () => {
     return (
@@ -28,7 +28,7 @@ const Nonebot = () => {
                     </div>
                 </div>
                 <p className="text-sm text-gray-400">
-                    推荐在本机调用；若需跨设备访问，请通过安全通道转发并增加鉴权。
+                    Bridge 固定监听本机。除健康检查外，外部脚本必须在启动应用前配置 HBUT_BRIDGE_TOKEN，并发送同值 Bearer Token。
                 </p>
             </section>
 
@@ -39,8 +39,8 @@ const Nonebot = () => {
                 </h2>
                 <pre className="bg-black/60 rounded-xl p-5 text-xs text-gray-300 overflow-x-auto border border-gray-800">
 {`GET  http://127.0.0.1:4399/health
-POST http://127.0.0.1:4399/login
-POST http://127.0.0.1:4399/fetch_grades`}
+POST http://127.0.0.1:4399/login        Authorization: Bearer $HBUT_BRIDGE_TOKEN
+POST http://127.0.0.1:4399/sync_grades  Authorization: Bearer $HBUT_BRIDGE_TOKEN`}
                 </pre>
                 <p className="text-sm text-gray-400">完整接口清单请参考「Tauri API 手册」。</p>
             </section>
@@ -51,18 +51,24 @@ POST http://127.0.0.1:4399/fetch_grades`}
                     NoneBot 调用示例
                 </h2>
                 <pre className="bg-black/60 rounded-xl p-5 text-xs text-gray-300 overflow-x-auto border border-gray-800">
-{`import httpx
+{`import os
+import httpx
 from nonebot import on_command
 
 cmd = on_command("成绩")
+token = os.environ["HBUT_BRIDGE_TOKEN"]
 
 @cmd.handle()
 async def handle():
+    headers = {"Authorization": f"Bearer {token}"}
     async with httpx.AsyncClient() as client:
-        resp = await client.get("http://127.0.0.1:4399/fetch_grades")
-        if resp.status_code == 200:
-            data = resp.json()
-            await cmd.finish(f"GPA: {data.get('data', {}).get('gpa', '-')}")`}
+        resp = await client.post(
+            "http://127.0.0.1:4399/sync_grades",
+            headers=headers,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        await cmd.finish(f"课程数: {len(data.get('data', {}).get('grades', []))}")`}
                 </pre>
             </section>
 
@@ -72,8 +78,9 @@ async def handle():
                     安全与限频
                 </h2>
                 <ul className="list-disc list-inside text-gray-400 space-y-2">
-                    <li>桥接端口仅监听 127.0.0.1，外网访问需自行转发。</li>
-                    <li>涉及缓存读取的接口需要 JWT 或本地信任策略。</li>
+                    <li>Bridge 固定监听 127.0.0.1，不接受局域网或公网绑定。</li>
+                    <li>除 /health 和只读嵌入资源外，脚本请求必须携带 HBUT_BRIDGE_TOKEN。</li>
+                    <li>缓存 API 还会按接口要求校验 JWT scope。</li>
                     <li>高频任务建议加本地缓存，避免触发登录频率限制。</li>
                 </ul>
             </section>

--- a/website/src/views/docs/TauriApi.tsx
+++ b/website/src/views/docs/TauriApi.tsx
@@ -1,4 +1,4 @@
-﻿import { Server, Shield, FileText, Database } from 'lucide-react';
+import { Server, Shield, FileText, Database } from 'lucide-react';
 
 const TauriApi = () => {
     return (
@@ -20,6 +20,8 @@ const TauriApi = () => {
                 <div className="p-6 rounded-xl bg-gray-900/60 border border-gray-800 space-y-2 text-gray-300">
                     <div>默认地址：<span className="text-cyan">http://127.0.0.1:4399</span></div>
                     <div>接口统一返回 ApiResponse：success / data / error / time。</div>
+                    <div><span className="text-cyan">/health</span> 可公开探测；其余业务接口要求可信应用 Origin，或 <span className="font-mono text-white">Authorization: Bearer $HBUT_BRIDGE_TOKEN</span>。</div>
+                    <div>外部脚本必须在启动应用前配置 HBUT_BRIDGE_TOKEN，并在每个受保护请求中发送同值令牌。</div>
                     <div>前端统一使用 /v2 语义调用，内部映射至 Bridge。</div>
                     <div>新增模块（图书/资料分享）已接入同一 Bridge 层，便于统一鉴权和日志追踪。</div>
                 </div>


### PR DESCRIPTION
## 概要

完成阶段一安全收口，覆盖本地 HTTP Bridge、Release 调试边界、Tauri CSP、Capability 最小化和回归测试。

## 主要变更

- 建立 `PublicHealth / PublicEmbed / Protected / DebugOnly` 路由访问级别，未知路由默认受保护。
- 增加 Bridge 中央访问中间件：可信 Tauri/Capacitor/Loopback Origin 或有效 Bearer Token。
- CORS 从任意 Origin/Method/Header 改为可信 Origin 谓词、显式方法和镜像请求头。
- Bridge 固定绑定 `127.0.0.1`，不再接受 Host 环境变量覆盖。
- Debug 路由仅在 Debug Router 中注册；Release 不注册 `/debug/*` 和 `/campus-guide-debug/*`。
- Release 不读取 `rust_backend_session.json`、`captured_requests.json`、`captured_requests1.json`。
- 启用明确的 Tauri CSP；移除 `notification:default`，保留实际使用的显式权限。
- 更新外部 Bridge 验证脚本和官网文档，受保护接口统一携带 `HBUT_BRIDGE_TOKEN`。
- 增加阶段一安全契约测试，并修复 Vitest 导入 TestFlight 脚本时的既有 shebang 解析阻断。

## 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`：通过
- `cargo check --manifest-path src-tauri/Cargo.toml`：通过
- `cargo check --release --manifest-path src-tauri/Cargo.toml`：通过（仅既有/预期 dead-code 警告）
- `cargo test --manifest-path src-tauri/Cargo.toml`：197 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`：通过（仓库既有 warning 未作为本阶段阻断）
- `npm run test:ci`：117 files / 611 tests passed
- `npx vite build --outDir .phase1-dist-check --emptyOutDir`：通过，临时产物已清理
- 官网文档三组契约测试：全部通过
- `npm --prefix website run build`：通过，32 个静态页面生成成功

## 已知基线问题

- `npx vue-tsc --noEmit` 仍会暴露仓库原有的跨 JS/TS 类型债务；本 PR 未扩大范围处理。
- 本机已有 Tauri dev 会话时，根目录 `npm run build` 包装命令停留在 `prepare_dist`；未中止用户进程，已用直接 Vite 生产构建完成前端验证。

Closes #532
Closes #533
Closes #534
Closes #535
Closes #536
Closes #537
Closes #538