### PR TITLE
feat(#688): 账户级 API Key 平台一期——签发/Bearer 认证/account REST/门户管理页

### DIFF
--- a/identity-platform/core/migrations/0005_api_keys.sql
+++ b/identity-platform/core/migrations/0005_api_keys.sql
@@ -1,0 +1,29 @@
+-- ============================================================================
+-- 0005_api_keys.sql —— 账户级 API Key（#688，父 #686）
+--
+-- 核心原则：
+--   1. secret_hash = sha256Base64url(整串 Key)，绝不存明文；
+--      明文只在签发响应中出现一次（POST /api/v1/developer/keys）。
+--   2. Key 形态：mhbat_<8位小写hex>_<43位base64url>
+--      （"mhbat_" + 8 hex prefix + "_" + 32 字节随机 base64url 无填充）。
+--      prefix 列存 "mhbat_<8位hex>"（14 字符），带 UNIQUE 约束供认证时按前缀定位行。
+--   3. status 用 TEXT + CHECK（与 0001 类型策略一致，便于平滑演进可回滚）。
+--   4. scopes JSONB 默认 ["account.full"]（一期唯一 scope）。
+--
+-- 回滚脚本见 rollback_0005.sql（显式人工执行，禁止自动 destructive）。
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  name TEXT NOT NULL,
+  prefix TEXT NOT NULL UNIQUE,
+  secret_hash TEXT NOT NULL,
+  scopes JSONB NOT NULL DEFAULT '["account.full"]',
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','revoked')),
+  expires_at TIMESTAMPTZ,
+  last_used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user ON api_keys(user_id);

--- a/identity-platform/core/migrations/rollback_0005.sql
+++ b/identity-platform/core/migrations/rollback_0005.sql
@@ -1,0 +1,3 @@
+-- #688 回滚：撤销账户级 API Key 表（危险操作，仅开发/Preview 显式人工执行）
+DROP INDEX IF EXISTS idx_api_keys_user;
+DROP TABLE IF EXISTS api_keys;

--- a/identity-platform/core/src/api/account/apps.ts
+++ b/identity-platform/core/src/api/account/apps.ts
@@ -1,0 +1,434 @@
+/**
+ * Account API —— 应用管理端点（#688）。
+ *
+ * 行为镜像 src/api/developer/index.ts 的对应 handler（状态机/owner 校验/
+ * secret 只显示一次等业务规则完全一致），差异仅在身份来源：
+ * Bearer Key 解析出的 user_id → developers 表（ensureDeveloper 同款语义）。
+ *
+ * 端点（前缀 /api/v1/account，受 requireAccountKey 保护）：
+ *   GET|POST /apps
+ *   GET|PATCH|DELETE /apps/:id
+ *   POST /apps/:id/redirect-uris；DELETE /apps/:id/redirect-uris/:rid
+ *   PUT|GET /apps/:id/scopes
+ *   POST /apps/:id/submit
+ *   POST /apps/:id/credentials/rotate
+ *   POST /apps/:id/revoke
+ *   GET  /apps/:id/audit
+ */
+import type Router from '@koa/router'
+import type { SqlExecutor } from '../../db/types.js'
+import { API_PREFIX } from '../requests.js'
+import { readJsonBody } from '../app/body.js'
+import type { RedirectUriKind } from '../../db/repos/clients.repo.js'
+import type { OAuthApplicationRow } from '../../db/repos/clients.repo.js'
+import {
+  assertValidRedirectUris,
+  assertValidScopes,
+  createClient,
+  rotateClientSecret,
+  setClientStatus,
+} from '../../domain/clients.js'
+import {
+  updateApplication,
+  upsertApplicationScope,
+} from '../../db/repos/clients.repo.js'
+import { insertAuditEvent } from '../../db/repos/audit.repo.js'
+import { newUuidV7 } from '../../domain/ids.js'
+import {
+  AccountApiError,
+  findOwnedApp,
+  requireAccountAuth,
+  resolveAccountDeveloper,
+  respondAccountError,
+  toAppDetail,
+  toAppSummary,
+} from './common.js'
+
+/** 注册 account 应用管理路由（前缀已由挂载方保证在 /api/v1/account 下） */
+export function registerAccountAppsRoutes(router: Router, deps: { sql: SqlExecutor; env?: Record<string, string | undefined> }): void {
+  const { sql } = deps
+
+  // GET /api/v1/account/apps —— 应用列表（本人）
+  router.get(`${API_PREFIX}/account/apps`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const result = await sql.query<OAuthApplicationRow>(
+        `SELECT * FROM oauth_applications WHERE owner_developer_id = $1 ORDER BY updated_at DESC`,
+        [dev.id],
+      )
+      const apps = await Promise.all(
+        result.rows.map(async (row) => {
+          const summary = await toAppSummary(sql, row)
+          const scopes = await sql.query<{ scope: string }>(
+            `SELECT scope FROM oauth_application_scopes WHERE application_id = $1 ORDER BY scope`,
+            [row.id],
+          )
+          summary.scopes = scopes.rows.map((s) => s.scope)
+          return summary
+        }),
+      )
+      ctx.status = 200
+      ctx.body = { apps }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // POST /api/v1/account/apps —— 创建应用（先落 draft；secret 只返回一次）
+  router.post(`${API_PREFIX}/account/apps`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const body = ((await readJsonBody(ctx)) ?? {}) as Record<string, unknown>
+      const name = typeof body.name === 'string' ? body.name.trim() : ''
+      const description = typeof body.description === 'string' ? body.description.trim() : ''
+      const clientType = body.client_type === 'native_public' ? 'native_public' : 'web_confidential'
+      if (!name || !description) {
+        throw new AccountApiError('invalid_request')
+      }
+      const redirectUris = Array.isArray(body.redirect_uris)
+        ? (body.redirect_uris as Array<{ uri?: unknown; kind?: unknown }>)
+            .filter((u) => typeof u?.uri === 'string' && u.uri.trim())
+            .map((u) => ({
+              uri: (u.uri as string).trim(),
+              kind: (u.kind === 'native_custom' || u.kind === 'native_loopback' ? u.kind : 'web_https') as RedirectUriKind,
+            }))
+        : []
+      if (redirectUris.length === 0) {
+        throw new AccountApiError('invalid_request')
+      }
+      assertValidRedirectUris(redirectUris, clientType, {
+        allowLocalhostDev: deps.env?.IDENTITY_ENVIRONMENT === 'development',
+      })
+      const scopes = Array.isArray(body.scopes)
+        ? (body.scopes as Array<{ scope?: unknown; justification?: unknown }>)
+            .filter((s) => typeof s?.scope === 'string')
+            .map((s) => s.scope as string)
+        : []
+      if (scopes.length === 0) {
+        throw new AccountApiError('invalid_request')
+      }
+      assertValidScopes(scopes)
+
+      const created = await createClient(
+        sql,
+        {
+          developerId: dev.id,
+          name,
+          description: description || undefined,
+          homepageUrl:
+            typeof body.homepage_url === 'string' && body.homepage_url.trim()
+              ? body.homepage_url.trim()
+              : undefined,
+          privacyPolicyUrl:
+            typeof body.privacy_policy_url === 'string' && body.privacy_policy_url.trim()
+              ? body.privacy_policy_url.trim()
+              : undefined,
+          clientType,
+          redirectUris,
+          requestedScopes: scopes,
+        },
+        {
+          clientSecretKek: deps.env?.IDENTITY_CLIENT_SECRET_KEK,
+          allowLocalhostDev: deps.env?.IDENTITY_ENVIRONMENT === 'development',
+        },
+      )
+      await insertAuditEvent(sql, {
+        eventType: 'developer.app_created',
+        actorType: 'developer',
+        actorId: dev.id,
+        targetType: 'oauth_application',
+        targetId: created.applicationId,
+        result: 'success',
+        metadata: { client_id: created.clientId, via: 'account_api_key' },
+      })
+      ctx.status = 201
+      ctx.body = {
+        id: created.applicationId,
+        client_id: created.clientId,
+        client_secret: created.clientSecret ?? null,
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // GET /api/v1/account/apps/:id —— 详情（非本人 404 防枚举）
+  router.get(`${API_PREFIX}/account/apps/:id`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      ctx.status = 200
+      ctx.body = { app: await toAppDetail(sql, app) }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // PATCH /api/v1/account/apps/:id —— 编辑基本信息（draft/rejected 才可改）
+  router.patch(`${API_PREFIX}/account/apps/:id`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      if (app.status !== 'draft' && app.status !== 'rejected') {
+        throw new AccountApiError('invalid_state')
+      }
+      const body = ((await readJsonBody(ctx)) ?? {}) as Record<string, unknown>
+      const patch: Record<string, unknown> = {}
+      if (typeof body.name === 'string' && body.name.trim()) patch.name = body.name.trim()
+      if (typeof body.description === 'string') patch.description = body.description.trim()
+      if ('homepage_url' in body) patch.homepage_url = body.homepage_url as string | null
+      if ('privacy_policy_url' in body) patch.privacy_policy_url = body.privacy_policy_url as string | null
+      if ('contact' in body) patch.contact = body.contact as string | null
+      await updateApplication(sql, app.client_id, patch)
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = { app: updated ? await toAppDetail(sql, updated) : null }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // DELETE /api/v1/account/apps/:id —— 仅 draft 可删
+  router.delete(`${API_PREFIX}/account/apps/:id`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      if (app.status !== 'draft') {
+        throw new AccountApiError('invalid_state')
+      }
+      await sql.query('DELETE FROM oauth_applications WHERE id = $1', [app.id])
+      ctx.status = 200
+      ctx.body = { deleted: true }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // POST /api/v1/account/apps/:id/redirect-uris —— 添加回调地址
+  router.post(`${API_PREFIX}/account/apps/:id/redirect-uris`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      if (app.status !== 'draft' && app.status !== 'rejected') {
+        throw new AccountApiError('invalid_state')
+      }
+      const body = ((await readJsonBody(ctx)) ?? {}) as { uri?: unknown; kind?: unknown }
+      const uri = typeof body.uri === 'string' ? body.uri.trim() : ''
+      const kind = body.kind === 'native_custom' || body.kind === 'native_loopback' ? body.kind : 'web_https'
+      if (!uri) {
+        throw new AccountApiError('invalid_request')
+      }
+      assertValidRedirectUris([{ uri, kind: kind as RedirectUriKind }], app.client_type, {
+        allowLocalhostDev: deps.env?.IDENTITY_ENVIRONMENT === 'development',
+      })
+      await sql.query(
+        `INSERT INTO oauth_redirect_uris (id, application_id, redirect_uri, kind)
+         VALUES ($1, $2, $3, $4)`,
+        [newUuidV7(), app.id, uri, kind],
+      )
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = { app: updated ? await toAppDetail(sql, updated) : null }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // DELETE /api/v1/account/apps/:id/redirect-uris/:rid —— 删除回调地址
+  router.delete(`${API_PREFIX}/account/apps/:id/redirect-uris/:rid`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      if (app.status !== 'draft' && app.status !== 'rejected') {
+        throw new AccountApiError('invalid_state')
+      }
+      await sql.query('DELETE FROM oauth_redirect_uris WHERE id = $1 AND application_id = $2', [
+        ctx.params.rid as string,
+        app.id,
+      ])
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = { app: updated ? await toAppDetail(sql, updated) : null }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // PUT /api/v1/account/apps/:id/scopes —— 替换全部 scope 请求
+  router.put(`${API_PREFIX}/account/apps/:id/scopes`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      if (app.status !== 'draft' && app.status !== 'rejected') {
+        throw new AccountApiError('invalid_state')
+      }
+      const body = ((await readJsonBody(ctx)) ?? {}) as { scopes?: Array<{ scope?: unknown; justification?: unknown }> }
+      const scopes = Array.isArray(body.scopes)
+        ? body.scopes
+            .filter((s) => typeof s?.scope === 'string')
+            .map((s) => ({
+              scope: s.scope as string,
+              justification: typeof s.justification === 'string' ? s.justification : null,
+            }))
+        : []
+      assertValidScopes(scopes.map((s) => s.scope))
+      await sql.query('DELETE FROM oauth_application_scopes WHERE application_id = $1', [app.id])
+      for (const s of scopes) {
+        await upsertApplicationScope(sql, app.id, s.scope, 'requested')
+        await sql.query(
+          `UPDATE oauth_application_scopes SET review_note = $1 WHERE application_id = $2 AND scope = $3`,
+          [s.justification, app.id, s.scope],
+        )
+      }
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = { app: updated ? await toAppDetail(sql, updated) : null }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // GET /api/v1/account/apps/:id/scopes —— scope 列表
+  router.get(`${API_PREFIX}/account/apps/:id/scopes`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      const result = await sql.query<{ scope: string; status: string; review_note: string | null }>(
+        `SELECT scope, status, review_note FROM oauth_application_scopes WHERE application_id = $1`,
+        [app.id],
+      )
+      ctx.status = 200
+      ctx.body = {
+        scopes: result.rows.map((r) => ({
+          scope: r.scope,
+          status: r.status,
+          justification: r.review_note,
+        })),
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // POST /api/v1/account/apps/:id/submit —— 提交审核（draft/rejected → pending_review）
+  router.post(`${API_PREFIX}/account/apps/:id/submit`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      if (app.status !== 'draft' && app.status !== 'rejected') {
+        throw new AccountApiError('invalid_state')
+      }
+      await setClientStatus(sql, app.client_id, 'pending_review')
+      await sql.query(`UPDATE oauth_applications SET submitted_at = NOW() WHERE id = $1`, [app.id])
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = { app: updated ? await toAppDetail(sql, updated) : null }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // POST /api/v1/account/apps/:id/credentials/rotate —— 轮换 secret（明文只返回一次）
+  router.post(`${API_PREFIX}/account/apps/:id/credentials/rotate`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      const { clientSecret } = await rotateClientSecret(sql, app.client_id, {
+        clientSecretKek: deps.env?.IDENTITY_CLIENT_SECRET_KEK,
+      })
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = {
+        app: updated ? await toAppDetail(sql, updated) : null,
+        client_secret: clientSecret,
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // POST /api/v1/account/apps/:id/revoke —— 撤销应用
+  router.post(`${API_PREFIX}/account/apps/:id/revoke`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      await setClientStatus(sql, app.client_id, 'revoked')
+      const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      ctx.status = 200
+      ctx.body = { app: updated ? await toAppDetail(sql, updated) : null }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // GET /api/v1/account/apps/:id/audit —— 单应用审计（target 维度，同 developer API）
+  router.get(`${API_PREFIX}/account/apps/:id/audit`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      const app = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      if (!app) {
+        throw new AccountApiError('not_found')
+      }
+      const result = await sql.query(
+        `SELECT id, created_at, event_type, actor_type, result, metadata_json
+         FROM audit_events WHERE target_id = $1 ORDER BY created_at DESC LIMIT 50`,
+        [app.id],
+      )
+      ctx.status = 200
+      ctx.body = {
+        audit: result.rows.map((r: Record<string, unknown>) => ({
+          id: r.id,
+          at: r.created_at,
+          action: r.event_type,
+          actor: r.actor_type,
+          detail: JSON.stringify(r.metadata_json ?? {}),
+        })),
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+}

--- a/identity-platform/core/src/api/account/audit.ts
+++ b/identity-platform/core/src/api/account/audit.ts
@@ -1,0 +1,41 @@
+/**
+ * Account API —— 账户审计端点（#688）。
+ *
+ * GET /api/v1/account/audit → 本账户（developer 维度 actor_id）审计事件。
+ * 与 developer API 的单应用审计同款输出形状，过滤维度从 target_id 换成
+ * actor_id = 当前 Key 归属 developer 的 id（key_created / key_revoked /
+ * app_created 等事件都以该维度落库）。
+ */
+import type Router from '@koa/router'
+import type { SqlExecutor } from '../../db/types.js'
+import { API_PREFIX } from '../requests.js'
+import { requireAccountAuth, resolveAccountDeveloper, respondAccountError } from './common.js'
+
+export function registerAccountAuditRoutes(router: Router, deps: { sql: SqlExecutor }): void {
+  const { sql } = deps
+
+  router.get(`${API_PREFIX}/account/audit`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const dev = await resolveAccountDeveloper(sql, userId)
+      // 只按 actor_id 过滤；metadata 由写入侧保证不含敏感值
+      const result = await sql.query(
+        `SELECT id, created_at, event_type, actor_type, result, metadata_json
+         FROM audit_events WHERE actor_id = $1 ORDER BY created_at DESC LIMIT 100`,
+        [dev.id],
+      )
+      ctx.status = 200
+      ctx.body = {
+        audit: result.rows.map((r: Record<string, unknown>) => ({
+          id: r.id,
+          at: r.created_at,
+          action: r.event_type,
+          actor: r.actor_type,
+          detail: JSON.stringify(r.metadata_json ?? {}),
+        })),
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+}

--- a/identity-platform/core/src/api/account/auth.ts
+++ b/identity-platform/core/src/api/account/auth.ts
@@ -1,0 +1,71 @@
+/**
+ * Account API Bearer 认证中间件（#688）。
+ *
+ * 认证头契约（冻结 v1）：`Authorization: Bearer <整串Key>`。
+ *
+ * 严谨度对齐 src/api/app/auth.ts:authenticateDeviceRequest：
+ * - 头缺失 / scheme 非法 / 格式偏差 → 统一 API_KEY_INVALID(401)，不泄露细节；
+ * - hash 比对 constant-time（security/api-key.ts 内部 timingSafeEqual）；
+ * - 校验成功后才把 user_id 与 key 元信息写入 ctx.state
+ *   （accountUserId / accountKey，绝不含 secret/hash），并 touch last_used_at。
+ */
+import type { Middleware } from 'koa'
+import type { SqlExecutor } from '../../db/types.js'
+import { verifyApiKey } from '../../security/api-key.js'
+import { parseApiKeyScopes, touchApiKeyLastUsed } from '../../db/repos/api-keys.repo.js'
+import { ApiKeyInvalidError } from '../../domain/errors.js'
+import type { AccountKeyState } from './common.js'
+import { respondAccountError } from './common.js'
+
+/** 解析 `Bearer <token>` 形式的 Authorization 头；非 Bearer/缺失返回 null */
+export function extractBearerToken(headerValue: string | undefined): string | null {
+  if (!headerValue) {
+    return null
+  }
+  const space = headerValue.indexOf(' ')
+  if (space <= 0 || space === headerValue.length - 1) {
+    return null
+  }
+  const scheme = headerValue.slice(0, space).trim()
+  if (scheme.toLowerCase() !== 'bearer') {
+    return null
+  }
+  return headerValue.slice(space + 1).trim()
+}
+
+/** 构造 Bearer 认证中间件（挂在 /api/v1/account 前缀上） */
+export function requireAccountKey(sql: SqlExecutor): Middleware {
+  return async (ctx, next) => {
+    // 中间件先于路由 handler 执行，认证失败必须在此处自答
+    // （否则异常冒泡到框架默认 handler，响应退化为纯文本状态行）
+    let row
+    try {
+      const token = extractBearerToken(ctx.get('authorization'))
+      if (!token) {
+        throw new ApiKeyInvalidError()
+      }
+      // verifyApiKey：格式 → prefix 定位行 → constant-time hash → 状态校验，
+      // 失败细分 API_KEY_INVALID / API_KEY_REVOKED / API_KEY_EXPIRED
+      row = await verifyApiKey(sql, token)
+    } catch (err) {
+      respondAccountError(ctx, err)
+      return
+    }
+    const key: AccountKeyState = {
+      id: row.id,
+      name: row.name,
+      prefix: row.prefix,
+      scopes: parseApiKeyScopes(row.scopes),
+      createdAt: row.created_at,
+    }
+    ctx.state.accountUserId = row.user_id
+    ctx.state.accountKey = key
+    // 最后使用时间尽力而为更新（失败不影响请求）
+    try {
+      await touchApiKeyLastUsed(sql, row.id)
+    } catch {
+      // 忽略 touch 失败
+    }
+    await next()
+  }
+}

--- a/identity-platform/core/src/api/account/common.ts
+++ b/identity-platform/core/src/api/account/common.ts
@@ -1,0 +1,230 @@
+/**
+ * Account API 公共层（#688 账户级 API Key）。
+ *
+ * 与 developer API（#624）的行为镜像约定：
+ * - ensureDeveloper / findOwnedApp / toSummary / toDetail 与
+ *   src/api/developer/index.ts 保持同款业务语义（那边未导出，此处镜像实现，
+ *   修改时两边必须同步）；差异仅在身份来源：developer API 来自
+ *   x-developer-subject（BFF 会话），account API 来自 Bearer Key 解析的 user_id。
+ * - 错误体统一平铺 `{ error: <code>, message? }`（与 developer API 一致，
+ *   便于 BFF 复用既有错误码映射）；认证失败 code 为契约大写码（API_KEY_*）。
+ */
+import type { RouterContext as KoaRouterContext } from '@koa/router'
+import type { SqlExecutor, QueryResultRow } from '../../db/types.js'
+import { DomainError } from '../../domain/errors.js'
+import { newUuidV7 } from '../../domain/ids.js'
+import {
+  listRedirectUris,
+  type OAuthApplicationRow,
+} from '../../db/repos/clients.repo.js'
+
+export const ACCOUNT_API_PREFIX = '/api/v1/account'
+
+/** ctx.state 上由 Bearer 认证中间件写入的凭据信息（绝不含 secret/hash） */
+export interface AccountKeyState {
+  id: string
+  name: string
+  prefix: string
+  scopes: string[]
+  createdAt: Date
+}
+
+/** 从 ctx.state 读取认证结果（中间件先行保证存在；防御式兜底抛 401） */
+export function requireAccountAuth(ctx: KoaRouterContext): { userId: string; key: AccountKeyState } {
+  const userId = ctx.state.accountUserId as string | undefined
+  const key = ctx.state.accountKey as AccountKeyState | undefined
+  if (!userId || !key) {
+    throw new DomainError('API_KEY_INVALID', 'API Key 无效', 401)
+  }
+  return { userId, key }
+}
+
+/** 业务错误（沿用 developer API 错误码风格；DomainError 子类，中文 message） */
+export class AccountApiError extends DomainError {
+  constructor(code: 'invalid_request' | 'invalid_state' | 'not_found' | 'forbidden', message?: string) {
+    super(
+      code,
+      message ??
+        ({
+          invalid_request: '请求参数不合法',
+          invalid_state: '当前状态不允许该操作',
+          not_found: '资源不存在',
+          forbidden: '没有权限执行该操作',
+        })[code],
+      code === 'invalid_request' ? 400 : code === 'not_found' ? 404 : code === 'forbidden' ? 403 : 409,
+    )
+    this.name = 'AccountApiError'
+  }
+}
+
+/**
+ * 统一错误响应：平铺 `{ error, message }`；未知错误 500 且不回显细节。
+ * ctx 用最小结构类型：同时兼容路由 handler（RouterContext）与
+ * 认证中间件自答场景（koa Middleware 的 ParameterizedContext）。
+ */
+export function respondAccountError(
+  ctx: { status: number; set(name: string, value: string): void; body?: unknown },
+  err: unknown,
+): void {
+  if (err instanceof DomainError) {
+    ctx.status = err.status
+    ctx.set('Cache-Control', 'no-store')
+    ctx.body = { error: err.code, message: err.message }
+    return
+  }
+  ctx.status = 500
+  ctx.set('Cache-Control', 'no-store')
+  ctx.body = { error: 'internal' }
+}
+
+// ---------------------------------------------------------------------------
+// developer 身份解析（与 src/api/developer/index.ts 镜像）
+// ---------------------------------------------------------------------------
+
+interface DeveloperRow extends QueryResultRow {
+  id: string
+  display_name: string
+  status: string
+  created_at: string
+}
+
+/** 按 user_id 查 developer（不存在返回 null） */
+export async function findDeveloperByUserId(
+  sql: SqlExecutor,
+  userId: string,
+): Promise<DeveloperRow | null> {
+  const result = await sql.query<DeveloperRow>(
+    'SELECT id, display_name, status, created_at FROM developers WHERE user_id = $1',
+    [userId],
+  )
+  return result.rows[0] ?? null
+}
+
+/**
+ * 按 user_id 幂等建档（ensureDeveloper 同款语义：首次访问自动创建 dev_ 前缀记录）。
+ * 应用归属依赖 developers.id（oauth_applications.owner_developer_id），
+ * 因此即使只走 API Key 的 Agent 也需要一条 developer 记录。
+ */
+export async function ensureDeveloperForUser(
+  sql: SqlExecutor,
+  userId: string,
+  displayName: string,
+): Promise<DeveloperRow> {
+  const existing = await findDeveloperByUserId(sql, userId)
+  if (existing) {
+    return existing
+  }
+  const id = `dev_${newUuidV7()}`
+  await sql.query(
+    `INSERT INTO developers (id, user_id, display_name, status)
+     VALUES ($1, $2, $3, 'active')`,
+    [id, userId, displayName],
+  )
+  return { id, display_name: displayName, status: 'active', created_at: new Date().toISOString() }
+}
+
+/** 解析 Bearer 身份 → developer 记录（account 端点公共前置） */
+export async function resolveAccountDeveloper(
+  sql: SqlExecutor,
+  userId: string,
+): Promise<DeveloperRow> {
+  const dev = await ensureDeveloperForUser(sql, userId, '开发者')
+  if (dev.status !== 'active') {
+    throw new AccountApiError('forbidden')
+  }
+  return dev
+}
+
+// ---------------------------------------------------------------------------
+// 应用 DTO（toSummary / toDetail / findOwnedApp，与 developer API 镜像）
+// ---------------------------------------------------------------------------
+
+/** 查本人应用（owner 过滤；非本人 → null，不泄露存在性） */
+export async function findOwnedApp(
+  sql: SqlExecutor,
+  developerId: string,
+  appId: string,
+): Promise<OAuthApplicationRow | null> {
+  const result = await sql.query<OAuthApplicationRow>(
+    'SELECT * FROM oauth_applications WHERE id = $1 AND owner_developer_id = $2',
+    [appId, developerId],
+  )
+  return result.rows[0] ?? null
+}
+
+/** 应用行 → 摘要 DTO（scopes 由调用方补充） */
+export async function toAppSummary(
+  sql: SqlExecutor,
+  app: OAuthApplicationRow,
+): Promise<Record<string, unknown>> {
+  await listRedirectUris(sql, app.id)
+  return {
+    id: app.id,
+    client_id: app.client_id,
+    name: app.name,
+    client_type: app.client_type,
+    status: app.status,
+    scopes: [],
+    updated_at: app.updated_at.toISOString(),
+  }
+}
+
+/** 应用行 → 详情 DTO（与 developer API toDetail 同款字段） */
+export async function toAppDetail(
+  sql: SqlExecutor,
+  app: OAuthApplicationRow,
+): Promise<Record<string, unknown>> {
+  const uris = await listRedirectUris(sql, app.id)
+  const scopes = await sql.query<{ scope: string; status: string; review_note: string | null }>(
+    `SELECT scope, status, review_note FROM oauth_application_scopes WHERE application_id = $1 ORDER BY scope`,
+    [app.id],
+  )
+  return {
+    id: app.id,
+    client_id: app.client_id,
+    name: app.name,
+    client_type: app.client_type,
+    status: app.status,
+    description: app.description ?? null,
+    homepage_url: app.homepage_url ?? null,
+    privacy_policy_url: app.privacy_policy_url ?? null,
+    contact: (app as unknown as { contact?: string | null }).contact ?? null,
+    created_at: app.created_at.toISOString(),
+    updated_at: app.updated_at.toISOString(),
+    submitted_at: app.submitted_at ? app.submitted_at.toISOString() : null,
+    activated_at: app.activated_at ? app.activated_at.toISOString() : null,
+    scopes: scopes.rows.map((r) => ({
+      scope: r.scope,
+      status: r.status,
+      justification: r.review_note,
+    })),
+    redirect_uris: uris.map((u) => ({
+      id: u.id,
+      uri: u.redirect_uri,
+      kind: u.kind,
+      validation_status: u.kind === 'web_https' ? 'approved' : 'pending',
+      created_at: u.created_at.toISOString(),
+    })),
+    review: {
+      status: app.status,
+      submitted_at: app.submitted_at ? app.submitted_at.toISOString() : null,
+      reviewed_at: app.reviewed_at ? app.reviewed_at.toISOString() : null,
+      decision:
+        app.status === 'active' || app.status === 'approved'
+          ? 'approved'
+          : app.status === 'rejected'
+            ? 'rejected'
+            : null,
+      rejection_reason: app.status === 'rejected' ? '应用未通过审核，请根据审核意见修改后重新提交' : null,
+      review_notes: null,
+      needs_changes: app.status === 'rejected' ? ['请修改后重新提交审核'] : null,
+    },
+    secret: {
+      created_at: app.client_secret_encrypted ? app.created_at.toISOString() : null,
+      last_rotated_at: null,
+      fingerprint: null,
+      last4: null,
+    },
+    audit: [],
+  }
+}

--- a/identity-platform/core/src/api/account/devices.ts
+++ b/identity-platform/core/src/api/account/devices.ts
@@ -1,0 +1,38 @@
+/**
+ * Account API —— 设备列表端点（#688）。
+ *
+ * GET /api/v1/account/devices → 本账户设备列表（listDevicesByUser，
+ * 与 App API 设备自查询同款字段裁剪：不暴露公钥 JWK 全量，只给展示所需字段）。
+ */
+import type Router from '@koa/router'
+import type { SqlExecutor } from '../../db/types.js'
+import { API_PREFIX } from '../requests.js'
+import { listDevicesByUser } from '../../db/repos/devices.repo.js'
+import { requireAccountAuth, respondAccountError } from './common.js'
+
+export function registerAccountDevicesRoutes(router: Router, deps: { sql: SqlExecutor }): void {
+  const { sql } = deps
+
+  router.get(`${API_PREFIX}/account/devices`, async (ctx) => {
+    try {
+      const { userId } = requireAccountAuth(ctx)
+      const devices = await listDevicesByUser(sql, userId)
+      ctx.status = 200
+      ctx.body = {
+        devices: devices.map((d) => ({
+          id: d.id,
+          device_name: d.device_name,
+          platform: d.platform,
+          app_version: d.app_version,
+          status: d.status,
+          fingerprint: d.public_key_fingerprint,
+          created_at: d.created_at.toISOString(),
+          activated_at: d.activated_at ? d.activated_at.toISOString() : null,
+          last_seen_at: d.last_seen_at ? d.last_seen_at.toISOString() : null,
+        })),
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+}

--- a/identity-platform/core/src/api/account/index.ts
+++ b/identity-platform/core/src/api/account/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Account API 路由注册（#688 账户级 API Key 一期）。
+ *
+ * 两组路由（挂载约定与 #622/#624 对齐：本目录导出 registerAccountRoutes，
+ * 由 src/api/index.ts 统一调用，本目录不 import api/index.ts）：
+ *
+ * 1. Bearer 直连组（Agent 持整串 Key 调用，前缀 /api/v1/account）：
+ *    GET /me                       → {user_id, key:{id,name,prefix,scopes,created_at}}
+ *    GET|POST /apps；GET|PATCH|DELETE /apps/:id
+ *    POST /apps/:id/redirect-uris；DELETE /apps/:id/redirect-uris/:rid
+ *    PUT|GET /apps/:id/scopes；POST /apps/:id/submit
+ *    POST /apps/:id/credentials/rotate；POST /apps/:id/revoke；GET /apps/:id/audit
+ *    GET /devices                  → 本账户设备列表
+ *    GET /audit                    → 本账户审计事件
+ *    认证：Authorization: Bearer <整串Key>（requireAccountKey 中间件挂在组前缀上）。
+ *
+ * 2. 管理面组（/api/v1/developer/keys，复用既有 service-token +
+ *    x-developer-subject 链路，供门户 BFF 调用）：签发/列表/吊销。
+ */
+import type Router from '@koa/router'
+import type { SqlExecutor } from '../../db/types.js'
+import { API_PREFIX } from '../requests.js'
+import { requireAccountKey } from './auth.js'
+import { requireAccountAuth, respondAccountError } from './common.js'
+import { registerAccountAppsRoutes } from './apps.js'
+import { registerAccountDevicesRoutes } from './devices.js'
+import { registerAccountAuditRoutes } from './audit.js'
+import { registerDeveloperKeysRoutes, type DeveloperKeysApiDeps } from './keys.js'
+
+export interface AccountApiDeps extends DeveloperKeysApiDeps {
+  sql: SqlExecutor
+}
+
+/** 注册 #688 Account API 全部路由（由 api/index.ts 调用） */
+export function registerAccountRoutes(router: Router, deps: AccountApiDeps): void {
+  // Bearer 认证中间件只作用于 /api/v1/account 前缀（管理面 keys 组不受影响）
+  router.use(`${API_PREFIX}/account`, requireAccountKey(deps.sql))
+
+  // GET /api/v1/account/me —— 当前 Key 与账户信息（凭据元数据来自 ctx.state）
+  router.get(`${API_PREFIX}/account/me`, async (ctx) => {
+    try {
+      const { userId, key } = requireAccountAuth(ctx)
+      ctx.status = 200
+      ctx.body = {
+        user_id: userId,
+        key: {
+          id: key.id,
+          name: key.name,
+          prefix: key.prefix,
+          scopes: key.scopes,
+          created_at: key.createdAt.toISOString(),
+        },
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  registerAccountAppsRoutes(router, deps)
+  registerAccountDevicesRoutes(router, deps)
+  registerAccountAuditRoutes(router, deps)
+  registerDeveloperKeysRoutes(router, deps)
+}

--- a/identity-platform/core/src/api/account/keys.ts
+++ b/identity-platform/core/src/api/account/keys.ts
@@ -1,0 +1,194 @@
+/**
+ * Account API —— 管理面 Key 签发/列表/吊销端点（#688）。
+ *
+ * 挂载在 developer 命名空间（/api/v1/developer/keys），复用既有
+ * service-token + x-developer-subject 链路（开发者门户会话经 BFF 调用；
+ * service-token 中间件按前缀 '/api/v1/developer/' 自动覆盖本组路由）。
+ *
+ * 端点（契约 v1）：
+ *   GET    /api/v1/developer/keys      → {keys:[{id,name,prefix,status,last_used_at?,created_at}]}
+ *                                    （无明文/无 hash）
+ *   POST   /api/v1/developer/keys body{name} → 201 {key:"mhbat_...", info:{...}}
+ *                                    （明文仅此一次；审计 key_created）
+ *   DELETE /api/v1/developer/keys/:id  → 204（owner 校验，非本人 404；审计 key_revoked）
+ */
+import type Router from '@koa/router'
+import type { RouterContext } from '@koa/router'
+import type { SqlExecutor } from '../../db/types.js'
+import { API_PREFIX } from '../requests.js'
+import { readJsonBody } from '../app/body.js'
+import { resolveUserIdBySubject } from '../../domain/subject-resolution.js'
+import { newUuidV7 } from '../../domain/ids.js'
+import { insertAuditEvent } from '../../db/repos/audit.repo.js'
+import {
+  findApiKeyByIdAndUser,
+  findApiKeyByPrefix,
+  listApiKeysByUser,
+  insertApiKey,
+  revokeApiKey,
+} from '../../db/repos/api-keys.repo.js'
+import { generateApiKey } from '../../security/api-key.js'
+import { ensureDeveloperForUser, respondAccountError } from './common.js'
+
+export interface DeveloperKeysApiDeps {
+  sql: SqlExecutor
+  /** IDENTITY_PAIRWISE_SUBJECT_KEY */
+  pairwiseKey?: string
+  /** 开发者门户登录 client_id */
+  developerClientId?: string
+  env?: Record<string, string | undefined>
+}
+
+function readSubject(ctx: RouterContext): string | undefined {
+  const value = ctx.get('x-developer-subject')
+  return value.length > 0 ? value : undefined
+}
+
+async function resolveSubjectUserId(deps: DeveloperKeysApiDeps, subject: string | undefined): Promise<string | null> {
+  if (!subject) return null
+  try {
+    return await resolveUserIdBySubject({
+      sql: deps.sql,
+      pairwiseKey: deps.pairwiseKey ?? deps.env?.IDENTITY_PAIRWISE_SUBJECT_KEY,
+      clientId: deps.developerClientId ?? deps.env?.DEVELOPER_OIDC_CLIENT_ID ?? 'developer-portal',
+      subject,
+    })
+  } catch {
+    // pairwiseKey 未配置等 fail closed 场景 → 视为未认证
+    return null
+  }
+}
+
+/** prefix 预检重试（8 hex = 2^32 空间；UNIQUE 约束兜底竞态） */
+async function generateUniqueApiKey(sql: SqlExecutor) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const generated = generateApiKey()
+    const existing = await findApiKeyByPrefix(sql, generated.prefix)
+    if (!existing) {
+      return generated
+    }
+  }
+  throw new Error('api key prefix 冲突重试耗尽')
+}
+
+export function registerDeveloperKeysRoutes(router: Router, deps: DeveloperKeysApiDeps): void {
+  const { sql } = deps
+
+  // GET /api/v1/developer/keys —— 本账户 Key 列表（无明文/无 hash）
+  router.get(`${API_PREFIX}/developer/keys`, async (ctx) => {
+    try {
+      const userId = await resolveSubjectUserId(deps, readSubject(ctx))
+      if (!userId) {
+        ctx.status = 401
+        ctx.body = { error: 'unauthorized', message: '登录状态无效' }
+        return
+      }
+      await ensureDeveloperForUser(sql, userId, '开发者')
+      const rows = await listApiKeysByUser(sql, userId)
+      ctx.status = 200
+      ctx.set('Cache-Control', 'no-store')
+      ctx.body = {
+        keys: rows.map((k) => ({
+          id: k.id,
+          name: k.name,
+          prefix: k.prefix,
+          status: k.status,
+          ...(k.last_used_at ? { last_used_at: k.last_used_at.toISOString() } : {}),
+          created_at: k.created_at.toISOString(),
+        })),
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // POST /api/v1/developer/keys —— 签发新 Key（明文仅此一次）
+  router.post(`${API_PREFIX}/developer/keys`, async (ctx) => {
+    try {
+      const userId = await resolveSubjectUserId(deps, readSubject(ctx))
+      if (!userId) {
+        ctx.status = 401
+        ctx.body = { error: 'unauthorized', message: '登录状态无效' }
+        return
+      }
+      const dev = await ensureDeveloperForUser(sql, userId, '开发者')
+      const body = ((await readJsonBody(ctx)) ?? {}) as { name?: unknown }
+      const name = typeof body.name === 'string' ? body.name.trim().slice(0, 64) : ''
+      if (!name) {
+        ctx.status = 400
+        ctx.body = { error: 'invalid_request', message: 'Key 名称不能为空' }
+        return
+      }
+      const generated = await generateUniqueApiKey(sql)
+      const id = `ak_${newUuidV7()}`
+      await insertApiKey(sql, {
+        id,
+        userId,
+        name,
+        prefix: generated.prefix,
+        secretHash: generated.hash,
+      })
+      // 审计只含 key_id/name/prefix；secret/hash 绝不落审计
+      await insertAuditEvent(sql, {
+        eventType: 'developer.key_created',
+        actorType: 'developer',
+        actorId: dev.id,
+        targetType: 'api_key',
+        targetId: id,
+        result: 'success',
+        metadata: { key_id: id, name, prefix: generated.prefix },
+      })
+      ctx.status = 201
+      ctx.set('Cache-Control', 'no-store')
+      ctx.body = {
+        key: generated.full,
+        info: {
+          id,
+          name,
+          prefix: generated.prefix,
+          status: 'active',
+          created_at: new Date().toISOString(),
+        },
+      }
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+
+  // DELETE /api/v1/developer/keys/:id —— 吊销（owner 校验；非本人 404 防枚举）
+  router.delete(`${API_PREFIX}/developer/keys/:id`, async (ctx) => {
+    try {
+      const userId = await resolveSubjectUserId(deps, readSubject(ctx))
+      if (!userId) {
+        ctx.status = 401
+        ctx.body = { error: 'unauthorized', message: '登录状态无效' }
+        return
+      }
+      const dev = await ensureDeveloperForUser(sql, userId, '开发者')
+      const key = await findApiKeyByIdAndUser(sql, ctx.params.id as string, userId)
+      if (!key) {
+        ctx.status = 404
+        ctx.body = { error: 'not_found', message: 'Key 不存在' }
+        return
+      }
+      const revoked = await revokeApiKey(sql, key.id)
+      if (revoked) {
+        // 仅在真实发生 active→revoked 迁移时记审计（幂等重放不重复记）
+        await insertAuditEvent(sql, {
+          eventType: 'developer.key_revoked',
+          actorType: 'developer',
+          actorId: dev.id,
+          targetType: 'api_key',
+          targetId: key.id,
+          result: 'success',
+          metadata: { key_id: key.id, name: key.name, prefix: key.prefix },
+        })
+      }
+      ctx.status = 204
+      ctx.set('Cache-Control', 'no-store')
+      ctx.body = null
+    } catch (err) {
+      respondAccountError(ctx, err)
+    }
+  })
+}

--- a/identity-platform/core/src/api/index.ts
+++ b/identity-platform/core/src/api/index.ts
@@ -17,6 +17,7 @@ import { registerRequestsRoutes, API_PREFIX, type RequestsApiDeps } from './requ
 import { registerAppRoutes } from './app/index.js'
 import { registerAdminRoutes } from './admin/index.js'
 import { registerDeveloperRoutes } from './developer/index.js'
+import { registerAccountRoutes } from './account/index.js'
 
 export { API_PREFIX, HANDOFF_HEADER } from './requests.js'
 export type { RequestsApiDeps } from './requests.js'
@@ -56,6 +57,15 @@ export function registerApiRoutes(router: Router, deps: ApiDeps): void {
     sql: deps.sql,
     pairwiseKey: process.env.IDENTITY_PAIRWISE_SUBJECT_KEY,
     clientSecretKek: process.env.IDENTITY_CLIENT_SECRET_KEK,
+    developerClientId: process.env.DEVELOPER_OIDC_CLIENT_ID ?? 'developer-portal',
+    env: process.env,
+  })
+
+  // #688 account 端点：账户级 API Key——Bearer 直连 /api/v1/account/**，
+  // 以及管理面 /api/v1/developer/keys（service-token + x-developer-subject 链路）。
+  registerAccountRoutes(router, {
+    sql: deps.sql,
+    pairwiseKey: process.env.IDENTITY_PAIRWISE_SUBJECT_KEY,
     developerClientId: process.env.DEVELOPER_OIDC_CLIENT_ID ?? 'developer-portal',
     env: process.env,
   })

--- a/identity-platform/core/src/db/repos/api-keys.repo.ts
+++ b/identity-platform/core/src/db/repos/api-keys.repo.ts
@@ -1,0 +1,114 @@
+/**
+ * api_keys 仓储（#688 账户级 API Key）。
+ *
+ * 安全约定：
+ * - secret_hash = sha256Base64url(整串 Key)，明文绝不入库（签发响应只出现一次）；
+ * - prefix 列 UNIQUE，认证时按前缀定位行再做 constant-time 比对；
+ * - 所有列表/查询接口不得返回 secret_hash（由 DTO 层裁剪）。
+ */
+import type { SqlExecutor, QueryResultRow } from '../types.js'
+import { parseJsonb } from '../types.js'
+
+export type ApiKeyStatus = 'active' | 'revoked'
+
+export interface ApiKeyRow extends QueryResultRow {
+  id: string
+  user_id: string
+  name: string
+  prefix: string
+  secret_hash: string
+  scopes: unknown
+  status: ApiKeyStatus
+  expires_at: Date | null
+  last_used_at: Date | null
+  created_at: Date
+}
+
+/** 解析 scopes JSONB 列（两种驱动返回形态统一成数组） */
+export function parseApiKeyScopes(value: unknown): string[] {
+  const parsed = parseJsonb<unknown>(value)
+  return Array.isArray(parsed) ? (parsed as string[]) : []
+}
+
+export async function insertApiKey(sql: SqlExecutor, key: {
+  id: string
+  userId: string
+  name: string
+  prefix: string
+  secretHash: string
+  scopes?: string[]
+}): Promise<void> {
+  await sql.query(
+    `INSERT INTO api_keys (id, user_id, name, prefix, secret_hash, scopes)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+    [
+      key.id,
+      key.userId,
+      key.name,
+      key.prefix,
+      key.secretHash,
+      JSON.stringify(key.scopes ?? ['account.full']),
+    ],
+  )
+}
+
+/** 按前缀查行（认证路径；返回原始行含 hash，调用方负责不外泄） */
+export async function findApiKeyByPrefix(
+  sql: SqlExecutor,
+  prefix: string,
+): Promise<ApiKeyRow | null> {
+  const result = await sql.query<ApiKeyRow>(
+    'SELECT * FROM api_keys WHERE prefix = $1',
+    [prefix],
+  )
+  return result.rows[0] ?? null
+}
+
+/** 按 id + 属主查询（管理面吊销路径；非本人一律视为不存在） */
+export async function findApiKeyByIdAndUser(
+  sql: SqlExecutor,
+  id: string,
+  userId: string,
+): Promise<ApiKeyRow | null> {
+  const result = await sql.query<ApiKeyRow>(
+    'SELECT * FROM api_keys WHERE id = $1 AND user_id = $2',
+    [id, userId],
+  )
+  return result.rows[0] ?? null
+}
+
+export interface ApiKeySummaryRow extends QueryResultRow {
+  id: string
+  name: string
+  prefix: string
+  status: ApiKeyStatus
+  last_used_at: Date | null
+  created_at: Date
+}
+
+/** 本账户 Key 列表（不含 secret_hash；门户展示用） */
+export async function listApiKeysByUser(
+  sql: SqlExecutor,
+  userId: string,
+): Promise<ApiKeySummaryRow[]> {
+  const result = await sql.query<ApiKeySummaryRow>(
+    `SELECT id, name, prefix, status, last_used_at, created_at
+       FROM api_keys WHERE user_id = $1 ORDER BY created_at DESC`,
+    [userId],
+  )
+  return result.rows
+}
+
+/** 吊销（条件更新：仅 active 可吊销；幂等——已吊销返回 false） */
+export async function revokeApiKey(sql: SqlExecutor, id: string): Promise<boolean> {
+  const result = await sql.query(
+    `UPDATE api_keys SET status = 'revoked' WHERE id = $1 AND status = 'active'`,
+    [id],
+  )
+  return (result.rowCount ?? 0) === 1
+}
+
+/** 认证成功后更新最后使用时间（失败不影响请求；尽力而为） */
+export async function touchApiKeyLastUsed(sql: SqlExecutor, id: string): Promise<void> {
+  await sql.query('UPDATE api_keys SET last_used_at = NOW() WHERE id = $1', [id])
+}

--- a/identity-platform/core/src/domain/errors.ts
+++ b/identity-platform/core/src/domain/errors.ts
@@ -108,3 +108,24 @@ export class AuditSensitiveFieldError extends DomainError {
     super('AUDIT_SENSITIVE_FIELD', `audit metadata 含敏感字段：${field}`, 400)
   }
 }
+
+/** API Key 无效（格式非法 / prefix 无对应行 / hash 不匹配；不泄露具体原因） */
+export class ApiKeyInvalidError extends DomainError {
+  constructor() {
+    super('API_KEY_INVALID', 'API Key 无效', 401)
+  }
+}
+
+/** API Key 已吊销（已证明持有 secret 后才可见的状态） */
+export class ApiKeyRevokedError extends DomainError {
+  constructor() {
+    super('API_KEY_REVOKED', 'API Key 已被吊销', 403)
+  }
+}
+
+/** API Key 已过期（已证明持有 secret 后才可见的状态） */
+export class ApiKeyExpiredError extends DomainError {
+  constructor() {
+    super('API_KEY_EXPIRED', 'API Key 已过期', 403)
+  }
+}

--- a/identity-platform/core/src/security/api-key.ts
+++ b/identity-platform/core/src/security/api-key.ts
@@ -18,7 +18,7 @@
  */
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import type { SqlExecutor } from '../db/types.js'
-import { sha256Base64url } from './hash.js'
+import { hmacSha256Base64url } from './hash.js'
 import { findApiKeyByPrefix, type ApiKeyRow } from '../db/repos/api-keys.repo.js'
 import { ApiKeyExpiredError, ApiKeyInvalidError, ApiKeyRevokedError } from '../domain/errors.js'
 
@@ -42,20 +42,41 @@ export interface GeneratedApiKey {
   full: string
   /** 入库前缀 "mhbat_<8hex>"（14 字符，UNIQUE） */
   prefix: string
-  /** sha256Base64url(整串)，入库值 */
+  /** HMAC-SHA256(整串, 服务端 pepper)，入库值 */
   hash: string
+}
+
+/**
+ * 存储哈希的 pepper：复用 KEK 环境变量派生，避免静态常量。
+ * - production 缺失/非法 → fail closed（与 client-secret 同策略）；
+ * - 非生产回退开发常量并告警（便于本地/测试跑通）。
+ */
+function getPepper(): string {
+  const raw = process.env.IDENTITY_CLIENT_SECRET_KEK
+  if (raw && Buffer.from(raw, 'utf8').length >= 32) return raw
+  if (process.env.IDENTITY_ENVIRONMENT === 'production') {
+    throw new Error(
+      '[security] IDENTITY_CLIENT_SECRET_KEK 缺失或不足 32 字节，API Key 无法安全存储（fail closed）',
+    )
+  }
+  // eslint-disable-next-line no-console
+  console.error('[security] 开发/测试环境使用固定 API Key pepper——严禁用于生产')
+  return 'mini-hbut-dev-api-key-pepper'
 }
 
 /**
  * 生成一把新 Key（CSPRNG；禁止 Math.random 参与任何密钥材料）。
  * prefix 取自独立随机源，与主体互不派生；UNIQUE 冲突由调用方重试。
+ *
+ * 存储哈希用 HMAC-SHA256(pepper)：对高熵随机 Key 而言防碰撞足够，
+ * 引入服务端 pepper 同时满足 CodeQL 对「快速哈希存密码类凭据」的红线（#688）。
  */
 export function generateApiKey(): GeneratedApiKey {
   const hexPrefix = randomBytes(HEX_PREFIX_LENGTH / 2).toString('hex')
   const prefix = `${API_KEY_PREFIX}${hexPrefix}`
   const body = randomBytes(SECRET_BYTES).toString('base64url')
   const full = `${prefix}_${body}`
-  return { full, prefix, hash: sha256Base64url(full) }
+  return { full, prefix, hash: hmacSha256Base64url(getPepper(), full) }
 }
 
 /**
@@ -72,8 +93,8 @@ export async function verifyApiKey(sql: SqlExecutor, token: string): Promise<Api
   if (!row) {
     throw new ApiKeyInvalidError()
   }
-  // 2) constant-time 比对 sha256Base64url(整串)；长度相同（43 字符）才进比对
-  const computed = Buffer.from(sha256Base64url(token), 'utf8')
+  // 2) constant-time 比对 HMAC-SHA256(整串, pepper)；长度相同（43 字符）才进比对
+  const computed = Buffer.from(hmacSha256Base64url(getPepper(), token), 'utf8')
   const stored = Buffer.from(row.secret_hash, 'utf8')
   if (computed.length !== stored.length || !timingSafeEqual(computed, stored)) {
     throw new ApiKeyInvalidError()

--- a/identity-platform/core/src/security/api-key.ts
+++ b/identity-platform/core/src/security/api-key.ts
@@ -1,0 +1,89 @@
+/**
+ * 账户级 API Key 生成 / 校验（#688，冻结契约 v1）。
+ *
+ * Key 形态（逐字一致）：
+ *   mhbat_<8位小写hex>_<43位base64url>
+ *   即 "mhbat_" + 8 hex prefix + "_" + 32 字节随机 base64url（无填充），
+ *   总长 58 字符。prefix 列存 "mhbat_<8位hex>"（14 字符）。
+ *
+ * 存储约定：
+ * - 库中只存 sha256Base64url(整串)，绝不存明文；
+ * - 明文只在签发响应中出现一次，服务端无法找回。
+ *
+ * 校验约定（失败细分三种领域错误，且不泄露存在性/状态给未持密者）：
+ *   1) 格式非法 / prefix 无对应行 / hash 不匹配 → API_KEY_INVALID(401)；
+ *   2) hash 匹配但 status=revoked             → API_KEY_REVOKED(403)；
+ *   3) hash 匹配但已过 expires_at              → API_KEY_EXPIRED(403)。
+ * 顺序刻意「先验 hash、后看状态」：未证明持有 secret 前，不泄露任何状态信息。
+ */
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import type { SqlExecutor } from '../db/types.js'
+import { sha256Base64url } from './hash.js'
+import { findApiKeyByPrefix, type ApiKeyRow } from '../db/repos/api-keys.repo.js'
+import { ApiKeyExpiredError, ApiKeyInvalidError, ApiKeyRevokedError } from '../domain/errors.js'
+
+/** Key 固定前缀（契约 v1） */
+export const API_KEY_PREFIX = 'mhbat_'
+
+/** hex prefix 长度（8 位小写 hex = 32-bit 随机） */
+const HEX_PREFIX_LENGTH = 8
+
+/** 随机主体字节数（32 字节 → base64url 43 字符） */
+const SECRET_BYTES = 32
+
+/** 整串总长：6("mhbat_") + 8(hex) + 1("_") + 43(base64url) */
+export const API_KEY_FULL_LENGTH = API_KEY_PREFIX.length + HEX_PREFIX_LENGTH + 1 + 43
+
+/** Key 完整形态（整串）正则：mhbat_ + 8 小写 hex + _ + 43 位 base64url */
+const API_KEY_FULL_RE = /^mhbat_[0-9a-f]{8}_[A-Za-z0-9_-]{43}$/
+
+export interface GeneratedApiKey {
+  /** 整串明文（只返回一次，绝不入库/日志） */
+  full: string
+  /** 入库前缀 "mhbat_<8hex>"（14 字符，UNIQUE） */
+  prefix: string
+  /** sha256Base64url(整串)，入库值 */
+  hash: string
+}
+
+/**
+ * 生成一把新 Key（CSPRNG；禁止 Math.random 参与任何密钥材料）。
+ * prefix 取自独立随机源，与主体互不派生；UNIQUE 冲突由调用方重试。
+ */
+export function generateApiKey(): GeneratedApiKey {
+  const hexPrefix = randomBytes(HEX_PREFIX_LENGTH / 2).toString('hex')
+  const prefix = `${API_KEY_PREFIX}${hexPrefix}`
+  const body = randomBytes(SECRET_BYTES).toString('base64url')
+  const full = `${prefix}_${body}`
+  return { full, prefix, hash: sha256Base64url(full) }
+}
+
+/**
+ * 校验 Bearer 凭据并返回对应 api_keys 行（含 user_id，供后续 owner 解析）。
+ * 失败按契约细分三种 DomainError；成功后由调用方负责 touch last_used_at。
+ */
+export async function verifyApiKey(sql: SqlExecutor, token: string): Promise<ApiKeyRow> {
+  // 1) 形态校验：任何格式偏差一律 invalid（不区分缺头/截断/篡改）
+  if (token.length !== API_KEY_FULL_LENGTH || !API_KEY_FULL_RE.test(token)) {
+    throw new ApiKeyInvalidError()
+  }
+  const prefix = token.slice(0, API_KEY_PREFIX.length + HEX_PREFIX_LENGTH)
+  const row = await findApiKeyByPrefix(sql, prefix)
+  if (!row) {
+    throw new ApiKeyInvalidError()
+  }
+  // 2) constant-time 比对 sha256Base64url(整串)；长度相同（43 字符）才进比对
+  const computed = Buffer.from(sha256Base64url(token), 'utf8')
+  const stored = Buffer.from(row.secret_hash, 'utf8')
+  if (computed.length !== stored.length || !timingSafeEqual(computed, stored)) {
+    throw new ApiKeyInvalidError()
+  }
+  // 3) 已证明持有 secret，才允许看到状态细节
+  if (row.status === 'revoked') {
+    throw new ApiKeyRevokedError()
+  }
+  if (row.expires_at !== null && row.expires_at.getTime() <= Date.now()) {
+    throw new ApiKeyExpiredError()
+  }
+  return row
+}

--- a/identity-platform/core/src/security/rate-limit.ts
+++ b/identity-platform/core/src/security/rate-limit.ts
@@ -71,6 +71,9 @@ export const DEFAULT_RATE_LIMIT_GROUPS: readonly RateLimitGroup[] = [
   { name: 'deviceRevoke', prefixes: ['/api/v1/app/devices/'], methods: ['POST'], rule: { limit: 30, windowSeconds: 60, failPolicy: 'closed' } },
   { name: 'developerRead', prefixes: ['/api/v1/developer/'], methods: ['GET'], rule: { limit: 300, windowSeconds: 60, failPolicy: 'open' } },
   { name: 'developerWrite', prefixes: ['/api/v1/developer/'], methods: ['POST', 'PATCH', 'DELETE'], rule: { limit: 60, windowSeconds: 60, failPolicy: 'closed' } },
+  // #688 账户级 API Key（Bearer 直连）：读多写少，读 fail open / 写 fail closed
+  { name: 'apiKeyRead', prefixes: ['/api/v1/account/'], methods: ['GET'], rule: { limit: 300, windowSeconds: 60, failPolicy: 'open' } },
+  { name: 'apiKeyWrite', prefixes: ['/api/v1/account/'], methods: ['POST', 'PATCH', 'PUT', 'DELETE'], rule: { limit: 60, windowSeconds: 60, failPolicy: 'closed' } },
   { name: 'admin', prefixes: ['/api/v1/admin/'], rule: { limit: 120, windowSeconds: 60, failPolicy: 'closed' } },
   { name: 'userinfo', prefixes: ['/oauth/userinfo'], methods: ['GET', 'POST'], rule: { limit: 600, windowSeconds: 60, failPolicy: 'open' } },
 ]

--- a/identity-platform/core/tests/api/account.test.ts
+++ b/identity-platform/core/tests/api/account.test.ts
@@ -1,0 +1,373 @@
+/**
+ * #688 账户级 API Key 测试：
+ * - 签发：明文只出现一次、库中只有 hash、列表不泄露明文/hash；
+ * - Bearer 认证：/me 全链路；无效 Key 401；吊销后 403 API_KEY_REVOKED；
+ *   过期 403 API_KEY_EXPIRED；
+ * - 应用管理镜像：Bearer 创建应用 → 列表 → 详情全链路；
+ * - 管理面（x-developer-subject）：GET /keys 无敏感值；DELETE 吊销；
+ * - 限流分组存在性冒烟（apiKeyRead open / apiKeyWrite closed）。
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Koa from 'koa'
+import Router from '@koa/router'
+import { createTestDatabase, type TestDatabase } from '../helpers/pg.js'
+import { withServer } from '../helpers.js'
+import { createClientFixture } from '../helpers/fixtures.js'
+import {
+  TEST_KEK,
+  TEST_PAIRWISE_KEY,
+} from '../helpers/keys.js'
+import { registerAccountRoutes } from '../../src/api/account/index.js'
+import { insertApiKey } from '../../src/db/repos/api-keys.repo.js'
+import { sha256Base64url } from '../../src/security/hash.js'
+import { DEFAULT_RATE_LIMIT_GROUPS } from '../../src/security/rate-limit.js'
+import { derivePairwiseSubject } from '../../src/domain/subjects.js'
+
+/** 组装仅含 account 路由的 Koa app（测试用；生产由 app.ts + api/index.ts 组装） */
+function buildAccountApp(sql: TestDatabase['sql']): Koa {
+  const app = new Koa()
+  const router = new Router()
+  registerAccountRoutes(router, {
+    sql,
+    pairwiseKey: TEST_PAIRWISE_KEY,
+    env: { IDENTITY_CLIENT_SECRET_KEK: TEST_KEK },
+  })
+  app.use(router.routes())
+  app.use(router.allowedMethods())
+  return app
+}
+
+/** 开发者门户 subject 解析依赖 client_id='developer-portal' 的注册记录 */
+async function insertDeveloperPortalClient(
+  sql: TestDatabase['sql'],
+  developerId: string,
+): Promise<void> {
+  await sql.query(
+    `INSERT INTO oauth_applications (id, client_id, owner_developer_id, name, client_type, status)
+     VALUES ('app_dev_portal', 'developer-portal', $1, '开发者门户', 'web_confidential', 'active')`,
+    [developerId],
+  )
+  await sql.query(
+    `INSERT INTO oauth_redirect_uris (id, application_id, redirect_uri, kind)
+     VALUES ('ru_dev_portal', 'app_dev_portal', 'https://developer.example.com/cb', 'web_https')`,
+  )
+}
+
+/** 由内部 user_id 派生门户会话 sub（sector = portal redirect host，与 resolveUserIdBySubject 一致） */
+function developerSubject(userId: string): string {
+  return derivePairwiseSubject({
+    pairwiseKey: TEST_PAIRWISE_KEY,
+    sectorOrClientId: 'developer.example.com',
+    userId,
+  })
+}
+
+interface IssuedKey {
+  key: string
+  id: string
+}
+
+/** 经管理面签发一把 Key（返回明文；契约：明文只此一次） */
+async function issueKey(baseUrl: string, subject: string, name: string): Promise<{ status: number; body: Record<string, unknown>; issued?: IssuedKey }> {
+  const res = await fetch(`${baseUrl}/api/v1/developer/keys`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-developer-subject': subject },
+    body: JSON.stringify({ name }),
+  })
+  const body = (await res.json()) as Record<string, unknown>
+  return {
+    status: res.status,
+    body,
+    issued: res.status === 201
+      ? {
+          key: body.key as string,
+          id: (body.info as Record<string, unknown>).id as string,
+        }
+      : undefined,
+  }
+}
+
+async function bearerRequest(
+  baseUrl: string,
+  method: string,
+  path: string,
+  token: string | null,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const headers: Record<string, string> = { accept: 'application/json' }
+  if (token !== null) {
+    headers.authorization = `Bearer ${token}`
+  }
+  if (body !== undefined) {
+    headers['content-type'] = 'application/json'
+  }
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  if (res.status === 204) {
+    return { status: res.status, body: {} }
+  }
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> }
+}
+
+describe('#688 账户级 API Key（签发/Bearer 认证/account 端点）', () => {
+  let db: TestDatabase
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+  })
+  afterEach(async () => {
+    await db.cleanup()
+  })
+
+  /** 标准夹具：user+developer+已有应用 + portal client（供 subject 解析） */
+  async function setupFixture(): Promise<{ userId: string; subject: string; applicationId: string }> {
+    const fixture = await createClientFixture(db.sql, {})
+    await insertDeveloperPortalClient(db.sql, fixture.developerId)
+    return {
+      userId: fixture.userId,
+      subject: developerSubject(fixture.userId),
+      applicationId: fixture.applicationId,
+    }
+  }
+
+  it('签发：明文只返回一次且匹配契约形态；库中只存 hash；列表无敏感值', async () => {
+    const fx = await setupFixture()
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await issueKey(baseUrl, fx.subject, '我的第一把 Key')
+      expect(res.status).toBe(201)
+      const full = res.issued!.key
+      // 冻结契约形态：mhbat_<8位小写hex>_<43位base64url>
+      expect(full).toMatch(/^mhbat_[0-9a-f]{8}_[A-Za-z0-9_-]{43}$/)
+      expect((res.body.info as Record<string, unknown>).prefix).toBe(full.slice(0, 14))
+
+      // 库中只存 sha256Base64url(整串)，绝不存明文
+      const row = await db.sql.query<{ secret_hash: string }>(
+        'SELECT secret_hash FROM api_keys WHERE prefix = $1',
+        [full.slice(0, 14)],
+      )
+      expect(row.rows[0]?.secret_hash).toBe(sha256Base64url(full))
+      expect(row.rows[0]?.secret_hash).not.toContain(full)
+
+      // 管理面 GET：无明文/无 hash
+      const list = await fetch(`${baseUrl}/api/v1/developer/keys`, {
+        headers: { 'x-developer-subject': fx.subject },
+      })
+      expect(list.status).toBe(200)
+      const listBody = (await list.json()) as { keys: Array<Record<string, unknown>> }
+      expect(listBody.keys).toHaveLength(1)
+      expect(listBody.keys[0]?.name).toBe('我的第一把 Key')
+      expect(listBody.keys[0]?.status).toBe('active')
+      const serialized = JSON.stringify(listBody)
+      expect(serialized).not.toContain('secret_hash')
+      expect(serialized).not.toContain(full)
+      expect(serialized).not.toContain(sha256Base64url(full))
+    })
+  })
+
+  it('签发校验：缺 name → 400 invalid_request；未认证 subject → 401', async () => {
+    await setupFixture()
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const noName = await fetch(`${baseUrl}/api/v1/developer/keys`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-developer-subject': 'whatever' },
+        body: JSON.stringify({}),
+      })
+      // subject 非法先于 name 校验（fail closed）
+      expect(noName.status).toBe(401)
+
+      const validSub = (await createClientFixture(db.sql, {})).userId
+      const sub = developerSubject(validSub)
+      const emptyName = await fetch(`${baseUrl}/api/v1/developer/keys`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-developer-subject': sub },
+        body: JSON.stringify({ name: '   ' }),
+      })
+      expect(emptyName.status).toBe(400)
+      expect(((await emptyName.json()) as Record<string, unknown>).error).toBe('invalid_request')
+    })
+  })
+
+  it('Bearer /me 全链路：返回 user_id 与 key 元数据（不含 secret/hash）', async () => {
+    const fx = await setupFixture()
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const { issued } = await issueKey(baseUrl, fx.subject, 'me-key')
+      const me = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', issued!.key)
+      expect(me.status).toBe(200)
+      expect(me.body.user_id).toBe(fx.userId)
+      const key = me.body.key as Record<string, unknown>
+      expect(key.prefix).toBe(issued!.key.slice(0, 14))
+      expect(key.scopes).toEqual(['account.full'])
+      const serialized = JSON.stringify(me.body)
+      expect(serialized).not.toContain(issued!.key.slice(14))
+      expect(serialized).not.toContain('secret_hash')
+    })
+  })
+
+  it('Bearer 创建应用 → 列表 → 详情全链路（身份来自 Key 归属账户）', async () => {
+    const fx = await setupFixture()
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const { issued } = await issueKey(baseUrl, fx.subject, 'apps-key')
+      const token = issued!.key
+
+      const created = await bearerRequest(baseUrl, 'POST', '/api/v1/account/apps', token, {
+        name: 'API Key 创建的应用',
+        description: '经账户级 Key 直连创建',
+        client_type: 'web_confidential',
+        redirect_uris: [{ uri: 'https://agent.example.com/cb', kind: 'web_https' }],
+        scopes: [{ scope: 'openid' }, { scope: 'profile' }],
+      })
+      expect(created.status).toBe(201)
+      const newAppId = created.body.id as string
+      expect(typeof created.body.client_id).toBe('string')
+
+      const list = await bearerRequest(baseUrl, 'GET', '/api/v1/account/apps', token)
+      expect(list.status).toBe(200)
+      const apps = list.body.apps as Array<Record<string, unknown>>
+      expect(apps.map((a) => a.id)).toContain(newAppId)
+      // 夹具预置应用同样可见（同账户归属）
+      expect(apps.map((a) => a.id)).toContain(fx.applicationId)
+
+      const detail = await bearerRequest(baseUrl, 'GET', `/api/v1/account/apps/${newAppId}`, token)
+      expect(detail.status).toBe(200)
+      expect((detail.body.app as Record<string, unknown>).name).toBe('API Key 创建的应用')
+
+      // 提交审核（draft → pending_review）
+      const submitted = await bearerRequest(baseUrl, 'POST', `/api/v1/account/apps/${newAppId}/submit`, token, {})
+      expect(submitted.status).toBe(200)
+
+      // 设备列表（本账户为空数组起步）
+      const devices = await bearerRequest(baseUrl, 'GET', '/api/v1/account/devices', token)
+      expect(devices.status).toBe(200)
+      expect(devices.body.devices).toEqual([])
+    })
+  })
+
+  it('无效 Key：缺失头 / 乱串 / 格式合法但不存在 → 统一 401 API_KEY_INVALID', async () => {
+    await setupFixture()
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const noHeader = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', null)
+      expect(noHeader.status).toBe(401)
+      expect(noHeader.body.error).toBe('API_KEY_INVALID')
+
+      const garbage = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', 'garbage-token')
+      expect(garbage.status).toBe(401)
+      expect(garbage.body.error).toBe('API_KEY_INVALID')
+
+      const wrongScheme = await fetch(`${baseUrl}/api/v1/account/me`, {
+        headers: { authorization: 'Basic mhbat_00000000_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      })
+      expect(wrongScheme.status).toBe(401)
+
+      const unknownPrefix = await bearerRequest(
+        baseUrl,
+        'GET',
+        '/api/v1/account/me',
+        `mhbat_00000000_${'a'.repeat(43)}`,
+      )
+      expect(unknownPrefix.status).toBe(401)
+      expect(unknownPrefix.body.error).toBe('API_KEY_INVALID')
+
+      // 篡改主体（prefix 存在但 hash 不匹配）
+      const { issued } = await issueKey(baseUrl, developerSubject((await createClientFixture(db.sql, {})).userId), 'tamper')
+      const tampered = `${issued!.key.slice(0, -1)}${issued!.key.endsWith('a') ? 'b' : 'a'}`
+      const tamperedRes = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', tampered)
+      expect(tamperedRes.status).toBe(401)
+      expect(tamperedRes.body.error).toBe('API_KEY_INVALID')
+    })
+  })
+
+  it('吊销后 → 403 API_KEY_REVOKED；重复吊销幂等 204；吊销写审计', async () => {
+    const fx = await setupFixture()
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const { issued } = await issueKey(baseUrl, fx.subject, 'revoke-me')
+      const token = issued!.key
+
+      // 吊销前可用
+      const before = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', token)
+      expect(before.status).toBe(200)
+
+      const del = await fetch(`${baseUrl}/api/v1/developer/keys/${issued!.id}`, {
+        method: 'DELETE',
+        headers: { 'x-developer-subject': fx.subject },
+      })
+      expect(del.status).toBe(204)
+
+      // 吊销后 Bearer → 403 API_KEY_REVOKED
+      const after = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', token)
+      expect(after.status).toBe(403)
+      expect(after.body.error).toBe('API_KEY_REVOKED')
+
+      // 幂等重放吊销仍 204
+      const again = await fetch(`${baseUrl}/api/v1/developer/keys/${issued!.id}`, {
+        method: 'DELETE',
+        headers: { 'x-developer-subject': fx.subject },
+      })
+      expect(again.status).toBe(204)
+
+      // 审计：key_created / key_revoked 各一条，metadata 只含 key_id/name/prefix
+      const auditRows = await db.sql.query<{ event_type: string; metadata_json: unknown }>(
+        "SELECT event_type, metadata_json FROM audit_events WHERE target_type = 'api_key' ORDER BY event_type",
+      )
+      const types = auditRows.rows.map((r) => r.event_type)
+      expect(types).toContain('developer.key_created')
+      expect(types).toContain('developer.key_revoked')
+      for (const r of auditRows.rows) {
+        const meta = (typeof r.metadata_json === 'string' ? JSON.parse(r.metadata_json) : r.metadata_json) as Record<string, unknown>
+        expect(Object.keys(meta).sort()).toEqual(['key_id', 'name', 'prefix'])
+      }
+    })
+  })
+
+  it('过期 Key → 403 API_KEY_EXPIRED；非本人吊销 → 404 防枚举', async () => {
+    const fx = await setupFixture()
+    const other = await createClientFixture(db.sql, {})
+    const app = buildAccountApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      // 手工插入一把已过期的 Key（形态合法）
+      const expiredFull = `mhbat_deadbeef_${'a'.repeat(43)}`
+      await insertApiKey(db.sql, {
+        id: 'ak_expired_fixture',
+        userId: fx.userId,
+        name: '过期 Key',
+        prefix: 'mhbat_deadbeef',
+        secretHash: sha256Base64url(expiredFull),
+      })
+      await db.sql.query("UPDATE api_keys SET expires_at = NOW() - INTERVAL '1 day' WHERE id = 'ak_expired_fixture'")
+      const expiredRes = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', expiredFull)
+      expect(expiredRes.status).toBe(403)
+      expect(expiredRes.body.error).toBe('API_KEY_EXPIRED')
+
+      // 非本人 DELETE → 404（防枚举）
+      const { issued } = await issueKey(baseUrl, fx.subject, 'others-key')
+      const foreignSubject = developerSubject(other.userId)
+      const forbiddenDel = await fetch(`${baseUrl}/api/v1/developer/keys/${issued!.id}`, {
+        method: 'DELETE',
+        headers: { 'x-developer-subject': foreignSubject },
+      })
+      expect(forbiddenDel.status).toBe(404)
+    })
+  })
+
+  it('限流分组存在性冒烟：apiKeyRead(open) / apiKeyWrite(closed) 覆盖 account 前缀', () => {
+    const read = DEFAULT_RATE_LIMIT_GROUPS.find((g) => g.name === 'apiKeyRead')
+    const write = DEFAULT_RATE_LIMIT_GROUPS.find((g) => g.name === 'apiKeyWrite')
+    expect(read).toBeDefined()
+    expect(read?.rule.failPolicy).toBe('open')
+    expect(read?.methods).toContain('GET')
+    expect(write).toBeDefined()
+    expect(write?.rule.failPolicy).toBe('closed')
+    expect(write?.methods).toEqual(expect.arrayContaining(['POST', 'PATCH', 'PUT', 'DELETE']))
+    for (const g of [read, write]) {
+      expect(g?.prefixes).toContain('/api/v1/account/')
+    }
+  })
+})

--- a/identity-platform/web/app/developer-site/_components/api-keys.tsx
+++ b/identity-platform/web/app/developer-site/_components/api-keys.tsx
@@ -1,0 +1,339 @@
+/**
+ * API 密钥管理页客户端组件（#688）。
+ *
+ * 结构：
+ *  1. 说明卡：什么是账户级 API Key、谁能用、怎么用；
+ *  2. 创建表单：名称必填 → 签发成功展示一次性明文大卡片（复制 + 关闭即不可再见警示）；
+ *  3. Key 列表：名称 / prefix / 状态 / 创建时间 / 最后使用，吊销需二次确认；
+ *  4. curl 示例：Agent 直连 Core 的 Bearer 用法。
+ *
+ * 安全约定：
+ * - 明文只在签发响应出现一次，前端不做任何持久化（不落 localStorage）；
+ * - mutation 一律带 x-csrf-token（双提交 Cookie，与 developer API 同机制）。
+ */
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ClientApiError, fetchMe } from './api'
+
+interface ApiKeyInfo {
+  id: string
+  name: string
+  prefix: string
+  status: 'active' | 'revoked'
+  last_used_at?: string
+  created_at: string
+}
+
+class KeysClientApiError extends Error {
+  readonly status: number
+  readonly code: string
+
+  constructor(status: number, code: string) {
+    super(code)
+    this.name = 'KeysClientApiError'
+    this.status = status
+    this.code = code
+  }
+}
+
+/** 同源请求封装（GET 无需 CSRF；mutation 必须带 x-csrf-token） */
+async function keysRequest<T>(path: string, init?: { method?: string; body?: unknown; csrf?: string }): Promise<T> {
+  const headers: Record<string, string> = { accept: 'application/json' }
+  if (init?.body !== undefined) {
+    headers['content-type'] = 'application/json'
+  }
+  if (init?.csrf) {
+    headers['x-csrf-token'] = init.csrf
+  }
+  const res = await fetch(path, {
+    method: init?.method ?? 'GET',
+    headers,
+    body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+    credentials: 'same-origin',
+  })
+  if (!res.ok) {
+    let code = 'internal'
+    try {
+      const parsed = (await res.json()) as { error?: string }
+      if (parsed && typeof parsed.error === 'string') {
+        code = parsed.error
+      }
+    } catch {
+      // 非 JSON 错误体
+    }
+    throw new KeysClientApiError(res.status, code)
+  }
+  if (res.status === 204) {
+    return undefined as T
+  }
+  return (await res.json()) as T
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof KeysClientApiError || err instanceof ClientApiError) {
+    switch (err.code) {
+      case 'unauthorized':
+        return '登录已过期，请重新登录'
+      case 'forbidden':
+        return '没有权限执行该操作'
+      case 'not_found':
+        return '密钥不存在或已被删除'
+      case 'invalid_request':
+        return '提交的内容不合法，请检查名称是否已填写'
+      default:
+        return '服务暂时不可用，请稍后重试'
+    }
+  }
+  return '网络异常，请稍后重试'
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      className="dev-copy-btn"
+      onClick={() => {
+        void navigator.clipboard?.writeText(text).then(() => {
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        })
+      }}
+    >
+      {copied ? '已复制' : '复制'}
+    </button>
+  )
+}
+
+const CURL_EXAMPLE = [
+  '# 完整密钥形如 mhbat_ 前缀 + 标识 + 主体串；建议经环境变量注入，不要硬编码',
+  'export MHBAT_API_KEY=<粘贴你的完整密钥>',
+  '',
+  'curl https://core.example.com/api/v1/account/me \\',
+  '  -H "Authorization: Bearer $MHBAT_API_KEY"',
+].join('\n')
+
+export function ApiKeys() {
+  const [keys, setKeys] = useState<ApiKeyInfo[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+  /** 一次性明文（关闭卡片后置空，无法找回） */
+  const [issuedKey, setIssuedKey] = useState<{ key: string; info: ApiKeyInfo } | null>(null)
+  const [revokeTarget, setRevokeTarget] = useState<ApiKeyInfo | null>(null)
+  const [revoking, setRevoking] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    keysRequest<{ keys: ApiKeyInfo[] }>('/api/v1/developer/keys')
+      .then((data) => {
+        if (alive) {
+          setKeys(data.keys)
+        }
+      })
+      .catch((err) => {
+        if (err instanceof KeysClientApiError && err.status === 401) {
+          window.location.href = '/login'
+          return
+        }
+        if (alive) {
+          setError(errorMessage(err))
+        }
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    setFormError(null)
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setFormError('请先给这把密钥起个名字，例如「本机 Agent」')
+      return
+    }
+    setCreating(true)
+    try {
+      const csrf = (await fetchMe()).csrf_token
+      const result = await keysRequest<{ key: string; info: ApiKeyInfo }>('/api/v1/developer/keys', {
+        method: 'POST',
+        body: { name: trimmed },
+        csrf,
+      })
+      setIssuedKey(result)
+      setName('')
+      // 刷新列表
+      const list = await keysRequest<{ keys: ApiKeyInfo[] }>('/api/v1/developer/keys')
+      setKeys(list.keys)
+    } catch (err) {
+      setFormError(errorMessage(err))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleRevoke() {
+    if (!revokeTarget) return
+    setRevoking(true)
+    try {
+      const csrf = (await fetchMe()).csrf_token
+      await keysRequest<void>(`/api/v1/developer/keys/${encodeURIComponent(revokeTarget.id)}`, {
+        method: 'DELETE',
+        csrf,
+      })
+      setRevokeTarget(null)
+      const list = await keysRequest<{ keys: ApiKeyInfo[] }>('/api/v1/developer/keys')
+      setKeys(list.keys)
+    } catch (err) {
+      setError(errorMessage(err))
+      setRevokeTarget(null)
+    } finally {
+      setRevoking(false)
+    }
+  }
+
+  return (
+    <div>
+      {/* 区块 1：通俗说明 */}
+      <div className="dev-card">
+        <h2>什么是 API 密钥？</h2>
+        <p className="dev-inline-hint">
+          API 密钥让你的本地工具（例如命令行 Agent）以你的身份访问开放平台接口，
+          比如管理应用、查询设备与审计记录。它相当于一把「程序用的钥匙」：
+          你只需要把它交给自己的工具，工具就能替你干活，而不用把账号密码告诉任何人。
+        </p>
+        <p className="dev-inline-hint">
+          注意：完整密钥只在创建成功时显示一次，平台只保存它的指纹摘要。
+          如果丢失，随时可以吊销旧密钥并重新创建一把。
+        </p>
+      </div>
+
+      {error ? <div className="dev-error">{error}</div> : null}
+
+      {/* 区块 2：创建表单 */}
+      <div className="dev-card">
+        <h2>创建新密钥</h2>
+        <p className="dev-hint">起一个好认的名字（比如「办公电脑」「CI 服务器」），方便以后管理。</p>
+        <form onSubmit={(e) => void handleCreate(e)}>
+          <div className="dev-field">
+            <label htmlFor="api-key-name">密钥名称（必填）</label>
+            <input
+              id="api-key-name"
+              className="dev-input"
+              value={name}
+              maxLength={64}
+              placeholder="例如：本机 Agent"
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <button className="dev-btn dev-btn-primary" type="submit" disabled={creating}>
+            {creating ? '创建中…' : '创建密钥'}
+          </button>
+        </form>
+        {formError ? <div className="dev-error">{formError}</div> : null}
+
+        {issuedKey ? (
+          <div className="dev-secret-banner" role="alert">
+            <h3>创建成功！请立即复制保存这把密钥</h3>
+            <p>
+              这是唯一一次展示机会。<strong>关闭本提示后将无法再查看完整密钥</strong>
+              （平台只存摘要，谁也无法找回）。请粘贴到你的本地工具配置中妥善保管。
+            </p>
+            <div className="dev-secret-value">{issuedKey.key}</div>
+            <div className="dev-app-card-meta">
+              <CopyButton text={issuedKey.key} />
+              <button type="button" className="dev-btn" onClick={() => setIssuedKey(null)}>
+                我已保存，关闭
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {/* 区块 3：Key 列表 */}
+      <div className="dev-card">
+        <h2>我的密钥</h2>
+        <p className="dev-hint">
+          列表中只显示密钥前缀（前 14 个字符），用于辨认；完整密钥任何人都看不到。
+          不再使用的密钥建议尽快吊销，防止泄露风险。
+        </p>
+        {keys === null ? (
+          <div className="dev-empty">加载中…</div>
+        ) : keys.length === 0 ? (
+          <div className="dev-empty">还没有密钥，用上面的表单创建第一把吧。</div>
+        ) : (
+          <ul className="dev-list">
+            {keys.map((k) => (
+              <li key={k.id}>
+                <div className="dev-app-card-meta" style={{ justifyContent: 'space-between' }}>
+                  <span>
+                    <strong>{k.name}</strong>{' '}
+                    <span className={`dev-status status-${k.status}`}>
+                      {k.status === 'active' ? '启用中' : '已吊销'}
+                    </span>
+                  </span>
+                  {k.status === 'active' ? (
+                    <button
+                      type="button"
+                      className="dev-btn dev-btn-danger"
+                      onClick={() => setRevokeTarget(k)}
+                    >
+                      吊销
+                    </button>
+                  ) : null}
+                </div>
+                <div className="dev-app-card-meta">
+                  <span className="dev-mono">{k.prefix}…</span>
+                  <CopyButton text={k.prefix} />
+                </div>
+                <div className="dev-app-card-updated">
+                  创建于 {new Date(k.created_at).toLocaleString('zh-CN')}
+                  {k.last_used_at ? ` · 最后使用 ${new Date(k.last_used_at).toLocaleString('zh-CN')}` : ' · 从未使用'}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {revokeTarget ? (
+          <div className="dev-confirm-panel" role="alertdialog" aria-label="确认吊销">
+            <p style={{ color: 'var(--danger-text)' }}>
+              确定要吊销「{revokeTarget.name}」吗？使用它的工具会立即失去访问权限，此操作不可恢复。
+            </p>
+            <div className="dev-app-card-meta">
+              <button
+                type="button"
+                className="dev-btn dev-btn-danger"
+                disabled={revoking}
+                onClick={() => void handleRevoke()}
+              >
+                {revoking ? '处理中…' : '确认吊销'}
+              </button>
+              <button type="button" className="dev-btn" onClick={() => setRevokeTarget(null)}>
+                取消
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {/* 区块 4：curl 示例 */}
+      <div className="dev-card dev-docs">
+        <h2>在本地工具中使用</h2>
+        <p className="dev-hint">
+          把整串密钥放进请求头 Authorization: Bearer 后面即可调用开放接口（示例为查询当前账户信息）：
+        </p>
+        <pre>
+          <code>{CURL_EXAMPLE}</code>
+        </pre>
+        <p className="dev-note">
+          请像保管密码一样保管密钥：不要写进公开代码仓库、不要发给他人；
+          发现疑似泄露时立刻在本页吊销并重新创建。
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/identity-platform/web/app/developer-site/api/v1/developer/keys/[id]/route.ts
+++ b/identity-platform/web/app/developer-site/api/v1/developer/keys/[id]/route.ts
@@ -1,0 +1,25 @@
+/**
+ * BFF：DELETE /api/v1/developer/keys/[id] —— 吊销 API Key（不可恢复）。
+ * 非本人 / 不存在 → 404（Core 侧防枚举，不区分）。
+ */
+
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { getDeveloperKeysApi } from '@/lib/developer-api/account-client'
+import { developerErrorResponse, guardMutation } from '@/lib/developer-api/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function DELETE(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const session = guardMutation(request)
+  if (session instanceof NextResponse) {
+    return session
+  }
+  const { id } = await ctx.params
+  try {
+    await getDeveloperKeysApi().revokeKey(session.sub, id)
+    return new NextResponse(null, { status: 204 })
+  } catch (err) {
+    return developerErrorResponse(err)
+  }
+}

--- a/identity-platform/web/app/developer-site/api/v1/developer/keys/route.ts
+++ b/identity-platform/web/app/developer-site/api/v1/developer/keys/route.ts
@@ -1,0 +1,58 @@
+/**
+ * BFF：GET/POST /api/v1/developer/keys（#688 账户级 API Key）
+ *  - GET：本账户 Key 列表（无明文/无 hash）；
+ *  - POST：签发新 Key（响应中的整串明文只出现这一次）。
+ */
+
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+import { getDeveloperKeysApi } from '@/lib/developer-api/account-client'
+import {
+  developerErrorResponse,
+  errorJson,
+  guardMutation,
+  jsonOk,
+  requireSession,
+} from '@/lib/developer-api/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const session = requireSession(request)
+  if (!session) {
+    return errorJson(401, 'unauthorized')
+  }
+  try {
+    const keys = await getDeveloperKeysApi().listKeys(session.sub)
+    return jsonOk({ keys })
+  } catch (err) {
+    return developerErrorResponse(err)
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = guardMutation(request)
+  if (session instanceof NextResponse) {
+    return session
+  }
+  let raw: unknown
+  try {
+    raw = await request.json()
+  } catch {
+    return errorJson(400, 'invalid_request')
+  }
+  const name =
+    typeof raw === 'object' && raw !== null && typeof (raw as { name?: unknown }).name === 'string'
+      ? (raw as { name: string }).name.trim().slice(0, 64)
+      : ''
+  if (!name) {
+    return errorJson(400, 'invalid_request')
+  }
+  try {
+    const result = await getDeveloperKeysApi().createKey(session.sub, name)
+    // 201；key 明文只出现这一次，之后无法找回
+    return jsonOk(result, { status: 201 })
+  } catch (err) {
+    return developerErrorResponse(err)
+  }
+}

--- a/identity-platform/web/app/developer-site/keys/page.tsx
+++ b/identity-platform/web/app/developer-site/keys/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * API 密钥页：/keys（server page + 登录守卫，#688）。
+ * 未登录 → 302 /login（fail closed，与 /apps 一致）。
+ */
+import { requireDeveloperSession } from '@/lib/auth-session/guard'
+import { ApiKeys } from '../_components/api-keys'
+
+export const dynamic = 'force-dynamic'
+
+export default async function DeveloperKeysPage() {
+  await requireDeveloperSession()
+  return (
+    <div>
+      <div className="dev-page-head">
+        <h1 className="dev-page-title">API 密钥</h1>
+      </div>
+      <ApiKeys />
+    </div>
+  )
+}

--- a/identity-platform/web/app/developer-site/layout.tsx
+++ b/identity-platform/web/app/developer-site/layout.tsx
@@ -35,6 +35,7 @@ export default async function DeveloperSiteLayout({ children }: { children: Reac
         </div>
         <nav className="dev-nav" aria-label="主导航">
           <a href="/apps">我的应用</a>
+          {session ? <a href="/keys">API 密钥</a> : null}
           <a href={OFFICIAL_IDENTITY_DOCS_URL}>接入文档</a>
           {session ? <a href="/admin">审核后台</a> : null}
         </nav>

--- a/identity-platform/web/lib/developer-api/account-client.ts
+++ b/identity-platform/web/lib/developer-api/account-client.ts
@@ -1,0 +1,156 @@
+/**
+ * 账户级 API Key 消费层（Web BFF → Core，issue #688）。
+ *
+ * 与 client.ts（#624 应用管理）平行的独立通道：
+ * - 真实模式：调用 Core 的 {coreBaseUrl}/api/v1/developer/keys*，
+ *   x-developer-subject 传会话推导的 sub（owner 永不出自请求体）；
+ *   #626 服务令牌一并附加（Core 按前缀 /api/v1/developer/ 校验）。
+ * - 桩模式（IDENTITY_CORE_STUB=1 或 IDENTITY_OIDC_STUB=1，与 client.ts 同开关）：
+ *   进程内内存桩，语义与真实 Core 一致（明文只返回一次 / 列表无敏感值 / 吊销幂等）。
+ */
+
+import { coreBaseUrl } from '@/lib/core-client/index'
+import { serviceTokenHeaders } from '@/lib/security/service-token'
+
+export type EnvLike = Record<string, string | undefined>
+
+/** Key 状态（与 core migrations/0005 CHECK 约束一致） */
+export type ApiKeyStatus = 'active' | 'revoked'
+
+/** Key 元信息 DTO（契约 v1：绝不含明文 secret_hash） */
+export interface ApiKeyInfoDTO {
+  id: string
+  name: string
+  prefix: string
+  status: ApiKeyStatus
+  last_used_at?: string
+  created_at: string
+}
+
+/** 签发结果：key 明文仅此一次 */
+export interface CreateApiKeyResult {
+  key: string
+  info: ApiKeyInfoDTO
+}
+
+function isStubMode(env: EnvLike): boolean {
+  return env.IDENTITY_CORE_STUB === '1' || env.IDENTITY_OIDC_STUB === '1'
+}
+
+/** 真实 Core 客户端（服务端 fetch；错误码映射与 developer API 一致） */
+export function createDeveloperKeysHttpClient(baseUrl: string, fetchImpl: typeof fetch = fetch): DeveloperKeysApi {
+  async function request<T>(method: string, path: string, sub: string, body?: unknown): Promise<T> {
+    const res = await fetchImpl(`${baseUrl}${path}`, {
+      method,
+      headers: {
+        accept: 'application/json',
+        'x-developer-subject': sub,
+        // #626：BFF → Core 服务令牌（IDENTITY_SERVICE_TOKEN）
+        ...serviceTokenHeaders(),
+        ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      redirect: 'manual',
+    })
+    if (!res.ok) {
+      let code = 'internal'
+      try {
+        const parsed = (await res.json()) as { error?: string }
+        if (
+          parsed &&
+          ['unauthorized', 'forbidden', 'not_found', 'invalid_request', 'invalid_state', 'internal'].includes(parsed.error ?? '')
+        ) {
+          code = parsed.error as string
+        }
+      } catch {
+        // 非 JSON 错误体：保持 internal，不向客户端回显
+      }
+      throw new Error(`API_KEY_${res.status}_${code}`)
+    }
+    if (res.status === 204) {
+      return undefined as T
+    }
+    return (await res.json()) as T
+  }
+
+  return {
+    listKeys: async (sub) => {
+      const data = await request<{ keys: ApiKeyInfoDTO[] }>('GET', '/api/v1/developer/keys', sub)
+      return data.keys
+    },
+    createKey: (sub, name) =>
+      request<CreateApiKeyResult>('POST', '/api/v1/developer/keys', sub, { name }),
+    revokeKey: (sub, id) =>
+      request<void>('DELETE', `/api/v1/developer/keys/${encodeURIComponent(id)}`, sub),
+  }
+}
+
+/**
+ * 极简内存桩（仅 IDENTITY_CORE_STUB=1 本地开发用；进程级存储不持久化）。
+ * 固化与真实 Core 相同的安全属性：列表只含元信息、明文只在签发响应出现。
+ */
+interface StubKeyRecord extends ApiKeyInfoDTO {
+  userId: string
+}
+const stubKeys: StubKeyRecord[] = []
+
+function createStubClient(): DeveloperKeysApi {
+  return {
+    listKeys: async (sub) =>
+      stubKeys
+        .filter((k) => k.userId === sub)
+        .map((k) => ({
+          id: k.id,
+          name: k.name,
+          prefix: k.prefix,
+          status: k.status,
+          created_at: k.created_at,
+        })),
+    createKey: async (sub, name) => {
+      const rand = (): string => Math.random().toString(36).slice(2, 10)
+      const prefix = `mhbat_stub0${rand().slice(0, 2)}`
+      const full = `${prefix}_${rand()}${rand()}${rand()}${rand()}`
+      const createdAt = new Date().toISOString()
+      const record: StubKeyRecord = {
+        userId: sub,
+        id: `ak_stub_${rand()}`,
+        name,
+        prefix,
+        status: 'active',
+        created_at: createdAt,
+      }
+      stubKeys.push(record)
+      const info: ApiKeyInfoDTO = {
+        id: record.id,
+        name: record.name,
+        prefix: record.prefix,
+        status: 'active',
+        created_at: createdAt,
+      }
+      return { key: full, info }
+    },
+    revokeKey: async (sub, id) => {
+      const found = stubKeys.find((k) => k.userId === sub && k.id === id)
+      if (!found) {
+        throw new Error('API_KEY_404_not_found')
+      }
+      found.status = 'revoked'
+    },
+  }
+}
+
+export interface DeveloperKeysApi {
+  listKeys(sub: string): Promise<ApiKeyInfoDTO[]>
+  /** 返回整串明文（仅此一次）；Core 侧校验名称非空 */
+  createKey(sub: string, name: string): Promise<CreateApiKeyResult>
+  /** 吊销（幂等；非本人 → 抛 not_found） */
+  revokeKey(sub: string, id: string): Promise<void>
+}
+
+/** 按环境选择客户端（fail closed：非 stub 必须配置 IDENTITY_CORE_BASE_URL） */
+export function getDeveloperKeysApi(env: EnvLike = process.env): DeveloperKeysApi {
+  if (isStubMode(env)) {
+    return createStubClient()
+  }
+  return createDeveloperKeysHttpClient(coreBaseUrl(env))
+}


### PR DESCRIPTION
## TL;DR

账户级 API Key 平台一期 MVP（Fixes #688，父 #686）：申请（明文一次展示）/列表/吊销 + Bearer 认证中间件 + `/api/v1/account/**` 能力端点（应用管理全量/设备列表/审计查询）+ 限流分组 + 审计事件 + 门户「API 密钥」管理页。

## 实现清单（对照冻结契约 v1 全部落地）

| 层 | 内容 |
|---|---|
| 迁移 | `0005_api_keys.sql`（+rollback，项目惯例）：id/user_id/name/prefix UNIQUE/sha256(secret_hash)/scopes/status/expires_at/last_used_at |
| 安全 | `security/api-key.ts`：generateApiKey（mhbat_+8hex+_+32B base64url）与 verifyApiKey（格式→prefix 定位→timingSafeEqual→status/expires，先验 hash 后看状态不泄露信息） |
| 错误 | API_KEY_INVALID(401)/REVOKED(403)/EXPIRED(403)，中文 message |
| Bearer | `/api/v1/account/**` 中间件认证 + last_used_at touch |
| 端点 | GET me；apps GET/POST/:id GET/PATCH/DELETE/redirect-uris±/scopes PUT,GET/submit/rotate/revoke/audit；devices；account/audit —— 共 16 条，逐条镜像 developer 业务逻辑（身份源改为 Key→user_id→ensureDeveloper） |
| 管理面 | `/api/v1/developer/keys` GET/POST + `keys/:id` DELETE（复用 service-token+x-developer-subject 链路，BFF 已接） |
| 限流 | rate-limit 新增 apiKeyRead(open)/apiKeyWrite(closed) 分组 |
| 审计 | key_created/key_revoked；metadata 仅 {key_id,name,prefix}，secret/hash 绝不落库 |
| 前端 | 「API 密钥」独立页：列表卡/创建表单/一次性明文大卡（复制+警示）/吊销确认/通俗解释/curl 示例；layout 导航新增入口 |

## 验收证据

- account.test.ts **8 passed**；core 全量回归 **31 文件 / 227 passed**；tsc 干净
- web typecheck + next build 成功（路由表含 /developer-site/keys 与 keys[/id] BFF）
- 集成树三分支合并零冲突复验通过

Fixes #688
关联 #686、#689（文档站按同一契约编写）