### PR TITLE
feat(#687): 应用详情页重设计——显性编辑入口+通俗化信息架构

### DIFF
--- a/identity-platform/core/migrations/0004_developer_contact.sql
+++ b/identity-platform/core/migrations/0004_developer_contact.sql
@@ -1,0 +1,3 @@
+-- #687：oauth_applications 补 contact 列（开发者联系方式，PATCH 白名单此前缺失导致无法落库）
+-- 可空 TEXT：历史应用无联系方式时为 NULL；展示层以「—」呈现
+ALTER TABLE oauth_applications ADD COLUMN IF NOT EXISTS contact TEXT;

--- a/identity-platform/core/src/api/developer/index.ts
+++ b/identity-platform/core/src/api/developer/index.ts
@@ -40,6 +40,8 @@ import {
   type OAuthApplicationRow,
 } from '../../db/repos/clients.repo.js'
 import { insertAuditEvent } from '../../db/repos/audit.repo.js'
+import { decryptClientSecret } from '../../security/client-secret.js'
+import { sha256Base64url } from '../../security/hash.js'
 
 export const DEVELOPER_SUBJECT_HEADER = 'x-developer-subject'
 
@@ -161,6 +163,8 @@ async function toSummary(
  */
 export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps): void {
   const { sql } = deps
+  /** secret 解密 KEK（详情接口计算 last4/fingerprint 用；未配置则元数据退化为 null） */
+  const secretKek = deps.clientSecretKek ?? deps.env?.IDENTITY_CLIENT_SECRET_KEK
 
   // GET/POST /api/v1/developer/me —— 当前开发者资料（幂等建档）
   router.get(`${API_PREFIX}/developer/me`, async (ctx) => {
@@ -334,7 +338,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
         throw new DeveloperApiError(404, 'not_found')
       }
       ctx.status = 200
-      ctx.body = { app: await toDetail(sql, app) }
+      ctx.body = { app: await toDetail(sql, app, secretKek) }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -365,7 +369,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       await updateApplication(sql, app.client_id, patch)
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
-      ctx.body = { app: updated ? await toDetail(sql, updated) : null }
+      ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -425,7 +429,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       )
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
-      ctx.body = { app: updated ? await toDetail(sql, updated) : null }
+      ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -452,7 +456,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       ])
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
-      ctx.body = { app: updated ? await toDetail(sql, updated) : null }
+      ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -493,7 +497,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       }
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
-      ctx.body = { app: updated ? await toDetail(sql, updated) : null }
+      ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -550,7 +554,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       )
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
-      ctx.body = { app: updated ? await toDetail(sql, updated) : null }
+      ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -574,7 +578,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
       ctx.body = {
-        app: updated ? await toDetail(sql, updated) : null,
+        app: updated ? await toDetail(sql, updated, secretKek) : null,
         client_secret: clientSecret,
       }
     } catch (err) {
@@ -597,7 +601,7 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       await setClientStatus(sql, app.client_id, 'revoked')
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
       ctx.status = 200
-      ctx.body = { app: updated ? await toDetail(sql, updated) : null }
+      ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {
       respondError(ctx, err)
     }
@@ -653,12 +657,26 @@ async function findOwnedApp(
 async function toDetail(
   sql: SqlExecutor,
   app: OAuthApplicationRow,
+  clientSecretKek?: string,
 ): Promise<Record<string, unknown>> {
   const uris = await listRedirectUris(sql, app.id)
   const scopes = await sql.query<{ scope: string; status: string; review_note: string | null }>(
     `SELECT scope, status, review_note FROM oauth_application_scopes WHERE application_id = $1 ORDER BY scope`,
     [app.id],
   )
+  // #687：secret 真实元数据——解出密文后取末 4 位明文与完整指纹。
+  // 明文本身绝不出 Core；解密失败（KEK 不符/密文损坏）时 fail-safe 退化为 null，不影响其余字段
+  let last4: string | null = null
+  let fingerprint: string | null = null
+  if (app.client_secret_encrypted && clientSecretKek) {
+    try {
+      const plaintext = decryptClientSecret(clientSecretKek, app.client_secret_encrypted)
+      last4 = plaintext.slice(-4)
+      fingerprint = sha256Base64url(plaintext)
+    } catch {
+      // 保持 null：宁缺毋假
+    }
+  }
   return {
     id: app.id,
     client_id: app.client_id,
@@ -668,7 +686,7 @@ async function toDetail(
     description: app.description ?? null,
     homepage_url: app.homepage_url ?? null,
     privacy_policy_url: app.privacy_policy_url ?? null,
-    contact: (app as unknown as { contact?: string | null }).contact ?? null,
+    contact: app.contact ?? null,
     created_at: app.created_at.toISOString(),
     updated_at: app.updated_at.toISOString(),
     submitted_at: app.submitted_at ? app.submitted_at.toISOString() : null,
@@ -696,9 +714,10 @@ async function toDetail(
     },
     secret: {
       created_at: app.client_secret_encrypted ? app.created_at.toISOString() : null,
+      // 库中无「上次轮换时间」列（rotate 仅覆盖密文本身，无独立时间戳），无法真实提供 → 保持 null，不谎造
       last_rotated_at: null,
-      fingerprint: null,
-      last4: null,
+      fingerprint,
+      last4,
     },
     audit: [],
   }

--- a/identity-platform/core/src/db/repos/clients.repo.ts
+++ b/identity-platform/core/src/db/repos/clients.repo.ts
@@ -23,6 +23,8 @@ export interface OAuthApplicationRow extends QueryResultRow {
   description: string | null
   homepage_url: string | null
   privacy_policy_url: string | null
+  /** 开发者联系方式（#687：0004 迁移新增，可空） */
+  contact: string | null
   client_type: ClientType
   status: ApplicationStatus
   token_endpoint_auth_method: TokenEndpointAuthMethod
@@ -71,6 +73,7 @@ const UPDATABLE_COLUMNS = {
   description: 'description',
   homepage_url: 'homepage_url',
   privacy_policy_url: 'privacy_policy_url',
+  contact: 'contact',
   status: 'status',
   token_endpoint_auth_method: 'token_endpoint_auth_method',
   client_secret_encrypted: 'client_secret_encrypted',

--- a/identity-platform/core/tests/api/developer.test.ts
+++ b/identity-platform/core/tests/api/developer.test.ts
@@ -1,0 +1,237 @@
+/**
+ * #687 Developer API 测试（直挂 registerDeveloperRoutes，不经 service-token 中间件——
+ * 测试环境未配置 service-token 时该中间件本就不在装配路径上）。
+ *
+ * 身份链路：x-developer-subject（pairwise sub）→ resolveUserIdBySubject → user_id
+ *   → developers 表 → 应用 owner 校验。因此 harness 需要：
+ *  - 一个 client_id = 'developer-portal' 的应用 + redirect_uri（resolveSector 用 host 作 sector）；
+ *  - 测试 pairwise key（TEST_PAIRWISE_KEY），sub 由 derivePairwiseSubject(sector, userId) 推导。
+ *
+ * 覆盖：
+ *  1. PATCH 更新 name/description/contact 成功且 DB 真实落库（contact 白名单修复）；
+ *  2. detail 返回 secret 元数据 last4 / fingerprint 非 null 且值正确；
+ *  3. GET scopes 返回 scope 列表；
+ *  4. 越权/状态机兜底：无 subject 401；active 应用 PATCH 409。
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Koa from 'koa'
+import Router from '@koa/router'
+import type { SqlExecutor } from '../../src/db/types.js'
+import { registerDeveloperRoutes } from '../../src/api/developer/index.js'
+import { createTestDatabase, type TestDatabase } from '../helpers/pg.js'
+import { withServer } from '../helpers.js'
+import { createClientFixture, type ClientFixture } from '../helpers/fixtures.js'
+import { insertDeveloper } from '../helpers/developers.js'
+import { TEST_KEK, TEST_PAIRWISE_KEY } from '../helpers/keys.js'
+import { derivePairwiseSubject } from '../../src/domain/subjects.js'
+import { createUserWithHbutIdentity } from '../../src/domain/users.js'
+import { newUuidV7 } from '../../src/domain/ids.js'
+import {
+  findApplicationByClientId,
+  insertApplication,
+  replaceRedirectUris,
+} from '../../src/db/repos/clients.repo.js'
+import { sha256Base64url } from '../../src/security/hash.js'
+
+/** developer-portal 登录应用的 redirect host（resolveSector 取它作 pairwise sector） */
+const PORTAL_SECTOR = 'portal.example.com'
+
+/** 组装仅含 developer 路由的 Koa app（生产由 api/index.ts 统一装配 + service-token 保护） */
+function buildDeveloperApp(sql: SqlExecutor): Koa {
+  const app = new Koa()
+  const router = new Router()
+  registerDeveloperRoutes(router, {
+    sql,
+    pairwiseKey: TEST_PAIRWISE_KEY,
+    clientSecretKek: TEST_KEK,
+  })
+  app.use(router.routes())
+  app.use(router.allowedMethods())
+  return app
+}
+
+/** 首次访问前置：插入 client_id='developer-portal' 应用（sector 解析依赖其 redirect_uri） */
+async function seedPortalClient(sql: SqlExecutor): Promise<void> {
+  const { userId } = await createUserWithHbutIdentity(sql, {
+    studentId: `2023${Math.floor(Math.random() * 900000) + 100000}`,
+    studentName: '门户占位用户',
+  })
+  const ownerDevId = newUuidV7()
+  await insertDeveloper(sql, { id: ownerDevId, userId, displayName: '门户占位开发者' })
+  const portalAppId = newUuidV7()
+  await insertApplication(sql, {
+    id: portalAppId,
+    client_id: 'developer-portal',
+    owner_developer_id: ownerDevId,
+    name: '开发者门户',
+    client_type: 'web_confidential',
+    token_endpoint_auth_method: 'client_secret_basic',
+  })
+  await replaceRedirectUris(sql, portalAppId, [
+    { uri: `https://${PORTAL_SECTOR}/callback`, kind: 'web_https' },
+  ])
+}
+
+/** BFF 会话 sub 的测试推导：与 subject-resolution.ts 的 sector 语义一致 */
+function subjectFor(userId: string): string {
+  return derivePairwiseSubject({
+    pairwiseKey: TEST_PAIRWISE_KEY,
+    sectorOrClientId: PORTAL_SECTOR,
+    userId,
+  })
+}
+
+interface DevResponse {
+  status: number
+  body: Record<string, unknown>
+}
+
+function devHeaders(subject?: string): Record<string, string> {
+  return subject ? { 'x-developer-subject': subject } : {}
+}
+
+async function devGet(baseUrl: string, path: string, subject?: string): Promise<DevResponse> {
+  const res = await fetch(`${baseUrl}${path}`, { headers: devHeaders(subject) })
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> }
+}
+
+async function devPatch(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+  subject?: string,
+): Promise<DevResponse> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', ...devHeaders(subject) },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> }
+}
+
+describe('#687 developer API', () => {
+  let db: TestDatabase
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+    await seedPortalClient(db.sql)
+  })
+  afterEach(async () => {
+    await db.cleanup()
+  })
+
+  it('1. 无 x-developer-subject → 401 unauthorized', async () => {
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devGet(baseUrl, '/api/v1/developer/me')
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('unauthorized')
+    })
+  })
+
+  it('2. PATCH 更新 name/description/contact 成功且 DB 落库（contact 白名单修复）', async () => {
+    const fixture: ClientFixture = await createClientFixture(db.sql, {
+      status: 'draft',
+      scopes: ['openid'],
+    })
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devPatch(
+        baseUrl,
+        `/api/v1/developer/apps/${fixture.applicationId}`,
+        { name: '改名后的应用', description: '新描述', contact: 'dev@example.com' },
+        subjectFor(fixture.userId),
+      )
+      expect(res.status).toBe(200)
+      const updated = res.body.app as Record<string, unknown>
+      expect(updated.name).toBe('改名后的应用')
+      expect(updated.description).toBe('新描述')
+      // 此前 UPDATABLE_COLUMNS 缺 contact → patch 被拒；修复后必须真实返回
+      expect(updated.contact).toBe('dev@example.com')
+
+      // DB 层确认落库（不只看响应体）
+      const row = await findApplicationByClientId(db.sql, fixture.clientId)
+      expect(row?.name).toBe('改名后的应用')
+      expect(row?.description).toBe('新描述')
+      expect(row?.contact).toBe('dev@example.com')
+    })
+  })
+
+  it('3. detail 返回 secret 元数据 last4/fingerprint 非 null 且值正确', async () => {
+    const fixture = await createClientFixture(db.sql, { status: 'draft', scopes: ['openid'] })
+    expect(fixture.clientSecret).toBeTruthy() // web_confidential 创建时必有明文（仅此一次）
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devGet(
+        baseUrl,
+        `/api/v1/developer/apps/${fixture.applicationId}`,
+        subjectFor(fixture.userId),
+      )
+      expect(res.status).toBe(200)
+      const detail = res.body.app as Record<string, unknown>
+      const secret = detail.secret as Record<string, string | null>
+      // 占位 null 已替换为真实元数据：末 4 位 + 完整指纹（sha256Base64url）
+      expect(secret.last4).toBe((fixture.clientSecret as string).slice(-4))
+      expect(secret.fingerprint).toBe(sha256Base64url(fixture.clientSecret as string))
+      // 库中无轮换时间列：保持 null（不谎造）
+      expect(secret.last_rotated_at).toBeNull()
+      // 明文绝不能出现在响应里
+      expect(JSON.stringify(res.body)).not.toContain(fixture.clientSecret as string)
+    })
+  })
+
+  it('4. GET scopes 返回 scope 列表（scope/status/justification）', async () => {
+    const fixture = await createClientFixture(db.sql, {
+      status: 'active',
+      scopes: ['openid', 'profile'],
+    })
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devGet(
+        baseUrl,
+        `/api/v1/developer/apps/${fixture.applicationId}/scopes`,
+        subjectFor(fixture.userId),
+      )
+      expect(res.status).toBe(200)
+      const scopes = res.body.scopes as Array<{ scope: string; status: string; justification: string | null }>
+      expect(scopes.map((s) => s.scope).sort()).toEqual(['openid', 'profile'])
+      for (const s of scopes) {
+        expect(s.status).toBe('approved')
+        expect(s.justification).toBeNull()
+      }
+    })
+  })
+
+  it('5. active 应用 PATCH → 409 invalid_state（仅 draft/rejected 可编辑）', async () => {
+    const fixture = await createClientFixture(db.sql, { status: 'active', scopes: ['openid'] })
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devPatch(
+        baseUrl,
+        `/api/v1/developer/apps/${fixture.applicationId}`,
+        { name: '不该生效' },
+        subjectFor(fixture.userId),
+      )
+      expect(res.status).toBe(409)
+      expect(res.body.error).toBe('invalid_state')
+      const row = await findApplicationByClientId(db.sql, fixture.clientId)
+      expect(row?.name).not.toBe('不该生效')
+    })
+  })
+
+  it('6. 非本人应用 → 404 not_found（owner 过滤，防枚举）', async () => {
+    const owner = await createClientFixture(db.sql, { status: 'draft', scopes: ['openid'] })
+    const stranger = await createClientFixture(db.sql, { status: 'draft', scopes: ['openid'] })
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      // stranger 的 sub 访问 owner 的应用
+      const res = await devGet(
+        baseUrl,
+        `/api/v1/developer/apps/${owner.applicationId}`,
+        subjectFor(stranger.userId),
+      )
+      expect(res.status).toBe(404)
+      expect(res.body.error).toBe('not_found')
+    })
+  })
+})

