### PR TITLE
fix(#633): 切换学期时清空远程课表，防止无数据学期误展示旧学期课表

### DIFF
--- a/src/features/schedule/composables/useScheduleData.ts
+++ b/src/features/schedule/composables/useScheduleData.ts
@@ -387,8 +387,11 @@ export const useScheduleData = (props: any, emit: any, options: ScheduleDataOpti
       offlineHint.value = ''
     }
     try {
+      // #633：切换学期时必须连远程课表一起清空——否则新学期请求失败/无数据时，
+      // 旧学期的 remoteScheduleData 会被当成"本学期缓存"展示（误报离线横幅 + 错课表）。
       if (requestedSemester && requestedSemester !== previousSemester) {
         customScheduleData.value = []
+        remoteScheduleData.value = []
         mergeScheduleSources({ remoteScheduleData, customScheduleData, scheduleData })
       }
       if (requestedSemester) {

--- a/src/utils/schedule_offline_banner_contract.spec.ts
+++ b/src/utils/schedule_offline_banner_contract.spec.ts
@@ -23,4 +23,17 @@ describe('schedule offline banner contract (#372)', () => {
     expect(view).toContain('!silentCachePaint && !loggedIn')
     expect(view).toContain('当前显示为缓存课表，教务暂不可用。')
   })
+
+  it('clears remote schedule data when switching semester (#633)', () => {
+    // 切换学期时若不清空 remoteScheduleData，旧学期数据会在新学期无数据（接口失败）
+    // 时被当成"本学期缓存"展示：误报「缓存课表/连接恢复」横幅 + 渲染错误课表。
+    // 契约：切换分支（requestedSemester !== previousSemester）内必须同时清空两端数据源。
+    const data = read('src/features/schedule/composables/useScheduleData.ts')
+    const switchBlockStart = data.indexOf('requestedSemester !== previousSemester')
+    expect(switchBlockStart).toBeGreaterThanOrEqual(0)
+    const switchBlock = data.slice(switchBlockStart, switchBlockStart + 400)
+    expect(switchBlock).toContain('customScheduleData.value = []')
+    expect(switchBlock).toContain('remoteScheduleData.value = []')
+    expect(switchBlock).toContain('mergeScheduleSources')
+  })
 })


### PR DESCRIPTION
## 概述

修复 #633：课表工具选择**教务未发布数据的学期**时，误展示上一学期课表并报「当前为缓存课表，连接恢复后自动刷新」。

Closes #633

## 根因

`src/features/schedule/composables/useScheduleData.ts` `fetchSchedule()` 切换学期分支（`requestedSemester !== previousSemester`）**只清空 `customScheduleData`，未清空 `remoteScheduleData`**。新学期接口返回 `success:false + "暂无可用课表"` 后，失败路径（`useScheduleData.ts:492-504`）只判断「是否有数据」就把它当作"本学期缓存"：亮离线横幅 + 渲染旧学期课表。

## 修复

切换学期时同步清空 `remoteScheduleData`，失败路径自然落入「暂无可用课表」分支，不再误报离线横幅、不再展示旧学期数据。

## 测试

- 新增契约测试（`schedule_offline_banner_contract.spec.ts`）：守护切换分支必须同时清空两端数据源
- 本地验证：契约测试 6/6 通过、`tsc --noEmit` 通过
