### PR TITLE
fix(#677): 设备绑定全自动无感——密钥在但缺本地绑定时静默补绑定

### DIFF
--- a/apps/client/src/app/coordinators/IdentityCoordinator.ts
+++ b/apps/client/src/app/coordinators/IdentityCoordinator.ts
@@ -52,6 +52,7 @@ import {
   setIdentitySuppressedForLogin
 } from '../../features/identity/identityStore'
 import { hasSensitiveScope } from '../../features/identity/identityScopes'
+import { resolveDeviceBinding } from '../../features/identity/deviceBinding'
 import {
   getIdentityDeviceDisplayName,
   invokeNative
@@ -251,45 +252,29 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
   }
 
   // ── 设备绑定（#622：用当前请求 handoff 获取 enrollment challenge） ────────
-  const ensureDeviceBound = async (handoff: string): Promise<string> => {
-    let status: IdentityLocalDeviceStatus | null = null
-    try {
-      status = await invokeNative<IdentityLocalDeviceStatus>('identity_device_status')
-    } catch {
-      status = null
-    }
-    if (status === null || status.available === false) {
-      throw new IdentityServiceError(
-        'secure_storage_unavailable',
-        '本机安全存储不可用，无法完成授权',
-        status?.error || 'identity_device_status unavailable'
-      )
-    }
-    if (!status.has_key) {
-      // 未绑定：当前请求 handoff 绑定创建 challenge（防匿名无限创建）
-      const { challenge } = await fetchEnrollmentChallenge({
-        baseUrl: getIdentityCoreBaseUrl(),
-        handoff
-      })
-      const enroll = await invokeNative<IdentityEnrollResult>('identity_enroll_device', {
-        baseUrl: getIdentityCoreBaseUrl(),
-        challenge,
-        deviceName: getIdentityDeviceDisplayName(),
-        handoff
-      })
-      setIdentityDeviceMeta({ deviceId: enroll.device_id, userId: enroll.user_id })
-      return enroll.device_id
-    }
-    const storedDeviceId = identityUiState.deviceId
-    if (!storedDeviceId) {
-      throw new IdentityServiceError(
-        'device_not_bound',
-        '当前设备尚未完成绑定，请先完成绑定后再授权',
-        'device key exists but device_id missing locally'
-      )
-    }
-    return storedDeviceId
-  }
+  // #677：三分支解析逻辑抽至 features/identity/deviceBinding.ts（可单测）；
+  // 「有密钥但缺本地绑定元数据」现在静默补绑定，不再硬报「尚未完成绑定」死路。
+  const ensureDeviceBound = async (handoff: string): Promise<string> =>
+    resolveDeviceBinding(
+      {
+        getDeviceStatus: () => invokeNative<IdentityLocalDeviceStatus>('identity_device_status'),
+        enroll: async (h) => {
+          const { challenge } = await fetchEnrollmentChallenge({
+            baseUrl: getIdentityCoreBaseUrl(),
+            handoff: h
+          })
+          return invokeNative<IdentityEnrollResult>('identity_enroll_device', {
+            baseUrl: getIdentityCoreBaseUrl(),
+            challenge,
+            deviceName: getIdentityDeviceDisplayName(),
+            handoff: h
+          })
+        },
+        getStoredDeviceId: () => identityUiState.deviceId,
+        saveDeviceMeta: (meta) => setIdentityDeviceMeta(meta)
+      },
+      handoff
+    )
 
   // ── 允许（approve） ───────────────────────────────────────────────────────
   const approveActive = async (): Promise<void> => {

--- a/apps/client/src/features/identity/deviceBinding.spec.ts
+++ b/apps/client/src/features/identity/deviceBinding.spec.ts
@@ -1,0 +1,76 @@
+// src/features/identity/deviceBinding.spec.ts
+//
+// #677：设备绑定解析三分支单测。
+// 回归背景：旧实现中「密钥已存在但本地缺 deviceId」会硬抛「当前设备尚未完成绑定」
+// 且不可自愈（如首次注册服务端提交中断、清过应用数据）；现改为静默补绑定。
+
+import { describe, expect, it, vi } from 'vitest'
+import { IdentityServiceError } from './types'
+import { resolveDeviceBinding, type DeviceBindingDeps } from './deviceBinding'
+
+const status = (has_key: boolean, available = true) => ({
+  available,
+  has_key,
+  fingerprint: has_key ? 'fp-x' : null,
+  error: null
+})
+
+const makeDeps = (over: Partial<DeviceBindingDeps> = {}): DeviceBindingDeps => ({
+  getDeviceStatus: vi.fn().mockResolvedValue(status(true)),
+  enroll: vi.fn().mockResolvedValue({ device_id: 'dev-new', user_id: 'user-1' }),
+  getStoredDeviceId: vi.fn().mockReturnValue('dev-stored'),
+  saveDeviceMeta: vi.fn(),
+  ...over
+})
+
+describe('#677 设备绑定解析（resolveDeviceBinding）', () => {
+  it('无密钥 → 用当前 handoff 自动注册并持久化元数据', async () => {
+    const deps = makeDeps({
+      getDeviceStatus: vi.fn().mockResolvedValue(status(false)),
+      getStoredDeviceId: vi.fn().mockReturnValue(null)
+    })
+    const deviceId = await resolveDeviceBinding(deps, 'handoff-1')
+    expect(deviceId).toBe('dev-new')
+    expect(deps.enroll).toHaveBeenCalledWith('handoff-1')
+    expect(deps.saveDeviceMeta).toHaveBeenCalledWith({ deviceId: 'dev-new', userId: 'user-1' })
+  })
+
+  it('有密钥且有本地 deviceId → 直接复用，不触发注册', async () => {
+    const deps = makeDeps()
+    const deviceId = await resolveDeviceBinding(deps, 'handoff-2')
+    expect(deviceId).toBe('dev-stored')
+    expect(deps.enroll).not.toHaveBeenCalled()
+    expect(deps.saveDeviceMeta).not.toHaveBeenCalled()
+  })
+
+  it('有密钥但缺本地 deviceId → 静默补绑定并持久化（不再硬报「尚未完成绑定」）', async () => {
+    const deps = makeDeps({
+      getStoredDeviceId: vi.fn().mockReturnValue(null),
+      enroll: vi.fn().mockResolvedValue({ device_id: 'dev-rebind', user_id: 'user-1' })
+    })
+    const deviceId = await resolveDeviceBinding(deps, 'handoff-3')
+    expect(deviceId).toBe('dev-rebind')
+    expect(deps.getStoredDeviceId).toHaveBeenCalled()
+    expect(deps.enroll).toHaveBeenCalledWith('handoff-3')
+    expect(deps.saveDeviceMeta).toHaveBeenCalledWith({ deviceId: 'dev-rebind', userId: 'user-1' })
+  })
+
+  it('安全存储不可用 → fail closed 抛 secure_storage_unavailable', async () => {
+    const deps = makeDeps({
+      getDeviceStatus: vi.fn().mockResolvedValue(status(false, false))
+    })
+    await expect(resolveDeviceBinding(deps, 'handoff-4')).rejects.toMatchObject({
+      code: 'secure_storage_unavailable'
+    })
+    expect(deps.enroll).not.toHaveBeenCalled()
+  })
+
+  it('安全存储命令本身抛错 → 同样 fail closed', async () => {
+    const deps = makeDeps({
+      getDeviceStatus: vi.fn().mockRejectedValue(new Error('invoke failed'))
+    })
+    await expect(resolveDeviceBinding(deps, 'handoff-5')).rejects.toBeInstanceOf(
+      IdentityServiceError
+    )
+  })
+})

--- a/apps/client/src/features/identity/deviceBinding.ts
+++ b/apps/client/src/features/identity/deviceBinding.ts
@@ -1,0 +1,53 @@
+// src/features/identity/deviceBinding.ts
+//
+// #677：设备绑定解析——`ensureDeviceBound` 的纯逻辑内核，依赖全部注入以便三分支单测。
+//
+// 行为合同（与 #622/#668 安全语义一致）：
+// - 安全存储不可用 → fail closed（secure_storage_unavailable），绝不降级到文件/内存；
+// - 无密钥 → 用当前请求 handoff 自动注册（防匿名设计不变）；
+// - 有密钥且本地有 deviceId → 直接复用；
+// - 有密钥但本地缺 deviceId（如首次注册服务端提交中断、清过应用数据）→
+//   **静默补绑定**：复用现有密钥重走一次注册拿回绑定关系（Rust create_if_missing
+//   会原样复用既有密钥），用户零感知；不再抛「尚未完成绑定」不可自愈错误。
+
+import { IdentityServiceError } from './types'
+import type { IdentityLocalDeviceStatus } from './types'
+
+export interface DeviceBindingDeps {
+  /** 读取本机设备状态（identity_device_status） */
+  getDeviceStatus: () => Promise<IdentityLocalDeviceStatus>
+  /** 用当前请求 handoff 执行一次 enrollment（取 challenge + Rust 注册命令） */
+  enroll: (handoff: string) => Promise<{ device_id: string; user_id: string }>
+  /** 本地持久化的 deviceId（可能因清应用数据/历史注册失败而缺失） */
+  getStoredDeviceId: () => string | null
+  /** 持久化绑定元数据 */
+  saveDeviceMeta: (meta: { deviceId: string; userId: string }) => void
+}
+
+/** 解析当前设备的绑定关系，返回可用于签名的 deviceId。 */
+export const resolveDeviceBinding = async (
+  deps: DeviceBindingDeps,
+  handoff: string
+): Promise<string> => {
+  let status: IdentityLocalDeviceStatus | null = null
+  try {
+    status = await deps.getDeviceStatus()
+  } catch {
+    status = null
+  }
+  if (status === null || status.available === false) {
+    throw new IdentityServiceError(
+      'secure_storage_unavailable',
+      '本机安全存储不可用，无法完成授权',
+      status?.error || 'identity_device_status unavailable'
+    )
+  }
+  const storedDeviceId = deps.getStoredDeviceId()
+  if (!status.has_key || !storedDeviceId) {
+    // #677：无密钥=首次注册；有密钥但缺元数据=静默补绑定。两条路径合一、零额外交互。
+    const enroll = await deps.enroll(handoff)
+    deps.saveDeviceMeta({ deviceId: enroll.device_id, userId: enroll.user_id })
+    return enroll.device_id
+  }
+  return storedDeviceId
+}


### PR DESCRIPTION
## TL;DR

设备授权全自动无感（Fixes #677，父 #668）：修复「密钥已在但本地缺绑定元数据」时的不可自愈死路——现在静默补绑定后继续授权；「允许/拒绝」确认交互保持不变。

## 改动

| 文件 | 内容 |
|---|---|
| `src/features/identity/deviceBinding.ts`（新增） | `resolveDeviceBinding` 纯逻辑内核：安全存储不可用→fail closed；无密钥→自动注册；有密钥有元数据→复用；**有密钥缺元数据→静默补绑定**。依赖全注入，便于三分支单测 |
| `src/app/coordinators/IdentityCoordinator.ts` | `ensureDeviceBound` 改为接线调用；删除 `device_not_bound` 死路分支 |
| `src/features/identity/deviceBinding.spec.ts`（新增） | 三分支 + fail closed 共 5 项单测 |

行为对照：
- 无密钥 → 自动注册（原行为保留）
- 有密钥 + 有 deviceId → 直接签名（原行为保留）
- 有密钥 + 缺 deviceId → **旧：硬报「尚未完成绑定」永久卡死 → 新：复用现有密钥重走注册（Rust create_if_missing 原样复用密钥），拿回 device_id 并持久化，用户零感知**

## 验收证据

- 新增 5 项单测全过；identity 相关 3 个 spec 文件 27 项全过
- 全量前端测试 **1100 passed**（唯一失败为工作树缺 dist 的环境问题，`vite build` 后复验 16/16 通过）
- `npm run typecheck`（vue-tsc）零错误
- identitySecurityContract 安全契约测试全部通过（重构未触碰信任边界）

Fixes #677
关联 #668、#669/#673
