### PR TITLE
fix: restore split regressions and session/nav issues (#586 #587)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,7 +67,8 @@ const {
   isConfigAdmin,
   aiModelOptions,
   showTabBar,
-  showHomeLayoutDebug
+  showHomeLayoutDebug,
+  homeScrollRestoring
 } = state
 
 const {
@@ -185,7 +186,11 @@ const {
       :enter-from-class="viewTransitionEnterFrom"
       :leave-to-class="viewTransitionLeaveTo"
     >
-      <div :key="`${currentView}:${viewRenderNonce}`" class="view-transition-root">
+      <div
+        :key="`${currentView}:${viewRenderNonce}`"
+        class="view-transition-root"
+        :class="{ 'home-scroll-restoring': homeScrollRestoring }"
+      >
       <!-- 首页 -->
       <Dashboard 
         v-if="currentView === 'home'"

--- a/src/app/contracts/runtime.ts
+++ b/src/app/contracts/runtime.ts
@@ -105,7 +105,7 @@ export interface SessionCoordinator {
   tryRestoreLatestSession(): Promise<boolean>
   attemptAutoRelogin(): Promise<boolean>
   attemptOnlineRecovery(options?: { silent?: boolean }): Promise<boolean>
-  refreshSessionSilently(): Promise<void>
+  refreshSessionSilently(options?: { quiet?: boolean }): Promise<void>
   persistSessionCookies(): Promise<void>
   startSessionKeepAlive(): void
   stopSessionKeepAlive(): void

--- a/src/app/coordinators/AuthCoordinator.ts
+++ b/src/app/coordinators/AuthCoordinator.ts
@@ -119,7 +119,8 @@ export const createAuthCoordinator = (runtime: AppRuntime): AuthCoordinator => {
     // 避免用户重新登录后仍长期停留在「会话已过期」状态。
     if (!isTestAccountSession() && hasTauri) {
       window.setTimeout(() => {
-        void runtime.session.refreshSessionSilently()
+        // 登录成功后探测静默：失败不立即弹「会话失效」横幅，仅后台恢复（#586 Bug2）
+        void runtime.session.refreshSessionSilently({ quiet: true })
       }, 2500)
     }
     runtime.lifecycle.recoverViewportAfterTransition()

--- a/src/app/coordinators/NavigationCoordinator.ts
+++ b/src/app/coordinators/NavigationCoordinator.ts
@@ -197,10 +197,34 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
   const restoreHomeScrollPosition = () => {
     const targetTop = readStoredHomeScrollTop()
     if (targetTop <= 0) return
+    // 恢复滚动期间隐藏视图，避免"先顶部后闪现底部"
+    state.homeScrollRestoring.value = true
     let tries = 0
     const maxTries = 24
+    let finished = false
+    const finishRestoring = () => {
+      if (finished) return
+      finished = true
+      state.homeScrollRestoring.value = false
+      cleanup()
+    }
+    // 用户主动滚动（滚轮/触摸）：立即取消恢复并解除隐藏，尊重用户意图，不再强制拽回
+    const onUserScrollInput = () => {
+      if (finished) return
+      finishRestoring()
+    }
+    const cleanup = () => {
+      window.removeEventListener('wheel', onUserScrollInput, { capture: true } as EventListenerOptions)
+      window.removeEventListener('touchstart', onUserScrollInput, { capture: true } as EventListenerOptions)
+    }
+    window.addEventListener('wheel', onUserScrollInput, { passive: true, capture: true })
+    window.addEventListener('touchstart', onUserScrollInput, { passive: true, capture: true })
     const applyScroll = () => {
-      if (state.currentView.value !== 'home') return
+      if (finished) return
+      if (state.currentView.value !== 'home') {
+        finishRestoring()
+        return
+      }
       try {
         if (state.appShellRef.value) {
           state.appShellRef.value.scrollTop = targetTop
@@ -211,9 +235,14 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
       } catch {
         // ignore
       }
-      tries += 1
       const current = getAppShellScrollTop()
-      if (Math.abs(current - targetTop) > 4 && tries < maxTries) {
+      // 恢复到位才解除隐藏；未到位（内容未撑开被 clamp）继续重试
+      if (Math.abs(current - targetTop) <= 4) {
+        finishRestoring()
+        return
+      }
+      tries += 1
+      if (tries < maxTries) {
         requestAnimationFrame(applyScroll)
       }
     }
@@ -223,6 +252,8 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
       ;[50, 120, 200, 320, 480, 700].forEach((ms) => {
         window.setTimeout(applyScroll, ms)
       })
+      // 兜底：最迟 900ms 后解除隐藏，避免异常时首页一直不可见
+      window.setTimeout(finishRestoring, 900)
     })
   }
 
@@ -347,6 +378,7 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     state.navDirection.value = direction || (push ? 'forward' : 'none')
     if (fromView === 'home' && normalized !== 'home') {
       rememberHomeScrollPosition()
+      state.homeScrollRestoring.value = false
     }
     const returningHome = normalized === 'home' && fromView !== 'home'
     const shouldRestoreHomeScroll =

--- a/src/app/coordinators/SessionCoordinator.ts
+++ b/src/app/coordinators/SessionCoordinator.ts
@@ -358,7 +358,29 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
     }
   }
 
-  const refreshSessionSilently = async () => {
+  // 会话刷新错误分类：网络类错误 ≠ 会话过期，避免误报「会话已过期」诱导用户反复登录
+  const classifySessionError = (err: unknown): 'network' | 'auth' | 'unknown' => {
+    const raw = String((err as Error)?.message || err || '').toLowerCase()
+    if (
+      /error sending request|timed? ?out|timeout|connection|connect |network|econnrefused|econnreset|dns |resolve|socket|eof|broken pipe/i.test(raw)
+    ) {
+      return 'network'
+    }
+    if (/login|401|403|unauthorized|session|expired|cookie|not logged/i.test(raw)) {
+      return 'auth'
+    }
+    return 'unknown'
+  }
+
+  // #587：网络/DNS 错误 ≠ 登录失败，提示文案区分，避免误导用户反复登录
+  const sessionFailureHint = (fallback: string): string => {
+    if (classifySessionError(state.jwxtSessionLastError.value) === 'network') {
+      return '网络异常，无法连接教务系统，稍后自动重试。'
+    }
+    return fallback
+  }
+
+  const refreshSessionSilently = async (options: { quiet?: boolean } = {}) => {
     if (isTestAccountSession()) return
     const cookies = localStorage.getItem(SESSION_COOKIE_KEY)
     if (!cookies) return
@@ -378,6 +400,25 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
         return
       }
       state.jwxtSessionLastError.value = formatSessionError(e)
+      const kind = classifySessionError(e)
+      if (kind === 'network') {
+        // 网络异常 ≠ 会话过期：静默记录，由 keep-alive 下轮重试，不弹「会话失效」横幅
+        console.warn('[Session] 会话刷新网络异常，稍后自动重试:', e)
+        return
+      }
+      if (options.quiet) {
+        // 登录成功后的首次探测：失败时静默后台恢复，不立即弹「会话失效」横幅（用户刚登录，勿误导）
+        console.warn('[Session] 登录后会话探测未通过，静默后台恢复:', e)
+        const relogged = await attemptAutoRelogin()
+        if (relogged) {
+          clearJwxtMaintenance()
+          startSessionKeepAlive()
+          startElectricityKeepAlive()
+          await persistSessionCookies()
+          notifySessionOnline('auto-relogin')
+        }
+        return
+      }
       console.warn('[Session] 会话刷新失败，尝试自动登录:', e)
       markJwxtMaintenance('会话失效，正在后台自动登录…', {
         phase: 'recovering',
@@ -386,7 +427,7 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
       const relogged = await attemptAutoRelogin()
       if (!relogged) {
         stopSessionKeepAlive()
-        markJwxtMaintenance('后台自动登录未成功，将定时重试。当前为缓存数据。', {
+        markJwxtMaintenance(sessionFailureHint('后台自动登录未成功，将定时重试。当前为缓存数据。'), {
           phase: 'failed',
           detail: state.jwxtSessionLastError.value
         })
@@ -515,7 +556,7 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
     state.mutable.jwxtRecoveryTimer = window.setInterval(() => {
       attemptOnlineRecovery({ silent: true }).then((ok) => {
         if (ok) return
-        markJwxtMaintenance('后台自动登录仍未成功，将继续重试。', {
+        markJwxtMaintenance(sessionFailureHint('后台自动登录仍未成功，将继续重试。'), {
           phase: 'failed',
           detail: state.jwxtSessionLastError.value || '恢复失败'
         })
@@ -676,7 +717,7 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
             detail: state.jwxtSessionLastError.value || '无可用记住密码'
           })
         } else {
-          markJwxtMaintenance('自动登录未成功，将继续在后台重试。当前展示缓存数据。', {
+          markJwxtMaintenance(sessionFailureHint('自动登录未成功，将继续在后台重试。当前展示缓存数据。'), {
             phase: 'failed',
             detail: state.jwxtSessionLastError.value || '恢复失败'
           })

--- a/src/app/state/appState.ts
+++ b/src/app/state/appState.ts
@@ -89,6 +89,8 @@ export interface AppState {
   moduleHostSession: Ref<Record<string, unknown>>
   appShellRef: Ref<HTMLElement | null>
   homeScrollSnapshot: Ref<number>
+  // 返回首页恢复滚动期间置 true：视图隐藏避免"先顶部后闪现底部"
+  homeScrollRestoring: Ref<boolean>
 
   // 登录 / 弹窗
   loginMode: Ref<string>
@@ -318,6 +320,7 @@ export const createAppState = (stores: AppStores, options: CreateAppStateOptions
     moduleHostSession: ref({}),
     appShellRef: ref(null),
     homeScrollSnapshot: ref(0),
+    homeScrollRestoring: ref(false),
 
     loginMode: ref(savedLoginMode && savedLoginMode !== 'auto' ? savedLoginMode : 'portal_password'),
     showLoginPrompt: ref(false),

--- a/src/components/ScheduleView.vue
+++ b/src/components/ScheduleView.vue
@@ -542,17 +542,36 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .schedule-view {
+  /* 以下 CSS 变量与拆分前 ScheduleView.vue（PR #585 之前）保持一致：
+     --slot-height 按视口高度动态计算，使课表随页面高度拉伸；拆分时曾被简化为固定 55px 导致高度压缩 */
+  --time-axis-width: 40px;
+  --topbar-height: 44px;
+  --date-header-height: 50px;
+  --schedule-bottom-gap: calc(108px + env(safe-area-inset-bottom));
+  --schedule-safe-top: 0px;
+  --slot-height: clamp(
+    46px,
+    calc(
+      (
+          var(--app-vh, 1vh) * 100
+          - var(--topbar-height)
+          - var(--date-header-height)
+          - var(--schedule-bottom-gap)
+        ) / 11
+    ),
+    70px
+  );
+  width: 100%;
+  height: calc(var(--app-vh, 1vh) * 100);
+  min-height: calc(var(--app-vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
-  height: 100vh;
   background: #f9f9ff;
+  font-family: var(--ui-font-family);
   overflow: hidden;
+  box-sizing: border-box;
+  padding-top: 0;
   position: relative;
-  --topbar-height: 54px;
-  --time-axis-width: 44px;
-  --date-header-height: 46px;
-  --slot-height: 55px;
-  --schedule-bottom-gap: 56px;
 }
 
 /* 语义化占位（原 semester-badge 无对应 DOM，保留选择器兼容外部样式覆盖） */
@@ -621,8 +640,7 @@ onBeforeUnmount(() => {
   .schedule-view {
     --time-axis-width: 32px;
     --topbar-height: 42px;
-    --date-header-height: 40px;
-    --slot-height: 50px;
+    --date-header-height: 44px;
   }
 }
 </style>

--- a/src/features/schedule/components/ScheduleAddCourseDialog.vue
+++ b/src/features/schedule/components/ScheduleAddCourseDialog.vue
@@ -84,6 +84,7 @@ const form = props.addCourseForm
   </Transition>
 </template>
 
+<style src="../styles/modal.css" scoped></style>
 <style scoped>
 .add-course-modal {
   width: min(92vw, 400px);

--- a/src/features/schedule/components/ScheduleBanners.vue
+++ b/src/features/schedule/components/ScheduleBanners.vue
@@ -72,19 +72,20 @@ const emit = defineEmits(['jump-current'])
 }
 
 .jump-current-btn {
+  /* 恢复拆分前样式：页面右侧垂直居中、蓝色半透明背景（拆分时被误改为底部黑底） */
   position: fixed;
-  bottom: calc(84px + env(safe-area-inset-bottom, 0px));
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 8px 18px;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 10px 12px;
+  border-radius: 14px;
   border: none;
-  border-radius: 9999px;
-  background: #111827;
-  color: #ffffff;
-  font-size: 13px;
+  background: rgba(59, 130, 246, 0.85);
+  color: white;
   font-weight: 600;
+  font-size: 12px;
+  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.3);
   cursor: pointer;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.28);
-  z-index: 30;
+  z-index: 12;
 }
 </style>

--- a/src/features/schedule/components/ScheduleConfirmDialog.vue
+++ b/src/features/schedule/components/ScheduleConfirmDialog.vue
@@ -37,6 +37,7 @@ const emit = defineEmits(['confirm'])
   </Transition>
 </template>
 
+<style src="../styles/modal.css" scoped></style>
 <style scoped>
 .confirm-overlay {
   z-index: 360;

--- a/src/features/schedule/components/ScheduleCourseDetail.vue
+++ b/src/features/schedule/components/ScheduleCourseDetail.vue
@@ -93,6 +93,7 @@ const emit = defineEmits([
   </Transition>
 </template>
 
+<style src="../styles/modal.css" scoped></style>
 <style scoped>
 .modal-body {
   display: grid;

--- a/src/features/schedule/components/ScheduleManageCoursesDialog.vue
+++ b/src/features/schedule/components/ScheduleManageCoursesDialog.vue
@@ -71,6 +71,7 @@ const emit = defineEmits(['close', 'toggle-semester', 'edit-course', 'delete-cou
   </Transition>
 </template>
 
+<style src="../styles/modal.css" scoped></style>
 <style scoped>
 .manage-course-modal {
   width: min(92vw, 560px);

--- a/src/styles/views/App.scoped.css
+++ b/src/styles/views/App.scoped.css
@@ -65,6 +65,12 @@
   min-height: 100%;
 }
 
+/* 返回首页恢复滚动期间隐藏视图，避免"先顶部后闪现底部" */
+.view-transition-root.home-scroll-restoring {
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* 视图切换动效（iOS 风格方向感知）：
    - 前进（push）：内容从下方滑入，离开时轻微上移淡出
    - 返回（back）：内容从上方滑入，离开时轻微下移淡出

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -509,14 +509,10 @@ const isJwxtCacheKey = (key: unknown): boolean => {
   return JWXT_KEY_PREFIXES.some((prefix) => text.startsWith(prefix))
 }
 
-const looksLikeMaintenanceIssue = (message: unknown): boolean => {
+// 网络/DNS/连接类错误：本地网络问题，≠ 学校维护（#587）
+const looksLikeNetworkIssue = (message: unknown): boolean => {
   const text = String(message || '').toLowerCase()
   if (!text) return false
-  // “无课表/假期”属于业务态，不应触发教务维护模式。
-  const noScheduleHints = ['暂无可用课表', '暂无课表', '无课表', '假期', 'vacation', 'no schedule']
-  if (noScheduleHints.some((hint) => text.includes(hint))) {
-    return false
-  }
   return (
     text.includes('error sending request for url') ||
     text.includes('connection refused') ||
@@ -528,6 +524,23 @@ const looksLikeMaintenanceIssue = (message: unknown): boolean => {
     text.includes('dns') ||
     text.includes('econn') ||
     text.includes('network') ||
+    text.includes('socket') ||
+    text.includes('eof') ||
+    text.includes('broken pipe')
+  )
+}
+
+const looksLikeMaintenanceIssue = (message: unknown): boolean => {
+  const text = String(message || '').toLowerCase()
+  if (!text) return false
+  // “无课表/假期”属于业务态，不应触发教务维护模式。
+  const noScheduleHints = ['暂无可用课表', '暂无课表', '无课表', '假期', 'vacation', 'no schedule']
+  if (noScheduleHints.some((hint) => text.includes(hint))) {
+    return false
+  }
+  // #587：网络/DNS 错误 ≠ 学校维护（由 looksLikeNetworkIssue 单独识别），
+  // 仅保留学校侧维护/不可用特征，避免断网/换代理时误报「教务系统正在维护」。
+  return (
     text.includes('维护') ||
     text.includes('暂不可用') ||
     text.includes('无法连接') ||
@@ -590,6 +603,8 @@ const persistFailureState = (count: number): void => {
 
 // 记录一次教务请求失败：达到连续失败阈值才置位维护模式；返回是否已进入维护模式。
 const recordJwxtFailure = (error: unknown, hint = ''): boolean => {
+  // #587：网络/DNS 错误是本地网络问题，不置位「教务维护」横幅（缓存回退仍生效）
+  if (looksLikeNetworkIssue(errorMessage(error))) return false
   const next = readFailureState() + 1
   persistFailureState(next)
   if (next >= MAINTENANCE_FAILURE_THRESHOLD) {
@@ -831,7 +846,8 @@ export async function fetchWithCache<T extends ApiPayload>(
         maintenanceMode ||
         (
           isJwxtCacheKey(key) &&
-          looksLikeMaintenanceIssue(message)
+          // 学校维护或网络异常均回退缓存展示（#587：网络错误不置维护横幅，但保留离线兜底）
+          (looksLikeMaintenanceIssue(message) || looksLikeNetworkIssue(message))
         )
       )
 

--- a/src/utils/api_reliability.spec.ts
+++ b/src/utils/api_reliability.spec.ts
@@ -175,7 +175,7 @@ describe('fetchWithTimeout', () => {
 // —— fetchWithCache 维护模式分类 ——
 
 describe('fetchWithCache 维护模式分类', () => {
-  it('断网（TypeError: Failed to fetch）回退 stale 缓存，连续失败达到阈值才置位维护', async () => {
+  it('断网（TypeError: Failed to fetch）回退 stale 缓存；网络错误不置位教务维护（#587）', async () => {
     const { storage, api: storageApi } = installStorage()
     installWindow()
     const api = await importApi()
@@ -186,17 +186,18 @@ describe('fetchWithCache 维护模式分类', () => {
     expect(first.fromCache).toBe(true)
     expect(first.stale).toBe(true)
     expect(first.data.offline).toBe(true)
-    expect(readStorage(storageApi, MAINTENANCE_KEY)).toBeNull() // 第一次失败仅计数，不置位
-    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBe('1')
+    // 网络错误 ≠ 学校维护：不累计维护失败、不置位维护横幅（缓存回退仍生效）
+    expect(readStorage(storageApi, MAINTENANCE_KEY)).toBeNull()
+    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBeNull()
 
     const second = await api.fetchWithCache<TestCachePayload>('grades:1:2024', fetcher)
     expect(second.fromCache).toBe(true)
-    expect(readStorage(storageApi, MAINTENANCE_KEY)).toBe('1') // 第二次失败达到阈值，置位维护
-    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBe('2')
+    expect(readStorage(storageApi, MAINTENANCE_KEY)).toBeNull()
+    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBeNull()
     expect(fetcher).toHaveBeenCalledTimes(2)
   })
 
-  it('超时错误回退 stale 缓存并累计失败计数', async () => {
+  it('超时错误回退 stale 缓存；网络错误不累计维护失败计数（#587）', async () => {
     const { storage, api: storageApi } = installStorage()
     installWindow()
     const api = await importApi()
@@ -210,7 +211,7 @@ describe('fetchWithCache 维护模式分类', () => {
     const result = await api.fetchWithCache<TestCachePayload>('schedule:1:2024', fetcher)
     expect(result.stale).toBe(true)
     expect(result.data.offline).toBe(true)
-    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBe('1')
+    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBeNull()
     expect(readStorage(storageApi, MAINTENANCE_KEY)).toBeNull()
   })
 
@@ -228,8 +229,8 @@ describe('fetchWithCache 维护模式分类', () => {
     await vi.advanceTimersByTimeAsync(100)
     await assertion
     expect(fetcher).toHaveBeenCalledTimes(1)
-    // 超时计入维护失败计数，但未达阈值不置位维护。
-    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBe('1')
+    // 超时属网络错误（#587）：不累计维护失败计数、不置位维护。
+    expect(readStorage(storageApi, MAINTENANCE_FAIL_COUNT_KEY)).toBeNull()
     expect(readStorage(storageApi, MAINTENANCE_KEY)).toBeNull()
   })
 

--- a/src/utils/session_credential_detection_contract.spec.ts
+++ b/src/utils/session_credential_detection_contract.spec.ts
@@ -53,7 +53,7 @@ describe('session credential detection contract (#520)', () => {
   it('attemptAutoRelogin calls auto_relogin_from_stored for backend-restorable credentials', () => {
     const sessionSource = readText('src/app/coordinators/SessionCoordinator.ts')
     const autoReloginStart = sessionSource.indexOf('const attemptAutoRelogin = async () => {')
-    const autoReloginEnd = sessionSource.indexOf('const refreshSessionSilently = async () => {', autoReloginStart)
+    const autoReloginEnd = sessionSource.indexOf('const refreshSessionSilently = async (options: { quiet?: boolean } = {}) => {', autoReloginStart)
     const autoReloginBlock = sessionSource.slice(autoReloginStart, autoReloginEnd)
 
     expect(autoReloginBlock).toContain('creds.backendRestorable')
@@ -66,7 +66,7 @@ describe('session credential detection contract (#520)', () => {
     const loginEnd = authSource.indexOf('const handleLogout = async', loginStart)
     const loginBlock = authSource.slice(loginStart, loginEnd)
 
-    expect(loginBlock).toContain('runtime.session.refreshSessionSilently()')
+    expect(loginBlock).toContain('runtime.session.refreshSessionSilently({ quiet: true })')
     expect(loginBlock).toContain('#520')
   })
 })

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,7 +51,9 @@ const m3Colors = {
 
 export default {
   darkMode: ['class'],
-  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  // 注意：模板拆分后视图模板位于 src/templates/views/*.html（通过 <template src> 引用），
+  // 必须纳入扫描范围，否则其中的 Tailwind class 全部不会生成（曾导致首页快捷入口竖排、图标变黑、UI 错位）
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx,html}'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## 概述

本会话修复的批次合入（对应 issue #586、#587 及拆分回归问题），共 17 个文件。

## 修复内容

1. **Tailwind 扫描范围**：content glob 加入 `html` 扩展名，覆盖拆出的 `src/templates/views/*.html`（否则其中全部 Tailwind class 不生成，导致首页快捷入口竖排、图标变黑、UI 错位）。
2. **课表样式回归**：`ScheduleBanners.vue` 的「回到当前周」按钮恢复拆分前样式（右侧垂直居中、蓝色半透明）；`ScheduleView.vue` 的 `.schedule-view` 恢复动态 `--slot-height` 与视口高度计算（课表随窗口拉伸）。
3. **#586**：
   - 课表课程详情弹窗错位：4 个弹窗组件补引 `modal.css`；
   - 会话过期误报循环：`refreshSessionSilently` 错误分类（网络≠过期）+ 登录后探测静默化；
   - 首页滚动"顶部闪现"：恢复滚动期间隐藏视图（`home-scroll-restoring`），修复 tries 并发耗尽问题。
4. **滚动取消**：返回首页恢复滚动期间，用户主动滚轮/触摸立即取消恢复，不再强制拽回。
5. **#587**：会话提示文案误导——`SessionCoordinator` 网络/DNS 错误显示「网络异常，无法连接教务系统」，不再误报「后台自动登录未成功」；`api.ts` 网络错误不再映射为「教务系统维护」（`looksLikeNetworkIssue` / `recordJwxtFailure` 排除 / `looksLikeMaintenanceIssue` 仅保留学校维护特征），断网缓存兜底保留。

## 验证

- `vitest run`：api_reliability 20 + session_credential_detection 6 + 契约测试 12 等全部通过
- `npm run build`：通过
- `vue-tsc`：无新增类型错误（仅剩用户本地未提交删除 capacitor-plugin 导致的预存在 7 个 TS2307）
- 浏览器实测：课表详情弹窗样式、首页滚动恢复/取消、快捷入口横排与彩色图标均正常

Closes #587
Closes #586