### PR TITLE
fix(#656): 设备密钥 keyring 损坏条目自愈（授权 fail closed）

### DIFF
--- a/apps/client/src-tauri/src/identity/device_key.rs
+++ b/apps/client/src-tauri/src/identity/device_key.rs
@@ -174,22 +174,30 @@ impl DeviceKeyStore {
             }
             return Ok(None);
         };
-        let bytes = general_purpose::URL_SAFE_NO_PAD
-            .decode(encoded.as_bytes())
-            .map_err(|e| {
+        let decoded = general_purpose::URL_SAFE_NO_PAD.decode(encoded.as_bytes());
+        let seed: [u8; 32] = match decoded {
+            Ok(raw) => match raw.as_slice().try_into() {
+                Ok(seed) => seed,
+                Err(_) => {
+                    eprintln!(
+                        "[identity] keyring load seed 长度不符: bytes_len={}",
+                        raw.len()
+                    );
+                    // 损坏条目自愈：不可解码的旧数据无法恢复为私钥，删除并视为“无密钥”，
+                    // 由 create_if_missing 重新生成（不降级其它安全语义，仅恢复同一逻辑 key）。
+                    let _ = self.keyring.delete_secret();
+                    return Ok(None);
+                }
+            },
+            Err(e) => {
                 eprintln!(
                     "[identity] keyring load decode 失败: len={} err={e}",
                     encoded.len()
                 );
-                IdentityError::KeyringWriteMismatch
-            })?;
-        let seed: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
-            eprintln!(
-                "[identity] keyring load seed 长度不符: bytes_len={}",
-                bytes.len()
-            );
-            IdentityError::KeyringWriteMismatch
-        })?;
+                let _ = self.keyring.delete_secret();
+                return Ok(None);
+            }
+        };
         Ok(Some(DeviceKey::from_seed(seed)))
     }
 }
@@ -361,6 +369,55 @@ mod tests {
             store.delete(),
             Err(IdentityError::KeyringUnavailable(_))
         ));
+    }
+
+    /// 模拟 Credential Manager 中已存在「损坏/不可解码」设备条目（#656）：
+    /// 初始内置一条坏凭据；删除后重新写入新值；decode/长度非法时触发自愈。
+    struct SelfHealKeyring {
+        inner: std::sync::Mutex<Option<String>>,
+        corrupted_shown: std::sync::atomic::AtomicBool,
+    }
+
+    impl Default for SelfHealKeyring {
+        fn default() -> Self {
+            Self {
+                inner: std::sync::Mutex::new(Some("!! corrupted-credential !!".to_string())),
+                corrupted_shown: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl KeyringLike for SelfHealKeyring {
+        fn get_secret(&self) -> Result<Option<String>, String> {
+            let mut guard = self.inner.lock().map_err(|e| e.to_string())?;
+            let first = !self
+                .corrupted_shown
+                .swap(true, std::sync::atomic::Ordering::SeqCst);
+            if first && guard.is_some() {
+                return Ok(Some("!! corrupted-credential !!".to_string()));
+            }
+            Ok(guard.clone())
+        }
+        fn set_secret(&self, value: &str) -> Result<(), String> {
+            *self.inner.lock().map_err(|e| e.to_string())? = Some(value.to_string());
+            Ok(())
+        }
+        fn delete_secret(&self) -> Result<(), String> {
+            *self.inner.lock().map_err(|e| e.to_string())? = None;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn corrupt_existing_entry_is_self_healed() {
+        // 损坏条目（不可解码）被删除并重建，而不是永久 fail closed（#656）
+        let keyring = SelfHealKeyring::default();
+        let store = DeviceKeyStore::with_keyring(Box::new(keyring));
+        // 首读损坏 → load 应删除损坏条目并按“无密钥”返回
+        assert!(store.load().expect("should self-heal").is_none());
+        // create_if_missing 重新生成并写后读校验通过
+        let key = store.create_if_missing().expect("创建应成功");
+        assert_eq!(store.fingerprint().unwrap_or(None), Some(key.fingerprint()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #656

## 问题

通过 Mini-HBUT 在授权页（auth.湖北工业大学.com IDN）/ 开发者平台登录授权时，报「授权失败 系统安全存储写入校验失败，已拒绝使用（fail closed）」，授权被永久拒绝。

## 查明过程

1. 错误唯一来源：`identity/errors.rs` 的 `KeyringWriteMismatch`，触发点：
   - `device_key.rs` `create_if_missing()` 的「写后读校验」重试 10×300ms 仍不一致；
   - `device_key.rs` `load()` 对既有条目 **base64/seed 解码失败**也映射为 `KeyringWriteMismatch`。
2. 本机（Windows 10 22H2, keyring crate 3.6.3, Credential Manager）实测：写→读 t0/300ms/3000ms **全部一致**，说明不是这台开发机的常态。
3. 关键：`create_if_missing` 先 `load()`，若 Credential Manager 里已存在**损坏/不可解码**的旧设备密钥条目，`load()` 解码失败 → 直接 `Err(KeyringWriteMismatch)`；因为每次重读同一损坏 blob，**重试永远无效** → 授权永久 fail closed，即使 keyring 本身可用。

## 修复

`load()` 读到不可解码 / seed 长度非法的既有条目时，判定为「损坏条目」：`eprintln` 记录诊断后**删除该条目并按无密钥返回**，由 `create_if_missing()` 重新生成设备密钥（自愈）。

**安全语义保持不变**：
- keyring 本身不可用（`KeyringUnavailable`）仍 100% fail closed，不降级到文件/SQLite；
- 仅对「可自愈的损坏条目」做恢复（损坏私钥本就不可用，删除没有任何安全损失）；
- 写后读仍不一致（写入真实损坏）时仍走 `KeyringWriteMismatch` fail closed。

## 验证

- ✅ 新增单测 `corrupt_existing_entry_is_self_healed`（模拟既有损坏条目 → 删除自愈 → create_if_missing 成功）
- ✅ `keyring_unavailable_fails_closed` 保持通过（不可用仍 fail closed）
- ✅ `cargo test --lib` = 282 passed / 0 failed
- ✅ `cargo fmt --check` 干净；新增代码无 clippy 警告
- 说明：本机无法直接复现用户环境损坏条目，修复基于代码路径推断 + 模拟单测覆盖；若用户侧仍有问题，错误日志已有 `eprintln` 定位（keyring load decode/长度 分支）。

## 关联

Closes #656