### PR TITLE
ci(#683): Dev 测试版自动编号为最新正式版 patch+1 的 beta

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -107,6 +107,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Dev 测试版编号策略（#683）：核心版本取 max(main/dev package.json 版本) 后
+          # patch 位 +1，即「最新正式版的下一个版本」（正式版 1.4.6 存续期 → 测试版 1.4.7-beta.N）。
+          # 正式版照旧走 bump 提交 + tag 流程，bump 合入 main 后此处自动顺延到新的 patch+1。
           VERSION="$(python - <<'PY'
           import json
           import os
@@ -133,6 +136,14 @@ jobs:
                   return -1
               return 0
 
+          def bump_patch(version: str) -> str:
+              parts = parse_core(version)
+              while len(parts) < 3:
+                  parts.append(0)
+              parts = parts[:3]
+              parts[2] += 1
+              return '.'.join(str(part) for part in parts)
+
           def fetch_main_version(repo: str, token: str) -> str:
               if not repo:
                   return ''
@@ -158,7 +169,7 @@ jobs:
               os.environ.get('GH_TOKEN', '').strip()
           )
           base_version = main_version if compare(main_version, current_version) >= 0 else current_version
-          print(base_version or current_version or '0.0.0')
+          print(bump_patch(base_version or current_version or '0.0.0'))
           PY
           )"
           # WiX/MSI：pre-release 数字段必须 ≤ 65535。GITHUB_RUN_ID 远超该上限会让

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,32 @@ node scripts/guard_sensitive_uploads.mjs pre-commit
 3. 关联 Issue：`Closes #123`
 4. 确保 CI（`.github/workflows/ci.yml`）通过
 
+## 版本号与发布策略
+
+### 正式版（Release）
+
+1. 在 `main` 上做一次 bump 提交，同步以下版本号（任一不一致会挂 `check:release-config` 门禁）：
+   - `apps/client/package.json` 与 `package-lock.json`
+   - `apps/client/src-tauri/tauri.conf.json`
+   - `apps/client/src-tauri/Cargo.toml`
+   - `scripts/verify_release_config.mjs` 的 `const expected = '...'`
+2. 发布说明写进仓库根目录的 `RELEASE_vX.Y.Z.md`，随 bump 提交合入（缺失则 Release 自动生成 Changed Files 列表）
+3. 在该提交上打 tag `vX.Y.Z` 并推送 → 触发 `Release Build`（要求 tag 位于 `main`）
+4. 产物命名、GitHub Release 与 CDN `latest.json` 均以 tag 为准自动生成
+
+### 测试版（Dev Build）
+
+- 版本号全自动，无需人为改任何文件：核心版本 = max(`main` / dev 分支 `package.json` 版本) 的 **patch+1**，
+  再拼 `-beta.<run_number>`。例：正式版 v1.4.6 存续期间，测试版为 `1.4.7-beta.N`
+- 正式版 bump 合入 `main` 后会自动同步并触发一次 Dev Build，测试版随即顺延为新的 patch+1
+- 触发入口：push 到 `dev` 分支 / 手动 workflow_dispatch / push 到 `main` 自动同步触发
+- 经 GitHub `dev-latest` 滚动 prerelease + CDN `releases/dev-latest.json` 分发，仅应用内打开「开发版」频道的用户可见
+
+### iOS TestFlight
+
+- 编号独立于上述两者：手动运行 `ios-testflight.yml` 输入 marketing version 与 build number
+  （build 号按 App Store Connect 序列递增），与 dev-beta 编号互不影响
+
 ## 代码约定
 
 ### Rust（`apps/client/src-tauri/`）

--- a/apps/client/src/utils/updater_channel.spec.ts
+++ b/apps/client/src/utils/updater_channel.spec.ts
@@ -120,6 +120,41 @@ describe('update channel (stable / dev)', () => {
     ).toBe(true)
   })
 
