### PR TITLE
feat(#702): 选课中心入口菜单增加测试阶段提示横幅（以教务系统/学习通为准）

### DIFF
--- a/apps/client/src/styles/dark-mode.css
+++ b/apps/client/src/styles/dark-mode.css
@@ -2692,3 +2692,14 @@ html.dark .history-footnote {
 html.dark .history-refresh-btn:active {
   background: #0f172a !important;
 }
+
+/* ─── 选课中心：入口菜单测试阶段提示横幅 ─── */
+html.dark body .course-selection-view .course-selection-test-banner {
+  background: rgba(120, 53, 15, 0.34) !important;
+  border-color: rgba(251, 191, 36, 0.36) !important;
+  color: #fde68a !important;
+}
+
+html.dark body .course-selection-view .course-selection-test-banner strong {
+  color: #fbbf24 !important;
+}

--- a/apps/client/src/styles/views/CourseSelectionView.scoped.css
+++ b/apps/client/src/styles/views/CourseSelectionView.scoped.css
@@ -114,6 +114,24 @@
   gap: 10px;
 }
 
+/* 测试阶段提示横幅：样式对齐 identity-test-banner（黄色虚线警示条） */
+.course-selection-test-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px dashed #eab308;
+  border-radius: 10px;
+  background: rgba(234, 179, 8, 0.08);
+  color: #854d0e;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.course-selection-test-banner strong {
+  color: #a16207;
+}
+
 .entry-tile {
   width: 100%;
   text-align: left;

--- a/apps/client/src/templates/views/CourseSelectionView.html
+++ b/apps/client/src/templates/views/CourseSelectionView.html
@@ -22,6 +22,10 @@
 
     <div class="content">
       <template v-if="centerMode === ENTRY_MODE_MENU">
+        <!-- 测试阶段提示：选课为高 stakes 操作，入口处必须声明以教务系统/学习通为准 -->
+        <div class="course-selection-test-banner" role="note">
+          🧪 <strong>功能提示</strong>：本功能目前处于测试阶段，可能无法正常使用。如需保证选课完整可靠，请前往教务系统或学习通自行选课。一切选课结果与标准，均以教务系统和学习通为准。
+        </div>
         <div class="entry-grid">
           <button type="button" class="entry-tile glass-card" @click="enterSelectionMode">
             <div class="entry-badge entry-badge-selection">选课</div>


### PR DESCRIPTION
## 概述

Closes #702

选课中心目前处于测试阶段、可用性无保障，但入口没有任何说明。本 PR 在进入选课中心后的**入口菜单页**顶部、「选课 / 信息查询」卡片上方，按其他模块既有横幅样式（`.identity-test-banner` 黄色警示条）新增一条测试阶段提示，声明完整选课请走教务系统/学习通、一切结果以二者为准。

## 变更内容（3 文件，+33 行）

- `apps/client/src/templates/views/CourseSelectionView.html`：菜单页（`ENTRY_MODE_MENU`）`entry-grid` 上方新增横幅节点，带 `role="note"` 与背景注释
- `apps/client/src/styles/views/CourseSelectionView.scoped.css`：新增 `.course-selection-test-banner` 亮色样式，视觉对齐 identity 的黄色虚线警示条；与下方卡片的间距交给 `.content` 既有 grid gap，不额外加 margin
- `apps/client/src/styles/dark-mode.css`：按仓库惯例追加暗色适配（琥珀色暗底 + 高对比文字，参照 `.banner.warn` 模式）

文案：

> 🧪 **功能提示**：本功能目前处于测试阶段，可能无法正常使用。如需保证选课完整可靠，请前往教务系统或学习通自行选课。一切选课结果与标准，均以教务系统和学习通为准。

仅在入口菜单页显示；切入选课/信息查询子模式后不出现，返回菜单恢复。

## 验证

- [x] `vue-tsc --noEmit` 类型检查通过
- [x] `vite build` 构建成功（外置 HTML 模板编译无误）
- [x] 全仓无测试引用 CourseSelectionView 模板文本，无契约回归面
- [ ] 真机/浏览器目检横幅亮暗两套主题效果（待 review）

## 关联

- Closes #702