### PR TITLE
fix(#681): 装配 appShellRef 修复底部 Tab 页滚动串扰，切页回顶真正生效

### DIFF
--- a/apps/client/src/App.vue
+++ b/apps/client/src/App.vue
@@ -13,6 +13,12 @@ import { useAppRuntime } from './app/useAppRuntime'
 // IdentityCoordinator 内完成（防止 App.vue 退化为上帝文件）。
 const { state, handlers, runtime, isIOSLike, isTestAccountSession } = useAppRuntime()
 
+// #681：装配全应用唯一滚动容器的 DOM 引用（切页回顶 / 首页滚动恢复均依赖）。
+// 必须经函数式 ref 写入 state.appShellRef，直接 :ref="ref 对象" 会被模板自动解包导致类型与语义双输。
+const bindAppShellRef = (el: unknown) => {
+  state.appShellRef.value = (el as HTMLElement | null) ?? null
+}
+
 const {
   currentView,
   activeTab,
@@ -167,7 +173,9 @@ const {
     @dismiss="handleSplashDismissed"
   />
 
+  <!-- #681：全应用唯一滚动容器，切页回顶依赖此 ref；缺失会导致滚动位置跨 Tab 串扰 -->
   <main
+    :ref="bindAppShellRef"
     class="app-shell"
     :class="{
       'no-scroll': currentView === 'ai',

--- a/apps/client/src/app/contracts/runtime.ts
+++ b/apps/client/src/app/contracts/runtime.ts
@@ -65,7 +65,7 @@ export interface NavigationCoordinator {
   closeDailyAccessDialog(): void
   handleDailyAccessInput(event: unknown): void
   submitDailyAccessKey(): void
-  syncFromHash(options?: { scrollToTop?: boolean }): Promise<void>
+  syncFromHash(): Promise<void>
   restoreViewFromSnapshot(
     snapshot: Record<string, unknown> | null,
     options?: { softRemount?: boolean; allowHardReload?: boolean; idleMs?: number; source?: string }

--- a/apps/client/src/app/coordinators/LifecycleCoordinator.ts
+++ b/apps/client/src/app/coordinators/LifecycleCoordinator.ts
@@ -40,19 +40,7 @@ export const createLifecycleCoordinator = (runtime: AppRuntime): LifecycleCoordi
   const hasTauri = isTauriRuntime()
   const isCapacitor = isCapacitorRuntime()
 
-  const forceScrollTop = () => {
-    try {
-      window.scrollTo(0, 0)
-      document.documentElement.scrollTop = 0
-      document.body.scrollTop = 0
-      if (state.appShellRef.value) {
-        state.appShellRef.value.scrollTop = 0
-      }
-    } catch {
-      // ignore
-    }
-  }
-
+  // #681：回顶实现唯一收敛在 navigation.forceScrollTop，此处不得再保留重复副本
   const updateViewportUnit = () => {
     if (typeof window === 'undefined') return
     // 优先 clientHeight，避免地址栏/键盘/可视窗口瞬时波动导致“二次缩放”
@@ -107,11 +95,11 @@ export const createLifecycleCoordinator = (runtime: AppRuntime): LifecycleCoordi
     updateViewportUnit()
     nextTick(() => {
       if (scrollToTop) {
-        forceScrollTop()
+        runtime.navigation.forceScrollTop()
       }
       requestAnimationFrame(() => {
         if (scrollToTop) {
-          forceScrollTop()
+          runtime.navigation.forceScrollTop()
         }
         updateViewportUnit()
       })

--- a/apps/client/src/app/coordinators/NavigationCoordinator.ts
+++ b/apps/client/src/app/coordinators/NavigationCoordinator.ts
@@ -354,7 +354,6 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     if (!isProtectedView(normalized) || hasDailyAccessGrant()) return true
     if (redirectToFallback) {
       const fallback = resolveAccessFallbackView(fallbackView)
-      state.mutable.pendingScrollToTopOnViewChange = false
       applyViewState(fallback)
       replaceHistorySnapshot(fallback)
     }
@@ -385,7 +384,6 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
       normalized === 'home' &&
       scrollToTop !== true &&
       (restoreScroll || returningHome)
-    state.mutable.pendingScrollToTopOnViewChange = !shouldRestoreHomeScroll
     applyViewState(normalized)
     if (push) {
       pushHistorySnapshot(normalized)
@@ -455,11 +453,10 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     return { sid: snapshot.sid, view: normalizeViewName(snapshot.view) }
   }
 
-  const syncFromHash = async ({ scrollToTop = false } = {}) => {
+  const syncFromHash = async () => {
     const route = parseHashRoute()
     if (!route) {
       if (state.currentView.value !== 'home') {
-        state.mutable.pendingScrollToTopOnViewChange = scrollToTop
         applyViewState('home')
       }
       return
@@ -474,7 +471,6 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     })) {
       return
     }
-    state.mutable.pendingScrollToTopOnViewChange = scrollToTop
     applyViewState(safeView)
     if (safeView === 'grades' && state.gradeData.value.length === 0) {
       void runtime.grade.loadGradesForCurrentView()
@@ -559,7 +555,7 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     }
     const prev = state.currentView.value
     state.navDirection.value = 'back'
-    await syncFromHash({ scrollToTop: false })
+    await syncFromHash()
     if (state.currentView.value === 'home' && prev !== 'home') {
       runtime.lifecycle.recoverViewportAfterTransition({ scrollToTop: false, blurActive: true })
       restoreHomeScrollPosition()
@@ -691,7 +687,6 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     })) {
       return
     }
-    state.mutable.pendingScrollToTopOnViewChange = false
     applyViewState(targetView)
     replaceHistorySnapshot(targetView)
     let didSoftRemount = false

--- a/apps/client/src/app/state/appState.ts
+++ b/apps/client/src/app/state/appState.ts
@@ -27,7 +27,6 @@ export interface AppMutable {
   isClosingByUser: boolean
   viewportResizeRaf: number
   desktopResizePerfTimer: null | number
-  pendingScrollToTopOnViewChange: boolean
   lastResumeHandledAt: number
   resumePendingSnapshot: null | Record<string, unknown>
   iosReloadFallbackAt: number
@@ -206,7 +205,6 @@ export const createAppState = (stores: AppStores, options: CreateAppStateOptions
     isClosingByUser: false,
     viewportResizeRaf: 0,
     desktopResizePerfTimer: null,
-    pendingScrollToTopOnViewChange: false,
     lastResumeHandledAt: 0,
     resumePendingSnapshot: null,
     iosReloadFallbackAt: 0,

--- a/apps/client/src/app/useAppRuntime.ts
+++ b/apps/client/src/app/useAppRuntime.ts
@@ -187,7 +187,7 @@ export const useAppRuntime = () => {
     let cachedIdentity = false
     try {
       cachedIdentity = await runtime.session.restoreCachedIdentityFromLocal()
-      await runtime.navigation.syncFromHash({ scrollToTop: false })
+      await runtime.navigation.syncFromHash()
     } catch (error) {
       console.warn('[Boot] local bootstrap failed:', error)
     }

--- a/apps/client/src/utils/app_shell_scroll_contract.spec.ts
+++ b/apps/client/src/utils/app_shell_scroll_contract.spec.ts
@@ -1,0 +1,53 @@
+// #681 契约测试：防止 app-shell 滚动装配与切页回顶机制回归。
+// 背景：全应用唯一滚动容器 <main class="app-shell"> 曾从未绑定 state.appShellRef，
+// 切页回顶（forceScrollTop）因此全程空转——首页滚动位置跨 Tab 串扰，
+// 课表页叠加 overflow:hidden 后直接卡死在底部且无法滑回。
+import { describe, it, expect } from 'vitest'
+import { readContractSource } from './contract_source_test'
+
+const appVue = readContractSource('src/App.vue')
+const navigationTs = readContractSource('src/app/coordinators/NavigationCoordinator.ts')
+const lifecycleTs = readContractSource('src/app/coordinators/LifecycleCoordinator.ts')
+const appStateTs = readContractSource('src/app/state/appState.ts')
+
+describe('app-shell 滚动装配契约（#681）', () => {
+  it('App.vue 的 main.app-shell 必须经 bindAppShellRef 装配 DOM 引用', () => {
+    // 缺失该绑定时 appShellRef 恒为 null，切页回顶与首页滚动恢复全部失效
+    expect(appVue).toMatch(/<main\s+:ref="bindAppShellRef"\s+class="app-shell"/)
+  })
+
+  it('bindAppShellRef 必须把元素写入 state.appShellRef', () => {
+    expect(appVue).toMatch(/state\.appShellRef\.value = \(el as HTMLElement \| null\) \?\? null/)
+  })
+})
+
+describe('切页回顶实现契约（#681）', () => {
+  it('forceScrollTop 必须清零共享容器的 scrollTop', () => {
+    // window/document 层清零在 html/body overflow:hidden 下全是 no-op，
+    // 真正生效的只有 .app-shell 这一层
+    expect(navigationTs).toMatch(/state\.appShellRef\.value\.scrollTop = 0/)
+  })
+
+  it('getAppShellScrollTop 必须优先读 appShellRef', () => {
+    expect(navigationTs).toMatch(/const shell = state\.appShellRef\.value/)
+  })
+
+  it('forceScrollTop 唯一实现收敛在 NavigationCoordinator', () => {
+    // 曾存在两份相同副本双处维护；LifecycleCoordinator 一律经 runtime.navigation 调用
+    expect(lifecycleTs).not.toMatch(/const forceScrollTop = \(\)/)
+    expect(lifecycleTs).toContain('runtime.navigation.forceScrollTop()')
+  })
+})
+
+describe('死代码清理契约（#681）', () => {
+  it('pendingScrollToTopOnViewChange 死旗标不得回归', () => {
+    // 该旗标曾有 5 处写入、0 处读取
+    for (const source of [navigationTs, lifecycleTs, appStateTs]) {
+      expect(source).not.toContain('pendingScrollToTopOnViewChange')
+    }
+  })
+
+  it('syncFromHash 的 scrollToTop 死参数不得回归（唯一消费者曾是上述死旗标）', () => {
+    expect(navigationTs).toMatch(/const syncFromHash = async \(\) => \{/)
+  })
+})

--- a/apps/client/src/utils/grade_navigation_contract.spec.ts
+++ b/apps/client/src/utils/grade_navigation_contract.spec.ts
@@ -36,7 +36,7 @@ describe('grade navigation contract', () => {
     const source = readSource('src/app/coordinators/NavigationCoordinator.ts')
     const block = extractBlock(
       source,
-      'const syncFromHash = async ({ scrollToTop = false } = {}) => {',
+      'const syncFromHash = async () => {',
       'const normalizeNavigateTarget = (target: unknown) => {'
     )
 


### PR DESCRIPTION
Closes #681

## 问题

所有 Tab 页共享唯一滚动容器 `<main class="app-shell">`（html/body 被 overflow:hidden 锁死），但切页回顶逻辑 `forceScrollTop()` 依赖的 `state.appShellRef` **全仓库从未装配**（恒为 null）→ 回顶全程空转：首页滚到底后切课表被拉到底且无法滑回（`schedule-full` 的 `overflow:hidden` 放大卡死），通知/我的页同样继承偏移。「返回首页恢复滚动位置」也因此一直存错值。属老问题，机制诞生于 #574 god-file 分解之前。

## 改动

- **P0 装配**（核心）：`App.vue` 经函数式 ref 将 `<main class="app-shell">` 写入 `state.appShellRef`（直接 `:ref="ref对象"` 会被模板自动解包导致类型错误，故用 `bindAppShellRef`）。装配后回顶、首页位置记忆/恢复自然复活，未改任何时机逻辑
- **P1 去重**：删除 `LifecycleCoordinator.ts` 里的重复 `forceScrollTop` 副本，唯一实现收敛到 `NavigationCoordinator`（组装顺序 navigation 先于 lifecycle，运行时经 `runtime.navigation` 调用）
- **P2 死代码**：删除死旗标 `pendingScrollToTopOnViewChange`（5 处写入 0 处读取）；其唯一消费者消失后，`syncFromHash` 的 `scrollToTop` 参数一并移除（契约接口 + 两处调用点同步更新）
- **P3 防回归**：新增 `app_shell_scroll_contract.spec.ts`（断言装配存在、清零实现存在、死代码零残留）；既有 `grade_navigation_contract.spec.ts` 仅同步更新了定位锚点字符串，断言语义不变

## 验证

- [x] `npm run typecheck`（vue-tsc）通过
- [x] `npm run test` 全绿：161 文件 / 1109 用例（含新增契约测试）
- [ ] 真机手工验收（合并后进行）：① 首页滑到底→切课表顶部可见可滑；② 切通知/我的从顶部开始；③ 课表→回首页恢复原位置；④ AI 页/模块宿主不受影响

## 风险评估

低。改动本质是让既有设计意图真正生效；resume/popstate 等 `recoverViewportAfterTransition({scrollToTop:true})` 路径从「无效」变为「真正回顶」，属预期行为。