### PR TITLE
fix(#659): Session NULL 数据契约 + 传输失败不锁 60s + 登录单飞与在线状态（v1.4.4→当前升级兼容）

### DIFF
--- a/apps/client/src-tauri/src/http_client/auth.rs
+++ b/apps/client/src-tauri/src/http_client/auth.rs
@@ -1017,8 +1017,13 @@ impl HbutClient {
         _lt: &str,        // 忽略前端传入的值
         _execution: &str, // 忽略前端传入的值
     ) -> Result<UserInfo, Box<dyn std::error::Error + Send + Sync>> {
+        // 60s 冷却门：只有「收到认证服务器真实响应」的记录才会触发（#659 根因 5）
         if let Some(remaining) = self.login_cooldown_remaining() {
             return Err(format!("登录频率过高，请{}秒后再试", remaining.as_secs()).into());
+        }
+        // 传输层/登录页失败后的短 backoff 门（独立、远小于 60s；避免网络异常时连点刷屏）
+        if let Some(remaining) = self.login_transport_backoff_remaining() {
+            return Err(format!("网络异常，请{}秒后再试", remaining.as_secs()).into());
         }
 
         let encoded_service = urlencoding::encode(TARGET_SERVICE);
@@ -1036,8 +1041,14 @@ impl HbutClient {
 
         let max_retries = 2;
         for attempt in 0..max_retries {
-            let mut page_info = self.get_login_page().await?;
-            page_info = self.resolve_login_page_with_fallbacks(page_info).await?;
+            let mut page_info = match self.login_fetch_login_page().await {
+                Ok(page) => page,
+                Err(err) => {
+                    // 登录页获取/解析失败：未收到认证服务器响应，不占 60s 冷却，仅记短 backoff
+                    self.last_login_short_backoff_at = Some(std::time::Instant::now());
+                    return Err(err);
+                }
+            };
             // get_login_page 使用 TARGET_SERVICE，如果已经登录会跳转到 JWXT
             if page_info.is_already_logged_in {
                 crate::hbut_debug!("[调试] 已登录（检测到），跳过登录 POST");
@@ -1055,7 +1066,11 @@ impl HbutClient {
             let captcha_required = page_info.captcha_required;
 
             if current_salt.is_empty() || current_execution.trim().is_empty() {
-                return Err("无法获取登录参数（加密盐值或 execution）".into());
+                // 参数解析失败：未收到认证服务器响应，不占 60s 冷却，仅记短 backoff 防连点
+                self.last_login_short_backoff_at = Some(std::time::Instant::now());
+                return Err(
+                    HttpClientError::other("无法获取登录参数（加密盐值或 execution）").into(),
+                );
             }
 
             println!(
@@ -1147,20 +1162,26 @@ impl HbutClient {
 
             // 5. 提交登录请求
             crate::hbut_debug!("[调试] 发送登录 POST 请求...");
-            // 只有真正发起 CAS 登录提交时才计入频率限制，避免参数解析异常触发误限频。
+            // 关键修复（#659 根因 5）：只有「收到认证服务器真实响应」后才计入 60s 冷却。
+            // `.send()` 传输层失败（网络/DNS/TLS/超时）不锁 60s，仅记 5s 短 backoff，
+            // 避免用户因网络抖动被锁死 60 秒无法重新登录。
+            let (response_url, status, html) =
+                match self.submit_cas_login(&login_url, &form_data).await {
+                    Ok(resp) => resp,
+                    Err(err) => {
+                        if is_transport_error(err.as_ref()) {
+                            crate::hbut_debug!(
+                                "[调试] 登录 POST 传输层失败，仅记 5s backoff，不计 60s 冷却"
+                            );
+                            self.last_login_short_backoff_at = Some(std::time::Instant::now());
+                        }
+                        return Err(err);
+                    }
+                };
+            // 已收到认证服务器真实响应：记一次完整 CAS 尝试（成功/认证失败/5xx 均受 60s 风控保护）
             self.last_login_attempt = Some(std::time::Instant::now());
-            let response = self
-                .client
-                .post(&login_url)
-                .header("Referer", &login_url)
-                .form(&form_data)
-                .send()
-                .await?;
 
             crate::hbut_debug!("[调试] 登录请求已发送，处理响应...");
-            let response_url = response.url().to_string();
-            let status = response.status();
-            let html = response.text().await?;
 
             println!(
                 "[调试] 登录响应状态: {}, 最终地址: {}",
@@ -1172,7 +1193,7 @@ impl HbutClient {
                 crate::hbut_debug!("[调试] 响应 HTML 片段: {}", html);
             }
 
-            if status.as_u16() >= 400 {
+            if status >= 400 {
                 super::utils::write_debug_artifact("debug_login_error_response_tauri.html", &html);
                 crate::hbut_debug!(
                     "[调试] 登录响应状态 >=400, wrote debug_login_error_response_tauri.html (len={})",
@@ -1185,7 +1206,7 @@ impl HbutClient {
                 return Err("服务器 IP 被学校冻结，请稍后再试或联系管理员".into());
             }
 
-            if status.as_u16() >= 500 {
+            if status >= 500 {
                 super::utils::write_debug_artifact("debug_login_response_tauri.html", &html);
                 crate::hbut_debug!(
                     "[调试] 登录响应状态 >=500, wrote debug_login_response_tauri.html (len={})",
@@ -1210,11 +1231,11 @@ impl HbutClient {
                     );
                     continue;
                 }
-                return Err(login_err.into());
+                return Err(HttpClientError::auth_failed(login_err).into());
             }
 
             // 明确的失败判定（避免继续走 SSO 导致“会话已过期”）
-            if status.as_u16() == 401 {
+            if status == 401 {
                 super::utils::write_debug_artifact("debug_login_401_response_tauri.html", &html);
                 crate::hbut_debug!(
                     "[调试] 登录响应状态 401, wrote debug_login_401_response_tauri.html (len={})",
@@ -1228,7 +1249,8 @@ impl HbutClient {
                     );
                     continue;
                 }
-                return Err("登录失败，请检查账号或密码".into());
+                // 401 属于认证服务器真实响应：认证失败，受 60s 冷却保护
+                return Err(HttpClientError::auth_failed("登录失败，请检查账号或密码").into());
             }
 
             let is_on_auth_page = response_url.contains("authserver/login")
@@ -1245,13 +1267,15 @@ impl HbutClient {
                     );
                     continue;
                 }
-                return Err("登录失败，请检查账号或密码".into());
+                // 仍停留在认证页：属于认证服务器真实响应，受 60s 冷却保护
+                return Err(HttpClientError::auth_failed("登录失败，请检查账号或密码").into());
             }
 
             // 检查是否登录成功（URL 发生变化通常表示成功）
             // v3: 排除教务系统自带登录页 /admin/login
             let is_on_jwxt_login = looks_like_academic_login_url(&response_url);
-            if status.is_success()
+            if status >= 200
+                && status < 300
                 && !is_on_jwxt_login
                 && (response_url.contains("ticket=")
                     || response_url.contains("jwxt")
@@ -1269,10 +1293,10 @@ impl HbutClient {
                 );
                 continue;
             } else {
-                return Err("登录失败，请稍后重试".into());
+                return Err(HttpClientError::other("登录失败，请稍后重试").into());
             }
 
-            let user_info = self.finalize_jwxt_user_session().await?;
+            let user_info = self.login_finalize_session().await?;
             // 成功登录
             self.last_login_time = Some(std::time::Instant::now());
             self.is_logged_in = true;
@@ -1285,7 +1309,56 @@ impl HbutClient {
             return Ok(user_info);
         }
 
-        Err("登录失败，请稍后重试".into())
+        Err(HttpClientError::other("登录失败，请稍后重试").into())
+    }
+
+    /// 获取登录页（含 fallback 探测）；测试构建可注入 mock 登录页。
+    async fn login_fetch_login_page(
+        &mut self,
+    ) -> Result<LoginPageInfo, Box<dyn std::error::Error + Send + Sync>> {
+        #[cfg(test)]
+        if let Some(inject) = &self.test_login_page {
+            return inject();
+        }
+        let mut page_info = self.get_login_page().await?;
+        page_info = self.resolve_login_page_with_fallbacks(page_info).await?;
+        Ok(page_info)
+    }
+
+    /// 提交 CAS 登录 POST，返回 (最终 URL, HTTP 状态码, 响应 HTML)。
+    /// 传输层失败（`.send()` / `text()` 的 reqwest 错误）原样透传，由调用方按分类处理；
+    /// 测试构建可注入 mock 结果（见 `test_cas_post`）。
+    async fn submit_cas_login(
+        &self,
+        login_url: &str,
+        form_data: &HashMap<String, String>,
+    ) -> Result<(String, u16, String), Box<dyn std::error::Error + Send + Sync>> {
+        #[cfg(test)]
+        if let Some(inject) = &self.test_cas_post {
+            return inject();
+        }
+        let response = self
+            .client
+            .post(login_url)
+            .header("Referer", login_url)
+            .form(form_data)
+            .send()
+            .await?;
+        let response_url = response.url().to_string();
+        let status = response.status().as_u16();
+        let html = response.text().await?;
+        Ok((response_url, status, html))
+    }
+
+    /// 登录成功后建立教务会话并拉取用户信息；测试构建可注入 mock。
+    async fn login_finalize_session(
+        &mut self,
+    ) -> Result<UserInfo, Box<dyn std::error::Error + Send + Sync>> {
+        #[cfg(test)]
+        if let Some(inject) = &self.test_finalize {
+            return inject();
+        }
+        self.finalize_jwxt_user_session().await
     }
 }
 
@@ -1315,5 +1388,217 @@ mod login_error_tests {
         let (msg, retryable) = detect_login_error_from_html(html).expect("should classify");
         assert_eq!(msg, "账号已被锁定");
         assert!(!retryable);
+    }
+}
+
+/// #659 根因 5 / 实现要求 E / 必测 6：
+/// 传输层失败（未收到认证服务器响应）不得触发 60s 登录硬锁；
+/// 只有「收到真实 CAS 响应」（成功/认证失败/5xx）才计入 60s 冷却。
+#[cfg(test)]
+mod login_cooldown_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// 构造隔离数据目录的测试客户端，避免快照文件污染真实 %LOCALAPPDATA%。
+    fn test_client() -> HbutClient {
+        let dir = tempfile::tempdir().expect("创建临时数据目录");
+        std::env::set_var("HBUT_APP_DATA_DIR", dir.path());
+        HbutClient::new()
+    }
+
+    fn mock_login_page() -> LoginPageInfo {
+        LoginPageInfo {
+            lt: "lt-mock".to_string(),
+            execution: "exec-mock".to_string(),
+            captcha_required: false,
+            salt: "0123456789abcdef".to_string(),
+            is_already_logged_in: false,
+        }
+    }
+
+    fn mock_user() -> UserInfo {
+        UserInfo {
+            student_id: "2024000000".to_string(),
+            student_name: "测试".to_string(),
+            college: None,
+            major: None,
+            class_name: None,
+            grade: None,
+        }
+    }
+
+    /// 已收到真实 CAS 响应后（距上次 500ms）：重复登录必须被 60s 冷却门拦截，
+    /// 文案为「登录频率过高，请59秒后再试」且在发起任何网络请求之前返回。
+    #[tokio::test]
+    async fn cooldown_gate_blocks_repeat_submit_with_59_seconds_message() {
+        let mut client = test_client();
+        client.last_login_attempt =
+            Some(std::time::Instant::now() - std::time::Duration::from_millis(500));
+        let err = client
+            .login("2024000000", "pwd_123", "", "", "")
+            .await
+            .expect_err("冷却门应拦截");
+        let msg = err.to_string();
+        assert!(msg.contains("登录频率过高，请59秒后再试"), "msg={msg}");
+        assert!(!msg.contains("网络异常"), "msg={msg}");
+    }
+
+    /// 传输层失败（距上次 500ms）：只被 5s 短 backoff 门拦截，文案为「网络异常」，
+    /// 远小于 60s，绝不以「请59秒后再试」锁死用户。
+    #[tokio::test]
+    async fn transport_backoff_gate_blocks_with_4_seconds_message() {
+        let mut client = test_client();
+        client.last_login_short_backoff_at =
+            Some(std::time::Instant::now() - std::time::Duration::from_millis(500));
+        let err = client
+            .login("2024000000", "pwd_123", "", "", "")
+            .await
+            .expect_err("short backoff 门应拦截");
+        let msg = err.to_string();
+        assert!(msg.contains("网络异常，请4秒后再试"), "msg={msg}");
+        assert!(!msg.contains("登录频率过高"), "msg={msg}");
+    }
+
+    /// 真实 reqwest 网络错误（连接拒绝）必须被识别为传输层错误；
+    /// 业务字符串 / 认证失败包装不是传输层错误。
+    #[tokio::test]
+    async fn real_reqwest_connect_error_is_classified_as_transport() {
+        let err = reqwest::Client::new()
+            .get("http://127.0.0.1:1/")
+            .timeout(std::time::Duration::from_secs(5))
+            .send()
+            .await
+            .expect_err("连接未监听端口应产生传输层错误");
+        assert!(
+            is_transport_error(&err),
+            "真实 reqwest 连接错误应识别为 Transport"
+        );
+
+        let biz: Box<dyn std::error::Error + Send + Sync> = "用户名或密码错误".to_string().into();
+        assert!(
+            !is_transport_error(biz.as_ref()),
+            "业务字符串错误不是 Transport"
+        );
+
+        assert!(is_transport_error(&HttpClientError::new(
+            HttpClientErrorKind::Transport,
+            "t"
+        )));
+        assert!(!is_transport_error(&HttpClientError::new(
+            HttpClientErrorKind::AuthFailed,
+            "a"
+        )));
+    }
+
+    /// 必测：传输层失败 → 登录返回传输类错误，且**不会**锁 60s；
+    /// 只触发独立短 backoff，立即重试被 5s 门拦截而非 60s 硬锁。
+    #[tokio::test]
+    async fn transport_failure_uses_short_backoff_and_keeps_user_unlocked() {
+        let mut client = test_client();
+        let page = mock_login_page();
+        client.test_login_page = Some(Arc::new(move || Ok(page.clone())));
+        let post_calls = Arc::new(AtomicUsize::new(0));
+        let calls = post_calls.clone();
+        let mock_err =
+            HttpClientError::new(HttpClientErrorKind::Transport, "mock: connection refused");
+        client.test_cas_post = Some(Arc::new(move || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(Box::new(mock_err.clone()) as Box<dyn std::error::Error + Send + Sync>)
+        }));
+
+        let result = client.login("2024000000", "pwd_123", "", "", "").await;
+        let err = result.expect_err("传输层失败应返回 Err");
+        assert!(is_transport_error(err.as_ref()), "登录返回的应为传输类错误");
+
+        // 传输层失败：不占 60s 冷却（用户不能被锁死）
+        assert!(
+            client.login_cooldown_remaining().is_none(),
+            "传输层失败不得触发 60s 冷却"
+        );
+        // 独立短 backoff 生效，且远小于 60s
+        let backoff = client
+            .login_transport_backoff_remaining()
+            .expect("应记录短 backoff");
+        assert!(backoff.as_secs() <= 5, "backoff={backoff:?} 应远小于 60s");
+
+        // 立即重试：被 5s backoff 门拦截（不发起 POST），文案是「网络异常」而非 60s 硬锁文案
+        let err2 = client
+            .login("2024000000", "pwd_123", "", "", "")
+            .await
+            .expect_err("backoff 门应拦截第二次登录");
+        let msg2 = err2.to_string();
+        assert!(msg2.contains("网络异常"), "msg={msg2}");
+        assert!(!msg2.contains("登录频率过高"), "msg={msg2}");
+        assert_eq!(
+            post_calls.load(Ordering::SeqCst),
+            1,
+            "backoff 期间不得再次发起 CAS POST"
+        );
+    }
+
+    /// 必测：收到真实 CAS 认证失败响应 → 重复登录仍受 60s 冷却保护（风控不可绕过）。
+    #[tokio::test]
+    async fn auth_failure_response_locks_60s_cooldown() {
+        let mut client = test_client();
+        let page = mock_login_page();
+        client.test_login_page = Some(Arc::new(move || Ok(page.clone())));
+        let err_html = r#"<span id="showErrorTip">用户名或密码错误</span>"#.to_string();
+        client.test_cas_post = Some(Arc::new(move || {
+            Ok((
+                "https://auth.hbut.edu.cn/authserver/login?service=x".to_string(),
+                200u16,
+                err_html.clone(),
+            ))
+        }));
+
+        let result = client.login("2024000000", "pwd_123", "", "", "").await;
+        let err = result.expect_err("认证失败应返回 Err");
+        assert!(err.to_string().contains("密码错误"), "msg={err}");
+        assert!(!is_transport_error(err.as_ref()), "认证失败不是传输层错误");
+
+        // 收到真实 CAS 响应 → 60s 冷却生效，且无短 backoff
+        let remaining = client
+            .login_cooldown_remaining()
+            .expect("认证失败应触发 60s 冷却");
+        assert!(remaining.as_secs() >= 55, "remaining={remaining:?}");
+        assert!(client.login_transport_backoff_remaining().is_none());
+
+        // 立即重复登录：被 60s 硬冷却门拦截（风控不能被移除或降级）
+        let err2 = client
+            .login("2024000000", "pwd_123", "", "", "")
+            .await
+            .expect_err("60s 冷却门应拦截");
+        let msg2 = err2.to_string();
+        assert!(msg2.contains("登录频率过高"), "msg={msg2}");
+        assert!(!msg2.contains("网络异常"), "msg={msg2}");
+    }
+
+    /// 成功路径不破坏：登录成功返回用户信息，且成功同样算一次完整 CAS 尝试（受 60s 保护）。
+    #[tokio::test]
+    async fn success_path_still_works_and_counts_as_cas_attempt() {
+        let mut client = test_client();
+        let page = mock_login_page();
+        client.test_login_page = Some(Arc::new(move || Ok(page.clone())));
+        let final_url = format!("{}/admin/?loginType=1", JWXT_BASE_URL);
+        client.test_cas_post = Some(Arc::new(move || {
+            Ok((final_url.clone(), 200u16, String::new()))
+        }));
+        let user_for_finalize = mock_user();
+        client.test_finalize = Some(Arc::new(move || Ok(user_for_finalize.clone())));
+
+        let info = client
+            .login("2024000000", "pwd_123", "", "", "")
+            .await
+            .expect("成功路径不应失败");
+        assert_eq!(info.student_id, "2024000000");
+        assert!(client.is_logged_in);
+
+        // 成功也算一次完整 CAS 尝试 → 受 60s 冷却保护
+        let remaining = client
+            .login_cooldown_remaining()
+            .expect("成功后应有 60s 冷却");
+        assert!(remaining.as_secs() >= 55, "remaining={remaining:?}");
+        assert!(client.login_transport_backoff_remaining().is_none());
     }
 }

--- a/apps/client/src-tauri/src/http_client/mod.rs
+++ b/apps/client/src-tauri/src/http_client/mod.rs
@@ -80,6 +80,74 @@ pub(super) const DEFAULT_LOCAL_OCR_FALLBACK_ENDPOINTS: &[&str] =
 /// Release 构建仅允许 HTTPS OCR，避免验证码图片经明文 HTTP 外传。
 pub(super) const DEFAULT_RELEASE_OCR_FALLBACK_ENDPOINTS: &[&str] = &[SECONDARY_OCR_ENDPOINT];
 
+/// 登录风控：完整 CAS 尝试（收到认证服务器真实响应）的冷却时长（60s）。
+pub(super) const LOGIN_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
+/// 传输层失败（未收到认证服务器响应，如网络/DNS/TLS/超时）后的短 backoff，
+/// 仅用于避免连点刷屏，远小于 60s 登录冷却，绝不把用户锁死（#659 根因 5）。
+pub(super) const TRANSPORT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// 客户端错误分类（风控与错误判定用，不改变对外字符串文案）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpClientErrorKind {
+    /// 传输层失败：未收到认证服务器真实响应（DNS/TCP/TLS/超时等）。
+    Transport,
+    /// 认证失败：收到认证服务器返回的业务失败响应（账号/密码/验证码/锁定等）。
+    AuthFailed,
+    /// 其它/业务错误（参数缺失、登录页异常、未知）。
+    Other,
+}
+
+/// 带分类的客户端错误。`Display` 只输出原始消息，保持对外字符串/结构兼容；
+/// 同时可经 `Box<dyn Error + Send + Sync>` 向下转型（downcast）获取 `kind`。
+#[derive(Debug, Clone)]
+pub struct HttpClientError {
+    kind: HttpClientErrorKind,
+    message: String,
+}
+
+impl HttpClientError {
+    pub fn new(kind: HttpClientErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// 构造认证失败类错误（收到认证服务器业务失败响应）。
+    pub fn auth_failed(message: impl Into<String>) -> Self {
+        Self::new(HttpClientErrorKind::AuthFailed, message)
+    }
+
+    /// 构造其它/业务类错误。
+    pub fn other(message: impl Into<String>) -> Self {
+        Self::new(HttpClientErrorKind::Other, message)
+    }
+
+    pub fn kind(&self) -> HttpClientErrorKind {
+        self.kind
+    }
+}
+
+impl std::fmt::Display for HttpClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for HttpClientError {}
+
+/// 判定错误是否为「传输层失败」（未收到认证服务器真实响应）。
+/// 识别 `HttpClientError::Transport` 与原生 `reqwest::Error`（connect/timeout/request/body）。
+pub(super) fn is_transport_error(err: &(dyn std::error::Error + Send + Sync + 'static)) -> bool {
+    if let Some(e) = err.downcast_ref::<HttpClientError>() {
+        return e.kind() == HttpClientErrorKind::Transport;
+    }
+    if let Some(re) = err.downcast_ref::<reqwest::Error>() {
+        return re.is_timeout() || re.is_connect() || re.is_request() || re.is_body();
+    }
+    false
+}
+
 /// Release 构建过滤掉非 HTTPS 的 OCR 端点。
 pub(super) fn filter_release_ocr_endpoints(endpoints: Vec<String>) -> Vec<String> {
     if cfg!(debug_assertions) {
@@ -246,6 +314,34 @@ pub struct HbutClient {
     pub(super) ocr_active_source: Option<String>,
     pub(super) ocr_last_error: Option<String>,
     pub(super) last_login_attempt: Option<std::time::Instant>,
+    /// 最近一次「未收到认证服务器响应」的登录失败时间（传输层/登录页获取/参数解析失败），
+    /// 用于 5s 短 backoff（#659：传输层失败不再锁 60s）。
+    pub(super) last_login_short_backoff_at: Option<std::time::Instant>,
+    /// 测试专用：注入「获取登录页」结果（None = 走真实链路）。
+    #[cfg(test)]
+    pub(super) test_login_page: Option<
+        std::sync::Arc<
+            dyn Fn() -> Result<LoginPageInfo, Box<dyn std::error::Error + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    >,
+    /// 测试专用：注入「CAS 登录 POST」结果（None = 走真实链路）。
+    #[cfg(test)]
+    pub(super) test_cas_post: Option<
+        std::sync::Arc<
+            dyn Fn() -> Result<(String, u16, String), Box<dyn std::error::Error + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    >,
+    /// 测试专用：注入「登录成功后建教务会话并拉取用户信息」结果（None = 走真实链路）。
+    #[cfg(test)]
+    pub(super) test_finalize: Option<
+        std::sync::Arc<
+            dyn Fn() -> Result<UserInfo, Box<dyn std::error::Error + Send + Sync>> + Send + Sync,
+        >,
+    >,
     pub(super) last_login_time: Option<std::time::Instant>,
     pub(super) last_relogin_attempt: Option<std::time::Instant>,
     pub(super) last_relogin_failed_at: Option<std::time::Instant>,
@@ -382,6 +478,13 @@ impl HbutClient {
             ocr_active_source: None,
             ocr_last_error: None,
             last_login_attempt: None,
+            last_login_short_backoff_at: None,
+            #[cfg(test)]
+            test_login_page: None,
+            #[cfg(test)]
+            test_cas_post: None,
+            #[cfg(test)]
+            test_finalize: None,
             last_login_time: None,
             last_relogin_attempt: None,
             last_relogin_failed_at: None,
@@ -549,14 +652,27 @@ impl HbutClient {
     }
 
     /// 登录频率控制：至少间隔 60 秒，降低 CAS 风控风险。
+    /// 仅在收到认证服务器真实响应（成功/认证失败/5xx 等业务响应）后才会记录，
+    /// 传输层失败不触发（见 `login_transport_backoff_remaining`，#659 根因 5）。
     pub(super) fn login_cooldown_remaining(&self) -> Option<std::time::Duration> {
-        const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
         let last = self.last_login_attempt?;
         let elapsed = last.elapsed();
-        if elapsed >= COOLDOWN {
+        if elapsed >= LOGIN_COOLDOWN {
             None
         } else {
-            Some(COOLDOWN - elapsed)
+            Some(LOGIN_COOLDOWN - elapsed)
+        }
+    }
+
+    /// 传输层失败（未收到认证服务器响应）后的短 backoff 剩余时间。
+    /// 独立于 60s 登录冷却，时长为 `TRANSPORT_BACKOFF`（5s），仅防连点刷屏，不锁死用户。
+    pub(super) fn login_transport_backoff_remaining(&self) -> Option<std::time::Duration> {
+        let last = self.last_login_short_backoff_at?;
+        let elapsed = last.elapsed();
+        if elapsed >= TRANSPORT_BACKOFF {
+            None
+        } else {
+            Some(TRANSPORT_BACKOFF - elapsed)
         }
     }
 

--- a/apps/client/src-tauri/src/infrastructure/db/credential.rs
+++ b/apps/client/src-tauri/src/infrastructure/db/credential.rs
@@ -160,13 +160,25 @@ pub(crate) fn reveal_session_secret(student_id: &str, stored: &str, field: &str)
 }
 
 /// 显式/幂等迁移：旧 Base64 密码列 → 密钥环。此函数不会在启动时自动调用。
+///
+/// 每行归类统计（#659 根因 4）：NULL/坏行进入自愈分支并计入 report，
+/// 不再被 `rows.flatten()` 静默吞掉。
 #[derive(Debug, Clone, Default)]
 pub struct CredMigrateReport {
+    /// 扫描的 user_sessions 行数
     pub scanned: usize,
-    pub migrated_to_keyring: usize,
-    pub kept_base64: usize,
-    pub keyring_ok: usize,
+    /// encrypted_password IS NULL 的历史空壳行：置 '' 自愈（行不删除，各 reader 可读）
+    pub null_shell_repaired: usize,
+    /// KEYRING_MARKER（或空串）且密钥环可恢复
+    pub keyring_marker_valid: usize,
+    /// base64 密码迁移进密钥环成功（落 KEYRING_MARKER）
+    pub base64_migrated: usize,
+    /// 密钥环不可用：保留 base64，并写入 remembered 兜底
+    pub keyring_unavailable: usize,
+    /// KEYRING 空壳且密钥环不可恢复，需用户手动登录
     pub empty_shells: usize,
+    /// 行数据不可读/学号非法（保留原行不覆盖）
+    pub malformed_error: usize,
 }
 
 /// 扫描 `user_sessions`，修复 1.4.3 密钥环空壳与未完成的 base64 迁移。
@@ -181,22 +193,50 @@ pub fn migrate_session_passwords_v2<P: AsRef<Path>>(path: P) -> Result<CredMigra
     let mut stmt = conn.prepare(
         "SELECT student_id, encrypted_password FROM user_sessions ORDER BY last_login DESC",
     )?;
+    // 契约化读取：student_id 主键按 Option 容错；encrypted_password 保留 Option
+    // 以区分「NULL 空壳自愈」与「字面空串」，NULL 行不再让 query_map 报错。
     let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        Ok((
+            row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+            row.get::<_, Option<String>>(1)?,
+        ))
     })?;
 
-    for row in rows.flatten() {
-        let (sid, enc) = row;
+    for row in rows {
+        let (sid, enc_opt) = match row {
+            Ok(pair) => pair,
+            Err(error) => {
+                // 不再 flatten 吞错：坏行保留原样、计入 malformed_error 并输出（#659）
+                report.malformed_error += 1;
+                eprintln!("[db] cred_migrate_v2 行读取失败（保留原行不覆盖）: {error}");
+                continue;
+            }
+        };
         report.scanned += 1;
         let sid = sid.trim().to_string();
         if sid.is_empty() {
+            report.malformed_error += 1;
+            eprintln!("[db] cred_migrate_v2: 空学号行，跳过");
             continue;
         }
+
+        // NULL 空壳自愈：写入 '' 使所有 reader 可读（#659），不删除行。
+        let enc = match enc_opt {
+            Some(value) => value,
+            None => {
+                conn.execute(
+                    "UPDATE user_sessions SET encrypted_password = '' WHERE student_id = ?1",
+                    params![sid],
+                )?;
+                report.null_shell_repaired += 1;
+                String::new()
+            }
+        };
 
         if enc == KEYRING_MARKER || enc.is_empty() {
             let from_ring = load_password_from_keyring_or_remembered(&sid);
             if !from_ring.is_empty() {
-                report.keyring_ok += 1;
+                report.keyring_marker_valid += 1;
                 let _ = crate::credential_store::save_remembered_credential(
                     &format!("hbut:{sid}"),
                     &from_ring,
@@ -217,7 +257,7 @@ pub fn migrate_session_passwords_v2<P: AsRef<Path>>(path: P) -> Result<CredMigra
                     "UPDATE user_sessions SET encrypted_password = ?1 WHERE student_id = ?2",
                     params![KEYRING_MARKER, sid],
                 )?;
-                report.migrated_to_keyring += 1;
+                report.base64_migrated += 1;
             } else {
                 // 密钥环不可用：显式保留 base64，并写入 remembered（若 keyring 部分可用）
                 let encoded = base64::engine::general_purpose::STANDARD.encode(password.as_bytes());
@@ -231,7 +271,7 @@ pub fn migrate_session_passwords_v2<P: AsRef<Path>>(path: P) -> Result<CredMigra
                     &format!("hbut:{sid}"),
                     &password,
                 );
-                report.kept_base64 += 1;
+                report.keyring_unavailable += 1;
             }
             continue;
         }
@@ -247,12 +287,14 @@ pub fn migrate_session_passwords_v2<P: AsRef<Path>>(path: P) -> Result<CredMigra
     )?;
 
     eprintln!(
-        "[db] cred_migrate_v2 done scanned={} keyring_ok={} migrated={} kept_b64={} empty_shells={}",
+        "[db] cred_migrate_v2 done scanned={} null_shell_repaired={} keyring_marker_valid={} base64_migrated={} keyring_unavailable={} empty_shells={} malformed_error={}",
         report.scanned,
-        report.keyring_ok,
-        report.migrated_to_keyring,
-        report.kept_base64,
-        report.empty_shells
+        report.null_shell_repaired,
+        report.keyring_marker_valid,
+        report.base64_migrated,
+        report.keyring_unavailable,
+        report.empty_shells,
+        report.malformed_error
     );
     Ok(report)
 }
@@ -483,10 +525,55 @@ mod tests {
 
         let report = migrate_session_passwords_v2(&path).expect("migrate");
         assert!(report.scanned >= 1);
-        assert!(report.migrated_to_keyring + report.kept_base64 >= 1);
+        assert!(report.base64_migrated + report.keyring_unavailable >= 1);
 
         let session = get_user_session(&path, sid).unwrap().expect("session");
         assert_eq!(session.password, password);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// encrypted_password IS NULL 的历史行：凭据迁移必须自愈而非被 flatten 吞掉，
+    /// 行不消失、任何 reader 可读（#659 必测 4 对应）。
+    #[test]
+    fn migrate_v2_repairs_null_password_shell_rows() {
+        let path = temp_db_path("migrate_null");
+        let _ = std::fs::remove_file(&path);
+        init_db(&path).expect("init");
+        let sid = "null-shell-0001";
+        {
+            let conn = open_connection(&path).unwrap();
+            // 等价 v1.4.4 空壳：只写 student_id + cookies，encrypted_password IS NULL
+            conn.execute(
+                "INSERT INTO user_sessions (student_id, cookies) VALUES (?1, 'c=1')",
+                params![sid],
+            )
+            .unwrap();
+        }
+
+        let report = migrate_session_passwords_v2(&path).expect("migrate");
+        assert!(report.scanned >= 1);
+        assert!(
+            report.null_shell_repaired >= 1,
+            "null_shell_repaired={}",
+            report.null_shell_repaired
+        );
+        assert_eq!(report.malformed_error, 0);
+
+        // 行未消失；NULL 已自愈为 ''，reader 正常可读
+        let conn = open_connection(&path).unwrap();
+        let enc: String = conn
+            .query_row(
+                "SELECT encrypted_password FROM user_sessions WHERE student_id = ?1",
+                params![sid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(enc, "");
+        drop(conn);
+
+        let session = get_user_session(&path, sid).unwrap().expect("session");
+        assert_eq!(session.password, "");
+        assert_eq!(session.cookies, "c=1");
         let _ = std::fs::remove_file(&path);
     }
 

--- a/apps/client/src-tauri/src/infrastructure/db/migrations.rs
+++ b/apps/client/src-tauri/src/infrastructure/db/migrations.rs
@@ -65,6 +65,82 @@ pub(crate) fn ensure_user_session_columns(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// `normalize_user_sessions_nulls` 的扫描/修复计数（#659 根因 2）。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UserSessionNullReport {
+    /// 存在至少一个契约列 IS NULL 的行数
+    pub scanned: usize,
+    /// 实际执行的 (行, 列) NULL→'' 修复次数
+    pub repaired: usize,
+}
+
+/// user_sessions 历史空壳 NULL 自愈（#659 根因 2）。
+///
+/// 幂等：仅把契约非空业务列中的 NULL 置为 ''，绝不覆盖非空值，
+/// 不删除 Session/缓存行；`user_sessions` 表不存在时静默返回零计数。
+/// 契约列 = 生产读取路径按 String 读取的列（session.rs 统一 row-mapper）：
+/// cookies / encrypted_password / one_code_token / electricity_refresh_token /
+/// electricity_token_expires_at。
+/// 失败以 Result 传播（调用方如 init_db 可见），计数随 report 返回并 eprintln 记录。
+pub fn normalize_user_sessions_nulls(conn: &Connection) -> Result<UserSessionNullReport> {
+    const CONTRACT_COLUMNS: [&str; 5] = [
+        "cookies",
+        "encrypted_password",
+        "one_code_token",
+        "electricity_refresh_token",
+        "electricity_token_expires_at",
+    ];
+
+    let empty = UserSessionNullReport::default();
+    // 表不存在（新库尚未经过 init_db）时静默跳过，避免 "no such table"
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='user_sessions'",
+            [],
+            |_| Ok(true),
+        )
+        .optional()?
+        .unwrap_or(false);
+    if !table_exists {
+        return Ok(empty);
+    }
+    // 缺列的旧库先补列，保证后续 UPDATE 引用的列一定存在
+    ensure_user_session_columns(conn)?;
+
+    let where_clause = CONTRACT_COLUMNS
+        .iter()
+        .map(|column| format!("{column} IS NULL"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let scanned: i64 = conn.query_row(
+        &format!("SELECT COUNT(*) FROM user_sessions WHERE {where_clause}"),
+        [],
+        |row| row.get(0),
+    )?;
+
+    let tx = conn.unchecked_transaction()?;
+    let mut repaired = 0usize;
+    for column in CONTRACT_COLUMNS {
+        // 列名来自编译期常量数组，无注入面
+        let affected = tx.execute(
+            &format!("UPDATE user_sessions SET {column} = '' WHERE {column} IS NULL"),
+            [],
+        )?;
+        repaired += affected;
+    }
+    tx.commit()?;
+
+    let report = UserSessionNullReport {
+        scanned: scanned as usize,
+        repaired,
+    };
+    eprintln!(
+        "[db] normalize_user_sessions_nulls: scanned={} repaired={}",
+        report.scanned, report.repaired
+    );
+    Ok(report)
+}
+
 /// 自定义课程可选颜色列（#470）：旧库幂等 ALTER，新建表 DDL 已含 color。
 pub(crate) fn ensure_custom_schedule_color_column(conn: &Connection) -> Result<()> {
     ensure_column(
@@ -421,6 +497,10 @@ pub fn init_db<P: AsRef<Path>>(path: P) -> Result<()> {
         6,
         "custom_schedule_courses.color optional user color",
     )?;
+
+    // 历史空壳 NULL 自愈（#659 根因 2）：幂等，仅契约列 NULL→''，不覆盖非空值；
+    // 失败直接传播（启动阶段 lib.rs 可见），计数经 eprintln/report 可观测。
+    normalize_user_sessions_nulls(&conn)?;
     drop(conn);
 
     // 安全迁移必须由用户明确触发。启动阶段只建表，不扫描或重写真实用户凭据。
@@ -566,6 +646,80 @@ mod tests {
             .expect("count");
         // init_db 记录版本 1,2,3,5,6；version 4 由 migrate_session_passwords_v2 单独记录
         assert_eq!(count, 5);
+        drop(conn);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// normalize_user_sessions_nulls（#659 必测）：历史空壳 NULL 自愈、幂等、
+    /// 绝不覆盖非空值、不删除行。
+    #[test]
+    fn normalize_user_sessions_nulls_repairs_and_is_idempotent() {
+        let path = temp_db_path("normalize");
+        let _ = std::fs::remove_file(&path);
+        init_db(&path).expect("init");
+        {
+            let conn = open_connection(&path).expect("open");
+            // 等价 v1.4.4 空壳：只写 student_id + last_login，其余契约列 NULL
+            conn.execute(
+                "INSERT INTO user_sessions (student_id, last_login)
+                 VALUES ('hist-001', CURRENT_TIMESTAMP)",
+                [],
+            )
+            .expect("seed shell");
+            // 部分 NULL 行（one_code_token / refresh / expires 为 NULL）
+            conn.execute(
+                "INSERT INTO user_sessions (student_id, cookies, encrypted_password, one_code_token)
+                 VALUES ('hist-002', 'c=1', '', NULL)",
+                [],
+            )
+            .expect("seed partial");
+            // 全非空行：不得被触碰、不得计入扫描
+            conn.execute(
+                "INSERT INTO user_sessions (student_id, cookies, encrypted_password, one_code_token, electricity_refresh_token, electricity_token_expires_at)
+                 VALUES ('hist-003', 'c=full', 'b64', 'tok', 'ref', '2099-01-01T00:00:00Z')",
+                [],
+            )
+            .expect("seed full");
+        }
+        let conn = open_connection(&path).expect("open");
+        let first = normalize_user_sessions_nulls(&conn).expect("normalize");
+        // hist-001: 5 个契约列 NULL；hist-002: 3 个 → scanned=2, repaired=8
+        assert_eq!(first.scanned, 2, "scanned={}", first.scanned);
+        assert_eq!(first.repaired, 8, "repaired={}", first.repaired);
+
+        // 全部契约列已非空
+        let bad: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM user_sessions WHERE cookies IS NULL
+                 OR encrypted_password IS NULL OR one_code_token IS NULL
+                 OR electricity_refresh_token IS NULL OR electricity_token_expires_at IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .expect("bad count");
+        assert_eq!(bad, 0);
+        // 非空值未被覆盖，行未删除
+        let full: (String, String) = conn
+            .query_row(
+                "SELECT cookies, encrypted_password FROM user_sessions WHERE student_id='hist-003'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("full row");
+        assert_eq!(full, ("c=full".to_string(), "b64".to_string()));
+        let (shell_cookies, shell_enc): (String, String) = conn
+            .query_row(
+                "SELECT cookies, encrypted_password FROM user_sessions WHERE student_id='hist-001'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("shell row");
+        assert_eq!((shell_cookies, shell_enc), (String::new(), String::new()));
+
+        // 幂等：第二次零扫描零修复
+        let second = normalize_user_sessions_nulls(&conn).expect("normalize 2");
+        assert_eq!(second.scanned, 0);
+        assert_eq!(second.repaired, 0);
         drop(conn);
         let _ = std::fs::remove_file(&path);
     }

--- a/apps/client/src-tauri/src/infrastructure/db/repositories/session.rs
+++ b/apps/client/src-tauri/src/infrastructure/db/repositories/session.rs
@@ -32,6 +32,41 @@ pub struct LatestUserSessionData {
     pub token_expires_at: String,
 }
 
+/// user_sessions 业务列统一 NULL 契约（#659 根因 1）。
+///
+/// cookies / encrypted_password / one_code_token / electricity_refresh_token /
+/// electricity_token_expires_at 一律按 `Option<String>` 读取：库中 NULL
+/// （v1.4.4 空壳行等历史形态）→ 空串，业务层对外类型不变（仍为 String），
+/// 绝不抛出 rusqlite `InvalidColumnType`。
+#[derive(Debug, Clone, Default)]
+struct UserSessionRow {
+    cookies: String,
+    encrypted_password: String,
+    one_code_token: String,
+    electricity_refresh_token: String,
+    electricity_token_expires_at: String,
+}
+
+fn text_or_empty(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<String> {
+    Ok(row.get::<_, Option<String>>(index)?.unwrap_or_default())
+}
+
+/// 收敛所有 user_sessions reader 的列映射（单点实现，禁止零散补丁）。
+/// `offset` 为业务列在 SELECT 中的起始索引：`get_user_session` 为 0，
+/// `get_latest_user_session` 在 student_id 之后为 1。
+fn map_user_session_row(
+    row: &rusqlite::Row<'_>,
+    offset: usize,
+) -> rusqlite::Result<UserSessionRow> {
+    Ok(UserSessionRow {
+        cookies: text_or_empty(row, offset)?,
+        encrypted_password: text_or_empty(row, offset + 1)?,
+        one_code_token: text_or_empty(row, offset + 2)?,
+        electricity_refresh_token: text_or_empty(row, offset + 3)?,
+        electricity_token_expires_at: text_or_empty(row, offset + 4)?,
+    })
+}
+
 // 保存用户会话；密码只写系统密钥环，失败时不再以 Base64 或明文落库。
 // 空 password/token 表示“本次没有新值”，UPSERT 会保留既有非空字段；这是记住密码与
 // 离线恢复的有意语义。真正删除凭据必须走 delete_remembered_credential/隐私清理流程。
@@ -116,24 +151,23 @@ pub fn get_user_session<P: AsRef<Path>>(
     let mut rows = stmt.query(params![student_id])?;
 
     if let Some(row) = rows.next()? {
-        let cookies: String = row.get(0)?;
-        let encrypted: String = row.get(1)?;
-        let token: String = row.get(2).unwrap_or_default();
-        let refresh_token: String = row.get(3).unwrap_or_default();
-        let token_expires_at: String = row.get(4).unwrap_or_default();
-
-        let password = resolve_session_password(student_id, &encrypted);
+        let row = map_user_session_row(row, 0)?;
+        let password = resolve_session_password(student_id, &row.encrypted_password);
 
         Ok(Some(UserSessionData {
-            cookies: reveal_session_secret(student_id, &cookies, "cookies"),
+            cookies: reveal_session_secret(student_id, &row.cookies, "cookies"),
             password,
-            one_code_token: reveal_session_secret(student_id, &token, "one_code_token"),
+            one_code_token: reveal_session_secret(
+                student_id,
+                &row.one_code_token,
+                "one_code_token",
+            ),
             refresh_token: reveal_session_secret(
                 student_id,
-                &refresh_token,
+                &row.electricity_refresh_token,
                 "electricity_refresh_token",
             ),
-            token_expires_at,
+            token_expires_at: row.electricity_token_expires_at,
         }))
     } else {
         Ok(None)
@@ -153,25 +187,24 @@ pub fn get_latest_user_session<P: AsRef<Path>>(path: P) -> Result<Option<LatestU
 
     if let Some(row) = rows.next()? {
         let student_id: String = row.get(0)?;
-        let cookies: String = row.get(1)?;
-        let encrypted: String = row.get(2)?;
-        let token: String = row.get(3).unwrap_or_default();
-        let refresh_token: String = row.get(4).unwrap_or_default();
-        let token_expires_at: String = row.get(5).unwrap_or_default();
-
-        let password = resolve_session_password(&student_id, &encrypted);
+        let row = map_user_session_row(row, 1)?;
+        let password = resolve_session_password(&student_id, &row.encrypted_password);
 
         Ok(Some(LatestUserSessionData {
-            cookies: reveal_session_secret(&student_id, &cookies, "cookies"),
+            cookies: reveal_session_secret(&student_id, &row.cookies, "cookies"),
             password,
-            one_code_token: reveal_session_secret(&student_id, &token, "one_code_token"),
+            one_code_token: reveal_session_secret(
+                &student_id,
+                &row.one_code_token,
+                "one_code_token",
+            ),
             refresh_token: reveal_session_secret(
                 &student_id,
-                &refresh_token,
+                &row.electricity_refresh_token,
                 "electricity_refresh_token",
             ),
             student_id,
-            token_expires_at,
+            token_expires_at: row.electricity_token_expires_at,
         }))
     } else {
         Ok(None)
@@ -194,9 +227,11 @@ pub fn save_electricity_tokens<P: AsRef<Path>>(
         protect_session_secret(student_id, refresh_token, "electricity_refresh_token");
     // UPSERT 原子更新（#550）：单条语句同时处理"行不存在则插入"与"行存在则更新"，
     // 避免 INSERT OR IGNORE + UPDATE 两步间的并发竞态；空值保留库中已有非空字段。
+    // 新行 INSERT 分支补齐契约非空列默认（cookies/encrypted_password = ''），
+    // 保证历史/新行任何 reader 均可读（#659）。ON CONFLICT 更新不触碰这些列的已有值。
     conn.execute(
-        "INSERT INTO user_sessions (student_id, one_code_token, electricity_refresh_token, electricity_token_expires_at, electricity_token_updated_at, last_login)
-         VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        "INSERT INTO user_sessions (student_id, cookies, encrypted_password, one_code_token, electricity_refresh_token, electricity_token_expires_at, electricity_token_updated_at, last_login)
+         VALUES (?1, '', '', ?2, ?3, ?4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
          ON CONFLICT(student_id) DO UPDATE SET
              one_code_token = CASE WHEN excluded.one_code_token <> '' THEN excluded.one_code_token ELSE user_sessions.one_code_token END,
              electricity_refresh_token = CASE WHEN excluded.electricity_refresh_token <> '' THEN excluded.electricity_refresh_token ELSE user_sessions.electricity_refresh_token END,
@@ -227,9 +262,11 @@ pub fn update_user_session_cookies_only<P: AsRef<Path>>(
     ensure_user_session_columns(&conn)?;
     let protected_cookies = protect_session_secret(sid, cookies, "cookies");
     // 单条 UPSERT 原子完成：加密失败产生空值时保留既有 cookie，不回退明文。
+    // 新行 INSERT 分支补齐契约非空列默认（encrypted_password/one_code_token 等 = ''），
+    // 保证任何 reader 可读（#659）。ON CONFLICT 更新只动 cookies/last_login。
     conn.execute(
-        "INSERT INTO user_sessions (student_id, cookies, last_login)
-         VALUES (?1, ?2, CURRENT_TIMESTAMP)
+        "INSERT INTO user_sessions (student_id, cookies, encrypted_password, one_code_token, electricity_refresh_token, electricity_token_expires_at, last_login)
+         VALUES (?1, ?2, '', '', '', '', CURRENT_TIMESTAMP)
          ON CONFLICT(student_id) DO UPDATE SET
            cookies = CASE WHEN excluded.cookies <> '' THEN excluded.cookies ELSE user_sessions.cookies END,
            last_login = CURRENT_TIMESTAMP",
@@ -491,6 +528,93 @@ mod tests {
         assert_eq!(session.one_code_token, "tok-abc");
         assert_eq!(session.refresh_token, "ref-xyz");
         assert!(session.cookies.contains("Code:"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// v1.4.4 历史空壳形态（INSERT 只写 student_id + last_login，其余业务列 NULL）：
+    /// init_db 幂等重跑触发 normalize 自愈后，任何 reader 可读、不抛
+    /// InvalidColumnType；无凭据语义正确（password/cookies 空串 → 上层需手动登录）。
+    #[test]
+    fn v144_null_shell_row_readable_after_init_db() {
+        let path = temp_db_path("v144_shell");
+        let _ = std::fs::remove_file(&path);
+        init_db(&path).expect("init");
+        let sid = "hist-v144-0001";
+        {
+            let conn = open_connection(&path).unwrap();
+            conn.execute(
+                "INSERT INTO user_sessions (student_id, last_login) VALUES (?1, CURRENT_TIMESTAMP)",
+                params![sid],
+            )
+            .unwrap();
+        }
+
+        // 迁移（init_db 启动路径）不报错，且自愈 NULL
+        init_db(&path).expect("re-init heal");
+
+        let session = get_user_session(&path, sid).expect("get").expect("session");
+        assert_eq!(session.cookies, "");
+        assert_eq!(session.password, "");
+        assert_eq!(session.one_code_token, "");
+        assert_eq!(session.refresh_token, "");
+        assert_eq!(session.token_expires_at, "");
+
+        let latest = get_latest_user_session(&path)
+            .expect("get latest")
+            .expect("latest");
+        assert_eq!(latest.student_id, sid);
+        assert_eq!(latest.cookies, "");
+        assert_eq!(latest.password, "");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// cookies-only UPSERT 在空库写新行：补齐契约列默认，各 reader 可读（#659 必测 3）。
+    #[test]
+    fn cookies_only_upsert_creates_readable_new_row() {
+        let path = temp_db_path("cookies_new");
+        let _ = std::fs::remove_file(&path);
+        init_db(&path).expect("init");
+        let sid = "fresh-cookies-0001";
+        update_user_session_cookies_only(&path, sid, "Code: a=1 | Auth: b=2").expect("upsert");
+
+        let session = get_user_session(&path, sid).expect("get").expect("session");
+        assert!(session.cookies.contains("Code: a=1"));
+        assert_eq!(session.password, "");
+        assert_eq!(session.one_code_token, "");
+
+        let latest = get_latest_user_session(&path)
+            .expect("latest")
+            .expect("row");
+        assert_eq!(latest.student_id, sid);
+        assert!(latest.cookies.contains("Code: a=1"));
+        assert_eq!(latest.password, "");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// electricity-only UPSERT 在空库写新行：补齐契约列默认，各 reader 可读（#659 必测 5）。
+    #[test]
+    fn electricity_tokens_upsert_creates_readable_new_row() {
+        let path = temp_db_path("electricity_new");
+        let _ = std::fs::remove_file(&path);
+        init_db(&path).expect("init");
+        let sid = "fresh-elec-0001";
+        let access = test_value("access");
+        let refresh = test_value("refresh");
+        save_electricity_tokens(&path, sid, &access, &refresh, "2099-01-01T00:00:00Z")
+            .expect("upsert");
+
+        let session = get_user_session(&path, sid).expect("get").expect("session");
+        assert_eq!(session.one_code_token, access);
+        assert_eq!(session.refresh_token, refresh);
+        assert_eq!(session.cookies, "");
+        assert_eq!(session.password, "");
+
+        let latest = get_latest_user_session(&path)
+            .expect("latest")
+            .expect("row");
+        assert_eq!(latest.student_id, sid);
+        assert_eq!(latest.one_code_token, access);
+        assert_eq!(latest.cookies, "");
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/apps/client/src/app/coordinators/SessionCoordinator.ts
+++ b/apps/client/src/app/coordinators/SessionCoordinator.ts
@@ -35,6 +35,7 @@ import { setCachedData } from '../../utils/api.js'
 import { startNotificationMonitor } from '../../utils/notify_center.js'
 import { resetCloudSyncCooldownForSession, runAutoCloudSyncAfterLogin } from '../../utils/cloud_sync.js'
 import { invokeNative, isTauriRuntime } from '../../platform/native'
+import { runExclusiveLogin, isLoginInFlight } from './sessionGate'
 
 export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinator => {
   const { state } = runtime
@@ -114,6 +115,7 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
     localStorage.removeItem('hbu_manual_logout')
     localStorage.removeItem(LOGOUT_REASON_KEY)
     seedTestAccountCaches(setCachedData, sid)
+    state.onlineSessionState.value = 'online'
     clearJwxtMaintenance()
     stopJwxtRecoveryPolling()
     return true
@@ -133,6 +135,8 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
     }
 
     state.studentId.value = cachedSid
+    // #659：仅恢复了本地缓存身份，在线会话尚未建立（与 isLoggedIn 解耦）
+    state.onlineSessionState.value = 'cached_offline'
     // 异步通知 Rust 侧，不阻塞首屏
     if (hasTauri) {
       invoke('set_offline_user_context', {
@@ -260,10 +264,13 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
       const chaoxingCreds = await getStoredChaoxingPassword()
       if (!chaoxingCreds) return false
       try {
-        const payload = await invoke('chaoxing_password_login', {
-          account: chaoxingCreds.account,
-          password: chaoxingCreds.password
-        })
+        // #659：自动重登与手动登录互斥单飞 —— 已有登录在飞时复用同一请求
+        const payload = await runExclusiveLogin(() =>
+          invoke('chaoxing_password_login', {
+            account: chaoxingCreds.account,
+            password: chaoxingCreds.password
+          })
+        )
         const sid = await resolveAutoLoginStudentId(payload as Record<string, unknown>)
         if (sid) {
           state.studentId.value = sid
@@ -290,9 +297,11 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
     // 直接调用后端 auto_relogin_from_stored 走完整 CAS 登录，立即恢复而非等轮询。
     if (creds.backendRestorable) {
       try {
-        const userInfo = await invoke('auto_relogin_from_stored', {
-          studentId: creds.username
-        })
+        const userInfo = await runExclusiveLogin(() =>
+          invoke('auto_relogin_from_stored', {
+            studentId: creds.username
+          })
+        )
         await persistSessionCookies()
         const sid = String(
           userInfo?.student_id || userInfo?.studentId || creds.username || ''
@@ -309,21 +318,25 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
       }
     }
 
-    const doLogin = async () => {
-      const userInfo = await invoke('login', {
-        username: creds.username,
-        password: creds.password,
-        captcha: '',
-        lt: '',
-        execution: ''
+    const doLogin = () =>
+      // #659：invoke('login') 走全局单飞门 —— 与手动登录互斥复用，
+      // 绝不在已有登录请求在飞时再次触发
+      runExclusiveLogin(async () => {
+        const userInfo = await invoke('login', {
+          username: creds.username,
+          password: creds.password,
+          captcha: '',
+          lt: '',
+          execution: ''
+        })
+        await persistSessionCookies()
+        const sid = String(userInfo?.student_id || creds.username || '').trim()
+        if (sid) {
+          state.studentId.value = sid
+          saveRememberedUsername(sid)
+        }
+        return userInfo
       })
-      await persistSessionCookies()
-      const sid = String(userInfo?.student_id || creds.username || '').trim()
-      if (sid) {
-        state.studentId.value = sid
-        saveRememberedUsername(sid)
-      }
-    }
 
     try {
       await doLogin()
@@ -510,8 +523,13 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
   const attemptOnlineRecovery = async (options: { silent?: boolean } = {}) => {
     if (isTestAccountSession()) return restoreTestAccountSession()
     if (!hasTauri || isManualLogout()) return false
+    // #659：手动/自动登录已在飞时，恢复链让路（下轮轮询再试），
+    // 避免「后台恢复」与「正在进行的登录」并发双请求
+    if (isLoginInFlight()) return false
     if (state.mutable.jwxtRecoveryInFlight) return false
     state.mutable.jwxtRecoveryInFlight = true
+    // 在线会话状态：进入恢复即明确「正在后台恢复」（轮询 silent 也如实记录）
+    state.onlineSessionState.value = 'recovering'
     if (!options.silent) {
       state.jwxtRecoveryPhase.value = 'recovering'
     }
@@ -617,6 +635,15 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
     if (!state.studentId.value && !options.force) return
     const detail = String(options.detail || state.jwxtSessionLastError.value || '').trim()
     const phase = normalizeRecoveryPhase(options.phase, detail ? 'failed' : 'maintenance')
+    // #659：维护/恢复相位与在线会话状态联动
+    if (phase === 'recovering') {
+      state.onlineSessionState.value = 'recovering'
+    } else if (phase === 'need_login') {
+      state.onlineSessionState.value = 'needs_login'
+    } else if (phase === 'failed') {
+      // 在线会话明确未恢复：只要本地身份仍在，就如实标记「缓存离线」
+      state.onlineSessionState.value = state.studentId.value ? 'cached_offline' : 'unknown'
+    }
     state.jwxtMaintenanceMode.value = true
     state.jwxtLastCheckTime.value = formatCheckTime()
     state.jwxtMaintenanceHint.value = hint || '教务系统正在维护或暂时不可用，当前为缓存数据。'
@@ -639,6 +666,14 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
   }
 
   const clearJwxtMaintenance = () => {
+    // #659：维护解除时校正在线会话状态 ——
+    // 本地身份存在且已脱离 unknown（曾恢复过缓存/曾在线）→ 视为在线会话建立；
+    // 身份已清空（登出）→ 回到 unknown
+    if (state.studentId.value && state.onlineSessionState.value !== 'unknown') {
+      state.onlineSessionState.value = 'online'
+    } else if (!state.studentId.value) {
+      state.onlineSessionState.value = 'unknown'
+    }
     state.jwxtMaintenanceMode.value = false
     state.jwxtMaintenanceHint.value = ''
     state.jwxtLastCheckTime.value = ''
@@ -658,6 +693,8 @@ export const createSessionCoordinator = (runtime: AppRuntime): SessionCoordinato
 
   const notifySessionOnline = (source = 'recovery') => {
     if (!state.studentId.value) return
+    // #659：会话在线信号是「在线会话已建立」的权威状态源
+    state.onlineSessionState.value = 'online'
     clearJwxtMaintenance()
     window.dispatchEvent(new CustomEvent('hbu-session-online', {
       detail: {

--- a/apps/client/src/app/coordinators/sessionGate.spec.ts
+++ b/apps/client/src/app/coordinators/sessionGate.spec.ts
@@ -1,0 +1,297 @@
+// src/app/coordinators/sessionGate.spec.ts
+//
+// GitHub #659（根因 6/7）全局登录单飞测试：
+//   - Gate 单飞核心：并发调用只有一个真实 fn 执行、复用同一 promise
+//   - manual login（axios adapter 层 invoke('login')）与 65s 后台恢复
+//     （attemptAutoRelogin → invoke('login')）并发时，login 只被调用一次
+//   - attemptOnlineRecovery 在已有登录在飞时让路（不触发 restore/login）
+//   - 失败后 Gate 释放，不长期阻塞后续登录
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import {
+  isLoginInFlight,
+  resetLoginGate,
+  runExclusiveLogin
+} from './sessionGate'
+import { createSessionCoordinator } from './SessionCoordinator'
+import { invokeNative } from '../../platform/native'
+import { loadChaoxingStoredPassword, loadPortalStoredPassword } from '../../composables/useSessionCredentials.js'
+import { handleAuthPost } from '../../utils/axios_adapter/auth'
+import type { OnlineSessionState } from '../../stores/auth'
+
+vi.mock('../../platform/native', () => ({
+  invokeNative: vi.fn(),
+  isTauriRuntime: vi.fn(() => true)
+}))
+
+vi.mock('../../composables/useSessionCredentials.js', () => ({
+  loadPortalStoredPassword: vi.fn(),
+  loadChaoxingStoredPassword: vi.fn()
+}))
+
+vi.mock('../../utils/test_account.js', () => ({
+  TEST_ACCOUNT: { studentId: '2510231106' },
+  isTestAccountSession: vi.fn(() => false),
+  isTestAccountCredentials: vi.fn(() => false)
+}))
+
+vi.mock('../../utils/test_account_fixtures.js', () => ({
+  getTestAccountGrades: vi.fn(() => []),
+  seedTestAccountCaches: vi.fn()
+}))
+
+vi.mock('../../utils/api.js', () => ({
+  setCachedData: vi.fn()
+}))
+
+vi.mock('../../utils/notify_center.js', () => ({
+  startNotificationMonitor: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('../../utils/cloud_sync.js', () => ({
+  resetCloudSyncCooldownForSession: vi.fn(),
+  runAutoCloudSyncAfterLogin: vi.fn(() => Promise.resolve())
+}))
+
+// ─── 测试基建 ───────────────────────────────────────────────────────────────
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear()
+}
+
+const makeState = () => ({
+  studentId: ref(''),
+  userUuid: ref(''),
+  gradeData: ref<unknown[]>([]),
+  gradeTeacherCache: ref(null),
+  gradeTeacherCacheSid: ref(''),
+  jwxtMaintenanceMode: ref(false),
+  jwxtMaintenanceHint: ref(''),
+  jwxtMaintenanceDetail: ref(''),
+  jwxtRecoveryPhase: ref('idle'),
+  jwxtLastCheckTime: ref(''),
+  jwxtSessionLastError: ref(''),
+  onlineSessionState: ref<OnlineSessionState>('unknown'),
+  mutable: {
+    sessionKeepAliveTimer: null as number | null,
+    electricityKeepAliveTimer: null as number | null,
+    jwxtRecoveryTimer: null as number | null,
+    jwxtRecoveryInFlight: false
+  }
+})
+
+const makeCoordinator = () => {
+  const state = makeState()
+  const runtime = {
+    state,
+    auth: { handleLogout: vi.fn() },
+    navigation: {}
+  } as unknown as Parameters<typeof createSessionCoordinator>[0]
+  const coordinator = createSessionCoordinator(runtime)
+  return { state, runtime, coordinator }
+}
+
+/** 初始化「后台自动重登」前置条件：门户记住密码 + 非学习通登录方式 */
+const seedAutoReloginPreconditions = () => {
+  storageMap.set('hbu_login_method', 'portal_password')
+  storageMap.set('hbu_login_temporary', '0')
+  vi.mocked(loadPortalStoredPassword).mockResolvedValue({
+    username: '2023000001',
+    password: 'pw-secret',
+    backendRestorable: false
+  })
+  vi.mocked(loadChaoxingStoredPassword).mockResolvedValue(null)
+}
+
+const flushAsync = async (times = 10) => {
+  for (let i = 0; i < times; i += 1) await Promise.resolve()
+}
+
+beforeEach(() => {
+  storageMap.clear()
+  resetLoginGate()
+  vi.clearAllMocks()
+  vi.stubGlobal('localStorage', stubStorage)
+  // SessionCoordinator 内部定时器 / notifySessionOnline 等依赖 window
+  vi.stubGlobal('window', {
+    dispatchEvent: vi.fn(),
+    setTimeout: vi.fn(() => 1),
+    clearTimeout: vi.fn(),
+    setInterval: vi.fn(() => 1),
+    clearInterval: vi.fn()
+  })
+  vi.mocked(invokeNative).mockImplementation(async (command: string) => {
+    if (command === 'get_cookies') return 'session_cookie=1'
+    if (command === 'set_offline_user_context') return null
+    if (command === 'login') return { student_id: '2023000001' }
+    throw new Error(`unexpected native command: ${command}`)
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+// ─── 1. Gate 单飞核心 ───────────────────────────────────────────────────────
+
+describe('sessionGate 单飞核心', () => {
+  it('并发 runExclusiveLogin：fn 只执行一次，调用方复用同一 promise', async () => {
+    const fn = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 5))
+      return 'login-result'
+    })
+    const p1 = runExclusiveLogin(fn)
+    const p2 = runExclusiveLogin(fn)
+    const p3 = runExclusiveLogin(fn)
+    expect(isLoginInFlight()).toBe(true)
+    const results = await Promise.all([p1, p2, p3])
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(results).toEqual(['login-result', 'login-result', 'login-result'])
+    expect(isLoginInFlight()).toBe(false)
+  })
+
+  it('失败同样释放门：reject 后新调用可再次执行 fn', async () => {
+    const failing = vi.fn(async () => {
+      throw new Error('登录被拒绝')
+    })
+    const p1 = runExclusiveLogin(failing)
+    await expect(p1).rejects.toThrow('登录被拒绝')
+    expect(isLoginInFlight()).toBe(false)
+    const ok = vi.fn(async () => 'second')
+    await expect(runExclusiveLogin(ok)).resolves.toBe('second')
+    expect(ok).toHaveBeenCalledTimes(1)
+  })
+
+  it('isLoginInFlight 覆盖整个请求生命周期（并发期间为 true）', async () => {
+    // resolve 存于对象属性：TS 对「闭包内赋值 + 闭包外调用」的 let 变量
+    // 会错误收窄为 never，属性访问不受控制流分析影响
+    const holder: { resolve: ((v: string) => void) | null } = { resolve: null }
+    const fn = vi.fn(() => new Promise<string>((r) => { holder.resolve = r }))
+    const p = runExclusiveLogin(fn)
+    await flushAsync()
+    expect(isLoginInFlight()).toBe(true)
+    holder.resolve?.('done')
+    await expect(p).resolves.toBe('done')
+    expect(isLoginInFlight()).toBe(false)
+  })
+})
+
+// ─── 2. manual login vs 65s 后台恢复竞争 ────────────────────────────────────
+
+describe('#659 manual login 与后台恢复竞争', () => {
+  /** 让 invoke('login') 挂起，由测试显式放行（保证 in-flight 窗口可控） */
+  const installDeferredLogin = () => {
+    let resolveLogin: ((value: unknown) => void) | null = null
+    vi.mocked(invokeNative).mockImplementation(async (command: string) => {
+      if (command === 'login') {
+        return new Promise((r) => { resolveLogin = r })
+      }
+      if (command === 'get_cookies') return 'session_cookie=1'
+      if (command === 'set_offline_user_context') return null
+      throw new Error(`unexpected native command: ${command}`)
+    })
+    const release = (value: unknown = { student_id: '2023000001' }) => resolveLogin?.(value)
+    return { release }
+  }
+
+  it('并发触发时 login 只被调用一次（后台恢复复用手动登录结果）', async () => {
+    seedAutoReloginPreconditions()
+    const { coordinator, state } = makeCoordinator()
+    state.studentId.value = '2023000001'
+    const { release } = installDeferredLogin()
+
+    // 手动登录（模拟 LoginV3 → axios adapter → invoke('login')）先进入门
+    const manualPromise = handleAuthPost('/v2/start_login', {
+      username: '2023000001',
+      password: 'user-typed-password',
+      captcha: '',
+      lt: '',
+      execution: ''
+    })
+    await flushAsync()
+    expect(isLoginInFlight()).toBe(true)
+    // 65s 轮询触发的后台自动重登在登录尚未结束时并发进入
+    const recoveryPromise = coordinator.attemptAutoRelogin()
+    await flushAsync()
+    release()
+    const [manualResult, recoveryOk] = await Promise.all([manualPromise, recoveryPromise])
+    const loginCalls = vi.mocked(invokeNative).mock.calls.filter(
+      ([command]) => command === 'login'
+    )
+    expect(loginCalls).toHaveLength(1)
+    expect(recoveryOk).toBe(true)
+    expect(manualResult).toMatchObject({ data: { success: true } })
+    expect(state.studentId.value).toBe('2023000001')
+  })
+
+  it('后台恢复先 in-flight：手动登录提交复用后台请求，不追加第二次 login', async () => {
+    seedAutoReloginPreconditions()
+    const { coordinator, state } = makeCoordinator()
+    state.studentId.value = '2023000001'
+    const { release } = installDeferredLogin()
+
+    const recoveryPromise = coordinator.attemptAutoRelogin()
+    await flushAsync()
+    expect(isLoginInFlight()).toBe(true)
+    const manualPromise = handleAuthPost('/v2/start_login', {
+      username: '2023000001',
+      password: 'pw',
+      captcha: '',
+      lt: '',
+      execution: ''
+    })
+    await flushAsync()
+    release()
+    const [recoveryOk, manualResult] = await Promise.all([recoveryPromise, manualPromise])
+    const loginCalls = vi.mocked(invokeNative).mock.calls.filter(
+      ([command]) => command === 'login'
+    )
+    expect(loginCalls).toHaveLength(1)
+    expect(recoveryOk).toBe(true)
+    expect(manualResult).toMatchObject({ data: { success: true } })
+  })
+
+  it('65s 轮询 attemptOnlineRecovery 在登录在飞时让路：不发起 restore/login', async () => {
+    seedAutoReloginPreconditions()
+    const { coordinator, state } = makeCoordinator()
+    state.studentId.value = '2023000001'
+    storageMap.set('hbu_session_cookies', 'cookie=1')
+    const { release } = installDeferredLogin()
+
+    const manualPromise = handleAuthPost('/v2/start_login', {
+      username: '2023000001',
+      password: 'pw',
+      captcha: '',
+      lt: '',
+      execution: ''
+    })
+    await flushAsync()
+    expect(isLoginInFlight()).toBe(true)
+    // 轮询恢复在手动登录尚未结束时进入：应让路（下轮再试）
+    const recoveryPromise = coordinator.attemptOnlineRecovery({ silent: true })
+    await flushAsync()
+    release()
+    const [recoveryOk, manualResult] = await Promise.all([recoveryPromise, manualPromise])
+
+    const loginCalls = vi.mocked(invokeNative).mock.calls.filter(
+      ([command]) => command === 'login'
+    )
+    const restoreCalls = vi.mocked(invokeNative).mock.calls.filter(
+      ([command]) => command === 'restore_session' || command === 'restore_latest_session'
+    )
+    expect(loginCalls).toHaveLength(1)
+    expect(restoreCalls).toHaveLength(0)
+    expect(recoveryOk).toBe(false)
+    expect(manualResult).toMatchObject({ data: { success: true } })
+  })
+})

--- a/apps/client/src/app/coordinators/sessionGate.ts
+++ b/apps/client/src/app/coordinators/sessionGate.ts
@@ -1,0 +1,47 @@
+/**
+ * 全局登录单飞（Singleflight）协调点（GitHub #659 根因 6/7）
+ *
+ * manual login（LoginV3）、boot 自动重登（useAppRuntime restoreTask）、
+ * 65s 轮询恢复（attemptOnlineRecovery → attemptAutoRelogin）、
+ * keep-alive/refresh 触发的重登共用此门：
+ *
+ *  - 同一时刻只允许一个真实 login 请求在飞（invoke('login') /
+ *    auto_relogin_from_stored / chaoxing_password_login /
+ *    portal_qr_confirm_login / chaoxing_qr_confirm_login）；
+ *  - 已有 in-flight 时，新的调用方直接复用同一个 promise（await 同一登录），
+ *    而不是再触发一次 login —— 从根上消除「手动登录 vs 后台自动恢复」
+ *    并发双 login 导致的“登录频率过高”与互踩。
+ *
+ * 模块级单例：与组件/API 层解耦，任何来源（UI / 轮询 / 恢复链）都能接入。
+ */
+let inFlightPromise: Promise<unknown> | null = null
+
+/** 当前是否已有登录请求在飞（供 UI 展示 / 恢复链让路判断） */
+export const isLoginInFlight = (): boolean => inFlightPromise !== null
+
+/**
+ * 在单飞门内执行一次登录动作：
+ *  - 无 in-flight：执行 fn 并持有其 promise，完成后释放（不论成败）；
+ *  - 已有 in-flight：不执行 fn，直接返回同一个 promise（复用对方结果）。
+ */
+export const runExclusiveLogin = <T>(fn: () => Promise<T>): Promise<T> => {
+  const existing = inFlightPromise
+  if (existing) return existing as Promise<T>
+
+  let task!: Promise<T>
+  task = (async () => {
+    try {
+      return await fn()
+    } finally {
+      // 仅当自己仍是 in-flight 持有者时才释放，防止清掉更晚接管的调用
+      if (inFlightPromise === task) inFlightPromise = null
+    }
+  })()
+  inFlightPromise = task
+  return task
+}
+
+/** 测试辅助：清空门内状态（生产代码不要调用） */
+export const resetLoginGate = (): void => {
+  inFlightPromise = null
+}

--- a/apps/client/src/app/coordinators/sessionOnlineState.spec.ts
+++ b/apps/client/src/app/coordinators/sessionOnlineState.spec.ts
@@ -1,0 +1,280 @@
+// src/app/coordinators/sessionOnlineState.spec.ts
+//
+// GitHub #659：onlineSessionState 状态流转测试
+//   - restoreCachedIdentityFromLocal → cached_offline（isLoggedIn 仍为 true）
+//   - 恢复开始 → recovering（attemptOnlineRecovery）
+//   - 恢复成功 → online（notifySessionOnline / 恢复成功路径）
+//   - 恢复失败 → cached_offline（相位 failed 联动）
+//   - 明确需重登 → needs_login（无可用凭据）
+//   - 离线缓存回归：在线失效但本地缓存存在时缓存身份可展示、
+//     手动登录可接管、不清成绩缓存
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { resetLoginGate } from './sessionGate'
+import { createSessionCoordinator } from './SessionCoordinator'
+import { invokeNative } from '../../platform/native'
+import { loadChaoxingStoredPassword, loadPortalStoredPassword } from '../../composables/useSessionCredentials.js'
+import type { OnlineSessionState } from '../../stores/auth'
+
+vi.mock('../../platform/native', () => ({
+  invokeNative: vi.fn(),
+  isTauriRuntime: vi.fn(() => true)
+}))
+
+vi.mock('../../composables/useSessionCredentials.js', () => ({
+  loadPortalStoredPassword: vi.fn(),
+  loadChaoxingStoredPassword: vi.fn()
+}))
+
+vi.mock('../../utils/test_account.js', () => ({
+  TEST_ACCOUNT: { studentId: '2510231106' },
+  isTestAccountSession: vi.fn(() => false),
+  isTestAccountCredentials: vi.fn(() => false)
+}))
+
+vi.mock('../../utils/test_account_fixtures.js', () => ({
+  getTestAccountGrades: vi.fn(() => []),
+  seedTestAccountCaches: vi.fn()
+}))
+
+vi.mock('../../utils/api.js', () => ({
+  setCachedData: vi.fn()
+}))
+
+vi.mock('../../utils/notify_center.js', () => ({
+  startNotificationMonitor: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('../../utils/cloud_sync.js', () => ({
+  resetCloudSyncCooldownForSession: vi.fn(),
+  runAutoCloudSyncAfterLogin: vi.fn(() => Promise.resolve())
+}))
+
+// ─── 测试基建 ───────────────────────────────────────────────────────────────
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear()
+}
+let gradeCacheCleared = false
+
+const makeState = () => ({
+  studentId: ref(''),
+  userUuid: ref(''),
+  gradeData: ref<unknown[]>([]),
+  gradeTeacherCache: ref(null),
+  gradeTeacherCacheSid: ref(''),
+  jwxtMaintenanceMode: ref(false),
+  jwxtMaintenanceHint: ref(''),
+  jwxtMaintenanceDetail: ref(''),
+  jwxtRecoveryPhase: ref('idle'),
+  jwxtLastCheckTime: ref(''),
+  jwxtSessionLastError: ref(''),
+  onlineSessionState: ref<OnlineSessionState>('unknown'),
+  mutable: {
+    sessionKeepAliveTimer: null as number | null,
+    electricityKeepAliveTimer: null as number | null,
+    jwxtRecoveryTimer: null as number | null,
+    jwxtRecoveryInFlight: false
+  }
+})
+
+const makeCoordinator = () => {
+  const state = makeState()
+  const runtime = {
+    state,
+    auth: { handleLogout: vi.fn() },
+    navigation: {}
+  } as unknown as Parameters<typeof createSessionCoordinator>[0]
+  const coordinator = createSessionCoordinator(runtime)
+  return { state, runtime, coordinator }
+}
+
+const flushAsync = async (times = 10) => {
+  for (let i = 0; i < times; i += 1) await Promise.resolve()
+}
+
+beforeEach(() => {
+  storageMap.clear()
+  gradeCacheCleared = false
+  resetLoginGate()
+  vi.clearAllMocks()
+  vi.stubGlobal('localStorage', stubStorage)
+  vi.stubGlobal('window', {
+    dispatchEvent: vi.fn(),
+    setTimeout: vi.fn(() => 1),
+    clearTimeout: vi.fn(),
+    setInterval: vi.fn(() => 1),
+    clearInterval: vi.fn()
+  })
+  vi.mocked(invokeNative).mockImplementation(async (command: string) => {
+    if (command === 'get_cookies') return 'session_cookie=1'
+    if (command === 'set_offline_user_context') return null
+    if (command === 'restore_session') return { student_id: '2023000001' }
+    if (command === 'login') return { student_id: '2023000001' }
+    throw new Error(`unexpected native command: ${command}`)
+  })
+  // 记录成绩缓存是否被清除（离线回归断言：不得清缓存）
+  const originalRemoveItem = stubStorage.removeItem
+  stubStorage.removeItem = (key: string) => {
+    if (String(key).startsWith('grades:')) gradeCacheCleared = true
+    originalRemoveItem(key)
+  }
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ─── 1. 缓存身份 ≠ 在线会话 ─────────────────────────────────────────────────
+
+describe('#659 缓存身份恢复（cached_offline）', () => {
+  it('恢复本地缓存身份：onlineSessionState=cached_offline，isLoggedIn 语义不变', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+
+    const ok = await coordinator.restoreCachedIdentityFromLocal()
+    expect(ok).toBe(true)
+    expect(state.studentId.value).toBe('2023000001')
+    // isLoggedIn（studentId 非空）行为保持不变
+    expect(state.studentId.value.length > 0).toBe(true)
+    // 但在线会话状态明确为「未恢复」
+    expect(state.onlineSessionState.value).toBe('cached_offline')
+    // 通知 Rust 侧离线上下文
+    expect(vi.mocked(invokeNative)).toHaveBeenCalledWith(
+      'set_offline_user_context',
+      expect.anything()
+    )
+  })
+
+  it('在线失效但本地缓存存在：缓存身份可展示、成绩缓存不被清除', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+    gradeCacheCleared = false
+
+    await coordinator.restoreCachedIdentityFromLocal()
+    // 在线会话恢复失败（cookie 恢复失败）
+    vi.mocked(invokeNative).mockRejectedValueOnce(new Error('会话已失效'))
+    const restored = await coordinator.tryRestoreSession()
+    expect(restored).toBe(false)
+    expect(state.studentId.value).toBe('2023000001')
+    expect(state.onlineSessionState.value).toBe('cached_offline')
+    expect(gradeCacheCleared).toBe(false)
+  })
+})
+
+// ─── 2. 状态流转：cached_offline → recovering → online / cached_offline ─────
+
+describe('#659 状态流转', () => {
+  it('恢复进行中 → recovering；恢复成功 → online；恢复失败 → cached_offline', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+    storageMap.set('hbu_session_cookies', 'cookie=1')
+    await coordinator.restoreCachedIdentityFromLocal()
+    expect(state.onlineSessionState.value).toBe('cached_offline')
+
+    // 恢复开始（可在 silent 轮询中触发）；同步段即进入「正在恢复」
+    const recoveryPromise = coordinator.attemptOnlineRecovery({ silent: true })
+    expect(state.onlineSessionState.value).toBe('recovering')
+    const ok = await recoveryPromise
+    expect(ok).toBe(true)
+    // restore_session 成功 → notifySessionOnline → online
+    expect(state.onlineSessionState.value).toBe('online')
+    expect(state.jwxtRecoveryPhase.value).toBe('idle')
+  })
+
+  it('恢复失败 → 相位 failed → onlineSessionState 回落 cached_offline', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+    await coordinator.restoreCachedIdentityFromLocal()
+
+    vi.mocked(invokeNative).mockImplementation(async (command: string) => {
+      if (command === 'restore_session' || command === 'restore_latest_session') {
+        throw new Error('会话恢复失败: 网络异常')
+      }
+      if (command === 'login') return { student_id: '2023000001' }
+      if (command === 'get_cookies') return 'session_cookie=1'
+      if (command === 'set_offline_user_context') return null
+      throw new Error(`unexpected native command: ${command}`)
+    })
+    vi.mocked(loadPortalStoredPassword).mockResolvedValue(null)
+    vi.mocked(loadChaoxingStoredPassword).mockResolvedValue(null)
+
+    const ok = await coordinator.attemptOnlineRecovery({ silent: false })
+    expect(ok).toBe(false)
+    expect(state.onlineSessionState.value).toBe('cached_offline')
+    expect(state.jwxtRecoveryPhase.value).toBe('failed')
+    // 本地缓存身份仍在（不踢登录页）
+    expect(state.studentId.value).toBe('2023000001')
+  })
+
+  it('无可用凭据且恢复失败 → needs_login', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+    await coordinator.restoreCachedIdentityFromLocal()
+
+    vi.mocked(invokeNative).mockImplementation(async (command: string) => {
+      if (command === 'restore_session' || command === 'restore_latest_session') {
+        throw new Error('会话已过期')
+      }
+      if (command === 'get_cookies') return 'session_cookie=1'
+      if (command === 'set_offline_user_context') return null
+      throw new Error(`unexpected native command: ${command}`)
+    })
+    vi.mocked(loadPortalStoredPassword).mockResolvedValue(null)
+    vi.mocked(loadChaoxingStoredPassword).mockResolvedValue(null)
+
+    await coordinator.handleRetrySessionRecovery()
+    await flushAsync()
+    expect(state.onlineSessionState.value).toBe('needs_login')
+    expect(state.jwxtRecoveryPhase.value).toBe('need_login')
+    // 缓存身份保留、缓存未清
+    expect(state.studentId.value).toBe('2023000001')
+    expect(gradeCacheCleared).toBe(false)
+  })
+
+  it('已登录自动恢复成功路径：notifySessionOnline 显式置 online', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+    storageMap.set('hbu_session_cookies', 'cookie=1')
+    await coordinator.restoreCachedIdentityFromLocal()
+    expect(state.onlineSessionState.value).toBe('cached_offline')
+
+    coordinator.notifySessionOnline('session-restore')
+    expect(state.onlineSessionState.value).toBe('online')
+    expect(state.jwxtMaintenanceMode.value).toBe(false)
+  })
+
+  it('登出后 clearJwxtMaintenance：onlineSessionState 回到 unknown', async () => {
+    const { coordinator, state } = makeCoordinator()
+    storageMap.set('hbu_username', '2023000001')
+    storageMap.set('hbu_login_method', 'portal_password')
+    storageMap.set('hbu_login_temporary', '0')
+    await coordinator.restoreCachedIdentityFromLocal()
+    expect(state.onlineSessionState.value).toBe('cached_offline')
+    // 模拟 AuthCoordinator 登出：清空身份后再清维护态
+    state.studentId.value = ''
+    coordinator.clearJwxtMaintenance()
+    expect(state.onlineSessionState.value).toBe('unknown')
+  })
+})

--- a/apps/client/src/app/state/appState.ts
+++ b/apps/client/src/app/state/appState.ts
@@ -8,6 +8,7 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import type { AppStores } from '../contracts/runtime'
+import type { OnlineSessionState } from '../../stores/auth'
 import {
   HOME_LAYOUT_DEBUG_FORCE_KEY,
   HOME_LAYOUT_DEBUG_HIDDEN_KEY,
@@ -66,6 +67,8 @@ export interface AppState {
   studentId: Ref<string>
   userUuid: Ref<string>
   isLoggedIn: Ref<boolean>
+  // GitHub #659：缓存身份 ≠ 在线会话。unknown/cached_offline/recovering/online/needs_login
+  onlineSessionState: Ref<OnlineSessionState>
   gradeData: Ref<unknown[]>
   gradesOffline: Ref<boolean>
   gradesSyncTime: Ref<string>
@@ -295,6 +298,7 @@ export const createAppState = (stores: AppStores, options: CreateAppStateOptions
     studentId: authRefs.studentId,
     userUuid: authRefs.userUuid,
     isLoggedIn: authRefs.isLoggedIn,
+    onlineSessionState: authRefs.onlineSessionState,
     gradeData: gradeRefs.grades,
     gradesOffline: gradeRefs.offline,
     gradesSyncTime: gradeRefs.syncTime,

--- a/apps/client/src/components/Dashboard.vue
+++ b/apps/client/src/components/Dashboard.vue
@@ -23,6 +23,7 @@ import { getForecastTemperatureBounds, getTemperatureColor, getTemperatureRangeS
 import { isTestAccountSession } from '../utils/test_account.js'
 import { filterAllowedModules, isModuleAllowed } from '../config/app_store_policy'
 import { decideHomeNavigate } from '../utils/moduleAccess'
+import { useAuthStore } from '../stores'
 
 const props = defineProps({
   studentId: { type: String, default: '' },
@@ -49,6 +50,10 @@ const emit = defineEmits([
 
 const maintenanceTitle = computed(() => {
   const phase = String(props.jwxtRecoveryPhase || '')
+  // #659：本地身份已恢复但教务在线会话未恢复（尚未进入恢复轮询）
+  if (onlineSessionState.value === 'cached_offline' && phase === 'idle') {
+    return '本地身份已恢复，教务在线会话未恢复'
+  }
   if (phase === 'recovering') return '正在后台恢复登录'
   if (phase === 'need_login') return '需要重新登录'
   if (phase === 'failed') return '会话恢复未成功'
@@ -57,6 +62,7 @@ const maintenanceTitle = computed(() => {
 
 const maintenancePhaseLabel = computed(() => {
   const phase = String(props.jwxtRecoveryPhase || '')
+  if (onlineSessionState.value === 'cached_offline' && phase === 'idle') return '展示缓存数据'
   if (phase === 'recovering') return '后台自动登录中'
   if (phase === 'need_login') return '请手动登录'
   if (phase === 'failed') return '将定时重试'
@@ -90,8 +96,21 @@ const maintenanceNotices = computed(() => {
  */
 const sessionDetailOpen = ref(false)
 
+/**
+ * 在线会话状态（GitHub #659）：缓存身份 ≠ 在线会话。
+ * 直接读 auth store（App.vue 未透传该 prop，避免改壳层）。
+ */
+const authStore = useAuthStore()
+const onlineSessionState = computed(() => authStore.onlineSessionState || '')
+
 const sessionStatusVisual = computed(() => {
   if (!props.isLoggedIn) return 'red'
+  // #659：优先以「在线会话状态」为准 —— 缓存身份 ≠ 在线会话
+  const online = String(onlineSessionState.value || '')
+  if (online === 'online') return 'green'
+  if (online === 'recovering') return 'blink'
+  if (online === 'cached_offline' || online === 'needs_login') return 'red'
+  // 兼容旧行为（unknown 时回退到维护相位判断）
   const phase = String(props.jwxtRecoveryPhase || 'idle')
   if (phase === 'recovering') return 'blink'
   if (phase === 'failed' || phase === 'need_login' || phase === 'maintenance') {

--- a/apps/client/src/components/LoginV3.vue
+++ b/apps/client/src/components/LoginV3.vue
@@ -29,10 +29,18 @@ import {
   NON_OFFICIAL_DISCLAIMER_ZH
 } from '../config/app_store_policy'
 import { saveRememberedUsername } from '../utils/remembered_username.js'
+import { runExclusiveLogin } from '../app/coordinators/sessionGate'
+import { useAuthStore } from '../stores'
 
 const props = defineProps({
   loginMode: { type: String, default: 'portal' }
 })
+
+const authStore = useAuthStore()
+/** 手动登录成功：在线会话已建立（与后台恢复路径的 notifySessionOnline 对齐） */
+const markLoginOnline = () => {
+  authStore.onlineSessionState = 'online'
+}
 
 const emit = defineEmits(['success', 'switchMode', 'showLegal'])
 
@@ -498,6 +506,7 @@ const handleTestAccountLogin = async () => {
     localStorage.removeItem('hbu_manual_logout')
     localStorage.removeItem(LOGOUT_REASON_KEY)
     seedTestAccountCaches(setCachedData, TEST_ACCOUNT.studentId)
+    markLoginOnline()
     statusMsg.value = '登录成功，已加载演示数据'
     emit('success', getTestAccountGrades())
   } finally {
@@ -557,6 +566,7 @@ const handlePasswordLogin = async () => {
     }
     applyLoginMethodStorage('portal_password')
     localStorage.removeItem(LOGOUT_REASON_KEY)
+    markLoginOnline()
     statusMsg.value = '✅ 登录成功，正在同步数据...'
     await emitSuccessWithGrades(sid || username.value)
   } catch (e) {
@@ -685,10 +695,12 @@ const confirmPortalQrLogin = async ({ allowPending = false } = {}) => {
   clearQrTimer()
 
   try {
-    const userInfo = await invoke('portal_qr_confirm_login', {
-      uuid: qrUuid.value,
-      service: 'https://e.hbut.edu.cn/login#/'
-    })
+    const userInfo = await runExclusiveLogin(() =>
+      invoke('portal_qr_confirm_login', {
+        uuid: qrUuid.value,
+        service: 'https://e.hbut.edu.cn/login#/'
+      })
+    )
     const sid = String(userInfo?.student_id || '').trim()
     if (!sid) {
       throw new Error('扫码成功但未获取到学号')
@@ -699,6 +711,7 @@ const confirmPortalQrLogin = async ({ allowPending = false } = {}) => {
     applyLoginMethodStorage('portal_qr_temp')
     localStorage.removeItem('hbu_manual_logout')
     localStorage.removeItem(LOGOUT_REASON_KEY)
+    markLoginOnline()
 
     qrState.value = 'success'
     qrStateMessage.value = '✅ 扫码登录成功，正在同步数据...'
@@ -729,6 +742,7 @@ const handleChaoxingLoginSuccess = async (payload, modeKey) => {
   applyLoginMethodStorage(modeKey)
   localStorage.removeItem('hbu_manual_logout')
   localStorage.removeItem(LOGOUT_REASON_KEY)
+  markLoginOnline()
   statusMsg.value = '✅ 学习通登录成功，正在进入首页...'
   pushDebugList(payload?.debug)
   emit('success', [])
@@ -751,10 +765,12 @@ const handleChaoxingPasswordLogin = async () => {
   loading.value = true
   statusMsg.value = '🔒 正在登录学习通...'
   try {
-    const payload = await invoke('chaoxing_password_login', {
-      account: chaoxingAccount.value,
-      password: chaoxingPassword.value
-    })
+    const payload = await runExclusiveLogin(() =>
+      invoke('chaoxing_password_login', {
+        account: chaoxingAccount.value,
+        password: chaoxingPassword.value
+      })
+    )
     await handleChaoxingLoginSuccess(payload, 'chaoxing_password')
   } catch (e) {
     statusMsg.value = `⚠️ 学习通登录失败：${friendlyLoginError(e.message || e)}`
@@ -899,11 +915,13 @@ const confirmChaoxingQrLogin = async () => {
   clearCxQrTimer()
 
   try {
-    const payload = await invoke('chaoxing_qr_confirm_login', {
-      uuid: cxQrUuid.value,
-      enc: cxQrEnc.value,
-      account_hint: chaoxingAccount.value || undefined
-    })
+    const payload = await runExclusiveLogin(() =>
+      invoke('chaoxing_qr_confirm_login', {
+        uuid: cxQrUuid.value,
+        enc: cxQrEnc.value,
+        account_hint: chaoxingAccount.value || undefined
+      })
+    )
     cxQrState.value = 'success'
     cxQrStateMessage.value = '✅ 学习通扫码登录成功，正在进入首页...'
     await handleChaoxingLoginSuccess(payload, 'chaoxing_qr_temp')

--- a/apps/client/src/stores/auth.ts
+++ b/apps/client/src/stores/auth.ts
@@ -6,12 +6,34 @@ export interface AuthSessionSnapshot {
   userUuid?: string | null
 }
 
+/**
+ * 在线会话状态（GitHub #659：区分「缓存本地身份」与「教务在线会话恢复」）
+ *
+ * - unknown：初始未知（未尝试恢复 / 已登出）
+ * - cached_offline：仅恢复了本地缓存身份（studentId 非空可展示缓存），
+ *   教务在线会话未恢复
+ * - recovering：后台正在恢复在线会话（自动重登 / cookie 恢复进行中）
+ * - online：在线会话已建立（cookie 桥接 / 自动重登 / 手动登录成功）
+ * - needs_login：明确需要重新登录（无可用凭据，等待用户手动登录）
+ *
+ * isLoggedIn 语义保持不变（studentId 非空即视为「已恢复本地身份」）；
+ * onlineSessionState 仅在 studentId 非空时有意义，用于向 UI 表达
+ * 「在线会话是否已恢复」。
+ */
+export type OnlineSessionState =
+  | 'unknown'
+  | 'cached_offline'
+  | 'recovering'
+  | 'online'
+  | 'needs_login'
+
 export const normalizeIdentifier = (value: unknown): string => String(value ?? '').trim()
 
 export const useAuthStore = defineStore('auth', () => {
   const studentId = ref('')
   const userUuid = ref('')
   const hydrated = ref(false)
+  const onlineSessionState = ref<OnlineSessionState>('unknown')
   const isLoggedIn = computed(() => studentId.value.length > 0)
 
   const hydrate = (snapshot: AuthSessionSnapshot = {}) => {
@@ -31,8 +53,18 @@ export const useAuthStore = defineStore('auth', () => {
   const clearSession = () => {
     studentId.value = ''
     userUuid.value = ''
+    onlineSessionState.value = 'unknown'
     hydrated.value = true
   }
 
-  return { studentId, userUuid, hydrated, isLoggedIn, hydrate, establishSession, clearSession }
+  return {
+    studentId,
+    userUuid,
+    hydrated,
+    onlineSessionState,
+    isLoggedIn,
+    hydrate,
+    establishSession,
+    clearSession
+  }
 })

--- a/apps/client/src/templates/views/Dashboard.html
+++ b/apps/client/src/templates/views/Dashboard.html
@@ -101,9 +101,11 @@
         </div>
 
         <div class="text-xs text-orange-700 mt-2 leading-relaxed">
-          {{ jwxtMaintenanceHint || (sessionStatusVisual === 'blink'
-            ? '正在后台恢复登录会话，请稍候…'
-            : '当前可能无法同步最新教务数据，可查看下方详情或重试。') }}
+          {{ jwxtMaintenanceHint || (onlineSessionState === 'cached_offline' && jwxtRecoveryPhase === 'idle'
+            ? '已恢复本地身份，教务在线会话未恢复，正在后台尝试恢复；成绩与课表缓存可正常查看，无需重新登录。'
+            : (sessionStatusVisual === 'blink'
+              ? '正在后台恢复登录会话，请稍候…'
+              : '当前可能无法同步最新教务数据，可查看下方详情或重试。')) }}
         </div>
 
         <div

--- a/apps/client/src/utils/axios_adapter/auth.ts
+++ b/apps/client/src/utils/axios_adapter/auth.ts
@@ -6,6 +6,7 @@ import {
   mockResponse,
   type JsonObject
 } from './bridge';
+import { runExclusiveLogin } from '../../app/coordinators/sessionGate';
 
 /** 处理登录与验证码端点；非认证端点返回 null。 */
 export const handleAuthPost = async (url: string, data: JsonObject): Promise<unknown | null> => {
@@ -32,13 +33,17 @@ export const handleAuthPost = async (url: string, data: JsonObject): Promise<unk
           error: errorMessage(response.error) || '登录失败'
         });
       }
-      const response = await invoke('login', {
-        username,
-        password,
-        captcha,
-        lt,
-        execution
-      });
+      // #659：手动登录提交走全局单飞门 —— 后台恢复已在登录时复用同一请求，
+      // 反之手动登录进行中时后台恢复也会让路，保证同一时刻只有一个 login
+      const response = await runExclusiveLogin(() =>
+        invoke('login', {
+          username,
+          password,
+          captcha,
+          lt,
+          execution
+        })
+      );
       return mockResponse({ success: true, data: response });
     } catch (error) {
       return mockResponse({ success: false, error: errorMessage(error) });


### PR DESCRIPTION
Closes #659

三个阶段（多 Agent 并行开发，分 3 个 commit），覆盖 issue 根因 1-7 与实现要求 A-G。

## 1. 根因确认（哪条写入路径制造 NULL、哪些入口扩大影响面）
- v1.4.4 的 `save_electricity_tokens()` 部分列 INSERT 可产生仅有 student_id/last_login 的 Session 空壳（cookies/encrypted_password=SQL NULL）；
- 当前 main 的 partial UPSERT（cookies-only / electricity-only 等）在新学号 INSERT 分支同样制造空壳；`get_user_session`/`get_latest_user_session` 对 cookies/encrypted_password 用硬 `?` 映射 → NULL 抛 `InvalidColumnType`；`migrate_session_passwords_v2` 用 `rows.flatten()` 静默吞掉坏行。

## 2. 数据迁移策略及安全性
- 新增幂等启动迁移 `normalize_user_sessions_nulls()`：仅把业务契约非空列（NULL→''）修复；不覆盖已有非空 Keyring marker/base64/envelope（不降级明文）、不删 Session/成绩/课表缓存；返回 scanned/repaired 报告，失败可观测。
- `migrate_session_passwords_v2` 改为分类统计（null_shell_repaired / keyring_marker_valid / base64_migrated / keyring_unavailable / malformed_error），NULL 行自愈，不再 flatten 吞错。

## 3. 长期 nullable 契约
统一 row-mapper：业务字符串字段 `Option<String> → 空串`（`map_user_session_row` + `text_or_empty`），所有 reader 复用；对外返回类型不变（String）。schema 保持可空（兼容老库），靠读取契约 + 启动自愈双保险。

## 4. 新的 login cooldown / transport error 状态机
- `HttpClientErrorKind(Transport/AuthFailed/Other)` + `is_transport_error()`；
- `last_login_attempt` 移到**收到真实 CAS 响应后**才记 60s 冷却（`LOGIN_COOLDOWN`）；
- 传输层/登录页获取/参数解析失败只记 **5s 短 backoff**（`TRANSPORT_BACKOFF`，文案“网络异常，请N秒后再试”），不再无条件锁 60s；
- 真实 CAS 重复提交仍受 60s 风控保护；命令签名与返回结构不变（前端契约稳定）。

## 5. manual login 与 background recovery singleflight
- 新增 `sessionGate.ts`：`runExclusiveLogin<T>()` 全局单飞（in-flight 时 await/reuse 同一 promise，不重复发起）；
- manual login（axios adapter + LoginV3 三条命令）、boot 恢复、65s 轮询 `attemptAutoRelogin`、keep-alive 全部接入；后台恢复在登录进行中直接让路（`isLoginInFlight()`），不再与手动登录互相制造“登录频率过高”。

## 6. v1.4.4 历史 DB fixture 构造与升级测试结果
- fixture：`INSERT INTO user_sessions(student_id, last_login) VALUES(...)`（等价 v1.4.4 空壳，encrypted_password IS NULL）；
- 测试：`v144_null_shell_row_readable_after_init_db`、`cookies_only_upsert_creates_readable_new_row`、`electricity_tokens_upsert_creates_readable_new_row`、`migrate_v2_repairs_null_password_shell_rows`、`normalize_user_sessions_nulls_repairs_and_is_idempotent` 全部通过；`restore_latest_session` 不再因 NULL 在 DB 读取阶段失败，无凭据时正确进入“需手动登录”。

## 7. 完整测试命令、退出码、关键测试
```bash
# Rust（apps/client/src-tauri）
cargo fmt -- --check          # OK (exit 0)
cargo test --lib              # 293 passed, 0 failed（含 Phase B 6 个新测试：transport_failure_uses_short_backoff…/auth_failure_response_locks_60s…/real_reqwest_connect_error_is_classified_as_transport…）
cargo clippy --lib            # 新增文件 0 告警
# 前端（apps/client）
npx vue-tsc --noEmit -p tsconfig.json   # exit 0
npx vitest run                # 159 files / 1095 tests passed（含 sessionGate.spec、sessionOnlineState.spec）
```

## 8. 仍无法自动修复的历史数据形态与用户侧兜底
- Keyring 本身不可用（系统安全存储故障）不受本次影响：凭据保留 base64/encrypted 原样，进入既有“需手动登录”路径（fail closed 不降级明文）。
- 若个别库存在不可解码的 encrypted_password（非 NULL 但损坏），迁移按 malformed_error 计数并跳过，不删除、不覆盖；用户手动重新登录即可重建。

## 9. 明确确认
本次修复**不需要**用户卸载、清数据、重新建立成绩缓存；保留离线缓存可查看（#355），失败不踢登录页；保持 #550 原子 UPSERT 并发可靠性；未放宽/移除任何测试门禁。

## 关联
- Closes #659
- 相关：#550（原子 UPSERT，保留）、#355（离线缓存体验，保留）、#520（可恢复凭据判定）