### PR TITLE
feat(#679): 多设备自绑定——同账号新设备凭认证会话直接注册授权，移除第二设备批准门槛

### DIFF
--- a/identity-platform/core/src/api/app/devices.ts
+++ b/identity-platform/core/src/api/app/devices.ts
@@ -20,7 +20,13 @@ import type Router from '@koa/router'
 import type { SqlExecutor } from '../../db/types.js'
 import { findIdentityByProviderSubject } from '../../db/repos/users.repo.js'
 import { insertUser, insertLinkedIdentity } from '../../db/repos/users.repo.js'
-import { listDevicesByUser, type DeviceRow } from '../../db/repos/devices.repo.js'
+import {
+  consumeEnrollmentChallenge,
+  findDeviceByFingerprint,
+  listDevicesByUser,
+  reactivateRevokedDevice,
+  type DeviceRow
+} from '../../db/repos/devices.repo.js'
 import {
   createEnrollmentChallenge,
   registerDevice,
@@ -30,10 +36,12 @@ import {
 } from '../../domain/devices.js'
 import { assertValidHbutSubject } from '../../domain/users.js'
 import {
+  ChallengeInvalidError,
   DeviceFingerprintExistsError,
   DomainError,
   DeviceNotActiveError,
 } from '../../domain/errors.js'
+import { sha256Base64url } from '../../security/hash.js'
 import { newUuidV7 } from '../../domain/ids.js'
 import { buildEnrollCanonical, jwkFingerprint, type EnrollCanonicalInput } from './canonical.js'
 import { verifyEd25519 } from './verify.js'
@@ -229,26 +237,63 @@ export function registerDeviceRoutes(router: Router, deps: DevicesApiDeps): void
         throw new InvalidSignatureError()
       }
 
-      // 原子事务：用户 + 身份 + 设备 + 激活 all-or-nothing（任何一步失败不产生部分写入）
+      // 原子事务：用户/身份/设备 all-or-nothing（任何一步失败不产生部分写入）。
+      // #679 多设备自绑定：同一学号的新设备凭有效 handoff+challenge+签名断言
+      // 直接挂到既有身份，不再要求「已绑定设备批准」；同密钥重试幂等返回既有绑定。
       const result = await deps.sql.withTransaction(async (tx) => {
         const identity = await findIdentityByProviderSubject(tx, 'hbut', input.studentId)
-        if (identity) {
-          // 相同学号已有绑定账户：第二设备必须走已有设备批准流程，绝不自动接管
-          throw new LinkRequiredError()
+        const existingDevice = await findDeviceByFingerprint(tx, fingerprint)
+
+        // 学号尚无身份 → 首台设备注册（原路径）
+        if (!identity) {
+          const userId = newUuidV7()
+          await insertUser(tx, { id: userId })
+          await insertLinkedIdentity(tx, {
+            id: newUuidV7(),
+            user_id: userId,
+            provider: 'hbut',
+            subject: input.studentId,
+            student_name_snapshot: input.studentName || null,
+            verification_method: 'mini_hbut_app',
+            verification_level: 'low',
+            verified_at: new Date(),
+          })
+          // 一次性消费 challenge + 指纹冲突检查 + 插入 pending 设备
+          const registered = await registerDevice(tx, {
+            userId,
+            publicKeyJwk: input.publicJwk,
+            platform: input.platform,
+            appVersion: input.appVersion || undefined,
+            deviceName: input.deviceName,
+            challenge: input.challenge,
+            challengePurpose: 'device_enrollment',
+          })
+          await activateDevice(tx, registered.deviceId)
+          return { userId, deviceId: registered.deviceId }
         }
-        const userId = newUuidV7()
-        await insertUser(tx, { id: userId })
-        await insertLinkedIdentity(tx, {
-          id: newUuidV7(),
-          user_id: userId,
-          provider: 'hbut',
-          subject: input.studentId,
-          student_name_snapshot: input.studentName || null,
-          verification_method: 'mini_hbut_app',
-          verification_level: 'low',
-          verified_at: new Date(),
-        })
-        // 一次性消费 challenge + 指纹冲突检查 + 插入 pending 设备
+
+        const userId = identity.user_id
+        if (existingDevice) {
+          if (existingDevice.user_id !== userId) {
+            // 指纹属于其他学号：跨账号冲突仍拒绝（指纹全局唯一不变式不变）
+            throw new DeviceFingerprintExistsError()
+          }
+          if (existingDevice.status === 'active') {
+            // 同密钥重试 / #677 补绑定重放：幂等返回既有绑定（不消费 challenge，重试安全）
+            return { userId, deviceId: existingDevice.id }
+          }
+          // revoked → 同密钥重新注册即重新激活（密码登录 + 签名断言即表达意图）
+          const consumedRevive = await consumeEnrollmentChallenge(
+            tx,
+            sha256Base64url(input.challenge),
+          )
+          if (!consumedRevive) throw new ChallengeInvalidError()
+          const reactivated = await reactivateRevokedDevice(tx, existingDevice.id)
+          if (!reactivated) throw new DeviceFingerprintExistsError()
+          return { userId, deviceId: existingDevice.id }
+        }
+
+        // 学号有身份 + 全新设备 → 挂到既有身份（多设备自绑定核心场景）
         const registered = await registerDevice(tx, {
           userId,
           publicKeyJwk: input.publicJwk,

--- a/identity-platform/core/src/db/repos/devices.repo.ts
+++ b/identity-platform/core/src/db/repos/devices.repo.ts
@@ -114,6 +114,21 @@ export async function setDeviceStatus(
   return false
 }
 
+/**
+ * #679 多设备自绑定：revoked 设备同密钥重新注册时重激活。
+ * 仅允许 revoked → active（pending/active 场景不经过本函数）；
+ * 重新激活会清空吊销痕迹（等同重新上架）。
+ */
+export async function reactivateRevokedDevice(sql: SqlExecutor, id: string): Promise<boolean> {
+  const result = await sql.query(
+    `UPDATE devices
+       SET status = 'active', activated_at = $2, revoked_at = NULL, revoked_reason = NULL, updated_at = NOW()
+     WHERE id = $1 AND status = 'revoked'`,
+    [id, new Date()],
+  )
+  return (result.rowCount ?? 0) === 1
+}
+
 /** 仅在经过签名验证的请求后更新 last_seen_at */
 export async function touchDeviceLastSeen(sql: SqlExecutor, id: string): Promise<void> {
   await sql.query('UPDATE devices SET last_seen_at = NOW() WHERE id = $1', [id])

--- a/identity-platform/core/tests/api/app-devices.test.ts
+++ b/identity-platform/core/tests/api/app-devices.test.ts
@@ -5,7 +5,7 @@
  * - invalid signature；
  * - expired challenge；
  * - duplicate public key；
- * - duplicate student identity → LINK_REQUIRED（不合并）；
+ * - 多设备自绑定（#679）：同学号新设备挂既有身份 / 同密钥幂等返回 / revoked 同钥重激活；
  * - test/demo account 拒绝 Production enrollment；
  * - Handoff 缺失/非法拒绝（防匿名创建 challenge）。
  * 另覆盖：challenge 端点需有效 handoff；enroll 原子性（失败无部分写入）。
@@ -196,7 +196,7 @@ describe('#622 enroll API', () => {
     expect((res.body.error as { code: string }).code).toBe('DEVICE_FINGERPRINT_EXISTS')
   })
 
-  it('6. duplicate student identity：同学号二次注册 → 409 LINK_REQUIRED（绝不自动接管）', async () => {
+  it('6. 多设备自绑定：同学号第二台设备挂到既有身份（#679）', async () => {
     const first = await enrollViaApi({
       handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
       studentId: '2023010107',
@@ -207,13 +207,80 @@ describe('#622 enroll API', () => {
       key: newTestDeviceKey(),
       studentId: '2023010107',
     })
-    expect(res.status).toBe(409)
-    expect((res.body.error as { code: string }).code).toBe('LINK_REQUIRED')
-    // 学号仍只绑定一个 user，第二把公钥没有挂上去
+    expect(res.status).toBe(201)
+    // 新设备挂到同一个 user_id，不再要求「已绑定设备批准」
+    expect(res.body.user_id).toBe(first.body.user_id)
     const identity = await findIdentityByProviderSubject(db.sql, 'hbut', '2023010107')
     expect(identity?.user_id).toBe(String(first.body.user_id))
     const devices = await listDevicesByUser(db.sql, String(first.body.user_id))
+    expect(devices.length).toBe(2)
+    expect(devices.every((d) => d.status === 'active')).toBe(true)
+  })
+
+  it('6b. 同密钥重复 enroll：幂等返回既有 device_id，不新增设备行（#677 补绑定重放安全）', async () => {
+    const key = newTestDeviceKey()
+    const first = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      key,
+      studentId: '2023010108',
+    })
+    expect(first.status).toBe(201)
+    const res = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      key,
+      studentId: '2023010108',
+    })
+    expect(res.status).toBe(201)
+    expect(res.body.device_id).toBe(first.body.device_id)
+    const devices = await listDevicesByUser(db.sql, String(first.body.user_id))
     expect(devices.length).toBe(1)
+  })
+
+  it('6c. revoked 设备同密钥重新 enroll → 重新激活可用（#679）', async () => {
+    const key = newTestDeviceKey()
+    const first = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      key,
+      studentId: '2023010109',
+    })
+    expect(first.status).toBe(201)
+    // 模拟服务端吊销（如用户在别的设备上撤销了本机）
+    await db.sql.query(
+      "UPDATE devices SET status = 'revoked', revoked_at = NOW(), revoked_reason = 'test' WHERE id = $1",
+      [String(first.body.device_id)],
+    )
+    const res = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      key,
+      studentId: '2023010109',
+    })
+    expect(res.status).toBe(201)
+    expect(res.body.device_id).toBe(first.body.device_id)
+    const device = await findActiveDeviceById(db.sql, String(first.body.device_id))
+    expect(device?.status).toBe('active')
+  })
+
+  it('6d. 指纹属于其他学号 → 仍拒绝 DEVICE_FINGERPRINT_EXISTS（跨账号防线不变）', async () => {
+    const keyA = newTestDeviceKey()
+    const firstA = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      key: keyA,
+      studentId: '2023010110',
+    })
+    expect(firstA.status).toBe(201)
+    const firstB = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      studentId: '2023010111',
+    })
+    expect(firstB.status).toBe(201)
+    // 学号 111 尝试用属于学号 110 的公钥注册
+    const res = await enrollViaApi({
+      handoffSecret: (await createHandoffRequest(db.sql)).handoffSecret,
+      key: keyA,
+      studentId: '2023010111',
+    })
+    expect(res.status).toBe(409)
+    expect((res.body.error as { code: string }).code).toBe('DEVICE_FINGERPRINT_EXISTS')
   })
 
   it('7. test/demo account：production 环境拒绝，development 允许', async () => {

--- a/identity-platform/pnpm-lock.yaml
+++ b/identity-platform/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         specifier: 16.3.0
         version: 16.3.0(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       openid-client:
-        specifier: ^6.8.5
+        specifier: 6.8.5
         version: 6.8.5
       qrcode:
         specifier: 1.5.4


### PR DESCRIPTION
## TL;DR

多设备自绑定（Fixes #679，父 #668）：同一学号的新设备凭有效 handoff+challenge+签名断言直接挂到既有身份并授权，**移除「第二设备需由已绑定设备批准」的 409 门槛**。授权「允许/拒绝」确认交互不变。

## 行为对照

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| 学号无身份（首台设备） | 创建身份+设备 | 不变 |
| 学号有身份 + 全新指纹 | **409 LINK_REQUIRED 死路** | 挂到既有 user_id，正常激活 |
| 学号有身份 + 同指纹重试（#677 补绑定） | 409 / DEVICE_FINGERPRINT_EXISTS | 幂等返回既有 device_id，不新增行、不消费 challenge |
| revoked 设备同密钥重新注册 | 指纹冲突拒绝 | 重激活恢复 active |
| 指纹属于其他学号 | 拒绝 | 仍拒绝（跨账号防线不变） |

安全校验全部保留：production 测试账号拦截、fresh issuedAt、Ed25519 验签、一次性 challenge 消费、handoff 校验。`handleError` 的 UNIQUE 并发兜底保留。

## 附带

- `pnpm-lock.yaml`：同步 #666 钉死 openid-client@6.8.5 后 web importer 的 specifier（^6.8.5 → 6.8.5），修复 `pnpm install --frozen-lockfile` 失败
- 客户端无需改动：#677 静默补绑定的重试将命中幂等返回；identityService 的 LINK_REQUIRED 映射保留为防御性代码

## 验收证据

- app-devices.test.ts 重写用例 6 + 新增 6b/6c/6d，13 项全过
- core 全量测试 **219 passed**
- 上线注意：core 为 Vercel 手动部署（mini-hbut-identity-core），合并后需重新部署才对生产生效

Fixes #679
关联 #668、#669/#673、#677/#678