+  it('numbers dev betas as latest-stable patch+1 and still offers safe upgrades (#683)', () => {
+    const beta147 = {
+      tag_name: 'dev-latest',
+      version: '1.4.7-beta.1',
+      prerelease: true,
+      channel: 'dev'
+    }
+    const stable147 = { tag_name: 'v1.4.7', version: '1.4.7', prerelease: false, channel: 'main' }
+
+    // 正式版 1.4.6 存续期，测试版编号为 1.4.7-beta.N（patch+1）：正式用户开 dev 可直升
+    expect(shouldOfferRelease(beta147, '1.4.6', 'dev')).toBe(true)
+    // stable 频道不受影响：1.4.6 → 1.4.7 正常提示
+    expect(shouldOfferRelease(stable147, '1.4.6', 'stable')).toBe(true)
+    // 同核心保守规则保留：1.4.7-beta.N 不被 1.4.7 正式拉回（决策点②）
+    expect(shouldOfferRelease(stable147, '1.4.7-beta.10', 'stable')).toBe(false)
+    // 防「降级」：更高 core 的装机不被低 core 的正式/beta 提示
+    expect(shouldOfferRelease(stable147, '1.4.8-beta.1', 'stable')).toBe(false)
+    expect(
+      shouldOfferRelease({ ...beta147, version: '1.4.7-beta.9' }, '1.4.8-beta.1', 'dev')
+    ).toBe(false)
+    // 同核心 beta 号递增提示、回退不提示
+    expect(
+      shouldOfferRelease({ ...beta147, version: '1.4.7-beta.11' }, '1.4.7-beta.10', 'dev')
+    ).toBe(true)
+    expect(shouldOfferRelease(beta147, '1.4.7-beta.2', 'dev')).toBe(false)
+    // 存量旧编号 1.4.6-beta.* 可自然迁移到新编号 1.4.7-beta.*
+    expect(shouldOfferRelease(beta147, '1.4.6-beta.358', 'dev')).toBe(true)
+  })
+
+  it('dev-build workflow derives beta base version as patch+1 (#683)', () => {
+    const workflow = readSource('../../.github/workflows/dev-build.yml')
+    expect(workflow).toContain('def bump_patch')
+    expect(workflow).toContain('print(bump_patch(base_version or current_version')
+  })
+
   it('builds download proxies for dev-latest tag', () => {
     const name = 'Mini-HBUT_1.4.3-beta.1_arm64.apk'
     const urls = buildUpdateDownloadUrls('dev-latest', name)


### PR DESCRIPTION
## TL;DR

Closes #683。Dev 测试版版本号从「与最新正式版同号 + -beta.N」改为「**最新正式版 patch+1** + -beta.N」：正式版 v1.4.6 存续期间测试版为 `1.4.7-beta.N`，v1.4.7 发布后自动顺延为 1.4.8-beta，全程无需人工改号。

## 改动内容

- `.github/workflows/dev-build.yml`（唯一行为变更）：meta job 在现有 max(main/dev package.json 版本) 基线上新增 `bump_patch()`，patch 位 +1 后输出。下游 stamp / 产物命名 / dev-latest Release / CDN 清单全部消费该值，自动跟随，零改动。
- `apps/client/src/utils/updater_channel.spec.ts`：新增编号方案提示矩阵用例（正式→更高 beta 提示、同核 beta 不被同号正式拉回、高 core 装机防降级、beta 号递增/回退、存量 1.4.6-beta.* 自然迁移）+ workflow 源契约断言（防止 bump_patch 被误删）。
- `CONTRIBUTING.md`：新增「版本号与发布策略」章节（正式版 bump+tag 流程、测试版自动编号规则、TestFlight 手动编号独立性）。

## 行为推演结论

前端更新器 `shouldOfferRelease()` 无需改动：stable 频道用户照常收到更高正式版；dev 频道按 core 与 beta 号比较；1.4.8-beta 装机不会被 1.4.7 拉回。附带收益：Tauri Android versionCode（major*1e6+minor*1e3+patch，忽略 prerelease 段）不再与正式版撞号，修复测试版 APK 无法覆盖安装正式版的隐患。

## 验证方式

- [x] `npx vitest run src/utils/updater_channel.spec.ts`：12 passed
- [x] 相邻回归 `updater_download_sources / apple_app_update / release_readiness_contract`：23 passed
- [x] meta Python 段本地干跑（当前仓库 package.json=1.4.6）：输出 `1.4.7`
- [x] workflow YAML 解析通过
- [ ] 合入后触发一次真实 Dev Build，核对产物名 / dev-latest Release 标题 / CDN dev-latest.json version 三处一致显示 `1.4.7-beta.*`