### PR TITLE
fix(#690): 登录二维码 canvas 内联兜底样式，外部 CSS 失效时不再溢出裁切

### DIFF
--- a/identity-platform/web/app/auth-site/_components/identity-qr.tsx
+++ b/identity-platform/web/app/auth-site/_components/identity-qr.tsx
@@ -82,6 +82,15 @@ export function IdentityQr({ payload, hidden, expired, fallbackUrl }: IdentityQr
             className="qr-canvas"
             role="img"
             aria-label="跨设备登录二维码：使用 Mini-HBUT App 扫描以完成登录"
+            // #690 内联兜底：canvas 内在尺寸 240px，若外部 CSS（.qr-canvas）未生效会撑破
+            // 128px 容器被裁切。内联样式保证任何加载状态下都完整缩放适配容器。
+            style={{
+              display: 'block',
+              width: '100%',
+              height: '100%',
+              maxWidth: '100%',
+              maxHeight: '100%',
+            }}
           />
           {expired ? (
             <div className="qr-expired-overlay" aria-live="polite">


### PR DESCRIPTION
## TL;DR

修复登录中继页二维码「缩放过大、显示不全」（Fixes #690，父 #686）：给渲染 canvas 加内联兜底样式，任何 CSS 加载状态下都完整缩放适配 128px 容器。

## 根因

`identity-qr.tsx` 用 `qrcode.toCanvas(canvas, { width: 240 })` 渲染出内在尺寸 240px 的 canvas；其显示尺寸完全依赖外部样式 `.qr-canvas { width/height:100% }`。该依赖链一旦失效（CSS chunk 未命中/被覆盖），canvas 以 240px 撑破 `.qr-render-wrap`（128×128 + overflow:hidden）→ 表现为比例过大且被裁切。

## 改动

canvas 元素追加内联样式：`display:block; width:100%; height:100%; max-width:100%; max-height:100%`——与外部 CSS 双保险，渲染逻辑零改动。

## 验收证据

- `tsc --noEmit` 零错误；`next build` 成功
- 1 文件 +9 行，纯展示层改动

Fixes #690
关联 #686