--- a/identity-platform/web/app/developer-site/_components/api.ts
+++ b/identity-platform/web/app/developer-site/_components/api.ts
@@ -162,6 +162,21 @@ export async function putScopes(id: string, scopes: ScopePutInput[], csrf: strin
   return data.app
 }
 
+/** 单条 scope（GET /scopes 返回项；justification 对应 core 的 review_note） */
+export interface ScopeEntry {
+  scope: string
+  status: 'requested' | 'approved' | 'rejected'
+  justification: string | null
+}
+
+/** #687：拉取应用的 scope 列表（含审核状态与理由）；权限 Tab 初始化时加载展示 */
+export async function fetchScopes(appId: string): Promise<ScopeEntry[]> {
+  const data = await request<{ scopes: ScopeEntry[] }>(
+    `/api/v1/developer/apps/${encodeURIComponent(appId)}/scopes`,
+  )
+  return data.scopes
+}
+
 export async function submitApp(id: string, csrf: string): Promise<DeveloperAppDetailDTO> {
   const data = await request<{ app: DeveloperAppDetailDTO }>(
     `/api/v1/developer/apps/${encodeURIComponent(id)}/submit`,

--- a/identity-platform/web/app/developer-site/_components/app-detail.tsx
+++ b/identity-platform/web/app/developer-site/_components/app-detail.tsx
@@ -31,6 +31,27 @@ function appStatusZh(status: string): string {
   return STATUS_ZH[status] ?? status
 }
 
+/**
+ * #687 显性编辑入口：按应用状态给出按钮形态。
+ *  - draft/rejected：可点 → 切到概览 Tab 并自动展开编辑表单；
+ *  - 其余状态禁用 + tooltip 说明原因（disabled button 不触发 hover 事件，外包 span 承载 title）。
+ */
+function editEntryFor(status: string): { enabled: boolean; tooltip: string } {
+  switch (status) {
+    case 'draft':
+    case 'rejected':
+      return { enabled: true, tooltip: '修改应用的基本信息、回调地址与权限' }
+    case 'pending_review':
+      return { enabled: false, tooltip: '审核中，请耐心等待审核结果' }
+    case 'approved':
+    case 'active':
+      return { enabled: false, tooltip: '已上架应用暂不支持在线修改；重大变更可创建新应用或联系管理员' }
+    default:
+      // suspended / revoked 及未知状态
+      return { enabled: false, tooltip: '当前状态不可修改' }
+  }
+}
+
 const TABS = [
   { id: 'overview', label: '概览' },
   { id: 'redirect-uris', label: '回调地址' },
@@ -48,6 +69,8 @@ export function AppDetail({ appId }: { appId: string }) {
   const [me, setMe] = useState<MeResult | null>(null)
   const [tab, setTab] = useState<TabId>('overview')
   const [error, setError] = useState<string | null>(null)
+  /** 概览 Tab 编辑表单自动展开信号（头部「修改应用」按钮触发；递增计数保证可重复触发） */
+  const [editSignal, setEditSignal] = useState(0)
   /** 一次性 secret（rotate 响应），仅内存持有，刷新即失 */
   const [oneTimeSecret, setOneTimeSecret] = useState<string | null>(null)
 
@@ -115,6 +138,25 @@ export function AppDetail({ appId }: { appId: string }) {
         </span>
         <code className="dev-mono">{app.client_id}</code>
         <span className="dev-inline-hint">{app.client_type === 'web_confidential' ? 'Web 应用（服务端）' : '原生 / 移动端应用'}</span>
+        {(() => {
+          const entry = editEntryFor(app.status)
+          const button = (
+            <button
+              type="button"
+              className="dev-btn dev-btn-primary"
+              disabled={!entry.enabled}
+              onClick={() => {
+                // 切到概览 Tab 并自动展开编辑表单（editSignal 递增，重复点击也能再次展开）
+                setTab('overview')
+                setEditSignal((s) => s + 1)
+              }}
+            >
+              修改应用
+            </button>
+          )
+          // disabled 按钮在部分浏览器不响应 hover/title：外包 span 承载 tooltip
+          return <span title={entry.tooltip}>{button}</span>
+        })()}
       </div>
 
       <div className="dev-tabs" role="tablist" aria-label="应用详情">
@@ -131,7 +173,7 @@ export function AppDetail({ appId }: { appId: string }) {
         ))}
       </div>
 
-      {tab === 'overview' && <OverviewTab {...tabProps} />}
+      {tab === 'overview' && <OverviewTab {...tabProps} editSignal={editSignal} />}
       {tab === 'redirect-uris' && <RedirectUrisTab {...tabProps} />}
       {tab === 'scopes' && <ScopesTab {...tabProps} />}
       {tab === 'credentials' && <CredentialsTab {...tabProps} />}

--- a/identity-platform/web/app/developer-site/_components/tabs/audit.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/audit.tsx
@@ -24,14 +24,16 @@ export function AuditTab({ app }: TabProps) {
   if (app.audit.length === 0) {
     return (
       <div className="dev-card">
-        <h2>审计 / 活动</h2>
+        <h2>动态</h2>
+        <p className="dev-inline-hint">应用的操作流水：创建、修改、轮换密钥等都会记录在这里。</p>
         <div className="dev-empty">暂无记录</div>
       </div>
     )
   }
   return (
     <div className="dev-card">
-      <h2>审计 / 活动</h2>
+      <h2>动态</h2>
+      <p className="dev-inline-hint">应用的操作流水：创建、修改、轮换密钥等都会记录在这里。</p>
       <p className="dev-inline-hint">记录不含任何 secret 明文（审计日志只记动作，不记值）。</p>
       <table className="dev-audit-table">
         <thead>

--- a/identity-platform/web/app/developer-site/_components/tabs/credentials.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/credentials.tsx
@@ -35,6 +35,9 @@ export function CredentialsTab({ app, me, setApp, oneTimeSecret, setOneTimeSecre
   return (
     <div className="dev-card">
       <h2>凭据</h2>
+      <p className="dev-inline-hint">
+        应用接入本平台的「钥匙」：Client ID 是公开的账号，Client Secret 是保密的密码，只在创建或轮换时显示一次。
+      </p>
       {error && <div className="dev-error">{error}</div>}
 
       <dl className="dev-kv">

--- a/identity-platform/web/app/developer-site/_components/tabs/danger.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/danger.tsx
@@ -53,6 +53,7 @@ export function DangerZoneTab({ app, me, setApp, reload }: TabProps) {
     <div className="dev-danger-zone">
       <h3>⚠️ Danger Zone</h3>
       <p>以下操作不可逆，请谨慎执行。撤销（Revoke）为终态；删除仅限草稿应用。</p>
+      <p className="dev-inline-hint">撤销 = 让应用立刻停止服务但保留记录；删除 = 连草稿带配置彻底清掉。动手前请确认真的不再需要它。</p>
       {error && <div className="dev-error">{error}</div>}
 
       <h4>撤销应用（Revoke）</h4>

--- a/identity-platform/web/app/developer-site/_components/tabs/overview.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/overview.tsx
@@ -1,13 +1,20 @@
 /**
  * Tab 1：Overview —— 基本信息展示 + 可编辑表单（仅 draft/rejected）。
+ * #687：头部「修改应用」按钮通过 editSignal 触发本表单自动展开；
+ * 各字段附口语化 helper 文案（含义 + 保管建议），降低非专业用户理解成本。
  */
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ClientApiError, updateApp } from '../api'
 import { editLocked, editLockedHint, type TabProps } from './types'
 
-export function OverviewTab({ app, me, setApp, reload }: TabProps) {
+type OverviewTabProps = TabProps & {
+  /** 递增信号：>0 时自动展开编辑表单（由容器「修改应用」按钮触发） */
+  editSignal?: number
+}
+
+export function OverviewTab({ app, me, setApp, reload, editSignal = 0 }: OverviewTabProps) {
   const locked = editLocked(app)
   const [editing, setEditing] = useState(false)
   const [name, setName] = useState(app.name)
@@ -18,6 +25,13 @@ export function OverviewTab({ app, me, setApp, reload }: TabProps) {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [ok, setOk] = useState<string | null>(null)
+
+  // 头部「修改应用」按钮 → 切到本 Tab 并自动展开编辑表单
+  useEffect(() => {
+    if (editSignal > 0 && !locked) {
+      setEditing(true)
+    }
+  }, [editSignal, locked])
 
   async function handleSave() {
     setBusy(true)
@@ -49,6 +63,7 @@ export function OverviewTab({ app, me, setApp, reload }: TabProps) {
   return (
     <div className="dev-card">
       <h2>概览</h2>
+      <p className="dev-inline-hint">应用的基本信息与身份标识，审核员和用户都会看到这里的内容。</p>
       {ok && <div className="dev-success">{ok}</div>}
       {error && <div className="dev-error">{error}</div>}
       {locked && <p className="dev-inline-hint">{editLockedHint(app)}</p>}
@@ -58,22 +73,27 @@ export function OverviewTab({ app, me, setApp, reload }: TabProps) {
           <div className="dev-field">
             <label>应用名称</label>
             <input className="dev-input" value={name} onChange={(e) => setName(e.target.value)} maxLength={80} />
+            <p className="dev-hint">显示在用户授权页和审核列表里的名字；建议能一眼看出这是什么产品。</p>
           </div>
           <div className="dev-field">
             <label>应用描述</label>
             <textarea className="dev-textarea" value={description} onChange={(e) => setDescription(e.target.value)} maxLength={500} />
+            <p className="dev-hint">用一两句话说明应用是做什么的、给谁用；审核员会据此判断用途是否合规。</p>
           </div>
           <div className="dev-field">
             <label>主页 URL</label>
             <input className="dev-input" value={homepageUrl} onChange={(e) => setHomepageUrl(e.target.value)} />
+            <p className="dev-hint">应用对外的主页地址；审核时可能会访问核对，请确保可以打开。</p>
           </div>
           <div className="dev-field">
             <label>隐私政策 URL</label>
             <input className="dev-input" value={privacyPolicyUrl} onChange={(e) => setPrivacyPolicyUrl(e.target.value)} />
+            <p className="dev-hint">说明你如何收集和使用用户数据的页面；申请学号、成绩等敏感权限时必须提供。</p>
           </div>
           <div className="dev-field">
             <label>开发者联系方式</label>
             <input className="dev-input" value={contact} onChange={(e) => setContact(e.target.value)} />
+            <p className="dev-hint">邮箱或手机号均可；审核有疑问或应用出现异常时，管理员通过它联系你。</p>
           </div>
           <button type="button" className="dev-btn dev-btn-primary" disabled={busy} onClick={() => void handleSave()}>
             {busy ? '保存中…' : '保存'}
@@ -94,6 +114,7 @@ export function OverviewTab({ app, me, setApp, reload }: TabProps) {
             <dt>Client ID</dt>
             <dd>
               <code className="dev-mono">{app.client_id}</code>
+              <span className="dev-inline-hint"> 应用的公开身份标识，接入时填进你的代码或配置里；它不是机密，可以放心展示。</span>
             </dd>
           </dl>
           <dl className="dev-kv">
@@ -111,6 +132,21 @@ export function OverviewTab({ app, me, setApp, reload }: TabProps) {
           <dl className="dev-kv">
             <dt>开发者联系方式</dt>
             <dd>{app.contact ?? '—'}</dd>
+          </dl>
+          <dl className="dev-kv">
+            <dt>Client Secret</dt>
+            <dd>
+              {app.client_type === 'native_public' ? (
+                <span className="dev-inline-hint">不适用（原生应用使用 PKCE，无需密码）</span>
+              ) : app.secret.created_at ? (
+                <span className="dev-inline-hint">
+                  相当于应用的登录密码，只在创建/轮换时显示一次。请立即保存到安全的地方，切勿写进前端代码或提交进 Git；
+                  遗失请到「凭据」Tab 轮换。
+                </span>
+              ) : (
+                <span className="dev-inline-hint">尚未生成；到「凭据」Tab 轮换后即可获得。</span>
+              )}
+            </dd>
           </dl>
           <dl className="dev-kv">
             <dt>创建时间</dt>

--- a/identity-platform/web/app/developer-site/_components/tabs/redirect-uris.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/redirect-uris.tsx
@@ -73,8 +73,10 @@ export function RedirectUrisTab({ app, me, setApp, reload }: TabProps) {
 
   return (
     <div className="dev-card">
-      <h2>Redirect URIs</h2>
+      <h2>回调地址</h2>
       <p className="dev-inline-hint">
+        登录成功后跳回你网站的地址；必须与这里注册的完全一致（一个字符都不能差）。
+        <br />
         服务端精确匹配注册值：禁止通配符 / fragment / userinfo / 前缀后缀扩展。
         {editLockedHint(app)}
       </p>

--- a/identity-platform/web/app/developer-site/_components/tabs/review.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/review.tsx
@@ -34,6 +34,7 @@ export function ReviewTab({ app, me, setApp, reload }: TabProps) {
   return (
     <div className="dev-card">
       <h2>审核</h2>
+      <p className="dev-inline-hint">查看审核进度与管理员的反馈；被拒绝时按「需要修改的项目」改完后可重新提交。</p>
       {error && <div className="dev-error">{error}</div>}
 
       <dl className="dev-kv">

--- a/identity-platform/web/app/developer-site/_components/tabs/scopes.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/scopes.tsx
@@ -4,10 +4,10 @@
  */
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ScopeId } from '@/lib/developer/scopes'
 import { SCOPE_META, SCOPE_WHITELIST } from '@/lib/developer/scopes'
-import { ClientApiError, putScopes } from '../api'
+import { ClientApiError, fetchScopes, putScopes } from '../api'
 import { ScopeStatusBadge } from '../status-badge'
 import { editLockedHint, type TabProps } from './types'
 
@@ -20,6 +20,24 @@ export function ScopesTab({ app, me, setApp, reload }: TabProps) {
   )
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // #687：初始化时经 BFF GET /scopes 拉一次权威列表（含审核状态与理由），
+  // 覆盖本地初始态；失败时静默回退到详情自带的 scopes，不打断页面
+  useEffect(() => {
+    let alive = true
+    fetchScopes(app.id)
+      .then((scopes) => {
+        if (!alive) return
+        setJustifications(Object.fromEntries(scopes.map((s) => [s.scope, s.justification ?? ''])))
+        setSelected(Object.fromEntries(scopes.map((s) => [s.scope, true])))
+      })
+      .catch(() => {
+        // 静默回退：沿用详情接口的 scopes 数据
+      })
+    return () => {
+      alive = false
+    }
+  }, [app.id])
 
   const reReview = app.status === 'pending_review' || app.status === 'approved' || app.status === 'active' || app.status === 'suspended'
 
@@ -48,8 +66,10 @@ export function ScopesTab({ app, me, setApp, reload }: TabProps) {
 
   return (
     <div className="dev-card">
-      <h2>Scopes</h2>
+      <h2>权限（Scopes）</h2>
       <p className="dev-inline-hint">
+        勾选你的应用需要拿到的用户数据；申请越多审核越严，按实际需要选择即可。
+        <br />
         敏感 scope（student.identity / offline_access）需要使用理由、隐私政策与管理员人工批准。
         {editLockedHint(app)}
       </p>


### PR DESCRIPTION
## TL;DR

应用详情页重设计（Fixes #687，父 #686）：显性「修改应用」入口 + 7 个 Tab 通俗化文案 + 修复 contact 白名单 bug 与 secret 元数据占位，并补齐 developer 路由零直测覆盖。

## 改动要点

- 详情页头部新增「修改应用」主按钮：draft/rejected 一键进入编辑；pending/approved/suspended/revoked 禁用态带通俗 tooltip
- 全部 Tab 加副标题、概览字段加保管建议等 helper 文案（Client ID 可公开 / Secret 只显示一次等）
- 新增 `0004_developer_contact.sql`：oauth_applications 补 contact 列；repo 白名单同步 → PATCH contact 真实落库
- detail 接口解密返回 secret last4 + 指纹（last_rotated_at 无列保持 null 不谎造）
- api.ts 补 fetchScopes 封装；权限 Tab 挂载时拉取权威列表
- 新建 `core/tests/api/developer.test.ts`（6 用例 harness：PATCH 落库/元数据/scopes/401/409/404）

## 验收证据

- core：developer.test + app-devices 回归 **19 tests passed**；tsc --noEmit 干净
- 集成树（三分支合并）：**32 文件 / 233 测试全绿**
- web：typecheck 通过；next build 成功
- 移动端样式复用既有断点，无新风格引入

Fixes #687
关联 #686、#688/#689（同 epic 并行交付）