### PR TITLE
fix(#669): 按 target 启用 keyring 平台原生后端，写路径增加重写韧性并细分后端缺失错误

### DIFF
--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -1017,6 +1017,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1038,7 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1051,7 +1061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1306,6 +1316,16 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -3162,7 +3182,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.6.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -5606,6 +5631,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6250,7 +6311,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -70,6 +70,9 @@ rqrr = "0.10.1"
 image = "0.25"
 dashmap = "6"
 url = "2"
+# keyring 基础行不带任何平台 feature：保证无原生后端的平台（如 Android）也能编译通过；
+# 各平台真正的持久化后端在下方 [target.*] 段按 target 启用
+# （#669：keyring v3 缺平台 feature 时会静默回退「零持久化」mock 存储，写入假成功）。
 keyring = "3"
 smcrypto = "0.3.1"
 # #622：设备 Ed25519 密钥与 approve 签名（V1 固定 Ed25519；私钥只进 OS keyring，fail closed）。
@@ -84,6 +87,17 @@ tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 rfd = "0.15"
 windows = { version = "0.61.3", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_Storage", "Win32_Storage_Xps", "Win32_UI_WindowsAndMessaging"] }
+# #669：必须显式启用 windows-native（Credential Manager），否则 keyring v3 静默回退零持久化 mock 存储。
+keyring = { version = "3", features = ["windows-native"] }
+
+# #669：Apple 平台启用系统 Keychain 原生后端（macOS Keychain / iOS Keychain）。
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+keyring = { version = "3", features = ["apple-native"] }
+
+# #669：Linux 使用 Secret Service D-Bus 后端（GNOME Keyring/KWallet）；
+# 不用 linux-native：keyutils 会话密钥环重启即失效，不满足持久化要求。
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3", features = ["sync-secret-service"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"

--- a/apps/client/src-tauri/src/identity/device_key.rs
+++ b/apps/client/src-tauri/src/identity/device_key.rs
@@ -249,6 +249,53 @@ impl KeyringLike for FileKeyring {
     }
 }
 
+/// 双实例探测当前 keyring 默认存储是否为「零持久化 mock」（#668/#669）：
+/// 实例 A set 成功而独立新建的实例 B 读不到即为 mock 特征。结果进程内缓存。
+///
+/// 判定依据：keyring v3 在未启用平台原生 feature 时，每个 `Entry` 各持一份独立内存
+/// 存储、互不可见且不落盘——A 写入后全新 B 实例读取必然 NoEntry；而真实后端
+/// （Credential Manager/Keychain/Secret Service）按 service+account 全局寻址，B 必能读到。
+fn backend_is_mock() -> bool {
+    static CACHE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        // 探测专用逻辑 key，与设备密钥完全隔离；探测值仅为时间戳，不含任何敏感材料。
+        const PROBE_SERVICE: &str = "mini-hbut-identity-probe";
+        const PROBE_ACCOUNT: &str = "backend-probe";
+        // target 与 RealKeyring 的 `{account}.{service}` 拼接格式保持一致。
+        let target = format!("{PROBE_ACCOUNT}.{PROBE_SERVICE}");
+        let probe_value = format!(
+            "probe-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        // 任何一步失败都按「非 mock」保守处理：宁可报 KeyringWriteMismatch，也不误判构建事故。
+        let entry_a = match keyring::Entry::new_with_target(&target, PROBE_SERVICE, PROBE_ACCOUNT) {
+            Ok(entry) => entry,
+            Err(_) => return false,
+        };
+        if entry_a.set_password(&probe_value).is_err() {
+            return false;
+        }
+        // 全新实例 B 独立寻址读取：NoEntry ⇒ A 写入未持久化 ⇒ 零持久化 mock；
+        // 只要 B 读得到任何内容（无论是否本次写入值），都证明存储跨实例可见，绝非 mock。
+        let is_mock = match keyring::Entry::new_with_target(&target, PROBE_SERVICE, PROBE_ACCOUNT) {
+            Ok(entry_b) => match entry_b.get_password() {
+                Err(keyring::Error::NoEntry) => true,
+                Ok(_) => false,
+                Err(_) => false,
+            },
+            Err(_) => false,
+        };
+        // 清理探测条目（忽略错误：探测键不含敏感材料，残留无安全影响）。
+        if let Ok(entry) = keyring::Entry::new_with_target(&target, PROBE_SERVICE, PROBE_ACCOUNT) {
+            let _ = entry.delete_credential();
+        }
+        is_mock
+    })
+}
+
 impl DeviceKeyStore {
     /// 读取密钥；不存在则生成并写入 Keyring（写后回读校验）。
     /// keyring 不可用或写回校验失败 → fail closed，不返回任何降级密钥。
@@ -294,7 +341,43 @@ impl DeviceKeyStore {
                 .map_err(|e| IdentityError::Internal(format!("写入显式测试设备密钥失败：{e}")))?;
             return Ok(key);
         }
-        Err(IdentityError::KeyringWriteMismatch)
+        // 至多一轮恢复（#669）：Windows Credential Manager 偶发「写入后短时不可见」
+        // 可能持续超过首轮重试窗口；先删除可能半写入的条目，再整体重写一次，
+        // 用缩短版回读循环确认，避免一次瞬时故障即永久 fail closed。
+        let _ = self.keyring.delete_secret();
+        if self.keyring.set_secret(&encoded).is_ok() {
+            for attempt in 1..=3 {
+                match self.load() {
+                    Ok(Some(stored)) if stored.fingerprint() == key.fingerprint() => {
+                        return Ok(key);
+                    }
+                    Ok(other) => {
+                        // 只记录公开指纹/存在性，不读取或打印任何私钥编码材料。
+                        eprintln!(
+                            "[identity] keyring 重写恢复第 {attempt} 次未匹配: present={} new_fp={} stored_fp={}",
+                            other.is_some(),
+                            key.fingerprint(),
+                            other.as_ref().map(|k| k.fingerprint()).unwrap_or_default()
+                        );
+                    }
+                    Err(err) => {
+                        // 恢复期间读取失败：记录后跳出，交由下方失败分支统一判定错误变体。
+                        eprintln!("[identity] keyring 重写恢复第 {attempt} 次读取失败: {err}");
+                        break;
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        }
+        // 最终错误细分：若探测确认默认存储是「零持久化 mock」（#668/#669 构建期事故），
+        // 报构建配置错误引导升级修复版；否则维持原有「写入校验失败」语义。
+        if backend_is_mock() {
+            Err(IdentityError::KeyringBackendMissing(
+                "keyring 默认存储为零持久化 mock（未启用平台原生后端），写入无法持久化".to_string(),
+            ))
+        } else {
+            Err(IdentityError::KeyringWriteMismatch)
+        }
     }
 
     /// 删除本地设备密钥（仅在用户确认或服务端 revoke 成功后调用）。

--- a/apps/client/src-tauri/src/identity/device_key.rs
+++ b/apps/client/src-tauri/src/identity/device_key.rs
@@ -261,8 +261,6 @@ fn backend_is_mock() -> bool {
         // 探测专用逻辑 key，与设备密钥完全隔离；探测值仅为时间戳，不含任何敏感材料。
         const PROBE_SERVICE: &str = "mini-hbut-identity-probe";
         const PROBE_ACCOUNT: &str = "backend-probe";
-        // target 与 RealKeyring 的 `{account}.{service}` 拼接格式保持一致。
-        let target = format!("{PROBE_ACCOUNT}.{PROBE_SERVICE}");
         let probe_value = format!(
             "probe-{}",
             std::time::SystemTime::now()
@@ -270,8 +268,9 @@ fn backend_is_mock() -> bool {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0)
         );
+        // 统一走平台分支的 Entry 打开方式（Windows 显式 target；Apple 后端不接受自定义 target）。
         // 任何一步失败都按「非 mock」保守处理：宁可报 KeyringWriteMismatch，也不误判构建事故。
-        let entry_a = match keyring::Entry::new_with_target(&target, PROBE_SERVICE, PROBE_ACCOUNT) {
+        let entry_a = match super::keyring::open_platform_entry(PROBE_SERVICE, PROBE_ACCOUNT) {
             Ok(entry) => entry,
             Err(_) => return false,
         };
@@ -280,7 +279,7 @@ fn backend_is_mock() -> bool {
         }
         // 全新实例 B 独立寻址读取：NoEntry ⇒ A 写入未持久化 ⇒ 零持久化 mock；
         // 只要 B 读得到任何内容（无论是否本次写入值），都证明存储跨实例可见，绝非 mock。
-        let is_mock = match keyring::Entry::new_with_target(&target, PROBE_SERVICE, PROBE_ACCOUNT) {
+        let is_mock = match super::keyring::open_platform_entry(PROBE_SERVICE, PROBE_ACCOUNT) {
             Ok(entry_b) => match entry_b.get_password() {
                 Err(keyring::Error::NoEntry) => true,
                 Ok(_) => false,
@@ -289,7 +288,7 @@ fn backend_is_mock() -> bool {
             Err(_) => false,
         };
         // 清理探测条目（忽略错误：探测键不含敏感材料，残留无安全影响）。
-        if let Ok(entry) = keyring::Entry::new_with_target(&target, PROBE_SERVICE, PROBE_ACCOUNT) {
+        if let Ok(entry) = super::keyring::open_platform_entry(PROBE_SERVICE, PROBE_ACCOUNT) {
             let _ = entry.delete_credential();
         }
         is_mock

--- a/apps/client/src-tauri/src/identity/errors.rs
+++ b/apps/client/src-tauri/src/identity/errors.rs
@@ -15,6 +15,11 @@ pub enum IdentityError {
     #[error("系统安全存储写入校验失败，已拒绝使用（fail closed）")]
     KeyringWriteMismatch,
 
+    /// 构建期配置错误：keyring 未启用平台原生后端（静默回退零持久化 mock 存储），
+    /// 属开发/打包事故而非用户环境问题，指向升级修复版本。
+    #[error("系统安全存储组件缺失（应用构建配置错误），请更新到修复版本；若持续出现请反馈版本号")]
+    KeyringBackendMissing(String),
+
     /// 本地没有已登录的学校会话，不能创建/使用设备身份。
     #[error("本地未登录学校账号，无法使用设备身份功能")]
     NoLocalLogin,

--- a/apps/client/src-tauri/src/identity/keyring.rs
+++ b/apps/client/src-tauri/src/identity/keyring.rs
@@ -37,11 +37,26 @@ impl RealKeyring {
     }
 
     fn entry(&self) -> Result<keyring::Entry, String> {
-        // 显式 target（与 Windows 默认拼接 {user}.{service} 一致），
-        // 避免默认路径在部分 Windows 版本上 CredWrite 后不可见的问题。
-        let target = format!("{}.{}", self.account, self.service);
-        keyring::Entry::new_with_target(&target, &self.service, &self.account)
-            .map_err(|e| e.to_string())
+        open_platform_entry(&self.service, &self.account)
+    }
+}
+
+/// 按平台打开 keyring Entry（#668/#669）。
+///
+/// - Windows：显式 target（`{account}.{service}`），规避部分系统版本上
+///   CredWrite 后同 service/account 默认寻址不可见的问题；
+/// - 其余平台（macOS/iOS Keychain、Linux Secret Service）：标准 service/account。
+///   Apple Security 框架不接受任意自定义 target（报「Attribute target is invalid:
+///   … is not User, System, Common, or Dynamic」），必须走默认寻址。
+pub(crate) fn open_platform_entry(service: &str, account: &str) -> Result<keyring::Entry, String> {
+    #[cfg(target_os = "windows")]
+    {
+        let target = format!("{}.{}", account, service);
+        keyring::Entry::new_with_target(&target, service, account).map_err(|e| e.to_string())
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        keyring::Entry::new(service, account).map_err(|e| e.to_string())
     }
 }
 


### PR DESCRIPTION
## TL;DR

按 target 启用 keyring 平台原生后端（#669，父 #668）：修复设备授权 100% 报「系统安全存储写入校验失败（fail closed）」的根因——此前 keyring 无任何平台 feature，Windows 静默回退零持久化 mock 存储。

## 改动

| 文件 | 内容 |
|---|---|
| `Cargo.toml` | Windows=`windows-native`、macOS/iOS=`apple-native`、Linux=`sync-secret-service`；基础行保留供 Android 编译兜底 |
| `src/identity/device_key.rs` | 写后校验全败时先 delete+重写一轮（3×300ms 缩短回读）再 fail closed；新增 `backend_is_mock()` 双实例探测（OnceLock 缓存），mock 特征时报新错误而非笼统 WriteMismatch |
| `src/identity/errors.rs` | 新增 `KeyringBackendMissing`：「系统安全存储组件缺失（应用构建配置错误），请更新到修复版本…」 |

安全语义不变：私钥仍只进 OS 安全存储，不产生任何 keyring 之外的落盘副本；探测值无敏感材料且即用即删。

## 验收证据

- `cargo tree -i keyring -f "{p} [{f}]"` → `keyring v3.6.3 [windows-native]`
- `cargo test --lib` → **293 passed; 0 failed**（含真后端往返测试，实际读写 Windows 凭据管理器）
- 测试运行后凭据管理器**零残留条目**（清理卫生验证）
- `cargo fmt --check` 干净；四分支集成树全量复验通过

Fixes #669
关联 #668、#656（诊断修正）、#657
