### PR TITLE
feat(#671): 接入 tauri-plugin-log 文件日志，恢复线上可观测性

### DIFF
--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -81,6 +81,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +1865,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2520,6 +2556,7 @@ dependencies = [
  "jni",
  "jsonwebtoken",
  "keyring",
+ "log",
  "md5",
  "ndk-context",
  "notify-rust",
@@ -2546,6 +2583,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-hbut-background",
  "tauri-plugin-keep-screen-on",
+ "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -3824,6 +3862,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6516,6 +6563,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6796,7 +6864,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ tauri-plugin-deep-link = "2"
 # 自研移动后台插件骨架（#611）：Android WorkManager / iOS BGTask 统一原生承载层。
 tauri-plugin-hbut-background = { path = "plugins/tauri-plugin-hbut-background" }
 serde = { version = "1.0", features = ["derive"] }
+# #671 线上可观测性：接入 tauri-plugin-log 提供 stdout + 日志目录双目标文件日志（release 版 stderr 被 windows_subsystem 丢弃）。
+tauri-plugin-log = "2"
+log = "0.4"
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "multipart", "rustls-tls", "stream"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs", "net", "sync", "time"] }

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -92,6 +92,30 @@ const GRADE_TEACHER_CACHE_TABLE: &str = "grade_teacher_cache";
 pub fn run() {
     let builder = tauri::Builder::default();
 
+    // #671 线上可观测性：文件日志（LogDir）+ stdout（dev 可见）。release 版 stderr 被
+    // windows_subsystem 丢弃，关键链路（identity / credential_store）必须有落盘日志。
+    // 级别策略：debug 全量 Debug；release 默认 Warn，identity/credential_store 模块放宽 Info。
+    // 单文件 1MB，保留最近 3 份（KeepSome）。
+    let builder = builder.plugin(
+        tauri_plugin_log::Builder::new()
+            .level(if cfg!(debug_assertions) {
+                log::LevelFilter::Debug
+            } else {
+                log::LevelFilter::Warn
+            })
+            .level_for("hbut_helper::identity", log::LevelFilter::Info)
+            .level_for("hbut_helper::credential_store", log::LevelFilter::Info)
+            .max_file_size(1_000_000)
+            .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3))
+            .targets([
+                tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                    file_name: Some("mini-hbut".into()),
+                }),
+            ])
+            .build(),
+    );
+
     // #621：Single Instance 必须最早注册（Windows/Linux 深链第二实例启动时，
     // 由它把 argv 交给已运行实例；deep-link 插件随后统一转发到前端 onOpenUrl 事件）。
     // 回调只负责聚焦已运行窗口，不解析/不打印完整 deep-link（argv 含 handoff secret）。


### PR DESCRIPTION
## TL;DR

接入 tauri-plugin-log（#671，父 #668）：release 版 stderr 被 windows_subsystem 丢弃且无任何日志文件机制，线上故障完全不可观测。最小接入恢复可诊断性。

## 改动

| 文件 | 内容 |
|---|---|
| `Cargo.toml` | `tauri-plugin-log = "2"` + `log = "0.4"` |
| `src/lib.rs` | 插件注册：debug=Debug / release=Warn；`hbut_helper::identity` 与 `hbut_helper::credential_store` 模块放宽 Info；targets = Stdout + LogDir(`mini-hbut`)；单文件 1MB、保留最近 3 份（KeepSome(3)） |

runtime_log 内存环保留为前端调试窗数据源，二者并行。identity 命令级打点未包含在本 PR（避免与并行分支冲突），后续小 PR 补充。

## 验收证据

- cargo check 零新增警告；cargo test --lib 293 全绿；fmt 干净
- 四分支集成树复验通过

Closes #671
关联 #668
