### PR TITLE
fix(#672): Android 设备身份与云同步主密钥显式降级，替代误导性写入报错

### DIFF
--- a/apps/client/src-tauri/src/credential_store.rs
+++ b/apps/client/src-tauri/src/credential_store.rs
@@ -42,6 +42,9 @@ pub fn delete_password(student_id: &str) {
 
 /// 返回账户级敏感字段主密钥。密钥只保存在系统密钥环，SQLite 不保存副本。
 pub fn load_or_create_secret_key(student_id: &str) -> Result<[u8; 32], String> {
+    // #672：Android 无 OS keyring 后端（keyring crate 不支持），显式降级而非误导性报错
+    #[cfg(target_os = "android")]
+    return Err("云同步加密主密钥在该平台暂不支持".to_string());
     use base64::{engine::general_purpose, Engine as _};
     use rand::RngCore;
 

--- a/apps/client/src-tauri/src/identity/commands.rs
+++ b/apps/client/src-tauri/src/identity/commands.rs
@@ -91,6 +91,9 @@ pub(crate) async fn identity_device_status() -> Result<DeviceStatusPayload, Stri
 /// 获取本机设备公钥（无私钥材料；首次调用自动创建密钥并写入 keyring）。
 #[tauri::command]
 pub(crate) async fn identity_get_public_key() -> Result<PublicKeyPayload, String> {
+    // #672：Android 无 OS keyring 后端（keyring crate 不支持），显式降级而非误导性报错
+    #[cfg(target_os = "android")]
+    return Err("该平台暂不支持设备身份注册，敬请期待后续版本".to_string());
     let store = real_store();
     let key = store.create_if_missing().map_err(|e| e.to_string())?;
     Ok(PublicKeyPayload {
@@ -113,6 +116,9 @@ pub(crate) async fn identity_enroll_device(
     device_name: String,
     handoff: String,
 ) -> Result<EnrollPayload, String> {
+    // #672：Android 无 OS keyring 后端（keyring crate 不支持），显式降级而非误导性报错
+    #[cfg(target_os = "android")]
+    return Err("该平台暂不支持设备身份注册，敬请期待后续版本".to_string());
     let base_url = resolve_identity_core_base_url(&base_url).map_err(|e| e.to_string())?;
     let device_name = device_name.trim().to_string();
     if device_name.is_empty() || device_name.chars().count() > 64 {
@@ -193,6 +199,9 @@ pub(crate) async fn identity_enroll_device(
 pub(crate) async fn identity_sign_auth_request(
     input: SignAuthRequestInput,
 ) -> Result<SignedApproval, String> {
+    // #672：Android 无 OS keyring 后端（keyring crate 不支持），显式降级而非误导性报错
+    #[cfg(target_os = "android")]
+    return Err("该平台暂不支持设备身份注册，敬请期待后续版本".to_string());
     let store = real_store();
     let key = store
         .load()
@@ -221,6 +230,9 @@ pub(crate) async fn identity_revoke_current_device_local(
     base_url: Option<String>,
     device_id: Option<String>,
 ) -> Result<(), String> {
+    // #672：Android 无 OS keyring 后端（keyring crate 不支持），显式降级而非误导性报错
+    #[cfg(target_os = "android")]
+    return Err("该平台暂不支持设备身份注册，敬请期待后续版本".to_string());
     let store = real_store();
     let base_url = base_url
         .map(|b| b.trim().to_string())


### PR DESCRIPTION
## TL;DR

Android 显式降级（#672，父 #668）：Android 上 keyring 无原生后端，设备身份注册会白耗约 3 秒重试后报误导性的「写入校验失败」。改为明确的平台降级文案。

## 改动（5 处门控，共 15 行）

| 位置 | 说明 |
|---|---|
| `src/identity/commands.rs:95,120,203,234` | enrollment/签名/删除等写操作命令在 Android 提前返回「该平台暂不支持设备身份注册，敬请期待后续版本」 |
| `src/credential_store.rs:46` | 云同步敏感字段主密钥路径显式报「该平台暂不支持」；「记住密码」既有文档化降级逻辑不动 |

只读查询类命令保持可用。

## 验收证据

- cargo check / cargo test --lib 全绿（293 passed）；fmt 干净
- 门控块极小且逐行语法自查（Windows 上 cfg 不可见无法编译验证，已人工复核类型匹配）
- 中期方案（Android Keystore 版 KeyringLike）将另立 issue

Fixes #672
关联 #668
