### PR TITLE
fix(#706): 移除后台检测 per-feature 独立开关，控制面收敛至通知类型开关

### DIFF
--- a/apps/client/src/components/NotificationView.vue
+++ b/apps/client/src/components/NotificationView.vue
@@ -42,10 +42,6 @@ const enableGradeNotices = ref(true)
 const enablePowerNotices = ref(true)
 const enableClassReminders = ref(true)
 const enableSchoolInboxNotices = ref(true)
-// #615：per-feature 后台检测开关（成绩/考试变化/学校消息，独立 enable/disable）
-const bgFeatureGrades = ref(true)
-const bgFeatureExams = ref(true)
-const bgFeatureSchool = ref(true)
 const bgNativeState = ref(null)
 const classLeadMinutes = ref(30)
 const checkInterval = ref(30)
@@ -125,18 +121,15 @@ const saveSettings = () => {
   localStorage.setItem('hbu_notify_school_inbox', enableSchoolInboxNotices.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_class_lead_min', String(classLeadMinutes.value))
   localStorage.setItem('hbu_notify_interval', String(checkInterval.value))
-  // #615：per-feature 后台检测开关（成绩/考试变化/学校消息独立 enable/disable）
-  localStorage.setItem('hbu_bg_feature_grades', bgFeatureGrades.value ? 'true' : 'false')
-  localStorage.setItem('hbu_bg_feature_exams', bgFeatureExams.value ? 'true' : 'false')
-  localStorage.setItem('hbu_bg_feature_school', bgFeatureSchool.value ? 'true' : 'false')
-  // #615：同步 #609 BackgroundCheckConfig 契约到后台插件（native business 列表
-  // 由适配器映射：grades/exams/school_inbox），并刷新真实状态展示。
+  // #706：同步 #609 BackgroundCheckConfig 契约到后台插件。check* 直接映射上方
+  // 通知类型开关（唯一控制面，原 per-feature 独立开关已移除）；native business
+  // 列表由适配器映射：grades/exams/school_inbox，并刷新真实状态展示。
   void platformBridge
     .setBackgroundCheckConfig({
       enabled: enableBackground.value,
-      checkGradeChanges: bgFeatureGrades.value,
-      checkExamChanges: bgFeatureExams.value,
-      checkSchoolInbox: bgFeatureSchool.value,
+      checkGradeChanges: enableGradeNotices.value,
+      checkExamChanges: enableExamReminders.value,
+      checkSchoolInbox: enableSchoolInboxNotices.value,
       intervalMinutes: checkInterval.value,
       schemaVersion: 1,
       updatedAt: new Date().toISOString()
@@ -171,19 +164,6 @@ const updateSettingsFromStorage = () => {
   checkInterval.value = [15, 30, 60].includes(settings.intervalMinutes)
     ? settings.intervalMinutes
     : 30
-  // #615：per-feature 开关（默认开启；与前台 notify_center_checks 同一 key）
-  const readFeature = (key, fallback = true) => {
-    try {
-      const raw = localStorage.getItem(key)
-      if (raw === null) return fallback
-      return raw === 'true'
-    } catch {
-      return fallback
-    }
-  }
-  bgFeatureGrades.value = readFeature('hbu_bg_feature_grades')
-  bgFeatureExams.value = readFeature('hbu_bg_feature_exams')
-  bgFeatureSchool.value = readFeature('hbu_bg_feature_school')
 }
 
 const findByValue = (list, value) =>
@@ -286,10 +266,11 @@ const bgFeatureStatusText = computed(() => {
 })
 
 // 学校消息：provider 后台不受支持时显示真实 unsupported/foreground-only 状态，
-// 而不是静默假成功（#615 验收：设置页显示真实状态）
+// 而不是静默假成功（#615 验收：设置页显示真实状态）。#706：开关来源收敛为
+// 上方通知类型开关 enableSchoolInboxNotices（原 per-feature 独立开关已移除）。
 const schoolFeatureStatusText = computed(() => {
   const school = schoolInboxSummary.value
-  const enabled = bgFeatureSchool.value
+  const enabled = enableSchoolInboxNotices.value
   if (!enabled) return '已关闭'
   if (school?.error) return `前台检测：${school.error}`
   if (school?.total != null) {
@@ -303,7 +284,7 @@ const schoolFeatureStatusText = computed(() => {
 
 const examsFeatureStatusText = computed(() => {
   const exams = examSummary.value
-  if (!bgFeatureExams.value) return '已关闭'
+  if (!enableExamReminders.value) return '已关闭'
   if (exams?.total != null) return `共 ${exams.total} 门考试（明日 ${exams.tomorrowCount || 0} 门）`
   return '等待检测'
 })
@@ -743,11 +724,6 @@ const handleOtherSettingChange = () => {
   saveSettings()
 }
 
-// #615：per-feature 开关变化 -> 落盘 + 同步 #609 配置到后台插件
-const handleBgFeatureChange = () => {
-  saveSettings()
-}
-
 const handleIntervalChange = () => {
   if (![15, 30, 60].includes(Number(checkInterval.value))) {
     checkInterval.value = 30
@@ -1045,32 +1021,8 @@ watch(
           </select>
         </div>
 
-        <!-- #615：per-feature 独立开关（成绩变化 / 考试安排变化 / 学校消息） -->
+        <!-- #706：后台检测调度状态展示；分项控制已收敛至上方通知类型开关 -->
         <div class="sync-features-block">
-          <div class="sync-feature-row">
-            <span class="sync-feature-label">成绩变化检测</span>
-            <span class="sync-feature-status">{{ bgNativeState ? (bgFeatureGrades ? '开启' : '关闭') : '' }}</span>
-            <label class="toggle-switch" @click.stop>
-              <input type="checkbox" v-model="bgFeatureGrades" @change="handleBgFeatureChange">
-              <span class="toggle-track"></span>
-            </label>
-          </div>
-          <div class="sync-feature-row">
-            <span class="sync-feature-label">考试安排变化检测</span>
-            <span class="sync-feature-status">{{ examsFeatureStatusText }}</span>
-            <label class="toggle-switch" @click.stop>
-              <input type="checkbox" v-model="bgFeatureExams" @change="handleBgFeatureChange">
-              <span class="toggle-track"></span>
-            </label>
-          </div>
-          <div class="sync-feature-row">
-            <span class="sync-feature-label">学校消息检测</span>
-            <span class="sync-feature-status">{{ schoolFeatureStatusText }}</span>
-            <label class="toggle-switch" @click.stop>
-              <input type="checkbox" v-model="bgFeatureSchool" @change="handleBgFeatureChange">
-              <span class="toggle-track"></span>
-            </label>
-          </div>
           <p class="sync-feature-hint">后台检测状态：{{ bgFeatureStatusText }}</p>
         </div>
       </section>

--- a/apps/client/src/styles/views/NotificationView.scoped.css
+++ b/apps/client/src/styles/views/NotificationView.scoped.css
@@ -269,34 +269,11 @@
   outline: none;
 }
 
-/* #615：per-feature 后台检测开关（成绩/考试变化/学校消息） */
+/* #615/#706：后台检测状态展示（分项开关行样式已随独立开关移除） */
 .sync-features-block {
   margin-top: 0.75rem;
   border-top: 1px solid var(--md-sys-color-surface-variant, #dfe3e7);
   padding-top: 0.5rem;
-}
-
-.sync-feature-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 0 0.5rem 2rem;
-}
-
-.sync-feature-label {
-  font-size: 14px;
-  color: var(--md-sys-color-on-surface, #171c1f);
-}
-
-.sync-feature-status {
-  flex: 1;
-  text-align: right;
-  margin-right: 0.5rem;
-  font-size: 12px;
-  color: var(--md-sys-color-outline, #727785);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .sync-feature-hint {

--- a/apps/client/src/utils/exams_signature.ts
+++ b/apps/client/src/utils/exams_signature.ts
@@ -1,5 +1,5 @@
 /**
- * #615 跨端 ExamSignatureV1 复刻 + per-feature 开关（纯逻辑，无 axios 依赖链）。
+ * #615 跨端 ExamSignatureV1 复刻（纯逻辑，无 axios 依赖链）。
  *
  * contract-fixtures/exams-signature-v1.json 为单一事实源（Android/iOS/前端三端一致）：
  *   normalize: 字符串 trim；nil/空串等价；courseName trim 后为空则整条记录不参与签名；
@@ -12,24 +12,9 @@
  */
 import { buildLedgerEventKey } from './notification_event_ledger'
 
-// ---- per-feature 后台检测开关（设置页三个独立开关；与 #609 BackgroundCheckConfig 对应） ----
-
-export const BG_FEATURE_KEY_GRADES = 'hbu_bg_feature_grades'
-export const BG_FEATURE_KEY_EXAMS = 'hbu_bg_feature_exams'
-export const BG_FEATURE_KEY_SCHOOL = 'hbu_bg_feature_school'
-
-/** 读取 per-feature 开关（默认开启；'false' 视为关闭）。 */
-export const readBgFeatureEnabled = (key: string, fallback = true): boolean => {
-  try {
-    const raw = localStorage.getItem(key)
-    if (raw === null) return fallback
-    return raw === 'true'
-  } catch {
-    return fallback
-  }
-}
-
 // ---- 跨端 ExamSignatureV1 复刻 ----
+// （#706：原 per-feature 后台检测开关 BG_FEATURE_KEY_*/readBgFeatureEnabled 已移除，
+//   检测控制统一收敛至通知类型开关。）
 
 const toSafeText = (value: unknown): string => String(value ?? '').trim()
 

--- a/apps/client/src/utils/exams_signature_contract.spec.ts
+++ b/apps/client/src/utils/exams_signature_contract.spec.ts
@@ -5,8 +5,8 @@
  */
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { beforeEach, describe, expect, it } from 'vitest'
-import { buildCrossEndExamSignature, readBgFeatureEnabled } from './exams_signature'
+import { describe, expect, it } from 'vitest'
+import { buildCrossEndExamSignature } from './exams_signature'
 import { buildLedgerEventKey } from './notification_event_ledger'
 
 const fixturePath = fileURLToPath(
@@ -74,17 +74,5 @@ describe('#615 跨端 ExamSignatureV1 复刻（contract-fixtures 单一事实源
     expect(buildLedgerEventKey('exams', signature)).toBe(`exams:${signature}`)
   })
 })
-
-describe('#615 per-feature 开关读取', () => {
-  beforeEach(() => {
-    if (typeof localStorage !== 'undefined') localStorage.clear()
-  })
-
-  it('缺失时默认开启；显式 false 关闭', () => {
-    expect(readBgFeatureEnabled('hbu_bg_feature_exams')).toBe(true)
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('hbu_bg_feature_exams', 'false')
-      expect(readBgFeatureEnabled('hbu_bg_feature_exams')).toBe(false)
-    }
-  })
-})
+// #706：per-feature 开关（readBgFeatureEnabled/BG_FEATURE_KEY_*）已随独立开关体系移除，
+// 检测控制统一收敛至通知类型开关；原读取测试一并删除。

--- a/apps/client/src/utils/legacy_background_migration.spec.ts
+++ b/apps/client/src/utils/legacy_background_migration.spec.ts
@@ -83,15 +83,17 @@ describe('migrateLegacyBackgroundState（#616 旧 Capacitor 后台状态迁移�
     expect(memory.storage.getItem('hbu_bg_enabled')).toBeNull()
   })
 
-  it('不删除 #615 新 per-feature config 键（hbu_bg_feature_*）', async () => {
+  it('#706：已移除的 per-feature 开关键（hbu_bg_feature_*）纳入清理', async () => {
     memory.storage.setItem('hbu_bg_feature_grades', 'false')
     memory.storage.setItem('hbu_bg_feature_exams', 'true')
+    memory.storage.setItem('hbu_bg_feature_school', 'false')
 
     const { migrateLegacyBackgroundState } = await loadModule()
     await migrateLegacyBackgroundState()
 
-    expect(memory.storage.getItem('hbu_bg_feature_grades')).toBe('false')
-    expect(memory.storage.getItem('hbu_bg_feature_exams')).toBe('true')
+    expect(memory.storage.getItem('hbu_bg_feature_grades')).toBeNull()
+    expect(memory.storage.getItem('hbu_bg_feature_exams')).toBeNull()
+    expect(memory.storage.getItem('hbu_bg_feature_school')).toBeNull()
   })
 
   it('迁移完成后写入标记，后续调用直接跳过', async () => {

--- a/apps/client/src/utils/legacy_background_migration.ts
+++ b/apps/client/src/utils/legacy_background_migration.ts
@@ -13,8 +13,10 @@
  * 1. 仅当新 config 键（hbu_notify_*）尚未设置时，才把旧键值搬迁过去；
  *    新键已存在则一律以新键为准（不覆盖用户新选择）。
  * 2. 迁移完成后删除旧键；重复执行（升级后再启动）因键已删除而自然幂等。
- * 3. `hbu_bg_feature_*`（成绩/考试/学校消息 per-feature 开关）是 #615 新 config，
- *    不属于旧 Capacitor 键，**绝不删除**。
+ * 3. `hbu_bg_feature_*`（成绩/考试/学校消息 per-feature 开关）曾是 #615 新 config；
+ *    #706 已移除该独立开关体系（控制收敛至 hbu_notify_* 类型开关），残留键
+ *    纳入本模块清理。注意：迁移标记已置位的旧安装不会重跑清理，但键已无任何
+ *    代码读取，属惰性数据，无功能影响。
  * 4. 旧原生 Preferences（CapacitorStorage / NSUserDefaults）在正式 Tauri 应用中
  *    不可达（WebView 存储空间不同），且旧插件类已从构建中移除，其残留为惰性数据：
  *    没有任何代码读取，也不会注册任何系统调度，无需也无法从 JS 侧清除；
@@ -53,7 +55,11 @@ const LEGACY_DISCARD_KEYS: readonly string[] = [
   'hbu_bg_api_base',
   'hbu_bg_login_method',
   'hbu_bg_dorm_selection',
-  'hbu_bg_chaoxing_notice_cookie'
+  'hbu_bg_chaoxing_notice_cookie',
+  // #706：per-feature 独立开关已移除，残留键为惰性废弃数据，纳入清理。
+  'hbu_bg_feature_grades',
+  'hbu_bg_feature_exams',
+  'hbu_bg_feature_school'
 ]
 
 /** 迁移完成的落盘标记（额外幂等保险，防止键清除失败时反复尝试）。 */

--- a/apps/client/src/utils/notify_center_checks.ts
+++ b/apps/client/src/utils/notify_center_checks.ts
@@ -60,28 +60,20 @@ export interface CheckResult extends Record<string, unknown> {
 // #615 考试变化/学校消息扩展（纯逻辑在 ./exams_signature.ts，避免 axios 依赖链）
 // ------------------------------------------------------------
 // - buildCrossEndExamSignature：跨端 ExamSignatureV1 复刻（fixture 单一事实源）；
-// - readBgFeatureEnabled/BG_FEATURE_KEY_*：per-feature 后台检测开关；
 // - examsChangeBaselineKeyFor/buildExamLedgerEventKey：前台 baseline 与 ledger 去重键。
+//   （#706：per-feature 开关 readBgFeatureEnabled/BG_FEATURE_KEY_* 已随独立开关移除。）
 // ============================================================
 
 import {
-  BG_FEATURE_KEY_GRADES,
-  BG_FEATURE_KEY_EXAMS,
-  BG_FEATURE_KEY_SCHOOL,
   buildCrossEndExamSignature,
   buildExamLedgerEventKey,
-  examsChangeBaselineKeyFor,
-  readBgFeatureEnabled
+  examsChangeBaselineKeyFor
 } from './exams_signature'
 
 export {
-  BG_FEATURE_KEY_GRADES,
-  BG_FEATURE_KEY_EXAMS,
-  BG_FEATURE_KEY_SCHOOL,
   buildCrossEndExamSignature,
   buildExamLedgerEventKey,
-  examsChangeBaselineKeyFor,
-  readBgFeatureEnabled
+  examsChangeBaselineKeyFor
 }
 
 const isSchoolInboxItemRead = (item: unknown): boolean => {
@@ -513,10 +505,11 @@ const checkExams = async (
       updated_at: nowIso()
     })
 
-    // #615：考试安排变化前台 diff（与后台 native exams_changed 共用跨端 signature）。
+    // #615/#706：考试安排变化前台 diff（与后台 native exams_changed 共用跨端 signature）。
     // 语义：首次成功只建立 baseline（不推历史）；后续发现可感知变化（增删/日期/时间/地点）
-    // 且 per-feature 开启时通知一次；ledger 去重保证后台已弹过的不再重复弹。
-    if (readBgFeatureEnabled(BG_FEATURE_KEY_EXAMS)) {
+    // 通知一次；ledger 去重保证后台已弹过的不再重复弹。原 per-feature 独立开关已移除，
+    // 检测是否运行由上方通知类型开关（enableExamReminder）经 runNotificationCheck 链路统一控制。
+    {
       const changeSig = await buildCrossEndExamSignature(exams)
       const baselineKey = examsChangeBaselineKeyFor(sid)
       const prevBaseline = toSafeText(localStorage.getItem(baselineKey))


### PR DESCRIPTION
## 概述

Closes #706（方案 A 已在 issue 中拍板）

「后台自动检查」卡片里的三个分项检测开关（成绩变化 / 考试安排变化 / 学校消息）行为不一致：只有考试一路真实 gate 前台检测，成绩与学校消息两项前台链路从未消费、桌面端配置被适配器原样丢弃——用户关闭后检测照跑，且与上方通知类型开关语义重合。本 PR 按拍板方案移除该独立开关体系，**通知类型开关成为唯一控制面**。

## 变更内容（7 文件，+40 / -137）

- `NotificationView.vue`：
  - 删除三个 `sync-feature-row` 开关行与 `bgFeatureGrades/Exams/School` refs、`handleBgFeatureChange`、两个仅供该区域使用的状态 computed；保留总开关、检查间隔与底部调度状态 hint
  - `setBackgroundCheckConfig` 的 `check*` 字段改为直接映射通知类型开关（`checkGradeChanges=enableGradeNotices` 等），保存时机并入现有 `handleOtherSettingChange` 链路
- `notify_center_checks.ts`：移除考试变化检测的 per-feature gate（原 `readBgFeatureEnabled(KEY_EXAMS)` 包裹改裸块），baseline/ledger 去重语义不变
- `exams_signature.ts`：删除 `BG_FEATURE_KEY_*` 与 `readBgFeatureEnabled`
- `legacy_background_migration.ts`：废弃键 `hbu_bg_feature_*` 纳入 `LEGACY_DISCARD_KEYS` 清理；注释同步更新（已打标旧安装不重跑，残留键无消费者属惰性数据）
- 测试：`exams_signature_contract.spec.ts` 删除开关读取用例；`legacy_background_migration.spec.ts` 「绝不删除」用例反转为「纳入清理」断言三键被删
- `NotificationView.scoped.css`：清理 `.sync-feature-row/label/status` 死样式

## 行为变化说明

- 桌面端：关闭「成绩提醒 / 考试提醒 / 学校消息」任一类型开关，对应检测真实停止（学校消息本就短路；考试变化 diff 不再有独立旁路）
- 移动端：后台插件 `BackgroundCheckConfig.check*` 来源从独立开关改为类型开关，契约字段与 schemaVersion 不变
- 已知取舍：「后台查数据但不推通知」的独立粒度不再保留（此前仅考试一路实现），已在 issue 决策点记录

## 验证

- [x] `vue-tsc --noEmit` 通过
- [x] 全量 vitest：1108 用例通过（1 例 iOS 资产扫描失败系 worktree 占位 dist 缺 assets 的环境问题，`vite build` 后复验 16/16 绿）
- [x] `vite build` 成功
- [x] 全局 rg 无 `bgFeature*/hbu_bg_feature*` 功能性残留

## 关联

- Closes #706 · 背景 #615 #609