### PR TITLE
fix(#653): 登录错误消息可读化（[object Object]/英文原文/按钮无提示/无超时）

### DIFF
--- a/apps/client/src/components/LoginV3.vue
+++ b/apps/client/src/components/LoginV3.vue
@@ -5,6 +5,7 @@ import { fetchRemoteConfig, applyOcrRuntimeConfig, getStoredOcrConfig } from '..
 import { invokeNative as invoke, isTauriRuntime } from '../platform/native'
 import { pushDebugLog } from '../utils/debug_logger'
 import { setCachedData } from '../utils/api.js'
+import { friendlyLoginError } from '../utils/login_errors.js'
 import {
   TEST_ACCOUNT,
   TEST_ACCOUNT_LOGIN_METHOD,
@@ -123,10 +124,12 @@ const isPortalMode = computed(() => activeMode.value === 'portal')
 const isChaoxingMode = computed(() => activeMode.value === 'chaoxing')
 const currentModeMeta = computed(() => LOGIN_MODES.find((item) => item.key === activeMode.value) || LOGIN_MODES[0])
 const canSubmitPasswordLogin = computed(() => {
-  return Boolean(username.value && password.value && agreePolicy.value && !loading.value)
+  // 仅提交中禁用；账号/密码/协议未满足时保持可点击，由 handlePasswordLogin
+  // 给出明确中文提示（否则按钮灰置时用户看不到任何原因说明）。
+  return !loading.value
 })
 const canSubmitChaoxingPasswordLogin = computed(() => {
-  return Boolean(chaoxingAccount.value && chaoxingPassword.value && agreePolicy.value && !loading.value)
+  return !loading.value
 })
 
 const isLikelyStudentId = (value) => /^\d{10}$/.test(String(value || '').trim())
@@ -535,7 +538,7 @@ const handlePasswordLogin = async () => {
     const result = res.data
 
     if (!result?.success) {
-      statusMsg.value = `❌ ${result?.error || '登录失败'}`
+      statusMsg.value = `❌ ${friendlyLoginError(result?.error || '')}`
       return
     }
 
@@ -558,7 +561,7 @@ const handlePasswordLogin = async () => {
     await emitSuccessWithGrades(sid || username.value)
   } catch (e) {
     const errMsg = e.response?.data?.error || e.message || '未知错误'
-    statusMsg.value = `⚠️ 登录失败: ${errMsg}`
+    statusMsg.value = `⚠️ ${friendlyLoginError(errMsg)}`
   } finally {
     loading.value = false
     await refreshOcrMode(String(getStoredOcrConfig().endpoint || '').trim())
@@ -754,7 +757,7 @@ const handleChaoxingPasswordLogin = async () => {
     })
     await handleChaoxingLoginSuccess(payload, 'chaoxing_password')
   } catch (e) {
-    statusMsg.value = `⚠️ 学习通登录失败: ${e.message || e}`
+    statusMsg.value = `⚠️ 学习通登录失败：${friendlyLoginError(e.message || e)}`
     pushDebug(`学习通密码登录失败: ${e.message || e}`)
   } finally {
     loading.value = false

--- a/apps/client/src/utils/axios_adapter/bridge.ts
+++ b/apps/client/src/utils/axios_adapter/bridge.ts
@@ -15,8 +15,20 @@ export const asRecord = (value: unknown): JsonObject =>
         ? value as JsonObject
         : {};
 
-export const errorMessage = (error: unknown): string =>
-    error instanceof Error ? error.message : String(error ?? '');
+export const errorMessage = (error: unknown): string => {
+    if (error instanceof Error) return error.message;
+    // 后端常以 { kind, message } / { error } 对象返回错误；直接 String(obj) 会变成
+    // "[object Object]"，这里优先取出可读字段，避免把对象序列化结果展示给用户。
+    if (error !== null && typeof error === 'object') {
+        const record = error as { message?: unknown; error?: unknown; kind?: unknown };
+        const candidate = [record.message, record.error, record.kind]
+            .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+            .map((item) => item.trim())
+            .find((item) => item.length > 0);
+        if (candidate) return candidate;
+    }
+    return String(error ?? '');
+};
 
 export const invoke = <T = JsonObject>(command: string, args?: JsonObject): Promise<T> =>
     invokeNative<T>(command, args);
@@ -45,9 +57,14 @@ export const parseJsonSafely = (text: string): unknown => {
     }
 };
 
-export const fetchBridgeJson = async (url: string, options: RequestInit = {}, fallbackUrl: string | null = null): Promise<unknown> => {
+const DEFAULT_BRIDGE_TIMEOUT_MS = 12000;
+
+export const fetchBridgeJson = async (url: string, options: RequestInit = {}, fallbackUrl: string | null = null, timeoutMs: number = DEFAULT_BRIDGE_TIMEOUT_MS): Promise<unknown> => {
+    // 请求带超时：本地 bridge/上游挂起时给用户明确提示，而不是无限等待
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
     try {
-        const res = await fetch(url, options);
+        const res = await fetch(url, controller ? { ...options, signal: controller.signal } : options);
         const contentType = res.headers.get('content-type') || '';
         const text = await res.text();
         if (looksLikeJson(contentType, text)) {
@@ -55,14 +72,19 @@ export const fetchBridgeJson = async (url: string, options: RequestInit = {}, fa
             if (parsed !== null) return parsed;
         }
         if (fallbackUrl && looksLikeHtml(contentType, text)) {
-            return fetchBridgeJson(fallbackUrl, options, null);
+            return fetchBridgeJson(fallbackUrl, options, null, timeoutMs);
         }
         return { success: false, error: `非JSON响应: ${text.slice(0, 200)}` };
     } catch (err) {
+        if (controller?.signal.aborted) {
+            return { success: false, error: '请求超时，请检查网络后重试' };
+        }
         if (fallbackUrl) {
-            return fetchBridgeJson(fallbackUrl, options, null);
+            return fetchBridgeJson(fallbackUrl, options, null, timeoutMs);
         }
         return { success: false, error: `请求失败: ${errorMessage(err)}` };
+    } finally {
+        if (timer !== null) clearTimeout(timer);
     }
 };
 

--- a/apps/client/src/utils/background_notification.spec.ts
+++ b/apps/client/src/utils/background_notification.spec.ts
@@ -33,6 +33,11 @@ const nativeMock = vi.hoisted(() => ({
 }))
 vi.mock('../platform/native', () => nativeMock)
 
+/** 相对当前 5 天前（在 7 天 ledger TTL 内）：避免固定时间戳随日期推移被过期清理（日期腐蚀）。 */
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+const RECENT_ISO = daysAgo(5)
+
 const installStorage = () => {
   const storage = new Map<string, string>()
   const api = {
@@ -66,12 +71,12 @@ const makeEvent = (
     source: 'android',
     kind,
     scope,
-    occurredAt: '2026-08-13T08:00:00Z',
+    occurredAt: RECENT_ISO,
     payload: {
       type,
       source: 'android-workmanager',
       targetView: 'grades',
-      detectedAt: '2026-08-13T08:00:00Z',
+      detectedAt: RECENT_ISO,
       presented,
       signature,
       meta: { notificationShown: presented }
@@ -197,7 +202,7 @@ describe('场景 B：前台先发现（ledger 已记录）→ 后台事件不重
   it('ledger 已有 grades:S2（前台弹过）→ 消费同签名事件时幂等刷新，不产生第二条通知记录', async () => {
     // 前台先弹：先写 ledger
     const { recordLedgerEntry } = await import('./notification_event_ledger')
-    recordLedgerEntry('s1', 'grades:S2', 'grades', '2026-08-12T10:00:00.000Z')
+    recordLedgerEntry('s1', 'grades:S2', 'grades', RECENT_ISO)
 
     const inbox = new FakeInbox()
     inbox.events = [makeEvent('evt-b1', { signature: 'S2' })]
@@ -216,7 +221,7 @@ describe('场景 B：前台先发现（ledger 已记录）→ 后台事件不重
 describe('场景 C：真正的新变化（S2 → S3）仍可再次通知', () => {
   it('去重粒度为 signature 而非当天：S3 与 S2 各自独立记录，互不抑制', async () => {
     const { recordLedgerEntry } = await import('./notification_event_ledger')
-    recordLedgerEntry('s1', 'grades:S2', 'grades', '2026-08-13T08:00:00.000Z')
+    recordLedgerEntry('s1', 'grades:S2', 'grades', RECENT_ISO)
 
     const inbox = new FakeInbox()
     inbox.events = [makeEvent('evt-c1', { signature: 'S3' })]

--- a/apps/client/src/utils/login_errors.spec.ts
+++ b/apps/client/src/utils/login_errors.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { friendlyLoginError, readableErrorText } from './login_errors'
+
+describe('readableErrorText', () => {
+  it('Error 实例取 message', () => {
+    expect(readableErrorText(new Error('boom'))).toBe('boom')
+  })
+
+  it('对象优先取 message / error / kind 可读字段', () => {
+    expect(readableErrorText({ kind: '业务错误', message: '账号已被锁定' })).toBe('账号已被锁定')
+    expect(readableErrorText({ error: '服务器 IP 被学校冻结，请稍后再试或联系管理员' })).toBe(
+      '服务器 IP 被学校冻结，请稍后再试或联系管理员'
+    )
+    expect(readableErrorText({ code: 500, error: { msg: 'x' } })).not.toBe('')
+  })
+
+  it('纯对象不序列化成 [object Object]', () => {
+    expect(friendlyLoginError({ message: 'server error' })).not.toBe('[object Object]')
+  })
+
+  it('null/undefined/空串返回空', () => {
+    expect(readableErrorText(null)).toBe('')
+    expect(readableErrorText(undefined)).toBe('')
+    expect(readableErrorText('')).toBe('')
+  })
+})
+
+describe('friendlyLoginError', () => {
+  it('[object Object] 与空错误给兜底文案', () => {
+    expect(friendlyLoginError('[object Object]')).toBe('登录失败，请稍后重试')
+    expect(friendlyLoginError('')).toBe('登录失败，请稍后重试')
+    expect(friendlyLoginError(null)).toBe('登录失败，请稍后重试')
+  })
+
+  it('reqwest 网络原文映射为可读中文', () => {
+    const raw =
+      'error sending request for url (https://auth.hbut.edu.cn/authserver/login?service=...): connection closed before message completed'
+    expect(friendlyLoginError(raw)).toBe('无法连接教务系统，请检查网络后重试')
+  })
+
+  it('连接超时原文映射为可读中文', () => {
+    expect(friendlyLoginError('request timed out')).toBe('无法连接教务系统，请检查网络后重试')
+  })
+
+  it('获取登录页失败（内嵌英文）映射为可读中文', () => {
+    const raw = '获取登录页失败: error sending request for url (...); 重试仍失败: ...'
+    expect(friendlyLoginError(raw)).toBe('无法连接教务系统，请检查网络后重试')
+  })
+
+  it('OCR 相关原文映射为识别服务提示', () => {
+    expect(friendlyLoginError('OCR all endpoints failed: xxx')).toBe('验证码识别服务暂不可用，请稍后重试')
+    expect(friendlyLoginError('OCR request failed: timeout')).toBe('验证码识别服务暂不可用，请稍后重试')
+  })
+
+  it('凭据错误（含缺字变体）统一文案', () => {
+    expect(friendlyLoginError('username或密码错误')).toBe('用户名或密码错误，请重新输入')
+    expect(friendlyLoginError('用户名或密码错误')).toBe('用户名或密码错误，请重新输入')
+    expect(friendlyLoginError('密码错误')).toBe('用户名或密码错误，请重新输入')
+  })
+
+  it('认证兜底文案给增强提示，避免误导', () => {
+    expect(friendlyLoginError('登录失败，请检查账号或密码')).toContain('验证码识别服务异常')
+  })
+
+  it('后端已有简洁中文原样展示', () => {
+    expect(friendlyLoginError('账号已被锁定')).toBe('账号已被锁定')
+    expect(friendlyLoginError('验证码错误')).toBe('验证码错误')
+    expect(friendlyLoginError('登录过于频繁，请稍后再试')).toBe('登录过于频繁，请稍后再试')
+    expect(friendlyLoginError('服务器 IP 被学校冻结，请稍后再试或联系管理员')).toBe(
+      '服务器 IP 被学校冻结，请稍后再试或联系管理员'
+    )
+  })
+
+  it('其它技术英文给兜底前缀', () => {
+    expect(friendlyLoginError('weird internal error')).toBe('登录失败：weird internal error')
+  })
+})

--- a/apps/client/src/utils/login_errors.ts
+++ b/apps/client/src/utils/login_errors.ts
@@ -1,0 +1,79 @@
+/**
+ * 登录链路底层错误文案 → 用户可读中文。
+ *
+ * 背景：登录错误大多来自 Rust 侧 `e.to_string()` 原文（如 reqwest 的
+ * `error sending request for url (...)`），或 bridge 对象被序列化成
+ * `[object Object]`。这里在展示层统一做一次可读化映射；后端已产出的
+ * 简洁中文（如"账号已被锁定"、"验证码错误"）保持不变。
+ */
+
+const hasCJK = (text: string): boolean => /[\u4e00-\u9fff]/.test(text)
+
+/** 后端以对象返回错误时优先取可读字段（避免出现 "[object Object]"）。 */
+export const readableErrorText = (raw: unknown): string => {
+  if (raw === null || raw === undefined) return ''
+  if (raw instanceof Error) return raw.message
+  if (typeof raw === 'object') {
+    const record = raw as { message?: unknown; error?: unknown; kind?: unknown }
+    for (const key of ['message', 'error', 'kind'] as const) {
+      if (typeof record[key] === 'string' && String(record[key]).trim()) {
+        return String(record[key]).trim()
+      }
+    }
+  }
+  return String(raw).trim()
+}
+
+/** 网络/连接层失败（reqwest、fetch 原文等）。 */
+const NETWORK_ERROR_RE =
+  /error sending request|timed out|timeout|connection (?:failed|closed|reset|refused)|failed to fetch|network (?:error|request)|ECONN|ENOTFOUND|ETIMEDOUT|无法连接|无法访问/i
+
+/** 验证码识别（OCR）相关原文。 */
+const OCR_ERROR_RE = /\bOCR\b|识别服务|valid.*code|recognition/i
+
+/** 用户凭据错误（含项目里已出现的缺字变体）。 */
+const CREDENTIAL_ERROR_RE =
+  /用户名或密码错误|username或密码错误|账号或密码错误|帐号或密码错误|密码错误|密码不正确|用户不存在|账号不存在|帐号不存在|认证失败/i
+
+/** 认证兜底："登录失败，请检查账号或密码"。 */
+const FALLBACK_CREDENTIAL_TEXT = '登录失败，请检查账号或密码'
+
+/** 将底层错误文案映射为用户可读中文；空对象/原文不可读时给出兜底。 */
+export const friendlyLoginError = (raw: unknown): string => {
+  const text = readableErrorText(raw)
+  if (!text || text === '[object Object]') {
+    return '登录失败，请稍后重试'
+  }
+
+  // 验证码/OCR 相关（优先于通用网络，因为 OCR 原文常以 "OCR request failed: ..." 开头）
+  if (OCR_ERROR_RE.test(text)) {
+    return '验证码识别服务暂不可用，请稍后重试'
+  }
+
+  // 网络/连接层失败：不把 reqwest 英文原文暴露给用户
+  if (NETWORK_ERROR_RE.test(text)) {
+    return '无法连接教务系统，请检查网络后重试'
+  }
+
+  if (/获取登录页失败/i.test(text)) {
+    return '暂无法获取登录信息，请检查网络后重试'
+  }
+
+  // 凭据错误：修正缺字变体并给出一致文案
+  if (CREDENTIAL_ERROR_RE.test(text)) {
+    return '用户名或密码错误，请重新输入'
+  }
+
+  // OCR 被吞后经过认证兜底单（无法从前端区分是否源于 OCR），改成更准确的提示
+  if (text === FALLBACK_CREDENTIAL_TEXT) {
+    return '登录失败，请确认账号密码正确；若验证码识别服务异常也会出现此提示，请稍后重试'
+  }
+
+  // 后端已产出的简洁中文文案（账号锁定/验证码错误/频率限制/IP 冻结等）原样展示
+  if (hasCJK(text)) {
+    return text
+  }
+
+  // 其它无法识别的技术原文
+  return `登录失败：${text}`
+}

--- a/apps/client/src/utils/notification_event_ledger.spec.ts
+++ b/apps/client/src/utils/notification_event_ledger.spec.ts
@@ -45,7 +45,13 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-const ISO_2026 = '2026-08-13T08:00:00.000Z'
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+// 相对当前时间 5 天前（在 7 天 TTL 内）：固定过去时间戳会随时间推移被
+// writeLedgerState 的过期清理剔除，导致"写入后可查询"断言全部失效（日期腐蚀）。
+const ISO_2026 = daysAgo(5)
+const ISO_2026_LATER = daysAgo(4)
 
 describe('Ledger 存取与去重', () => {
   it('record 后可查询，同 eventKey 幂等不重复入账', () => {
@@ -54,11 +60,11 @@ describe('Ledger 存取与去重', () => {
     expect(added).toBe(true)
     expect(hasLedgerEntry('s1', 'grades:S2')).toBe(true)
     // 幂等：再次记录只刷新时间，不新增条目
-    const again = recordLedgerEntry('s1', 'grades:S2', 'grades', '2026-08-14T08:00:00.000Z')
+    const again = recordLedgerEntry('s1', 'grades:S2', 'grades', ISO_2026_LATER)
     expect(again).toBe(false)
     const state = readLedgerState('s1')
     expect(state.entries).toHaveLength(1)
-    expect(state.entries[0].notifiedAt).toBe('2026-08-14T08:00:00.000Z')
+    expect(state.entries[0].notifiedAt).toBe(ISO_2026_LATER)
     expect(state.scope).toBe('s1')
     expect(state.schema).toBe(LEDGER_SCHEMA_VERSION)
   })


### PR DESCRIPTION
## 修复内容

Closes #653

登录失败时界面错误消息不可读的问题，本次在**前端展示层**统一修复（不改 Rust）：

1. **`[object Object]` 根因（最严重）**：真实 4399 bridge 的 400 响应 `error` 是 `{kind, message}` 对象，`bridge.ts` 的 `errorMessage` 之前 `String(obj)` 直接变 `[object Object]`。已改为优先提取 `message` / `error` / `kind` 可读字段。
2. **网络层英文原文**：reqwest 的 `error sending request for url (...)`、`获取登录页失败: ...` 等原文直达用户。新增 `friendlyLoginError` 映射为「无法连接教务系统，请检查网络后重试」等中文；保留后端已有的简洁中文（账号锁定/验证码错误/频率限制/IP 冻结等）。
3. **按钮禁用无提示**：空账号/未勾协议时登录按钮直接禁用、看不到任何原因。改为仅提交中禁用，点击时由表单校验显示「请输入完整的账号和密码」「请先阅读并同意免责声明与隐私政策」。
4. **连接挂起无超时**：`fetchBridgeJson` 增加 12s 超时，挂起时提示「请求超时，请检查网络后重试」，不再无限停在「正在登录...」。
5. **OCR 失败误导**：对「登录失败，请检查账号或密码」的认证兜底文案增强提示，避免用户误以为只是密码错误。
6. 学习通登录错误同样走可读化映射。

## 改动文件

- `apps/client/src/utils/axios_adapter/bridge.ts`（errorMessage 对象化 + fetchBridgeJson 超时）
- `apps/client/src/utils/login_errors.ts`（新增，错误可读化映射）
- `apps/client/src/components/LoginV3.vue`（应用可读化 + 按钮禁用策略调整）
- `apps/client/src/utils/login_errors.spec.ts`（新增，13 个单测）

## 验证

- ✅ `vue-tsc --noEmit` 通过
- ✅ `login_errors.spec.ts` 13/13 通过
- ✅ `vite build` 成功
- ✅ 浏览器实测（本地 mock bridge 复现真实响应结构）：
  - 密码错误（对象 error）→ `❌ 用户名或密码错误，请重新输入`（原来 `[object Object]`）
  - 教务连不上 → `❌ 无法连接教务系统，请检查网络后重试`（原来 reqwest 英文原文）
  - 空账号 / 未勾协议 → 可点击并显示明确中文提示（原来按钮禁用无提示）
  - 挂起超时 → 12s 后 `❌ 请求超时，请检查网络后重试`（原来无限「正在登录...」）

> 说明：修复落点仅前端展示层（决策：`error` 对象序列化、按钮提示、超时、OCR 兜底文案统一在前端解决）。