### PR TITLE
fix(ci): restore post-merge website and Capacitor workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Production build smoke
         run: npm run build
 
+      - name: Website module build smoke
+        env:
+          MODULE_OUTPUT_ROOT: ${{ runner.temp }}/mini-hbut-module-smoke
+        run: node scripts/build_website_modules.mjs --modules clumsy_bird_hbut
+
+      - name: Capacitor sync smoke
+        run: npx cap sync
+
       - name: Run Vitest
         run: npm run test:ci
 
@@ -62,6 +70,9 @@ jobs:
           node scripts/check-frontend-safety.mjs
           node scripts/check-design-tokens.mjs
           node scripts/check_arch_guards.mjs
+          node scripts/test_npm_cli_path.mjs
+          node scripts/test_capacitor_tar_compat.mjs
+          node scripts/test_post_merge_workflow_contract.mjs
 
       - name: Sensitive upload guard (tracked files)
         run: node scripts/guard_sensitive_uploads.mjs pre-commit

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - dev
   workflow_dispatch:
+    inputs:
+      smoke_only:
+        description: Verify web build and Capacitor sync without publishing beta artifacts
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -87,6 +93,7 @@ jobs:
           compression-level: 0
 
   meta:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.smoke_only != true }}
     needs: source
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -44,4 +44,4 @@ jobs:
         if: steps.merge.outputs.dev_pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run "Dev Build" --ref dev
+        run: gh workflow run "Dev Build" --ref dev -f smoke_only=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mini-hbut",
       "version": "1.4.5",
+      "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "prebuild": "node scripts/prepare_dist.mjs",
+    "postinstall": "node scripts/patch_capacitor_tar_compat.mjs",
     "prebuild:web": "node scripts/prepare_dist.mjs",
     "dev": "node scripts/vite_run.mjs",
     "dev:lowmem": "node scripts/vite_dev_lowmem.mjs",

--- a/scripts/build_website_modules.mjs
+++ b/scripts/build_website_modules.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { execFileSync } from 'node:child_process'
+import { resolveNpmCliPath } from './npm_cli_path.mjs'
 
 const BASE_URL = String(process.env.MODULE_BASE_URL || 'https://hbut.6661111.xyz/modules').trim().replace(/\/+$/, '')
 const SOURCE_ROOT = path.resolve(process.env.MODULE_SOURCE_ROOT || 'website/modules-src')
@@ -38,18 +39,9 @@ const MODULE_VERSION =
 
 const ensureDir = (dir) => fs.mkdirSync(dir, { recursive: true })
 
