### PR TITLE
fix(updater): prevent same-core stable update prompt for beta installs

### DIFF
--- a/src/utils/updater.js
+++ b/src/utils/updater.js
@@ -273,13 +273,8 @@ function parseVersion(version) {
 export function compareVersions(v1, v2) {
   const left = parseVersion(v1)
   const right = parseVersion(v2)
-  const len = Math.max(left.core.length, right.core.length)
-  for (let i = 0; i < len; i += 1) {
-    const lv = left.core[i] || 0
-    const rv = right.core[i] || 0
-    if (lv > rv) return 1
-    if (lv < rv) return -1
-  }
+  const coreCmp = compareVersionCore(left, right)
+  if (coreCmp !== 0) return coreCmp
 
   if (left.isPrerelease && !right.isPrerelease) return -1
   if (!left.isPrerelease && right.isPrerelease) return 1
@@ -297,6 +292,17 @@ export function compareVersions(v1, v2) {
     return String(lv).localeCompare(String(rv))
   }
 
+  return 0
+}
+
+function compareVersionCore(left, right) {
+  const len = Math.max(left.core.length, right.core.length)
+  for (let i = 0; i < len; i += 1) {
+    const lv = left.core[i] || 0
+    const rv = right.core[i] || 0
+    if (lv > rv) return 1
+    if (lv < rv) return -1
+  }
   return 0
 }
 
@@ -375,7 +381,7 @@ export function isDevRelease(release) {
 
 /**
  * 是否应对用户提示更新。
- * - stable：仅正式版且版本更高（含「当前为 beta、远端同 core 正式版」可提示回落）
+ * - stable：仅正式版且核心版本真正更高；同 core 的 beta 不回落到正式版
  * - dev：允许 prerelease；完整 semver 比较；core 低于当前安装的 dev 不提示
  */
 export function shouldOfferRelease(release, currentVersion, channel = 'stable') {
@@ -387,6 +393,11 @@ export function shouldOfferRelease(release, currentVersion, channel = 'stable') 
   if (preferred === 'stable') {
     if (!isStableRelease(release)) return false
     if (!currentText) return true
+    const latest = parseVersion(latestVersion)
+    const current = parseVersion(currentText)
+    // 本项目 beta 后缀是滚动开发构建号。同一核心版本的正式版并不是
+    // 对该 beta 的升级，否则 1.4.5-beta.363 会被错误提示“更新”到 1.4.5。
+    if (current.isPrerelease) return compareVersionCore(latest, current) > 0
     return compareVersions(latestVersion, currentText) > 0
   }
 
@@ -397,16 +408,7 @@ export function shouldOfferRelease(release, currentVersion, channel = 'stable') 
   const latest = parseVersion(latestVersion)
   const current = parseVersion(currentText)
   // 远端 core 落后于当前安装（例如装了 1.4.4 却只剩 1.4.3-beta）→ 不提示
-  const coreCmp = (() => {
-    const len = Math.max(latest.core.length, current.core.length)
-    for (let i = 0; i < len; i += 1) {
-      const lv = latest.core[i] || 0
-      const rv = current.core[i] || 0
-      if (lv > rv) return 1
-      if (lv < rv) return -1
-    }
-    return 0
-  })()
+  const coreCmp = compareVersionCore(latest, current)
   if (coreCmp < 0) return false
   // 同 core：用户已装正式版，远端为更新/任意 beta → 允许（主动开 dev）
   if (coreCmp === 0 && !current.isPrerelease && latest.isPrerelease) return true

--- a/src/utils/updater_channel.spec.ts
+++ b/src/utils/updater_channel.spec.ts
@@ -81,6 +81,21 @@ describe('update channel (stable / dev)', () => {
     expect(shouldOfferRelease(stable, '1.4.4', 'stable')).toBe(false)
   })
 
+  it('does not offer a same-core stable release to a rolling beta install', () => {
+    const stable145 = {
+      tag_name: 'v1.4.5',
+      version: '1.4.5',
+      prerelease: false,
+      channel: 'main'
+    }
+    const stable146 = { ...stable145, tag_name: 'v1.4.6', version: '1.4.6' }
+
+    expect(shouldOfferRelease(stable145, '1.4.5-beta.363', 'stable')).toBe(false)
+    expect(shouldOfferRelease(stable146, '1.4.5-beta.363', 'stable')).toBe(true)
+    expect(shouldOfferRelease(stable145, '1.4.4-beta.999', 'stable')).toBe(true)
+    expect(shouldOfferRelease(stable146, '1.4.5', 'stable')).toBe(true)
+  })
+
   it('offers dev builds when user opts into beta channel', () => {
     const beta = {
       tag_name: 'dev-latest',


### PR DESCRIPTION
## 背景

修复 #566：安装开发版 `1.4.5-beta.363` 时，稳定更新通道错误地把同核心版本 `1.4.5` 视为可更新版本。

## 修复

- stable 通道下，当前安装为 beta 时仅在远端正式版核心版本更高时提示；
- 同核心版本的 beta → stable 不再提示；
- 保持正式版之间和 dev 通道的完整 SemVer 行为不变；
- 增加 `1.4.5-beta.363 → 1.4.5` 等回归测试。

## 验证

- `1.4.5-beta.363 → 1.4.5`：不提示；
- `1.4.5-beta.363 → 1.4.6`：提示；
- `1.4.4-beta.999 → 1.4.5`：提示；
- 本地 `check:all` 通过：131 个测试文件、780 项前端测试、235 项 Rust 测试；
- Rust release check、官网 32 页构建、14 个锁文件审计和发布配置验证通过；
- 版本保持 1.4.5。

Closes #566