### PR TITLE
feat(#664): TestFlight 上传后自动关联出口合规声明（AppEncryptionDeclaration）

### DIFF
--- a/.github/workflows/ios-testflight-finalize.yml
+++ b/.github/workflows/ios-testflight-finalize.yml
@@ -19,6 +19,11 @@ on:
         description: Optional beta group name; blank selects the first internal group
         required: false
         type: string
+      export_compliance:
+        description: "Export compliance: auto (link approved AppEncryptionDeclaration) / off / explicit declaration id"
+        required: false
+        type: string
+        default: "auto"
       locale:
         description: TestFlight localization locale
         required: false
@@ -85,6 +90,7 @@ jobs:
           TESTFLIGHT_WHATS_NEW: ${{ inputs.whats_new }}
           TESTFLIGHT_BETA_GROUP: ${{ inputs.beta_group }}
           TESTFLIGHT_LOCALE: ${{ inputs.locale }}
+          TESTFLIGHT_EXPORT_COMPLIANCE: ${{ inputs.export_compliance }}
         run: node tools/ci/submit_testflight.mjs
 
       - name: Cleanup App Store Connect API key

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -19,6 +19,11 @@ on:
         description: "TestFlight 测试组名称。留空自动选择第一个内部测试组（= 自动提交内部测试）。"
         required: false
         type: string
+      export_compliance:
+        description: "出口合规：auto（自动关联已批准 AppEncryptionDeclaration）/ off（跳过）/ 指定声明 id。"
+        required: false
+        type: string
+        default: "auto"
 
 permissions:
   contents: read
@@ -430,6 +435,7 @@ jobs:
           BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
           TESTFLIGHT_WHATS_NEW: ${{ inputs.whats_new }}
           TESTFLIGHT_BETA_GROUP: ${{ inputs.beta_group }}
+          TESTFLIGHT_EXPORT_COMPLIANCE: ${{ inputs.export_compliance }}
         run: |
           set -euo pipefail
           # 复用上方 "Install App Store Connect API key" 步骤写入的 .p8 私钥

--- a/tools/ci/submit_testflight.d.mts
+++ b/tools/ci/submit_testflight.d.mts
@@ -30,3 +30,14 @@ export function createBetaBuildLocalizationBody(options: {
   locale: string
   whatsNew: string
 }): unknown
+
+export function createAppEncryptionDeclarationLookupPath(options: {
+  appId: string
+  limit?: number
+}): string
+
+export function createBuildEncryptionDeclarationLinkageBody(
+  declarationId: string,
+): {
+  data: { type: string; id: string }
+}

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -174,6 +174,23 @@ export function createBetaBuildLocalizationBody({ buildId, locale, whatsNew }) {
   }
 }
 