-// npm CLI 固定走 Node 安装目录下随 Node 分发的 npm-cli.js，
-// 不依赖 PATH/ComSpec 等环境变量，避免命令注入（CodeQL js/shell-command-injection-from-environment）
-const NPM_CLI_PATH = path.join(
-  path.dirname(process.execPath),
-  'node_modules',
-  'npm',
-  'bin',
-  'npm-cli.js'
-)
-if (!fs.existsSync(NPM_CLI_PATH)) {
-  throw new Error(`未找到 npm CLI（${NPM_CLI_PATH}），请通过 npm run 调用本脚本`)
-}
+// npm CLI 仅从可信的 process.execPath 推导固定候选路径；兼容 Windows 官方安装器与
+// actions/setup-node 的 Unix 布局，不读取 PATH/ComSpec 等环境命令，避免命令注入。
+const NPM_CLI_PATH = resolveNpmCliPath()
 
 const runCommand = (binary, args, options = {}) => {
   const cwd = options.cwd || process.cwd()

--- a/scripts/check_all.mjs
+++ b/scripts/check_all.mjs
@@ -4,6 +4,9 @@ import { runCheckPlan, runCommand, runNode, runNpm, rustChecksEnabled, repoRoot 
 const steps = [
   () => runNpm('Dependency alignment', ['run', 'check:dependency-alignment']),
   () => runNpm('RustSec acceptance scope', ['run', 'check:rustsec-acceptances']),
+  () => runNode('npm CLI path contract', 'scripts/test_npm_cli_path.mjs'),
+  () => runNode('Capacitor tar compatibility contract', 'scripts/test_capacitor_tar_compat.mjs'),
+  () => runNode('Post-merge workflow contract', 'scripts/test_post_merge_workflow_contract.mjs'),
   () => runNpm('Frontend production build', ['run', 'build']),
   () => runNpm('Frontend test suite', ['run', 'test:ci']),
   () => runNpm('Vue typecheck', ['exec', '--', 'vue-tsc', '--noEmit', '-p', 'tsconfig.json']),

--- a/scripts/npm_cli_path.mjs
+++ b/scripts/npm_cli_path.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const unique = (values) => [...new Set(values)]
+
+/**
+ * Return fixed npm-cli.js candidates derived only from the trusted Node executable path.
+ * No PATH, shell, ComSpec, or other environment-controlled command is executed.
+ */
+export const npmCliCandidates = (execPath = process.execPath, platform = process.platform) => {
+  const pathApi = platform === 'win32' ? path.win32 : path.posix
+  const nodeDir = pathApi.dirname(execPath)
+  return unique([
+    // Official Windows node installer: <nodeDir>/node_modules/npm/bin/npm-cli.js
+    pathApi.join(nodeDir, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    // actions/setup-node and common Unix installs: <prefix>/lib/node_modules/npm/bin/npm-cli.js
+    pathApi.resolve(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    // Some portable Unix layouts keep node_modules next to bin.
+    pathApi.resolve(nodeDir, '..', 'node_modules', 'npm', 'bin', 'npm-cli.js')
+  ])
+}
+
+export const resolveNpmCliPath = ({
+  execPath = process.execPath,
+  platform = process.platform,
+  existsSync = fs.existsSync
+} = {}) => {
+  const candidates = npmCliCandidates(execPath, platform)
+  const resolved = candidates.find((candidate) => existsSync(candidate))
+  if (resolved) return resolved
+  throw new Error(`未找到 npm CLI；已检查固定路径：${candidates.join(', ')}`)
+}

--- a/scripts/patch_capacitor_tar_compat.mjs
+++ b/scripts/patch_capacitor_tar_compat.mjs
@@ -1,0 +1,39 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const LEGACY_CALL = 'await tar_1.default.extract({ file: src, cwd: dir });'
+const COMPAT_CALL = 'await (tar_1.default ?? tar_1).extract({ file: src, cwd: dir });'
+
+export const resolveCapacitorTemplatePath = () => {
+  const cliEntry = require.resolve('@capacitor/cli')
+  return path.join(path.dirname(cliEntry), 'util', 'template.js')
+}
+
+/**
+ * Capacitor CLI 6 was compiled against tar 6's synthetic default export. The security override
+ * intentionally keeps tar 7.5.22, whose CommonJS export exposes extract directly. Patch only the
+ * exact known call site and fail closed if the installed source is unexpected.
+ */
+export const patchCapacitorTarTemplate = (filePath) => {
+  const source = fs.readFileSync(filePath, 'utf8')
+  if (source.includes(COMPAT_CALL)) return { status: 'unchanged', filePath }
+
+  const matches = source.split(LEGACY_CALL).length - 1
+  if (matches !== 1) {
+    throw new Error(
+      `Capacitor tar 兼容补丁拒绝修改未知源码：期望 1 个调用，实际 ${matches} 个（${filePath}）`
+    )
+  }
+
+  fs.writeFileSync(filePath, source.replace(LEGACY_CALL, COMPAT_CALL), 'utf8')
+  return { status: 'patched', filePath }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const result = patchCapacitorTarTemplate(resolveCapacitorTemplatePath())
+  console.log(`[capacitor-tar-compat] ${result.status}: ${result.filePath}`)
+}

--- a/scripts/test_capacitor_tar_compat.mjs
+++ b/scripts/test_capacitor_tar_compat.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { patchCapacitorTarTemplate } from './patch_capacitor_tar_compat.mjs'
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-hbut-cap-tar-'))
+try {
+  const fixture = path.join(root, 'template.js')
+  fs.writeFileSync(
+    fixture,
+    'async function extractTemplate(src, dir) {\n    await tar_1.default.extract({ file: src, cwd: dir });\n}\n',
+    'utf8'
+  )
+  assert.equal(patchCapacitorTarTemplate(fixture).status, 'patched')
+  assert.match(fs.readFileSync(fixture, 'utf8'), /\(tar_1\.default \?\? tar_1\)\.extract/)
+  assert.equal(patchCapacitorTarTemplate(fixture).status, 'unchanged')
+
+  const unexpected = path.join(root, 'unexpected.js')
+  fs.writeFileSync(unexpected, 'export const untouched = true\n', 'utf8')
+  assert.throws(() => patchCapacitorTarTemplate(unexpected), /拒绝修改未知源码/)
+} finally {
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+console.log('Capacitor tar compatibility contract passed')

--- a/scripts/test_npm_cli_path.mjs
+++ b/scripts/test_npm_cli_path.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { npmCliCandidates, resolveNpmCliPath } from './npm_cli_path.mjs'
+
+const windowsExec = String.raw`C:\Program Files\nodejs\node.exe`
+const windowsExpected = String.raw`C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js`
+assert.equal(npmCliCandidates(windowsExec, 'win32')[0], windowsExpected)
+assert.equal(
+  resolveNpmCliPath({
+    execPath: windowsExec,
+    platform: 'win32',
+    existsSync: (candidate) => candidate === windowsExpected
+  }),
+  windowsExpected
+)
+
+const linuxExec = '/opt/hostedtoolcache/node/22.23.1/x64/bin/node'
+const linuxExpected = '/opt/hostedtoolcache/node/22.23.1/x64/lib/node_modules/npm/bin/npm-cli.js'
+assert.ok(npmCliCandidates(linuxExec, 'linux').includes(linuxExpected))
+assert.equal(
+  resolveNpmCliPath({
+    execPath: linuxExec,
+    platform: 'linux',
+    existsSync: (candidate) => candidate === linuxExpected
+  }),
+  linuxExpected
+)
+
+assert.throws(
+  () => resolveNpmCliPath({ execPath: linuxExec, platform: 'linux', existsSync: () => false }),
+  /未找到 npm CLI/
+)
+
+console.log('npm CLI path contract passed')

--- a/scripts/test_post_merge_workflow_contract.mjs
+++ b/scripts/test_post_merge_workflow_contract.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+const devBuild = fs.readFileSync('.github/workflows/dev-build.yml', 'utf8')
+const syncMain = fs.readFileSync('.github/workflows/sync-main-to-dev.yml', 'utf8')
+
+assert.match(devBuild, /workflow_dispatch:\s+inputs:\s+smoke_only:/s)
+assert.match(devBuild, /meta:\s+if: \$\{\{ github\.event_name != 'workflow_dispatch' \|\| inputs\.smoke_only != true \}\}/s)
+assert.match(devBuild, /deploy-dev-release:/)
+assert.match(syncMain, /gh workflow run "Dev Build" --ref dev -f smoke_only=true/)
+assert.doesNotMatch(syncMain, /gh workflow run "Dev Build" --ref dev\s*$/m)
+
+console.log('post-merge workflow smoke-only contract passed')


### PR DESCRIPTION
## 背景

PR #558 已完成并合并，但合并后的自动工作流暴露出两项回归：

1. `Sync Website` 在 Linux runner 上无法按固定路径定位 `npm-cli.js`；
2. `Dev Build` 的 `npx cap sync` 因安全 override 使用 `tar@7.5.22`，与 Capacitor CLI 6 的 tar 6 默认导入方式不兼容。

## 修复

- 从可信的 `process.execPath` 推导跨平台 npm CLI 固定候选路径，不读取 PATH/ComSpec；
- 安装后对 Capacitor CLI 的已知 tar 调用点应用精确、幂等、失败关闭的兼容补丁，继续保留安全版 `tar@7.5.22`；
- 在常规 CI 中增加网站模块实际构建与 `npx cap sync` 冒烟；
- main 自动同步 dev 时只触发 `smoke_only`，避免自动覆盖 `dev-latest` 开发版资产；人工推送 dev 仍保留完整多平台开发构建；
- 增加 npm CLI、Capacitor tar 兼容和 post-merge workflow 契约测试。

## 验证

- `npm run check:all` 通过：前端 129 files / 773 tests，Rust 235 tests；
- `npm run check:release` 通过：网站 32 页、14 个 npm lockfile audit 0 vulnerabilities、release config 验证通过；
- 干净 detached worktree 中 `npm ci` 成功执行 postinstall；
- 网站模块实际构建通过；
- 主应用生产构建通过；
- Android + iOS `npx cap sync` 均通过；
- 版本保持 1.4.5。

## 发布约束

本 PR 不创建 Tag/Release，不提交构建产物，不触发正式发布或 TestFlight。