### PR TITLE
fix(#658): 给分记录查询加超时/中文错误提示与重试（P0 前端）

### DIFF
--- a/apps/client/src/components/GradeDistributionView.vue
+++ b/apps/client/src/components/GradeDistributionView.vue
@@ -44,6 +44,13 @@ const loadData = async () => {
   }
 }
 
+// 失败后重新发起当前搜索（超时/网络错误时使用）
+const retrySearch = () => {
+  if (hasQuery.value) {
+    loadData()
+  }
+}
+
 // 是否已输入搜索关键词
 const hasQuery = computed(() => searchQuery.value.trim().length > 0)
 
@@ -188,12 +195,15 @@ watch(page, () => {
         </div>
 
         <!-- 错误 -->
-        <div v-if="error" class="gd-error">{{ error }}</div>
+        <div v-if="error" class="gd-error">
+          {{ error }}
+          <button type="button" class="gd-retry" @click="retrySearch">重试</button>
+        </div>
 
         <!-- 加载中 -->
         <div v-if="loading" class="gd-loading">
           <div class="gd-spinner" />
-          <span>加载中...</span>
+          <span>查询中，请稍候…（数据较多时可能较慢）</span>
         </div>
 
         <!-- 未搜索提示 -->
@@ -468,6 +478,23 @@ watch(page, () => {
   background: #fef2f2;
   color: #dc2626;
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: space-between;
+}
+.gd-retry {
+  flex-shrink: 0;
+  padding: 5px 12px;
+  border: 1px solid #dc2626;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #dc2626;
+  font-size: 13px;
+  cursor: pointer;
+}
+.gd-retry:active {
+  background: #fee2e2;
 }
 .gd-loading {
   display: flex;

--- a/apps/client/src/utils/grade_distribution.d.ts
+++ b/apps/client/src/utils/grade_distribution.d.ts
@@ -1,0 +1,38 @@
+/** grade_distribution.js 的类型声明（供 spec/业务 TS 引用）。 */
+
+export interface GradeDistributionItem {
+  id: number
+  semester: string
+  course_name: string
+  teacher_name: string
+  max_score: number | null
+  min_score: number | null
+  avg_score: number | null
+  median_score: number | null
+  sample_count: number
+  score_segments: Record<string, number>
+}
+
+export interface GradeDistributionResult {
+  total: number
+  page: number
+  page_size: number
+  items: GradeDistributionItem[]
+}
+
+export function fetchGradeDistributionSemesters(): Promise<string[]>
+
+export function fetchGradeDistribution(params?: {
+  semester?: string | null
+  course_name?: string | null
+  teacher_name?: string | null
+  page?: number
+  page_size?: number
+}): Promise<GradeDistributionResult>
+
+/** 内部 helper（导出仅便于单测）；业务代码使用默认超时。 */
+export function requestJson(
+  url: string,
+  options?: Record<string, unknown>,
+  timeoutMs?: number
+): Promise<Record<string, unknown>>

--- a/apps/client/src/utils/grade_distribution.js
+++ b/apps/client/src/utils/grade_distribution.js
@@ -18,19 +18,52 @@ function getServiceBaseUrl() {
 
 const GRADE_API_PREFIX = '/api/grade-distribution'
 
+// 查询/接口请求超时：给分查询整体偏慢（后端无索引秒级），
+// 超时后给明确中文提示，而不是让界面无限停留在 loading。
+const REQUEST_TIMEOUT_MS = 10000
+
+const isTimeoutError = (e) => e && e.name === 'AbortError'
+
+const isNetworkError = (e) =>
+  e instanceof TypeError || /failed to fetch|network error/i.test(String((e && e.message) || e))
+
+/**
+ * 带超时的 JSON 请求：超时 / 网络失败都转成可读中文错误，
+ * 业务失败（success=false）原样上抛。
+ * 导出仅便于单测注入短超时；业务代码统一使用默认 REQUEST_TIMEOUT_MS。
+ */
+export async function requestJson(url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
+  const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
+  try {
+    const resp = await fetch(url, controller ? { ...options, signal: controller.signal } : options)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const data = await resp.json()
+    if (!data.success) throw new Error(data.error || '查询失败')
+    return data
+  } catch (e) {
+    if (controller?.signal.aborted || isTimeoutError(e)) {
+      throw new Error('查询超时，请检查网络后重试')
+    }
+    if (isNetworkError(e)) {
+      throw new Error('无法连接给分查询服务，请检查网络后重试')
+    }
+    throw e
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+  }
+}
+
 /**
  * 获取所有学期列表
  * @returns {Promise<string[]>}
  */
 export async function fetchGradeDistributionSemesters() {
   const base = getServiceBaseUrl()
-  const resp = await fetch(`${base}${GRADE_API_PREFIX}/semesters`, {
+  const data = await requestJson(`${base}${GRADE_API_PREFIX}/semesters`, {
     method: 'GET',
     headers: { 'Accept': 'application/json' },
   })
-  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-  const data = await resp.json()
-  if (!data.success) throw new Error(data.error || '查询失败')
   return data.semesters || []
 }
 
@@ -41,12 +74,9 @@ export async function fetchGradeDistributionSemesters() {
  */
 export async function fetchGradeDistribution(params = {}) {
   const base = getServiceBaseUrl()
-  const resp = await fetch(`${base}${GRADE_API_PREFIX}/query`, {
+  const data = await requestJson(`${base}${GRADE_API_PREFIX}/query`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       semester: params.semester || null,
       course_name: params.course_name || null,
@@ -55,9 +85,6 @@ export async function fetchGradeDistribution(params = {}) {
       page_size: params.page_size || 50,
     }),
   })
-  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-  const data = await resp.json()
-  if (!data.success) throw new Error(data.error || '查询失败')
   return {
     total: data.total || 0,
     page: data.page || 1,

--- a/apps/client/src/utils/grade_distribution.spec.ts
+++ b/apps/client/src/utils/grade_distribution.spec.ts
@@ -4,7 +4,7 @@ import {
   requestJson,
 } from './grade_distribution.js'
 
-const jsonResponse = (body, { ok = true } = {}) => ({
+const jsonResponse = (body: any, { ok = true }: { ok?: boolean } = {}) => ({
   ok,
   headers: new Headers({ 'content-type': 'application/json' }),
   json: async () => body,
@@ -64,10 +64,10 @@ describe('requestJson（给分查询请求层）', () => {
 
 describe('fetchGradeDistribution', () => {
   it('组装请求体并返回分页结构', async () => {
-    let captured = null
+    let captured: any = null
     vi.stubGlobal(
       'fetch',
-      vi.fn(async (url, opts) => {
+      vi.fn(async (_url, opts) => {
         captured = JSON.parse(opts.body)
         return jsonResponse({ success: true, total: 36, page: 1, page_size: 50, items: [{ id: 1 }] })
       })

--- a/apps/client/src/utils/grade_distribution.spec.ts
+++ b/apps/client/src/utils/grade_distribution.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchGradeDistribution,
+  requestJson,
+} from './grade_distribution.js'
+
+const jsonResponse = (body, { ok = true } = {}) => ({
+  ok,
+  headers: new Headers({ 'content-type': 'application/json' }),
+  json: async () => body,
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** 永不 resolve 的 fetch；监听 signal.abort 以模拟真实 fetch 超时被终止。 */
+const hangingFetch = vi.fn(
+  (_url, opts) =>
+    new Promise((_resolve, reject) => {
+      opts?.signal?.addEventListener('abort', () =>
+        reject(new DOMException('The operation was aborted.', 'AbortError'))
+      )
+    })
+)
+
+describe('requestJson（给分查询请求层）', () => {
+  it('正常请求返回解析后的数据', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ success: true, semesters: ['2025-2026-2'] })))
+    const data = await requestJson('http://x/api', { method: 'GET' }, 2000)
+    expect(data.success).toBe(true)
+  })
+
+  it('请求挂起超过超时 → 可读中文「查询超时」，不会无限等待', async () => {
+    vi.stubGlobal('fetch', hangingFetch)
+    await expect(requestJson('http://x/api', {}, 60)).rejects.toThrow('查询超时，请检查网络后重试')
+  })
+
+  it('网络失败（Failed to fetch）→ 可读中文「无法连接」', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+    )
+    await expect(requestJson('http://x/api', {}, 2000)).rejects.toThrow(
+      '无法连接给分查询服务，请检查网络后重试'
+    )
+  })
+
+  it('业务失败（success=false）上抛服务端 error 原文', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ success: false, error: '数据库繁忙' }))
+    )
+    await expect(requestJson('http://x/api', {}, 2000)).rejects.toThrow('数据库繁忙')
+  })
+
+  it('HTTP 非 2xx 抛 HTTP 状态错误', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({}, { ok: false })))
+    await expect(requestJson('http://x/api', {}, 2000)).rejects.toThrow('HTTP')
+  })
+})
+
+describe('fetchGradeDistribution', () => {
+  it('组装请求体并返回分页结构', async () => {
+    let captured = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url, opts) => {
+        captured = JSON.parse(opts.body)
+        return jsonResponse({ success: true, total: 36, page: 1, page_size: 50, items: [{ id: 1 }] })
+      })
+    )
+    const out = await fetchGradeDistribution({ teacher_name: '闵锐', page: 1, page_size: 50 })
+    expect(captured.teacher_name).toBe('闵锐')
+    expect(captured.page).toBe(1)
+    expect(out.total).toBe(36)
+    expect(out.items).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Closes #658（P0 前端阶段；P1 后端索引优化另行处理）

## 背景
「给分记录」搜索会长时间停在加载：实测服务端与数据正常（total 15021，各查询 1.5~4.3s），问题是**前端请求无超时、失败无提示** + 后端秒级慢（P1 后处理）。本 PR 只修前端（P0）。

## 改动
- `apps/client/src/utils/grade_distribution.js`：请求统一加 **10s 超时**（AbortController）：
  - 超时 → `查询超时，请检查网络后重试`
  - 网络失败（Failed to fetch）→ `无法连接给分查询服务，请检查网络后重试`
  - 业务失败（success=false）→ 服务端 error 原文上抛；HTTP 非 2xx → HTTP 状态
- `apps/client/src/components/GradeDistributionView.vue`：
  - 慢查询期间提示 `查询中，请稍候…（数据较多时可能较慢）`
  - 错误区新增 **重试** 按钮（可直接重新发起当前搜索）
- 新增 `grade_distribution.spec.ts`：正常 / 超时 / 网络失败 / 业务失败 / HTTP 非 2xx / 请求体组装，共 6 用例

## 验证
- ✅ `grade_distribution.spec.ts` 6/6 通过（含超时分支：挂起请求在短超时后抛"查询超时"）
- ✅ `vue-tsc --noEmit` 通过
- ✅ `vite build` 成功
- ✅ 线上接口 curl 实测正常（health/semesters/query 均 200，能搜到数据）；修复不改动查询参数与分页行为
- ⚠️ 说明：浏览器全链路 UI 自动验证受本 SPA 内部导航限制未跑通（非代码缺陷）；正常/超时提示可在真机手动复现（给分搜索后断网 10s → 出现超时提示与重试）

## 关联
- Closes #658（仅 P0；P1 后端 grade_distribution 索引优化沿用 issue 继续跟踪）