+/** 查询某 App 的出口合规（App Encryption Declarations）列表。 */
+export function createAppEncryptionDeclarationLookupPath({ appId, limit = 200 }) {
+  const qs = new URLSearchParams({
+    'filter[app]': appId,
+    'fields[appEncryptionDeclarations]': 'appEncryptionDeclarationState,usesEncryption',
+    limit: String(limit),
+  })
+  return `/appEncryptionDeclarations?${qs}`
+}
+
+/** 把 build 关联到出口合规声明的 linkage 请求体。 */
+export function createBuildEncryptionDeclarationLinkageBody(declarationId) {
+  return {
+    data: { type: 'appEncryptionDeclarations', id: declarationId },
+  }
+}
+
 function recentCommits(max = 8) {
   try {
     const out = execFileSync('git', ['log', '--no-merges', '--pretty=format:%h %s', '-n', String(max)], {
@@ -304,6 +321,45 @@ async function findBetaGroup(token, { appId, groupName }) {
   return internal
 }
 
+/**
+ * 自动出口合规（"允许出口"）：把构建关联到 App 已批准的 App Encryption Declaration。
+ * mode: 'auto'（默认，查已批准声明）/ 'off'（跳过）/ 其它值视为显式声明 id。
+ * 无可用声明时仅告警，不中断测试组投递。
+ */
+async function assignExportCompliance(token, { appId, buildId, mode }) {
+  const normalized = String(mode || 'auto').trim().toLowerCase()
+  if (normalized === 'off') {
+    console.log('⏭️ 已跳过出口合规（export_compliance=off）')
+    return
+  }
+  let declarationId = ''
+  if (normalized !== 'auto') {
+    declarationId = normalized // 视为显式声明 id
+  } else {
+    const data = await apiRequest(token, createAppEncryptionDeclarationLookupPath({ appId }))
+    const list = data.data || []
+    const approved = list.find(
+      (item) => item.attributes?.appEncryptionDeclarationState === 'APPROVED',
+    )
+    declarationId = (approved || list[0])?.id || ''
+  }
+  if (!declarationId) {
+    console.warn(
+      '⚠️ 未找到可用的 App Encryption Declaration，跳过出口合规关联（首次需在 App Store Connect 创建并等待审核；不影响测试组投递）',
+    )
+    return
+  }
+  await apiRequest(
+    token,
+    `/builds/${encodeURIComponent(buildId)}/relationships/appEncryptionDeclaration`,
+    {
+      method: 'PATCH',
+      body: createBuildEncryptionDeclarationLinkageBody(declarationId),
+    },
+  )
+  console.log(`✅ 已关联出口合规声明（声明 id=${declarationId}）`)
+}
+
 async function main() {
   const {
     APPSTORE_KEY_ID,
@@ -315,6 +371,7 @@ async function main() {
     TESTFLIGHT_WHATS_NEW = '',
     TESTFLIGHT_BETA_GROUP = '',
     TESTFLIGHT_LOCALE = DEFAULT_TESTFLIGHT_LOCALE,
+    TESTFLIGHT_EXPORT_COMPLIANCE = 'auto',
   } = process.env
 
   for (const [name, value] of Object.entries({
@@ -361,6 +418,17 @@ async function main() {
     whatsNew,
   })
   console.log('✅ 测试说明已填写')
+
+  // 2.5) 出口合规（"允许出口"）关联；失败不中断测试组投递
+  try {
+    await assignExportCompliance(token, {
+      appId: APPLE_APP_ID,
+      buildId,
+      mode: TESTFLIGHT_EXPORT_COMPLIANCE,
+    })
+  } catch (err) {
+    console.warn(`⚠️ 出口合规关联失败（不影响测试组投递）：${err.message}`)
+  }
 
   // 3) 加入测试组（内部组 = 自动提交；外部组需要 Beta App Review）
   const group = await findBetaGroup(token, { appId: APPLE_APP_ID, groupName: TESTFLIGHT_BETA_GROUP })

--- a/tools/ci/submit_testflight.test.mjs
+++ b/tools/ci/submit_testflight.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * submit_testflight.mjs 纯函数单测（node --test）。
+ * 运行：node --test tools/ci/submit_testflight.test.mjs
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  buildWhatsNew,
+  createAppEncryptionDeclarationLookupPath,
+  createBetaBuildLocalizationBody,
+  createBuildEncryptionDeclarationLinkageBody,
+  createJwt,
+  createPrereleaseBuildsPath,
+  createPrereleaseLookupPath,
+  parseTestAccount,
+} from './submit_testflight.mjs'
+
+test('createPrereleaseLookupPath 过滤 App/版本/平台', () => {
+  const path = createPrereleaseLookupPath({ appId: '6787857278', versionName: '1.4.7' })
+  assert.match(path, /^\/preReleaseVersions\?/)
+  assert.match(path, /filter%5Bapp%5D=6787857278/)
+  assert.match(path, /filter%5Bversion%5D=1\.4\.7/)
+  assert.match(path, /filter%5Bplatform%5D=IOS/)
+})
+
+test('createPrereleaseBuildsPath 定位版本下构建', () => {
+  const path = createPrereleaseBuildsPath('prv-123')
+  assert.equal(path, '/preReleaseVersions/prv-123/builds?fields%5Bbuilds%5D=version%2CprocessingState%2CuploadedDate%2Cexpired&limit=200')
+})
+
+test('createAppEncryptionDeclarationLookupPath 含 app 过滤与所需字段', () => {
+  const path = createAppEncryptionDeclarationLookupPath({ appId: '6787857278' })
+  assert.match(path, /^\/appEncryptionDeclarations\?/)
+  assert.match(path, /filter%5Bapp%5D=6787857278/)
+  assert.match(path, /appEncryptionDeclarationState/)
+  assert.match(path, /usesEncryption/)
+  const limited = createAppEncryptionDeclarationLookupPath({ appId: 'a1', limit: 50 })
+  assert.match(limited, /limit=50/)
+})
+
+test('createBuildEncryptionDeclarationLinkageBody 结构正确', () => {
+  const body = createBuildEncryptionDeclarationLinkageBody('decl-9')
+  assert.deepEqual(body, {
+    data: { type: 'appEncryptionDeclarations', id: 'decl-9' },
+  })
+})
+
+test('createBetaBuildLocalizationBody 结构正确', () => {
+  const body = createBetaBuildLocalizationBody({ buildId: 'b1', locale: 'zh-Hans', whatsNew: 'hello' })
+  assert.equal(body.data.type, 'betaBuildLocalizations')
+  assert.equal(body.data.attributes.whatsNew, 'hello')
+  assert.equal(body.data.relationships.build.data.id, 'b1')
+})
+
+test('createJwt 非 PEM 输入报错（结构校验）', () => {
+  // 不使用真实密钥材料：仅验证非法 PM 时抛错，且不触碰 secret-guard 扫描
+  assert.throws(() => createJwt({ keyId: 'k1', issuerId: 'i1', privateKeyPem: 'not-a-pem' }))
+})
+
+test('buildWhatsNew 手动输入优先并支持字面 \\n', () => {
+  const text = buildWhatsNew({ manual: '行一\\n行二', versionName: '1.4.7', buildNumber: '28' })
+  assert.equal(text, '行一\n行二')
+})
+
+test('buildWhatsNew 自动生成包含版本与 commit、不含账号明文校验', () => {
+  const text = buildWhatsNew({
+    manual: '',
+    versionName: '1.4.7',
+    buildNumber: '28',
+    commits: ['abc123 修复A'],
+    account: { username: 'demo-user', password: 'demo-pwd' },
+  })
+  assert.ok(text.includes('v1.4.7（build 28）'))
+  assert.ok(text.includes('- abc123 修复A'))
+  assert.ok(text.includes('演示测试账号：demo-user / demo-pwd'))
+})
+
+test('buildWhatsNew 超过 4000 字符截断', () => {
+  const text = buildWhatsNew({ manual: 'x'.repeat(4200), versionName: '1', buildNumber: '1' })
+  assert.ok(text.length <= 4000)
+})
+
+test('parseTestAccount 从源码提取账号', () => {
+  const source = "export const TEST_ACCOUNT = { username: 'u1', password: 'p1', studentId: '123' }"
+  const acc = parseTestAccount(source)
+  assert.equal(acc.username, 'u1')
+  assert.equal(acc.password, 'p1')
+  assert.equal(acc.studentId, '123')
+})
+
+test('parseTestAccount 缺字段返回 null', () => {
+  assert.equal(parseTestAccount('export const X = { username: "a" }'), null)
+  assert.equal(parseTestAccount(''), null)
+})


### PR DESCRIPTION
Closes #664

## 背景
TestFlight 上传后处理（`tools/ci/submit_testflight.mjs`）已自动完成：等构建处理 → 填 What to Test → 拉入内部/外部测试组（内组即时发布、外组自动提交 Beta Review）。唯一仍需人工的「允许出口（Export Compliance）」勾选本次自动化：构建不再停在 Missing Compliance。

## 改动
- `tools/ci/submit_testflight.mjs`：
  - 纯函数 `createAppEncryptionDeclarationLookupPath`（按 app 过滤声明，取状态/是否加密）、`createBuildEncryptionDeclarationLinkageBody`
  - 主流程新增 `assignExportCompliance`（第 2.5 步）：`auto`（默认，优先关联 `APPROVED` 声明）/ `off`（跳过）/ 指定声明 id → `PATCH /v1/builds/{id}/relationships/appEncryptionDeclaration`；无可用声明时 warn 且**不中断**测试组投递
- `submit_testflight.d.mts`：同步导出
- `.github/workflows/ios-testflight.yml`、`ios-testflight-finalize.yml`：新增 `export_compliance` 输入（默认 auto）并透传 env
- 新增 `tools/ci/submit_testflight.test.mjs`：node --test 11 用例（路径构造/linkage body/既有纯函数回归，覆盖 createJwt 非法输入等）

## 验证
- ✅ `node --check`、`node --test` 11/11 通过
- ⏳ 下一步：合并后实际运行一次 `iOS TestFlight Upload`（1.4.7 + build 28, export_compliance=auto）验证日志与上传成功