### PR TITLE
fix: iOS TestFlight 版本号/build 号留空时从 ASC 自动递增 + 三项后处理全自动化

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version_name:
-        description: "Marketing version. Empty uses package.json version."
+        description: "Marketing version. Empty auto-bumps above the highest version already on App Store Connect."
         required: false
         type: string
       build_number:
-        description: "TestFlight build number. Empty uses GitHub run number."
+        description: "TestFlight build number. Empty auto-increments above the highest CFBundleVersion already on App Store Connect."
         required: false
         type: string
       whats_new:
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
       beta_group:
-        description: "TestFlight 测试组名称。留空自动选择第一个内部测试组（= 自动提交内部测试）。"
+        description: "TestFlight 测试组名称，可逗号分隔多个。留空自动选第一个外部组（并自动提交 Beta App Review），无外部组时回落第一个内部组。"
         required: false
         type: string
       export_compliance:
@@ -74,35 +74,6 @@ jobs:
           find apps/client/src-tauri -type f \( -name "*.ics" -o -name "*.bak" -o -name "*.tmp" \) -delete
           find . -type f \( -name "*.log" -o -name "*.cache" \) -delete || true
 
-      - name: Resolve TestFlight version
-        id: version
-        shell: bash
-        run: |
-          set -euo pipefail
-          VERSION_NAME="${{ inputs.version_name }}"
-          BUILD_NUMBER="${{ inputs.build_number }}"
-
-          if [ -z "$VERSION_NAME" ]; then
-            VERSION_NAME="$(node -p "JSON.parse(require('fs').readFileSync('apps/client/package.json','utf8')).version")"
-          fi
-          if [ -z "$BUILD_NUMBER" ]; then
-            BUILD_NUMBER="${GITHUB_RUN_NUMBER}"
-          fi
-
-          if ! [[ "$VERSION_NAME" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
-            echo "::error::version_name must look like 1, 1.2, or 1.2.3; got '$VERSION_NAME'"
-            exit 1
-          fi
-          if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::error::build_number must be numeric; got '$BUILD_NUMBER'"
-            exit 1
-          fi
-
-          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
-          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "VERSION_NAME=$VERSION_NAME"
-          echo "BUILD_NUMBER=$BUILD_NUMBER"
-
       - name: Verify signing and upload secrets
         shell: bash
         env:
@@ -137,6 +108,37 @@ jobs:
             fi
           done
           exit "$missing"
+
+      - name: Install App Store Connect API key
+        id: asc_key
+        shell: bash
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          PRIVATE_KEYS_DIR="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$PRIVATE_KEYS_DIR"
+          printf '%s' "$APPSTORE_PRIVATE_KEY" > "$PRIVATE_KEYS_DIR/AuthKey_${APPSTORE_KEY_ID}.p8"
+          chmod 600 "$PRIVATE_KEYS_DIR/AuthKey_${APPSTORE_KEY_ID}.p8"
+          echo "path=$PRIVATE_KEYS_DIR/AuthKey_${APPSTORE_KEY_ID}.p8" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve TestFlight version
+        id: version
+        shell: bash
+        env:
+          APPLE_APP_ID: ${{ env.VITE_APPLE_APP_ID }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY_PATH: ${{ steps.asc_key.outputs.path }}
+          INPUT_VERSION_NAME: ${{ inputs.version_name }}
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          set -euo pipefail
+          # 手动输入优先；留空项实时查询 App Store Connect 自动递增。
+          # 修复 90062：package.json 版本可能不高于 ASC 已批准版本（1.4.6 列车已关闭），
+          # run number 也不保证大于 ASC 历史 build 号，二者都不能代表 ASC 现状。
+          node tools/ci/resolve_testflight_version.mjs
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -196,18 +198,6 @@ jobs:
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
           echo "keychain_path=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"
-
-      - name: Install App Store Connect API key
-        shell: bash
-        env:
-          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
-          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
-        run: |
-          set -euo pipefail
-          PRIVATE_KEYS_DIR="$HOME/.appstoreconnect/private_keys"
-          mkdir -p "$PRIVATE_KEYS_DIR"
-          printf '%s' "$APPSTORE_PRIVATE_KEY" > "$PRIVATE_KEYS_DIR/AuthKey_${APPSTORE_KEY_ID}.p8"
-          chmod 600 "$PRIVATE_KEYS_DIR/AuthKey_${APPSTORE_KEY_ID}.p8"
 
       - name: Build signed iOS archive
         shell: bash

--- a/apps/client/src/utils/submit_testflight_contract.spec.ts
+++ b/apps/client/src/utils/submit_testflight_contract.spec.ts
@@ -56,6 +56,24 @@ describe("TestFlight 自动化提交契约", () => {
     expect(workflow).toContain("AuthKey_${APPSTORE_KEY_ID}.p8");
   });
 
+  it("版本号留空时从 App Store Connect 自动递增，而非回读 package.json/run number", () => {
+    const workflow = readWorkflow();
+
+    // Resolve 步骤必须走 ASC 查询脚本（修复 90062：1.4.6 已批准且列车关闭）
+    expect(workflow).toContain("node tools/ci/resolve_testflight_version.mjs");
+    expect(workflow).not.toContain("Empty uses package.json version.");
+    expect(workflow).not.toContain("Empty uses GitHub run number.");
+
+    const script = readFileSync(
+      resolve(process.cwd(), "../../tools/ci/resolve_testflight_version.mjs"),
+      "utf8",
+    );
+    // 以 ASC 现状为唯一递增基准
+    expect(script).toContain("/preReleaseVersions?");
+    expect(script).toContain("/builds?");
+    expect(script).toContain("sort: '-version'");
+  });
+
   it("脚本使用官方 App Store Connect REST API 完成填写与提交", () => {
     const script = readScript();
 

--- a/tools/ci/resolve_testflight_version.mjs
+++ b/tools/ci/resolve_testflight_version.mjs
@@ -1,0 +1,190 @@
+/**
+ * TestFlight 版本号 / build 号自动递增解析（由 .github/workflows/ios-testflight.yml 调用）
+ *
+ * 背景：App Store Connect 要求 CFBundleShortVersionString 必须高于该 App「已批准」的
+ * 历史 marketing 版本（错误码 90062，且已关闭的版本列车不可复用，见 90186），
+ * CFBundleVersion（build 号）必须在 App 内全局唯一且大于同列车历史值。
+ * package.json 的版本只反映代码仓库状态、GitHub run number 只反映 workflow 计数，
+ * 二者都不代表 ASC 现状，直接回读会撞上述限制（2026-08-24 run 32735810871 即因此失败）。
+ *
+ * 职责（仅当 workflow_dispatch 对应输入留空时查询 ASC）：
+ *  1. version_name 留空 → 查询 ASC 全部 iOS prerelease 版本，取最高版本尾段 +1；
+ *     ASC 尚无版本时回退 apps/client/package.json 版本尾段 +1
+ *  2. build_number 留空 → 查询 ASC 最大 CFBundleVersion，+1；尚无构建时从 1 开始
+ * 手动输入优先级始终最高：填了就不查询、不改写。
+ *
+ * 认证：与 altool 上传共用同一把 App Store Connect API Key（JWT 复用
+ * submit_testflight.mjs 的 createJwt/apiRequest），无需新增密钥。
+ */
+
+import { appendFileSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import { createJwt, apiRequest } from './submit_testflight.mjs'
+
+/* ------------------------------------------------------------------ */
+/* 纯函数（可单测）                                                     */
+/* ------------------------------------------------------------------ */
+
+/** 把版本号解析为最多三段的整数数组；非法输入返回 null。 */
+export function parseVersionParts(version) {
+  const raw = String(version ?? '').trim()
+  if (!raw || raw.includes('+') || raw.includes('-')) return null
+  const parts = raw.split('.').map((p) => Number.parseInt(p, 10))
+  if (parts.length < 1 || parts.length > 3) return null
+  if (parts.some((n) => !Number.isInteger(n) || n < 0)) return null
+  return parts
+}
+
+/** 逐段数值比较，缺失段视为 0（"1.4" === "1.4.0"）。 */
+export function compareVersionParts(a, b) {
+  const len = Math.max(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    const diff = (a[i] || 0) - (b[i] || 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+/**
+ * 计算下一个 marketing 版本：候选里最高版本的尾段 +1（保持原段数）。
+ * 候选全非法/为空时回退 fallback（同样尾段 +1）。
+ * @param {string[]} versions ASC 已存在的版本号列表
+ * @param {string} fallback 回退基准（如 package.json 版本）
+ */
+export function nextMarketingVersion(versions, fallback) {
+  const parsed = (versions || []).map(parseVersionParts).filter(Boolean)
+  const fallbackParts = parseVersionParts(fallback)
+  if (!fallbackParts && parsed.length === 0) {
+    throw new Error(`无法推导下一版本号：ASC 无历史版本且回退版本非法（${fallback}）`)
+  }
+  let base =
+    parsed.length > 0
+      ? parsed.sort(compareVersionParts)[parsed.length - 1]
+      : fallbackParts
+  const bumped = [...base]
+  bumped[bumped.length - 1] += 1
+  return bumped.join('.')
+}
+
+/**
+ * 计算下一个 build 号：已知最大值 +1；列表为空时 fallback +1。
+ * @param {Array<number|string>} buildNumbers ASC 已存在的 CFBundleVersion 列表
+ * @param {number} fallback 无历史时的起始值（默认 0 → 首个 build 为 1）
+ */
+export function nextBuildNumber(buildNumbers, fallback = 0) {
+  const numbers = (buildNumbers || [])
+    .map((v) => Number(v))
+    .filter((n) => Number.isInteger(n) && n >= 0)
+  return Math.max(...numbers, fallback) + 1
+}
+
+/** 查询某 App 全部 iOS prerelease 版本（marketing version 维度）。 */
+export function createPrereleaseVersionsPath({ appId, limit = 200 }) {
+  const qs = new URLSearchParams({
+    'filter[app]': appId,
+    'filter[platform]': 'IOS',
+    'fields[preReleaseVersions]': 'version',
+    limit: String(limit),
+  })
+  return `/preReleaseVersions?${qs}`
+}
+
+/** 按 CFBundleVersion 倒序查询某 App 的构建（第一条即最大 build 号）。 */
+export function createMaxBuildLookupPath({ appId, limit = 50 }) {
+  const qs = new URLSearchParams({
+    'filter[app]': appId,
+    'fields[builds]': 'version',
+    sort: '-version',
+    limit: String(limit),
+  })
+  return `/builds?${qs}`
+}
+
+/* ------------------------------------------------------------------ */
+/* 主流程                                                               */
+/* ------------------------------------------------------------------ */
+
+function readClientPackageVersion() {
+  try {
+    const pkg = JSON.parse(readFileSync('apps/client/package.json', 'utf8'))
+    return pkg.version || ''
+  } catch {
+    return '' // 仓库结构变化时降级：仅当 ASC 也查不到版本才会用到回退值
+  }
+}
+
+async function main() {
+  const {
+    APPLE_APP_ID,
+    APPSTORE_KEY_ID,
+    APPSTORE_ISSUER_ID,
+    APPSTORE_PRIVATE_KEY_PATH,
+    INPUT_VERSION_NAME = '',
+    INPUT_BUILD_NUMBER = '',
+    GITHUB_OUTPUT,
+  } = process.env
+
+  let versionName = String(INPUT_VERSION_NAME).trim()
+  let buildNumber = String(INPUT_BUILD_NUMBER).trim()
+
+  // 任一输入留空才需要访问 ASC；手动输入优先，不做任何改写
+  if (!versionName || !buildNumber) {
+    for (const [name, value] of Object.entries({
+      APPLE_APP_ID,
+      APPSTORE_KEY_ID,
+      APPSTORE_ISSUER_ID,
+      APPSTORE_PRIVATE_KEY_PATH,
+    })) {
+      if (!value) throw new Error(`缺少环境变量 ${name}`)
+    }
+    const privateKeyPem = readFileSync(APPSTORE_PRIVATE_KEY_PATH, 'utf8')
+    const token = createJwt({ keyId: APPSTORE_KEY_ID, issuerId: APPSTORE_ISSUER_ID, privateKeyPem })
+
+    if (!versionName) {
+      const data = await apiRequest(token, createPrereleaseVersionsPath({ appId: APPLE_APP_ID }))
+      const versions = (data.data || [])
+        .map((item) => item.attributes?.version)
+        .filter(Boolean)
+      versionName = nextMarketingVersion(versions, readClientPackageVersion())
+      console.log(
+        versions.length > 0
+          ? `📈 ASC 现存最高版本之上自动递增（历史 ${versions.length} 个版本）`
+          : '📈 ASC 无历史版本，按 package.json 版本递增',
+      )
+    }
+
+    if (!buildNumber) {
+      const data = await apiRequest(token, createMaxBuildLookupPath({ appId: APPLE_APP_ID }))
+      const buildNumbers = (data.data || [])
+        .map((item) => item.attributes?.version)
+        .filter((v) => v != null)
+      buildNumber = String(nextBuildNumber(buildNumbers))
+      console.log('🔢 以 ASC 最大 build 号之上自动递增')
+    }
+  }
+
+  // 与旧行内校验一致：最终结果必须是合法的三段以内数字版本号 / 纯数字 build 号
+  if (!/^[0-9]+(\.[0-9]+){0,2}$/.test(versionName)) {
+    throw new Error(`version_name must look like 1, 1.2, or 1.2.3; got '${versionName}'`)
+  }
+  if (!/^[0-9]+$/.test(buildNumber)) {
+    throw new Error(`build_number must be numeric; got '${buildNumber}'`)
+  }
+
+  console.log(`VERSION_NAME=${versionName}`)
+  console.log(`BUILD_NUMBER=${buildNumber}`)
+  if (GITHUB_OUTPUT) {
+    appendFileSync(GITHUB_OUTPUT, `version_name=${versionName}\nbuild_number=${buildNumber}\n`)
+  }
+}
+
+/* 直接运行时才执行主流程；node --test import 纯函数时不执行。 */
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])
+if (isMain) {
+  main().catch((err) => {
+    console.error(`❌ ${err.message}`)
+    process.exit(1)
+  })
+}

--- a/tools/ci/resolve_testflight_version.test.mjs
+++ b/tools/ci/resolve_testflight_version.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * resolve_testflight_version.mjs 纯函数单测（node --test）。
+ * 运行：node --test tools/ci/resolve_testflight_version.test.mjs
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  compareVersionParts,
+  createMaxBuildLookupPath,
+  createPrereleaseVersionsPath,
+  nextBuildNumber,
+  nextMarketingVersion,
+  parseVersionParts,
+} from './resolve_testflight_version.mjs'
+
+test('parseVersionParts 解析 1~3 段数字版本，拒绝非法输入', () => {
+  assert.deepEqual(parseVersionParts('1.4.7'), [1, 4, 7])
+  assert.deepEqual(parseVersionParts('1.4'), [1, 4])
+  assert.deepEqual(parseVersionParts('2'), [2])
+  assert.equal(parseVersionParts('1.4.7-beta'), null)
+  assert.equal(parseVersionParts('1.4.7+build'), null)
+  assert.equal(parseVersionParts(''), null)
+  assert.equal(parseVersionParts('a.b'), null)
+  assert.equal(parseVersionParts('1.2.3.4'), null)
+})
+
+test('compareVersionParts 逐段比较，缺失段视为 0', () => {
+  assert.equal(compareVersionParts([1, 4, 7], [1, 4, 6]), 1)
+  assert.equal(compareVersionParts([1, 4], [1, 4, 0]), 0)
+  assert.equal(compareVersionParts([1, 4], [1, 5]), -1)
+  assert.equal(compareVersionParts([2], [1, 9, 9]), 1)
+})
+
+test('nextMarketingVersion 取最高版本尾段 +1', () => {
+  assert.equal(
+    nextMarketingVersion(['1.4.6', '1.4.7', '1.3.0'], '9.9.9'),
+    '1.4.8',
+  )
+  // 字符串排序会错判（"10" < "9"），必须数值比较
+  assert.equal(nextMarketingVersion(['1.4.10', '1.4.9'], '0.0.1'), '1.4.11')
+  // 保持原段数
+  assert.equal(nextMarketingVersion(['1.5'], '0.0.1'), '1.6')
+  // 非法候选被过滤
+  assert.equal(nextMarketingVersion(['1.4.7', 'bad', ''], '1.0.0'), '1.4.8')
+})
+
+test('nextMarketingVersion 无候选时回退 fallback 并 +1', () => {
+  assert.equal(nextMarketingVersion([], '1.4.6'), '1.4.7')
+  assert.equal(nextMarketingVersion(['bad'], '1.4.6'), '1.4.7')
+  assert.throws(() => nextMarketingVersion([], ''))
+})
+
+test('nextBuildNumber 取最大 build 号 +1', () => {
+  assert.equal(nextBuildNumber([25, 27, 12]), 28)
+  assert.equal(nextBuildNumber(['27', 9]), 28)
+  assert.equal(nextBuildNumber([]), 1)
+  assert.equal(nextBuildNumber([null, undefined, 'x']), 1)
+})
+
+test('createPrereleaseVersionsPath 过滤 App/平台并只取 version 字段', () => {
+  const path = createPrereleaseVersionsPath({ appId: '6787857278' })
+  assert.match(path, /^\/preReleaseVersions\?/)
+  assert.match(path, /filter%5Bapp%5D=6787857278/)
+  assert.match(path, /filter%5Bplatform%5D=IOS/)
+  const url = new URL(`https://example.test${path}`)
+  assert.equal(url.searchParams.get('fields[preReleaseVersions]'), 'version')
+  assert.equal(url.searchParams.get('limit'), '200')
+})
+
+test('createMaxBuildLookupPath 按 CFBundleVersion 倒序取第一条', () => {
+  const path = createMaxBuildLookupPath({ appId: '6787857278' })
+  assert.match(path, /^\/builds\?/)
+  assert.match(path, /filter%5Bapp%5D=6787857278/)
+  assert.match(path, /sort=-version/)
+  const url = new URL(`https://example.test${path}`)
+  assert.equal(url.searchParams.get('fields[builds]'), 'version')
+})

--- a/tools/ci/submit_testflight.d.mts
+++ b/tools/ci/submit_testflight.d.mts
@@ -36,8 +36,26 @@ export function createAppEncryptionDeclarationLookupPath(options: {
   limit?: number
 }): string
 
+export function createAppEncryptionDeclarationBody(options: {
+  appId: string
+}): unknown
+
+export function createBetaGroupsLookupPath(options: {
+  appId: string
+  limit?: number
+}): string
+
+export function selectBetaGroups(groups: unknown[], groupNameInput: string | undefined): unknown[]
+
 export function createBuildEncryptionDeclarationLinkageBody(
   declarationId: string,
 ): {
   data: { type: string; id: string }
 }
+
+export function apiRequest(
+  token: string,
+  pathname: string,
+  options?: { method?: string; body?: unknown },
+  retries?: number,
+): Promise<any>

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -6,10 +6,13 @@
  *  2. 填写「测试说明（What to Test）」：
  *     - 优先使用 workflow 输入 TESTFLIGHT_WHATS_NEW（支持字面 \n 换行）
  *     - 留空则自动生成：最近 git 提交 + src/utils/test_account.js 中的演示测试账号
- *  3. 把构建加入 beta 测试组：
- *     - 指定 TESTFLIGHT_BETA_GROUP 按名字匹配；留空选第一个内部测试组
- *     - 内部组 = 自动提交，内部测试员立即可安装
- *     - 外部组 = 额外提交 Beta App Review（betaAppReviewSubmissions）
+ *  3. 出口合规（Export Compliance）：auto 模式关联已批准的 App Encryption
+ *     Declaration；该 App 尚无声明时按「不包含加密算法」自动创建并关联
+ *  4. 把构建加入 beta 测试组：
+ *     - TESTFLIGHT_BETA_GROUP 支持逗号分隔多个组名精确匹配；留空自动选第一个
+ *       外部组（无外部组回落第一个内部组）
+ *     - 内部组 = 自动生效，内部测试员立即可安装
+ *     - 任一外部组 = 额外提交 Beta App Review（betaAppReviewSubmissions）
  *
  * 认证：App Store Connect API Key（APPSTORE_KEY_ID / APPSTORE_ISSUER_ID /
  * APPSTORE_PRIVATE_KEY_PATH），与 altool 上传用的是同一把钥匙，无需新增密钥。
@@ -99,7 +102,7 @@ export function buildWhatsNew({ manual, versionName, buildNumber, commits = [], 
 /* 内部工具                                                             */
 /* ------------------------------------------------------------------ */
 
-async function apiRequest(token, pathname, { method = 'GET', body } = {}, retries = 2) {
+export async function apiRequest(token, pathname, { method = 'GET', body } = {}, retries = 2) {
   let lastError
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
@@ -184,6 +187,20 @@ export function createAppEncryptionDeclarationLookupPath({ appId, limit = 200 })
   return `/appEncryptionDeclarations?${qs}`
 }
 
+/**
+ * 创建「不包含加密算法」的出口合规声明请求体。
+ * 对应 TestFlight 网页上的 Export Compliance = No（标准免税声明），无需人工回答问卷。
+ */
+export function createAppEncryptionDeclarationBody({ appId }) {
+  return {
+    data: {
+      type: 'appEncryptionDeclarations',
+      attributes: { usesEncryption: false },
+      relationships: { app: { data: { type: 'apps', id: appId } } },
+    },
+  }
+}
+
 /** 把 build 关联到出口合规声明的 linkage 请求体。 */
 export function createBuildEncryptionDeclarationLinkageBody(declarationId) {
   return {
@@ -205,7 +222,8 @@ function recentCommits(max = 8) {
 
 function loadTestAccount() {
   try {
-    return parseTestAccount(readFileSync('src/utils/test_account.js', 'utf8'))
+    // workflow 以仓库根为 cwd 调用本脚本，客户端已迁移至 apps/client/
+    return parseTestAccount(readFileSync('apps/client/src/utils/test_account.js', 'utf8'))
   } catch {
     return null // 仓库结构变化时降级，测试说明不含账号段
   }
@@ -296,35 +314,59 @@ async function upsertBetaBuildLocalization(token, { buildId, locale, whatsNew })
   return created?.data?.id
 }
 
-async function findBetaGroup(token, { appId, groupName }) {
+/** 查询某 App 全部 beta 测试组（含内/外部与全构建访问标记）。 */
+export function createBetaGroupsLookupPath({ appId, limit = 200 }) {
   const qs = new URLSearchParams({
     'filter[app]': appId,
     'fields[betaGroups]': 'name,isInternalGroup,hasAccessToAllBuilds',
-    limit: '200',
+    limit: String(limit),
   })
-  const data = await apiRequest(token, `/betaGroups?${qs}`)
-  const groups = data.data || []
-  if (groupName) {
-    const group = groups.find((g) => g.attributes?.name === groupName)
-    if (!group) {
-      const names = groups.map((g) => g.attributes?.name).join('、') || '（无可用测试组）'
-      throw new Error(`找不到测试组「${groupName}」。App Store Connect 中该 App 的可用测试组：${names}`)
-    }
-    console.log(`✅ 使用指定测试组「${groupName}」${group.attributes?.isInternalGroup ? '（内部组）' : '（外部组）'}`)
-    return group
+  return `/betaGroups?${qs}`
+}
+
+/**
+ * 解析测试组选择输入：按名字精确匹配（可逗号分隔多个）；留空 = 自动模式。
+ * 自动模式优先选第一个「外部」测试组（面向公众测试者，配合自动提交 Beta App
+ * Review 实现全自动外发），没有外部组时回落第一个内部组。
+ */
+export function selectBetaGroups(groups, groupNameInput) {
+  const names = String(groupNameInput || '')
+    .split(',')
+    .map((n) => n.trim())
+    .filter(Boolean)
+  if (names.length > 0) {
+    const picked = names.map((name) => {
+      const group = groups.find((g) => g.attributes?.name === name)
+      if (!group) {
+        const available = groups.map((g) => g.attributes?.name).join('、') || '（无可用测试组）'
+        throw new Error(`找不到测试组「${name}」。App Store Connect 中该 App 的可用测试组：${available}`)
+      }
+      return group
+    })
+    console.log(
+      `✅ 使用指定测试组：${picked.map((g) => `「${g.attributes?.name}」${g.attributes?.isInternalGroup ? '（内部）' : '（外部）'}`).join('、')}`,
+    )
+    return picked
+  }
+
+  const external = groups.find((g) => g.attributes?.isInternalGroup === false)
+  if (external) {
+    console.log(`✅ 自动选择第一个外部测试组「${external.attributes?.name}」（将自动提交 Beta App Review）`)
+    return [external]
   }
   const internal = groups.find((g) => g.attributes?.isInternalGroup === true)
   if (!internal) {
-    throw new Error('未指定测试组名，且该 App 没有内部测试组。请先在 App Store Connect 创建内部测试组，或填写 beta_group 输入')
+    throw new Error('未指定测试组名，且该 App 没有任何测试组。请先在 App Store Connect 创建测试组，或填写 beta_group 输入')
   }
-  console.log(`✅ 自动选择第一个内部测试组「${internal.attributes?.name}」`)
-  return internal
+  console.log(`✅ 无外部测试组，自动选择第一个内部测试组「${internal.attributes?.name}」`)
+  return [internal]
 }
 
 /**
  * 自动出口合规（"允许出口"）：把构建关联到 App 已批准的 App Encryption Declaration。
- * mode: 'auto'（默认，查已批准声明）/ 'off'（跳过）/ 其它值视为显式声明 id。
- * 无可用声明时仅告警，不中断测试组投递。
+ * mode: 'auto'（默认）/ 'off'（跳过）/ 其它值视为显式声明 id。
+ * auto 模式下若该 App 尚无任何声明，自动按「不包含加密算法」创建新声明并关联，
+ * 全程无需打开 App Store Connect 网页。
  */
 async function assignExportCompliance(token, { appId, buildId, mode }) {
   const normalized = String(mode || 'auto').trim().toLowerCase()
@@ -342,11 +384,19 @@ async function assignExportCompliance(token, { appId, buildId, mode }) {
       (item) => item.attributes?.appEncryptionDeclarationState === 'APPROVED',
     )
     declarationId = (approved || list[0])?.id || ''
+    if (!declarationId) {
+      // 首次上传：App 还没有加密合规声明。按「不包含加密算法」（usesEncryption=false）
+      // 自动创建并关联，等价于在网页上回答 Export Compliance = No。
+      console.log('🆕 该 App 尚无出口合规声明，自动创建「不包含加密算法」声明…')
+      const created = await apiRequest(token, '/appEncryptionDeclarations', {
+        method: 'POST',
+        body: createAppEncryptionDeclarationBody({ appId }),
+      })
+      declarationId = created?.data?.id || ''
+    }
   }
   if (!declarationId) {
-    console.warn(
-      '⚠️ 未找到可用的 App Encryption Declaration，跳过出口合规关联（首次需在 App Store Connect 创建并等待审核；不影响测试组投递）',
-    )
+    console.warn('⚠️ 出口合规声明创建/查找失败，跳过关联（不影响测试组投递）')
     return
   }
   await apiRequest(
@@ -357,7 +407,7 @@ async function assignExportCompliance(token, { appId, buildId, mode }) {
       body: createBuildEncryptionDeclarationLinkageBody(declarationId),
     },
   )
-  console.log(`✅ 已关联出口合规声明（声明 id=${declarationId}）`)
+  console.log(`✅ 已关联出口合规声明（声明 id=${declarationId}，usesEncryption=false）`)
 }
 
 async function main() {
@@ -430,19 +480,24 @@ async function main() {
     console.warn(`⚠️ 出口合规关联失败（不影响测试组投递）：${err.message}`)
   }
 
-  // 3) 加入测试组（内部组 = 自动提交；外部组需要 Beta App Review）
-  const group = await findBetaGroup(token, { appId: APPLE_APP_ID, groupName: TESTFLIGHT_BETA_GROUP })
-  if (group.attributes?.hasAccessToAllBuilds === true) {
-    console.log(`✅ 测试组「${group.attributes?.name}」已配置自动访问所有构建，无需重复关联`)
-  } else {
-    await apiRequest(token, `/builds/${buildId}/relationships/betaGroups`, {
-      method: 'POST',
-      body: { data: [{ type: 'betaGroups', id: group.id }] },
-    })
-    console.log(`✅ 构建已加入测试组「${group.attributes?.name}」`)
+  // 3) 加入测试组（内部组 = 自动生效；外部组额外提交 Beta App Review）
+  const groupsData = await apiRequest(token, createBetaGroupsLookupPath({ appId: APPLE_APP_ID }))
+  const pickedGroups = selectBetaGroups(groupsData.data || [], TESTFLIGHT_BETA_GROUP)
+  let needsBetaReview = false
+  for (const group of pickedGroups) {
+    if (group.attributes?.hasAccessToAllBuilds === true) {
+      console.log(`✅ 测试组「${group.attributes?.name}」已配置自动访问所有构建，无需重复关联`)
+    } else {
+      await apiRequest(token, `/builds/${buildId}/relationships/betaGroups`, {
+        method: 'POST',
+        body: { data: [{ type: 'betaGroups', id: group.id }] },
+      })
+      console.log(`✅ 构建已加入测试组「${group.attributes?.name}」`)
+    }
+    if (group.attributes?.isInternalGroup === false) needsBetaReview = true
   }
 
-  if (group.attributes?.isInternalGroup === false) {
+  if (needsBetaReview) {
     try {
       await apiRequest(token, '/betaAppReviewSubmissions', {
         method: 'POST',

--- a/tools/ci/submit_testflight.test.mjs
+++ b/tools/ci/submit_testflight.test.mjs
@@ -7,14 +7,23 @@ import { test } from 'node:test'
 
 import {
   buildWhatsNew,
+  createAppEncryptionDeclarationBody,
   createAppEncryptionDeclarationLookupPath,
   createBetaBuildLocalizationBody,
+  createBetaGroupsLookupPath,
   createBuildEncryptionDeclarationLinkageBody,
   createJwt,
   createPrereleaseBuildsPath,
   createPrereleaseLookupPath,
   parseTestAccount,
+  selectBetaGroups,
 } from './submit_testflight.mjs'
+
+/** 构造 betaGroups 资源对象（与 ASC 响应结构对齐的最小形态）。 */
+const group = (id, name, { internal = false, allBuilds = false } = {}) => ({
+  id,
+  attributes: { name, isInternalGroup: internal, hasAccessToAllBuilds: allBuilds },
+})
 
 test('createPrereleaseLookupPath 过滤 App/版本/平台', () => {
   const path = createPrereleaseLookupPath({ appId: '6787857278', versionName: '1.4.7' })
@@ -37,6 +46,47 @@ test('createAppEncryptionDeclarationLookupPath 含 app 过滤与所需字段', (
   assert.match(path, /usesEncryption/)
   const limited = createAppEncryptionDeclarationLookupPath({ appId: 'a1', limit: 50 })
   assert.match(limited, /limit=50/)
+})
+
+test('createAppEncryptionDeclarationBody 声明「不包含加密算法」', () => {
+  assert.deepEqual(createAppEncryptionDeclarationBody({ appId: 'app-1' }), {
+    data: {
+      type: 'appEncryptionDeclarations',
+      attributes: { usesEncryption: false },
+      relationships: { app: { data: { type: 'apps', id: 'app-1' } } },
+    },
+  })
+})
+
+test('createBetaGroupsLookupPath 过滤 App 并携带内外部标记字段', () => {
+  const url = new URL(
+    `https://example.test${createBetaGroupsLookupPath({ appId: 'app-1' })}`,
+  )
+  assert.equal(url.pathname, '/betaGroups')
+  assert.equal(url.searchParams.get('filter[app]'), 'app-1')
+  assert.equal(
+    url.searchParams.get('fields[betaGroups]'),
+    'name,isInternalGroup,hasAccessToAllBuilds',
+  )
+})
+
+test('selectBetaGroups 指定名字精确匹配，支持逗号分隔多个', () => {
+  const groups = [group('g1', '内部组', { internal: true }), group('g2', '外部组'), group('g3', '公测')]
+  const picked = selectBetaGroups(groups, '外部组, 公测')
+  assert.deepEqual(picked.map((g) => g.id), ['g2', 'g3'])
+  assert.throws(() => selectBetaGroups(groups, '不存在的组'), /找不到测试组/)
+})
+
+test('selectBetaGroups 留空时外部组优先，无外部组回落内部组', () => {
+  const withExternal = [group('i1', '内部组', { internal: true }), group('e1', '外部组')]
+  assert.deepEqual(selectBetaGroups(withExternal, '').map((g) => g.id), ['e1'])
+  // 外部组排在后面也要被选中
+  assert.deepEqual(selectBetaGroups(withExternal.slice().reverse(), '').map((g) => g.id), ['e1'])
+
+  const internalOnly = [group('i1', '内部组', { internal: true })]
+  assert.deepEqual(selectBetaGroups(internalOnly, '').map((g) => g.id), ['i1'])
+
+  assert.throws(() => selectBetaGroups([], ''), /没有任何测试组/)
 })
 
 test('createBuildEncryptionDeclarationLinkageBody 结构正确', () => {


### PR DESCRIPTION
## 背景

run 32735810871（2026-08-24）iOS TestFlight 上传失败，Apple 报 90062：

> CFBundleShortVersionString [1.4.6] must contain a higher version than that of the previously approved version [1.4.6]

**根因**：workflow 的 version_name 留空时回落 `apps/client/package.json`（仍是 1.4.6），而 1.4.6 已是 ASC 上已批准版本且列车已关闭（不可 reopen）；build 号回落 GitHub run number，与 ASC build 序列无关。

## 修复

### 版本号自动递增（核心）
- 新增 `tools/ci/resolve_testflight_version.mjs`：
  - `version_name` 留空 → 查询 ASC 全部 iOS prerelease 版本，取最高版本尾段 +1（数值比较防 `10 < 9` 错判），无历史版本时回退 package.json 尾段 +1
  - `build_number` 留空 → 查询 ASC 最大 CFBundleVersion（`sort=-version`）+1
  - 手动输入优先级最高：填了就不查询、不改写
- 复用既有 App Store Connect API Key（JWT/请求函数从 submit_testflight.mjs 导入），零新增密钥
- workflow 步骤重排：ASC API key 安装提前到版本解析之前

### 三项后处理全自动化补齐（上传后无需打开 ASC 网页）
| 操作 | 原状 | 现状 |
|---|---|---|
| 出口合规「不包含加密算法」 | 仅关联已批准声明，首次需人工 | 无声明时自动创建 `usesEncryption:false` 声明并关联 |
| 加入测试组 | 留空默认内部组 | 留空自动选第一个外部组（支持逗号分隔多组名） |
| 提交审核 | 选外部组时提交 Beta Review | 保持自动，随外部组默认化必然触发 |

顺带修复 `loadTestAccount` 相对路径错误（CI cwd=仓库根，演示测试账号此前从未真正写入测试说明）。

## 验证
- `node --test` 22/22 通过（新增版本递增/组选择/声明体纯函数用例）
- vitest 契约测试 12/12 通过（含新增的「禁止回落 package.json/run number」契约）
- PyYAML 校验两个 workflow 结构 OK；冒烟验证手动输入直通与缺密钥报错两条路径