### PR TITLE
chore(website): sitemap 收录 /docs/identity-oidc 开发者文档页

### DIFF
--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -48,4 +48,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://hbut.6661111.xyz/docs/identity-oidc</loc>
+    <lastmod>2026-08-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## 内容

`website/public/sitemap.xml` 补录开发者文档页 `/docs/identity-oidc`（2026-08-16 随 PR #635 上线，当时漏收）。

- URL 采用无尾斜杠形式，与站内 `trailingSlash: false` 配置及 DocsLayout 实际链接一致
- `changefreq=monthly`、`priority=0.6`，对齐其他 docs 子页条目
- 合并后由 sync-website.yml（push main 触发）自动部署到 EdgeOne 主站与 gh-pages 备用站
