### PR TITLE
fix(#697): 移除 identity-overlay 每 3 秒的诊断轮询上报，消除运行时日志刷屏

### DIFF
--- a/apps/client/src/features/identity/components/IdentityApprovalOverlay.vue
+++ b/apps/client/src/features/identity/components/IdentityApprovalOverlay.vue
@@ -54,29 +54,6 @@ const shouldShow = computed(
     !props.blockingAnnouncementVisible
 )
 
-// 测试诊断：轮询上报 Overlay 状态（定位 phase 变化后 computed 不重算的问题）
-let ovDiagTimer: ReturnType<typeof setInterval> | null = null
-const ovDiagReport = (): void => {
-  try {
-    void fetch('http://127.0.0.1:4399/debug/logs/push', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        scope: 'identity-overlay',
-        level: 'info',
-        message: `shouldShow=${String(shouldShow.value)} visible=${overlayVisible.value} force=${props.forceUpdateVisible} block=${props.blockingAnnouncementVisible} phase=${ui.approvalPhase} active=${ui.activeRequestId}`
-      })
-    }).catch(() => undefined)
-  } catch {
-    /* 静默 */
-  }
-}
-ovDiagReport()
-ovDiagTimer = setInterval(ovDiagReport, 3000)
-onBeforeUnmount(() => {
-  if (ovDiagTimer) clearInterval(ovDiagTimer)
-})
-
 /** 动作进行中（approving/denying）：禁用全部操作按钮 */
 const busy = computed(() => phase.value === 'approving' || phase.value === 'denying')
 


### PR DESCRIPTION
## 概述

Closes #697

`IdentityApprovalOverlay.vue` 中遗留了一段为排查「phase 变化后 computed 不重算」而临时加入的诊断定时器（引入于 ef1bfdfd / #635）：组件挂载即每 3 秒向本地 Bridge `/debug/logs/push` 上报一次组件状态快照，且无状态变化判断，导致运行时日志被 `identity-overlay ... phase=idle` 心跳无限刷屏；release 构建下该端点不存在但仍每 3 秒空转 fetch 静默失败。

本 PR 直接移除该诊断块（原排查目标早已闭环，且全仓无任何测试引用它）。

## 变更内容

- 删除 `apps/client/src/features/identity/components/IdentityApprovalOverlay.vue` 中第 57-78 行的 `ovDiagReport` 定时器及其清理逻辑（-23 行，无其他改动）

## 验证

- [x] `vue-tsc --noEmit` 类型检查通过
- [x] `vitest run src/features/identity`：7 个测试文件、80 个用例全绿（含读取该组件源码文本的 #623 契约测试）
- [x] 确认全仓无测试/代码引用 `ovDiag`
- [ ] 应用闲置 ≥ 1 分钟日志无新增 `identity-overlay` 条目（待合并后实测）

## 关联

- Closes #697