### PR TITLE
fix(#661): 培养方案详情弹窗居中于视口而非整页内容

### DIFF
--- a/apps/client/src/components/TrainingPlanView.vue
+++ b/apps/client/src/components/TrainingPlanView.vue
@@ -361,56 +361,60 @@ onMounted(async () => {
         <button @click="handleNext" :disabled="pagination.page >= pagination.totalPages">下一页</button>
       </div>
 
-      <div v-if="showDetail" class="modal-overlay" @click="closeDetail">
-        <div class="modal-content" @click.stop>
-          <div class="modal-header">
-            <h3>{{ selectedCourse?.kcmc || '课程详情' }}</h3>
-            <button class="close-btn" @click="closeDetail">×</button>
-          </div>
-          <div class="modal-body">
-            <div class="detail-item">
-              <span class="label">课程编号</span>
-              <span class="value">{{ selectedCourse?.kcbh || '-' }}</span>
+      <!-- Teleport 到 body：.content 的 fill-mode 入场动画会残留 transform，
+           劫持 position:fixed 包含块，导致弹窗居中于整页内容而非视口 -->
+      <Teleport to="body">
+        <div v-if="showDetail" class="modal-overlay" @click="closeDetail">
+          <div class="modal-content" @click.stop>
+            <div class="modal-header">
+              <h3>{{ selectedCourse?.kcmc || '课程详情' }}</h3>
+              <button class="close-btn" @click="closeDetail">×</button>
             </div>
-            <div class="detail-item">
-              <span class="label">课程性质</span>
-              <span class="value">{{ resolveCourseNature(selectedCourse?.kcxz) }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">选/必修</span>
-              <span class="value">{{ selectedCourse?.sfbx || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">课程归属</span>
-              <span class="value">{{ selectedCourse?.kcgs || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">开设学年</span>
-              <span class="value">{{ selectedCourse?.gradename || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">开设学期</span>
-              <span class="value">{{ selectedCourse?.kkxq || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">学分</span>
-              <span class="value">{{ selectedCourse?.xf || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">开课院系</span>
-              <span class="value">{{ selectedCourse?.kkyxmc || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">开课教研室</span>
-              <span class="value">{{ selectedCourse?.kkjysmc || '-' }}</span>
-            </div>
-            <div class="detail-item">
-              <span class="label">考试形式</span>
-              <span class="value">{{ selectedCourse?.ksxs || '-' }}</span>
+            <div class="modal-body">
+              <div class="detail-item">
+                <span class="label">课程编号</span>
+                <span class="value">{{ selectedCourse?.kcbh || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">课程性质</span>
+                <span class="value">{{ resolveCourseNature(selectedCourse?.kcxz) }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">选/必修</span>
+                <span class="value">{{ selectedCourse?.sfbx || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">课程归属</span>
+                <span class="value">{{ selectedCourse?.kcgs || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">开设学年</span>
+                <span class="value">{{ selectedCourse?.gradename || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">开设学期</span>
+                <span class="value">{{ selectedCourse?.kkxq || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">学分</span>
+                <span class="value">{{ selectedCourse?.xf || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">开课院系</span>
+                <span class="value">{{ selectedCourse?.kkyxmc || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">开课教研室</span>
+                <span class="value">{{ selectedCourse?.kkjysmc || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="label">考试形式</span>
+                <span class="value">{{ selectedCourse?.ksxs || '-' }}</span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </Teleport>
     </section>
   </div>
 </template>


### PR DESCRIPTION
## 概要

Fixes #661

培养方案页点击课程卡片后，详情弹窗居中于**整页内容的中部**而非手机屏幕，需下滑很远才能看到。本 PR 将弹窗挂载到 `body`，使其定位基准恢复为视口。

## 根因

- `.content` 容器带入场动画 `animation: training-fade-up 0.32s ease both`
- `animation-fill-mode: both` 使动画结束后**永久保留末帧** `transform: translateY(0)`
- 按 CSS 规范，持有非 `none` transform 的祖先会成为其 `position: fixed` 后代的包含块
- 于是 `.modal-overlay { position: fixed; inset: 0; align-items: center }` 相对整个内容高度垂直居中——列表越长弹窗沉得越深；系统开启「减弱动态效果」时动画被禁用反而正常，属仅真机可复现问题

## 修复方式

- 将 `.modal-overlay/.modal-content` 弹窗段包进 `<Teleport to="body">`，与 GradeView、AcademicProgressView、TModal 等既有正确模式对齐
- scoped 样式经编译期 data 属性继续生效，**CSS 零改动**，视觉与动画不变
- 弹窗旁附注释说明劫持机制，防止后续回退

## 全局排查（详见 #661）

逐一核对全部 13 个含全屏 fixed 弹层的组件：其余均有 `<Teleport to="body">` 保护或无残留 transform 动画源，**本 bug 为培养方案页独有**。

## 验证

- [x] `cd apps/client && npm run build` 通过（8.3s 无错误）
- [x] diff 仅涉及 TrainingPlanView.vue 单文件模板段（+50/-46），无样式/逻辑改动
- [ ] 真机/移动模拟下长列表顶部点卡片弹窗即现（待 review 自测）