### PR TITLE
fix(ci): release notes 优先使用仓库内手写 RELEASE_<版本>.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,16 @@ jobs:
           echo "Resolved previous stable tag: ${PREVIOUS_TAG:-<none>}"
 
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          # 优先使用仓库内手写的发布说明 RELEASE_v<版本>.md（如 RELEASE_v1.4.6.md），
+          # 存在则直接作为 Release body；不存在才自动生成 Changed Files 列表
+          REPO_NOTES="RELEASE_v${CURRENT_TAG#v}.md"
+          if [ -f "$REPO_NOTES" ]; then
+            echo "Using repository release notes: ${REPO_NOTES}"
+            cp "$REPO_NOTES" "$NOTES_FILE"
+            echo "body_path=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+            echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           {
             echo "## Changed Files"
             echo


### PR DESCRIPTION
## 问题

release.yml 的 Release notes 由程序自动生成（Changed Files 文件列表），即使仓库已提交手写的 `RELEASE_v<版本>.md`（如 `RELEASE_v1.4.6.md`，参考 v1.4.5 格式）也不会被使用。

## 修复

`Generate release notes with changed files` 步骤先检查仓库根目录是否存在 `RELEASE_v${CURRENT_TAG#v}.md`：
- 存在 → 直接复制为 Release body（手写说明优先）
- 不存在 → 保持原有自动生成 Changed Files 逻辑

## 验证

- YAML 解析通过
- 逻辑：tag `v1.4.6` → 查找 `RELEASE_v1.4.6.md` → 命中即使用
- 不影响已发布的 v1.4.6（其 body 已手动替换为手写说明）