### PR TITLE
fix: #598 push 事件全量验证失效——changes job 始终运行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,20 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  # PR 变更范围检测：仅 pull_request 事件运行，输出 frontend / rust 两个范围
-  # push 到 main/dev 时不做裁剪（全量验证），由下游 job 的 if 条件兜底
+  # PR 变更范围检测：输出 frontend / rust 两个范围
+  # 该 job 必须始终运行（不能按事件 skip）——否则 needs 链会把下游 job 一并跳过，
+  # 导致 push main 的全量验证静默失效（#598 修复记录）
   changes:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
-      rust: ${{ steps.filter.outputs.rust }}
+      # push / 非 PR 事件输出恒 true（全量验证）；PR 事件取 paths-filter 实际结果
+      frontend: ${{ github.event_name == 'pull_request' && steps.filter.outputs.frontend || 'true' }}
+      rust: ${{ github.event_name == 'pull_request' && steps.filter.outputs.rust || 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name == 'pull_request'
         with:
           filters: |
             frontend:

--- a/src/utils/pr_gate_contract.spec.ts
+++ b/src/utils/pr_gate_contract.spec.ts
@@ -13,13 +13,17 @@ describe('PR fast gate', () => {
     expect(workflow).toContain('dorny/paths-filter@v3')
     expect(workflow).toContain("'src/**'")
     expect(workflow).toContain("'src-tauri/**'")
-    expect(workflow).toContain('frontend: ${{ steps.filter.outputs.frontend }}')
-    expect(workflow).toContain('rust: ${{ steps.filter.outputs.rust }}')
+    expect(workflow).toContain("frontend: ${{ github.event_name == 'pull_request' && steps.filter.outputs.frontend || 'true' }}")
+    expect(workflow).toContain("rust: ${{ github.event_name == 'pull_request' && steps.filter.outputs.rust || 'true' }}")
   })
 
   it('keeps frontend/rust jobs conditional on PR but always active on push', () => {
     expect(workflow).toContain("if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'")
     expect(workflow).toContain("if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'")
+    // changes job 必须始终运行（不能在非 PR 事件 skip），否则 needs 链会把下游
+    // job 一并跳过，导致 push main 全量验证静默失效
+    expect(workflow).toContain("frontend: ${{ github.event_name == 'pull_request' && steps.filter.outputs.frontend || 'true' }}")
+    expect(workflow).toContain("rust: ${{ github.event_name == 'pull_request' && steps.filter.outputs.rust || 'true' }}")
   })
 
   it('provides a Windows-only cargo check without packaging an installer', () => {


### PR DESCRIPTION
## 问题

#605 合并后观察到 main 的 push CI **静默失效**：`changes` job 因 `if: github.event_name == 'pull_request'` 在 push 时被 skip，而 GitHub Actions 的 needs 链会把下游 job（test-frontend / test-rust / test-rust-windows）**一并自动跳过**（即使其 if 条件为 true）——`pr-gate` 因 `if: always()` 显示绿，掩盖了真实问题。

实测证据（#605 合并后的 push main CI）：

```text
pr-gate               completed  success
changes               completed  skipped
test-rust             completed  skipped
test-frontend         completed  skipped
test-rust-windows     completed  skipped
```

## 修复

`changes` job **始终运行**（不再按事件 skip），outputs 用表达式：

- PR 事件：取 `steps.filter.outputs.*`（paths-filter 实际计算）
- 其他事件（push）：短路输出恒 `true` → 下游全量运行

```yaml
outputs:
  frontend: ${{ github.event_name == 'pull_request' && steps.filter.outputs.frontend || 'true' }}
  rust: ${{ github.event_name == 'pull_request' && steps.filter.outputs.rust || 'true' }}
```

契约测试同步冻结该行为（防止未来回退）。

## 验证

- 本地：YAML 校验 ✓、契约测试 4/4 ✓
- 合并后需观察 main 的 push CI：changes success + test-frontend/test-rust/test-rust-windows 全量运行