### PR TITLE
feat: #598 分层精简 PR 门禁——PR Fast Gate + Release Readiness 后置 + Dry Run 收窄 + cargo-audit 缓存

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,31 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # PR 变更范围检测：仅 pull_request 事件运行，输出 frontend / rust 两个范围
+  # push 到 main/dev 时不做裁剪（全量验证），由下游 job 的 if 条件兜底
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vite.config.*'
+            rust:
+              - 'src-tauri/**'
+
   test-frontend:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -90,6 +114,8 @@ jobs:
         run: npm exec -- tauri info
 
   test-rust:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,3 +158,59 @@ jobs:
 
       - name: Cargo clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --lib
+
+  # Windows-only 编译保护：只做 cargo check，不构建 NSIS、不启动 EXE、不上传产物
+  # 替代旧的 Windows Release Dry Run 对普通源码 PR 的全量打包（#598 Layer 4）
+  test-rust-windows:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install frontend deps
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Build frontend dist (tauri build.rs prerequisite)
+        run: npm run build
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+          shared-key: mini-hbut-pr-rust-check-windows
+
+      - name: Cargo check (Windows-only compile protection)
+        run: cargo check --manifest-path src-tauri/Cargo.toml --lib
+
+  # 稳定名称的 PR Gate：#598 要求 required check 名称稳定，不出现永久 Pending
+  # 只接受 success / skipped，任何 failure / cancelled / timed_out 都阻断合并
+  pr-gate:
+    needs: [changes, test-frontend, test-rust, test-rust-windows]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required gate results
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          FRONTEND: ${{ needs.test-frontend.result }}
+          RUST: ${{ needs.test-rust.result }}
+          RUST_WINDOWS: ${{ needs.test-rust-windows.result }}
+        run: |
+          for gate in "$CHANGES" "$FRONTEND" "$RUST" "$RUST_WINDOWS"; do
+            case "$gate" in
+              success|skipped) ;;
+              *)
+                echo "PR Gate blocked: required check ended with '$gate'"
+                exit 1
+                ;;
+            esac
+          done
+          echo "PR Gate: all required checks passed (success or skipped)"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -67,7 +67,14 @@ jobs:
         with:
           node-version: 22
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache pinned cargo-audit binary
+        uses: actions/cache@v4
+        id: cargo-audit-cache
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-0.22.2
       - name: Install pinned cargo-audit
+        if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --locked --version 0.22.2
       - name: Verify accepted advisory scopes
         run: node scripts/verify_rustsec_acceptances.mjs

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,8 +1,7 @@
 name: Release Readiness
 
 on:
-  pull_request:
-    branches: [main]
+  # #598：完整 Release Readiness 后置到 main 合并后，普通 PR 不再重复执行 check:all
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/windows-release-dry-run.yml
+++ b/.github/workflows/windows-release-dry-run.yml
@@ -1,6 +1,8 @@
 name: Windows Release Dry Run
 
 on:
+  # #598：普通源码 PR 不再触发完整 NSIS Release build + smoke
+  # 仅 packaging / release 配置相关变更才在 PR 与 main 上运行
   pull_request:
     branches: [main]
     paths:
@@ -8,9 +10,29 @@ on:
       - "package.json"
       - "package-lock.json"
       - "vite.config.*"
-      - "src/**"
-      - "src-tauri/**"
-      - "scripts/**"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - "src-tauri/tauri.conf.json"
+      - "src-tauri/build.rs"
+      - "src-tauri/icons/**"
+      - "scripts/ci/windows_release_smoke.ps1"
+      - "scripts/verify_release_config.mjs"
+      - ".github/workflows/release.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/windows-release-dry-run.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.*"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - "src-tauri/tauri.conf.json"
+      - "src-tauri/build.rs"
+      - "src-tauri/icons/**"
+      - "scripts/ci/windows_release_smoke.ps1"
+      - "scripts/verify_release_config.mjs"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 concurrency:

--- a/src/utils/dependency_audit_contract.spec.ts
+++ b/src/utils/dependency_audit_contract.spec.ts
@@ -10,6 +10,8 @@ describe('dependency audit governance', () => {
     const workflow = read('.github/workflows/dependency-audit.yml')
     expect(workflow).toContain('contents: read')
     expect(workflow).toContain('persist-credentials: false')
+    expect(workflow).toContain('actions/cache@v4')
+    expect(workflow).toContain('~/.cargo/bin/cargo-audit')
     expect(workflow).toContain('cargo install cargo-audit --locked --version 0.22.2')
     expect(workflow).toContain('node scripts/verify_rustsec_acceptances.mjs')
     expect(workflow).toContain('cargo audit --file src-tauri/Cargo.lock')

--- a/src/utils/pr_gate_contract.spec.ts
+++ b/src/utils/pr_gate_contract.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const read = (relativePath: string) => fs.readFileSync(path.join(root, relativePath), 'utf8').replace(/\r\n?/g, '\n')
+
+describe('PR fast gate', () => {
+  const workflow = read('.github/workflows/ci.yml')
+
+  it('runs change-scope detection before conditional frontend/rust jobs', () => {
+    expect(workflow).toContain('changes:')
+    expect(workflow).toContain('dorny/paths-filter@v3')
+    expect(workflow).toContain("'src/**'")
+    expect(workflow).toContain("'src-tauri/**'")
+    expect(workflow).toContain('frontend: ${{ steps.filter.outputs.frontend }}')
+    expect(workflow).toContain('rust: ${{ steps.filter.outputs.rust }}')
+  })
+
+  it('keeps frontend/rust jobs conditional on PR but always active on push', () => {
+    expect(workflow).toContain("if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'")
+    expect(workflow).toContain("if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'")
+  })
+
+  it('provides a Windows-only cargo check without packaging an installer', () => {
+    expect(workflow).toContain('test-rust-windows:')
+    expect(workflow).toContain('runs-on: windows-latest')
+    expect(workflow).toContain('cargo check --manifest-path src-tauri/Cargo.toml --lib')
+    expect(workflow).not.toContain('--bundles nsis')
+  })
+
+  it('always reports a stable PR Gate that only accepts success or skipped', () => {
+    expect(workflow).toContain('pr-gate:')
+    expect(workflow).toContain('if: always()')
+    expect(workflow).toContain('success|skipped')
+    // 禁止 continue-on-error 把真实失败伪装成成功（#598 非目标）
+    expect(workflow).not.toContain('continue-on-error')
+  })
+})


### PR DESCRIPTION
## 背景

关联 issue：[#598 [CI] 分层精简 PR 门禁，后置 CodeQL / Release / Dry Run 以缩短合并等待](https://github.com/superdaobo/mini-hbut/issues/598)

当前普通 PR 到 main 会同时触发 CI + Release Readiness（check:release 含完整 check:all）+ Windows Release Dry Run（~20min NSIS）+ CodeQL 3 语言，等待 15~25+ min。本 PR 落地四层架构的 PR 侧部分（Layer 1/2/4 + Dependency Audit 优化），**不删除任何门禁，只移动执行位置**。

## 改动内容

### ci.yml → PR Fast Gate（Layer 1）

- 新增 `changes` job（仅 pull_request，dorny/paths-filter@v3）：输出 `frontend` / `rust` 变更范围
- `test-frontend` / `test-rust` 加条件 `if: github.event_name != 'pull_request' || needs.changes.outputs.xxx == 'true'`——**保留 job id 不变**，旧 required contexts 继续产生 check，迁移期安全；push main 全量运行
- 新增 `test-rust-windows`（windows-latest）：`cargo check --lib` 只编译不打包，保护 Windows-only 编译错误（Layer 4 替代 Dry Run 对普通 PR 的触发）
- 新增 `pr-gate` 汇总 job（`if: always()`，只接受 success/skipped）——稳定名称的 required check 候选

### release-readiness.yml（Layer 2）

- 移除 `pull_request:` 触发，仅 `push main` + `workflow_dispatch`——完整 check:release 能力保留，但不再每个 PR 重复跑一遍

### windows-release-dry-run.yml（Layer 4）

- paths 从 `src/** src-tauri/** scripts/**` 收窄为 packaging 相关（Cargo.toml/lock、tauri.conf.json、build.rs、icons、smoke 脚本、release.yml 等）
- 新增 `push main` 触发（同 paths）——普通源码 PR 不再自动完整打包 NSIS

### dependency-audit.yml

- rustsec job 加 `actions/cache@v4` 缓存 `~/.cargo/bin/cargo-audit`（key: OS + 0.22.2），install 仅在缓存未命中时执行——验收目标：命中后 RustSec 从 ~3min 降至几十秒

### 契约测试

- 新增 `src/utils/pr_gate_contract.spec.ts`：冻结 PR Gate 结构（changes / pr-gate / windows check / `if: always()` / 禁止 continue-on-error）
- `dependency_audit_contract.spec.ts` 追加 cache 断言

## 验证

- 本地：YAML 语法校验（python yaml）✓；定向契约测试 16/16 ✓；`npm run test:ci` 全量 138 文件 822 测试 ✓；vue-tsc ✓；架构守卫 / god-files / dist 边界 / post-merge workflow 契约 ✓
- CI 验证：本 PR 自身即验证 frontend（src/** 变更）+ rust（src-tauri/** 未变更时 skip）+ PR Gate

## 后续（本 PR 不含）

- CodeQL 分层（PR 只跑 JS/TS）将在 branch protection 移除 `Analyze (rust)` required 后单独提交（避免 required context 永久 Pending）
- branch protection 两阶段迁移（+PR Gate → 收敛单一 required）由维护者按 issue 顺序执行