### PR TITLE
feat(#698): 本机桥新增只读学业数据端点族与本机令牌门禁

### DIFF
--- a/apps/client/src-tauri/src/http_server/auth.rs
+++ b/apps/client/src-tauri/src/http_server/auth.rs
@@ -190,12 +190,18 @@ pub(crate) enum BridgeRoutePolicy {
     PublicHealth,
     PublicEmbed,
     Protected,
+    /// `/local/*` 只读数据端点族（#698）：传输层仅拦不可信 Origin，
+    /// 真正鉴权由 handler 内 `ensure_local_data_auth` 校验本机 Agent 令牌。
+    LocalData,
     DebugOnly,
 }
 
 pub(crate) fn bridge_route_policy(path: &str) -> BridgeRoutePolicy {
     if path == "/health" {
         BridgeRoutePolicy::PublicHealth
+    } else if path.starts_with("/local/") {
+        // #698：本机只读学业数据端点族，独立于 WebView/Bridge 令牌体系
+        BridgeRoutePolicy::LocalData
     } else if path.starts_with("/exports/")
         || path.starts_with("/module_bundle/content/")
         || path == "/school-website"
@@ -303,6 +309,79 @@ pub(crate) fn bridge_auth_error(
 }
 
 // ────────────────────────────────────────────────────────────
+/// `/local/*` 端点族的机器可读错误码（#698 契约固定形状：`{"error": CODE}`）。
+///
+/// 该端点族面向外部本机 Agent，错误体不使用桥内 ApiResponse 包装，
+/// 保证消费者按稳定错误码解析。
+pub(crate) fn local_data_error(
+    status: StatusCode,
+    code: &str,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (status, Json(serde_json::json!({ "error": code })))
+}
+
+/// 401 + `{"error":"LOCAL_TOKEN_INVALID"}`：缺头 / 格式错 / 不匹配。
+pub(crate) fn local_token_invalid_error() -> (StatusCode, Json<serde_json::Value>) {
+    local_data_error(StatusCode::UNAUTHORIZED, "LOCAL_TOKEN_INVALID")
+}
+
+/// 401 + `{"error":"NOT_LOGGED_IN"}`：未登录学校账号，无本地学业数据可用。
+pub(crate) fn not_logged_in_error() -> (StatusCode, Json<serde_json::Value>) {
+    local_data_error(StatusCode::UNAUTHORIZED, "NOT_LOGGED_IN")
+}
+
+// ────────────────────────────────────────────────────────────
+/// 提取 `Authorization: LocalToken <hex>` 头中的令牌
+/// （scheme 按 HTTP 规范大小写不敏感；Bearer 或缺失返回 None）。
+pub(crate) fn extract_local_agent_token(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get("authorization")?.to_str().ok()?.trim();
+    let (scheme, value) = raw.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("localtoken") {
+        return None;
+    }
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+// ────────────────────────────────────────────────────────────
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalTokenDecision {
+    Valid,
+    Invalid,
+}
+
+/// 本机令牌纯校验逻辑（expected 为 None 表示令牌未加载，一律拒绝 fail closed）。
+pub(crate) fn check_local_agent_token(
+    provided: Option<&str>,
+    expected: Option<&str>,
+) -> LocalTokenDecision {
+    match (provided, expected) {
+        (Some(provided), Some(expected)) if tokens_equal(provided, expected) => {
+            LocalTokenDecision::Valid
+        }
+        _ => LocalTokenDecision::Invalid,
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+/// `/local/*` 只读数据端点族的本机令牌门禁（三个端点共用的守卫函数）。
+///
+/// 通过 → Ok；缺头 / 格式错 / 与启动时加载的本机令牌不匹配 →
+/// 401 `{"error":"LOCAL_TOKEN_INVALID"}`。
+pub(crate) fn ensure_local_data_auth(
+    headers: &HeaderMap,
+    state: &HttpState,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    let provided = extract_local_agent_token(headers);
+    let expected = state.local_agent_token.as_deref();
+    if check_local_agent_token(provided.as_deref(), expected) == LocalTokenDecision::Valid {
+        Ok(())
+    } else {
+        Err(local_token_invalid_error())
+    }
+}
+
+// ────────────────────────────────────────────────────────────
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BridgeAccessDecision {
     Allow,
@@ -328,6 +407,16 @@ pub(crate) fn decide_bridge_access(
 
     if has_explicit_untrusted_origin(headers) {
         return BridgeAccessDecision::ForbiddenOrigin;
+    }
+
+    // #698：LocalData 传输层仅放行 GET/HEAD（端点严格只读），
+    // 本机令牌校验由 handler 内 ensure_local_data_auth 完成。
+    if policy == BridgeRoutePolicy::LocalData {
+        return if matches!(*method, Method::GET | Method::HEAD) {
+            BridgeAccessDecision::Allow
+        } else {
+            BridgeAccessDecision::Unauthorized
+        };
     }
 
     if policy == BridgeRoutePolicy::PublicEmbed && matches!(*method, Method::GET | Method::HEAD) {

--- a/apps/client/src-tauri/src/http_server/local_token.rs
+++ b/apps/client/src-tauri/src/http_server/local_token.rs
@@ -1,0 +1,165 @@
+//! 本机 Agent 令牌生命周期（#698）。
+//!
+//! 契约：
+//! - 令牌文件固定为 `%APPDATA%/mini-hbut/local-agent-token`，内容为 64 位小写 hex；
+//! - App 启动时缺失则生成并写入；存在且格式合法则复用（持久化保证外部 Agent 引用稳定）；
+//! - 文件存在但内容非法（非 64 位小写 hex）时重置为新令牌；
+//! - 目录不存在则创建。
+//!
+//! 该令牌仅用于本机 HTTP Bridge `/local/*` 只读数据端点族门禁
+//! （请求头 `Authorization: LocalToken <hex>`）；Bridge 本身仍只绑定 127.0.0.1。
+
+use rand::RngCore;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// 令牌文件所在目录名（契约固定：`%APPDATA%/mini-hbut/`）。
+const LOCAL_AGENT_TOKEN_DIR: &str = "mini-hbut";
+
+/// 令牌文件名（契约固定）。
+const LOCAL_AGENT_TOKEN_FILE: &str = "local-agent-token";
+
+/// 解析令牌文件路径（契约默认 + 测试/高级部署可覆盖）。
+///
+/// 优先级：
+/// 1. `HBUT_LOCAL_AGENT_TOKEN_PATH` 显式指定完整文件路径；
+/// 2. `%APPDATA%/mini-hbut/local-agent-token`（非 Windows 依次回退
+///    `LOCALAPPDATA` / `HOME`，仅作兜底，契约面向 Windows 桌面）。
+pub(crate) fn local_agent_token_path() -> Option<PathBuf> {
+    if let Ok(raw) = std::env::var("HBUT_LOCAL_AGENT_TOKEN_PATH") {
+        let path = PathBuf::from(raw.trim());
+        if !path.as_os_str().is_empty() {
+            return Some(path);
+        }
+    }
+    let base = std::env::var("APPDATA")
+        .or_else(|_| std::env::var("LOCALAPPDATA"))
+        .or_else(|_| std::env::var("HOME"))
+        .ok()?;
+    Some(
+        PathBuf::from(base)
+            .join(LOCAL_AGENT_TOKEN_DIR)
+            .join(LOCAL_AGENT_TOKEN_FILE),
+    )
+}
+
+/// 校验令牌文本：64 位小写 hex（0-9 a-f）。
+fn is_valid_local_agent_token(text: &str) -> bool {
+    text.len() == 64
+        && text
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// 生成新令牌：32 随机字节 → 64 位小写 hex。
+fn generate_local_agent_token() -> String {
+    let mut bytes = [0_u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// 在指定路径确保令牌文件存在并返回令牌（纯路径参数化，便于单测）：
+/// - 缺失 / 内容非法 → 生成新令牌并以 tmp+rename 原子写入（#550 同款，避免写一半被读取）；
+/// - 存在且格式合法 → 原样复用（外部 Agent 长期引用稳定）。
+fn ensure_local_agent_token_at(path: &Path) -> std::io::Result<String> {
+    if let Ok(existing) = std::fs::read_to_string(path) {
+        let token = existing.trim();
+        if is_valid_local_agent_token(token) {
+            return Ok(token.to_string());
+        }
+    }
+
+    let token = generate_local_agent_token();
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    std::fs::write(&tmp, &token)?;
+    // Windows 上 rename 使用 MOVEFILE_REPLACE_EXISTING，可覆盖非法旧文件
+    std::fs::rename(&tmp, path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(token)
+}
+
+/// 启动入口：确保本机 Agent 令牌可用；失败仅告警并返回 None，
+/// 此时 `/local/*` 端点因 expected 为空而一律拒绝（fail closed）。
+pub(crate) fn ensure_local_agent_token() -> Option<Arc<str>> {
+    let path = local_agent_token_path()?;
+    match ensure_local_agent_token_at(&path) {
+        Ok(token) => Some(Arc::from(token)),
+        Err(error) => {
+            eprintln!(
+                "[HTTP] 本机 Agent 令牌初始化失败（/local 端点将拒绝访问）path={}: {}",
+                path.display(),
+                error
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 合法令牌判定：64 位小写 hex 通过，其余（大写 / 超长 / 过短 / 非 hex）拒绝。
+    #[test]
+    fn token_format_validation_accepts_only_64_lowercase_hex() {
+        assert!(is_valid_local_agent_token(&"a".repeat(64)));
+        assert!(is_valid_local_agent_token(&"0123456789abcdef".repeat(4)));
+
+        assert!(!is_valid_local_agent_token(&"A".repeat(64))); // 大写非法
+        assert!(!is_valid_local_agent_token(&"g".repeat(64))); // 非 hex 字符
+        assert!(!is_valid_local_agent_token(&"a".repeat(63))); // 少一位
+        assert!(!is_valid_local_agent_token(&"a".repeat(65))); // 多一位
+        assert!(!is_valid_local_agent_token("")); // 空
+    }
+
+    /// 生成器输出恒满足格式契约（64 位小写 hex）。
+    #[test]
+    fn generated_token_is_64_lowercase_hex() {
+        let token = generate_local_agent_token();
+        assert!(
+            is_valid_local_agent_token(&token),
+            "生成结果必须合法: {token}"
+        );
+        assert_ne!(generate_local_agent_token(), token, "随机令牌不应重复");
+    }
+
+    /// 生命周期冒烟：缺失 → 生成并写入；再次调用 → 复用同一令牌；
+    /// 写入非法内容 → 重置为新合法令牌。目录不存在时自动创建。
+    #[test]
+    fn ensure_token_creates_reuses_and_resets_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "hbut_local_token_test_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let path = dir.join("nested").join("local-agent-token");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // 缺失 → 生成并写入
+        let first = ensure_local_agent_token_at(&path).expect("首次生成应成功");
+        assert!(is_valid_local_agent_token(&first));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), first);
+
+        // 存在且合法 → 复用（持久化保证外部 Agent 引用稳定）
+        let second = ensure_local_agent_token_at(&path).expect("复用应成功");
+        assert_eq!(second, first);
+
+        // 内容非法 → 重置为新合法令牌
+        std::fs::write(&path, "not-a-valid-token").unwrap();
+        let third = ensure_local_agent_token_at(&path).expect("重置应成功");
+        assert!(is_valid_local_agent_token(&third));
+        assert_ne!(third, first);
+
+        // 清理临时目录
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/apps/client/src-tauri/src/http_server/mod.rs
+++ b/apps/client/src-tauri/src/http_server/mod.rs
@@ -16,6 +16,7 @@
 //! - `routes`：按领域拆分的 Router 与 Handler
 
 mod auth;
+mod local_token;
 mod response;
 mod routes;
 mod state;
@@ -158,6 +159,8 @@ pub fn spawn_http_server(client: Arc<RwLock<HbutClient>>, app: AppHandle) {
         client,
         local_api_key: load_local_api_public_key(),
         bridge_token: generate_bridge_session_token(),
+        // #698：启动时确保本机 Agent 令牌存在（缺失则生成写入，存在则复用）
+        local_agent_token: local_token::ensure_local_agent_token(),
         app,
     };
     let gen = life
@@ -286,7 +289,8 @@ fn build_router() -> Router<HttpState> {
         .merge(routes::online_learning::router())
         .merge(routes::system::router())
         .merge(routes::proxy::router())
-        .merge(routes::ai::router());
+        .merge(routes::ai::router())
+        .merge(routes::local_data::router());
 
     #[cfg(debug_assertions)]
     let app = app
@@ -442,9 +446,62 @@ mod ensure_http_bridge_tests {
             bridge_route_policy("/course_selection/select"),
             BridgeRoutePolicy::Protected
         );
+        // #698：本机只读数据端点族使用独立 LocalData 策略
+        assert_eq!(
+            bridge_route_policy("/local/profile"),
+            BridgeRoutePolicy::LocalData
+        );
+        assert_eq!(
+            bridge_route_policy("/local/grades"),
+            BridgeRoutePolicy::LocalData
+        );
+        assert_eq!(
+            bridge_route_policy("/local/timetable"),
+            BridgeRoutePolicy::LocalData
+        );
         assert_eq!(
             bridge_route_policy("/debug/state"),
             BridgeRoutePolicy::DebugOnly
+        );
+    }
+
+    #[test]
+    fn local_data_routes_allow_get_without_bridge_context_but_reject_other_methods() {
+        // 外部本机 Agent 无 WebView Origin / Bridge 令牌：GET 由 handler 内
+        // 本机令牌门禁兜底；非只读方法在传输层直接拒绝。
+        let empty = HeaderMap::new();
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::LocalData,
+                &Method::GET,
+                &empty,
+                false,
+                true,
+            ),
+            BridgeAccessDecision::Allow
+        );
+
+        for method in [Method::POST, Method::PUT, Method::DELETE] {
+            assert_eq!(
+                decide_bridge_access(BridgeRoutePolicy::LocalData, &method, &empty, false, true,),
+                BridgeAccessDecision::Unauthorized
+            );
+        }
+
+        let mut hostile = HeaderMap::new();
+        hostile.insert(
+            "origin",
+            HeaderValue::from_static("https://attacker.example"),
+        );
+        assert_eq!(
+            decide_bridge_access(
+                BridgeRoutePolicy::LocalData,
+                &Method::GET,
+                &hostile,
+                false,
+                true,
+            ),
+            BridgeAccessDecision::ForbiddenOrigin
         );
     }
 

--- a/apps/client/src-tauri/src/http_server/routes/local_data.rs
+++ b/apps/client/src-tauri/src/http_server/routes/local_data.rs
@@ -1,0 +1,407 @@
+//! 本机只读学业数据端点族（#698）：
+//! - `GET /local/profile` —— 学号 / 姓名 / 专业等基本档案
+//! - `GET /local/grades` —— 全部成绩单（按学期分组）
+//! - `GET /local/timetable` —— 课表
+//!
+//! 门禁：三端点共用 [`ensure_local_data_auth`]（`Authorization: LocalToken <hex>`，
+//! 令牌来自 `%APPDATA%/mini-hbut/local-agent-token`，见 `http_server::local_token`）。
+//!
+//! 数据来源（严格只读，全部复用既有内部函数，不触发网络、不写缓存）：
+//! - profile：内存登录快照 `HbutClient.user_info`
+//! - grades ：SQLite `grades_cache` + 教师缓存合并
+//!   （`grade::service::merge_teacher_cache_into_payload`）
+//! - timetable：SQLite `schedule_cache`
+//!
+//! 错误契约（机器可解析）：401 `{"error":"LOCAL_TOKEN_INVALID"}` /
+//! 401 `{"error":"NOT_LOGGED_IN"}` / 404 `{"error":"NO_LOCAL_DATA"}`。
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{Json, Router};
+use reqwest::header::HeaderMap;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::http_server::auth::{ensure_local_data_auth, not_logged_in_error};
+use crate::http_server::response::{ok, ApiResponse};
+use crate::http_server::state::HttpState;
+
+// ────────────────────────────────────────────────────────────
+/// 404 + `{"error":"NO_LOCAL_DATA"}`：已登录但本地尚无该数据缓存。
+fn no_local_data_error() -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({ "error": "NO_LOCAL_DATA" })),
+    )
+}
+
+/// 当前登录学号快照；未登录学校账号返回 None。
+async fn current_student_id(state: &HttpState) -> Option<String> {
+    let client = state.client.read().await;
+    client
+        .user_info
+        .as_ref()
+        .map(|user| user.student_id.clone())
+}
+
+// ────────────────────────────────────────────────────────────
+/// 纯读 SQLite 缓存表（不写任何状态）；错误统一降级为字符串消息。
+fn read_local_cache(
+    db_path: &Path,
+    table: &str,
+    uid: &str,
+) -> Result<Option<(Value, String)>, String> {
+    crate::db::get_cache(db_path, table, uid).map_err(|e| e.to_string())
+}
+
+/// 将成绩记录数组按学期（term 字段）分组为升序的
+/// `[{ term, courses }]` 结构（无 term 的记录归入空字符串组）。
+fn group_grades_by_term(records: &[Value]) -> Vec<Value> {
+    let mut grouped: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
+    for record in records {
+        let term = record
+            .get("term")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        grouped.entry(term).or_default().push(record);
+    }
+    grouped
+        .into_iter()
+        .map(|(term, courses)| {
+            json!({
+                "term": term,
+                "courses": courses.into_iter().cloned().collect::<Vec<_>>(),
+            })
+        })
+        .collect()
+}
+
+// ────────────────────────────────────────────────────────────
+/// GET /local/profile：学号 / 姓名 / 学院 / 专业 / 班级 / 年级。
+///
+/// 数据源为登录后的内存档案快照（`user_info`），纯读不落盘。
+async fn profile(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+) -> Result<Json<ApiResponse<Value>>, (StatusCode, Json<Value>)> {
+    ensure_local_data_auth(&headers, &state)?;
+    let client = state.client.read().await;
+    let Some(user) = client.user_info.as_ref() else {
+        return Err(not_logged_in_error());
+    };
+    Ok(ok(json!({
+        "student_id": user.student_id,
+        "name": user.student_name,
+        "college": user.college,
+        "major": user.major,
+        "class_name": user.class_name,
+        "grade": user.grade,
+    })))
+}
+
+// ────────────────────────────────────────────────────────────
+/// GET /local/grades：本地成绩缓存整表 + 任课教师合并，按学期分组返回。
+async fn grades(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+) -> Result<Json<ApiResponse<Value>>, (StatusCode, Json<Value>)> {
+    ensure_local_data_auth(&headers, &state)?;
+    let Some(uid) = current_student_id(&state).await else {
+        return Err(not_logged_in_error());
+    };
+
+    let Some((payload, sync_time)) =
+        read_local_cache(Path::new(crate::DB_FILENAME), "grades_cache", &uid)
+            .map_err(no_local_data_error_for_db)?
+    else {
+        return Err(no_local_data_error());
+    };
+
+    // 复用共享用例的只读合并：将本地教师缓存并入记录（不写库），
+    // 与 Tauri get_grades_local 双通道 payload 一致。
+    let payload = crate::grade::service::merge_teacher_cache_into_payload(
+        payload,
+        &uid,
+        &crate::grade::service::SqliteGradeCache,
+    );
+    let records = payload.get("data").and_then(Value::as_array).cloned();
+    let records = records.unwrap_or_default();
+    let total_courses = records.len();
+    let offline = payload
+        .get("offline")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    Ok(ok(json!({
+        "success": true,
+        "student_id": uid,
+        "sync_time": sync_time,
+        "offline": offline,
+        "total_courses": total_courses,
+        "terms": group_grades_by_term(&records),
+    })))
+}
+
+/// 缓存读取失败（如数据库损坏）与「无缓存」区分开：前者透传 500。
+fn no_local_data_error_for_db(message: String) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": "DB_READ_FAILED", "message": message })),
+    )
+}
+
+// ────────────────────────────────────────────────────────────
+/// GET /local/timetable：本地课表缓存透传（含 meta.semester / offline 等），
+/// 仅补充 student_id 字段。
+async fn timetable(
+    State(state): State<HttpState>,
+    headers: HeaderMap,
+) -> Result<Json<ApiResponse<Value>>, (StatusCode, Json<Value>)> {
+    ensure_local_data_auth(&headers, &state)?;
+    let Some(uid) = current_student_id(&state).await else {
+        return Err(not_logged_in_error());
+    };
+
+    let Some((mut payload, _)) =
+        read_local_cache(Path::new(crate::DB_FILENAME), "schedule_cache", &uid)
+            .map_err(no_local_data_error_for_db)?
+    else {
+        return Err(no_local_data_error());
+    };
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("student_id".to_string(), json!(uid));
+    }
+    Ok(ok(payload))
+}
+
+// GENERATED DOMAIN ROUTERS — 路由协议由原始 method+path 清单生成。
+
+pub(crate) fn router() -> Router<HttpState> {
+    Router::new()
+        .route("/local/profile", get(profile))
+        .route("/local/grades", get(grades))
+        .route("/local/timetable", get(timetable))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http_server::auth::{
+        bridge_route_policy, check_local_agent_token, extract_local_agent_token,
+        local_token_invalid_error, not_logged_in_error, BridgeRoutePolicy, LocalTokenDecision,
+    };
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    /// 构造隔离临时 DB（不受 HBUT_DB_PATH 污染，先例见 application/academic.rs 测试）。
+    fn temp_db(tag: &str) -> std::path::PathBuf {
+        std::env::remove_var("HBUT_DB_PATH");
+        let dir = std::env::temp_dir().join(format!(
+            "hbut_local_data_test_{tag}_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let db_path = dir.join("test.db");
+        let _ = std::fs::remove_file(&db_path);
+        crate::db::init_db(&db_path).expect("测试数据库初始化失败");
+        db_path
+    }
+
+    fn auth_header(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_str(value).unwrap());
+        headers
+    }
+
+    // ── 门禁：令牌提取 ────────────────────────────────────────
+
+    #[test]
+    fn extract_accepts_localtoken_scheme_case_insensitive() {
+        assert_eq!(
+            extract_local_agent_token(&auth_header("LocalToken abc123")),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            extract_local_agent_token(&auth_header("localtoken abc123")),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            extract_local_agent_token(&auth_header("LOCALTOKEN  abc123  ")),
+            Some("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_rejects_missing_empty_or_other_schemes() {
+        assert_eq!(extract_local_agent_token(&HeaderMap::new()), None);
+        assert_eq!(extract_local_agent_token(&auth_header("LocalToken")), None);
+        assert_eq!(
+            extract_local_agent_token(&auth_header("LocalToken   ")),
+            None
+        );
+        assert_eq!(
+            extract_local_agent_token(&auth_header("Bearer abc123")),
+            None,
+            "Bearer 是 Bridge 会话令牌体系，不得混入本机令牌门禁"
+        );
+    }
+
+    // ── 门禁：正反用例 ────────────────────────────────────────
+
+    #[test]
+    fn token_check_passes_only_on_exact_match() {
+        let expected = Some("a".repeat(64));
+        assert_eq!(
+            check_local_agent_token(Some(&"a".repeat(64)), expected.as_deref()),
+            LocalTokenDecision::Valid
+        );
+        // 错误令牌
+        assert_eq!(
+            check_local_agent_token(Some(&"b".repeat(64)), expected.as_deref()),
+            LocalTokenDecision::Invalid
+        );
+        // 缺少令牌头
+        assert_eq!(
+            check_local_agent_token(None, expected.as_deref()),
+            LocalTokenDecision::Invalid
+        );
+        // 服务端未加载令牌 → fail closed
+        assert_eq!(
+            check_local_agent_token(Some(&"a".repeat(64)), None),
+            LocalTokenDecision::Invalid
+        );
+        assert_eq!(
+            check_local_agent_token(None, None),
+            LocalTokenDecision::Invalid
+        );
+    }
+
+    #[test]
+    fn error_contract_shapes_are_stable() {
+        let (status, body) = local_token_invalid_error();
+        assert_eq!(status, axum::http::StatusCode::UNAUTHORIZED);
+        assert_eq!(body.0["error"], "LOCAL_TOKEN_INVALID");
+
+        let (status, body) = not_logged_in_error();
+        assert_eq!(status, axum::http::StatusCode::UNAUTHORIZED);
+        assert_eq!(body.0["error"], "NOT_LOGGED_IN");
+
+        let (status, body) = no_local_data_error();
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(body.0["error"], "NO_LOCAL_DATA");
+    }
+
+    // ── 路由策略 ─────────────────────────────────────────────
+
+    #[test]
+    fn local_routes_use_localdata_policy_and_stay_get_only() {
+        for path in ["/local/profile", "/local/grades", "/local/timetable"] {
+            assert_eq!(bridge_route_policy(path), BridgeRoutePolicy::LocalData);
+        }
+        // 非 /local/ 前缀不受影响
+        assert_ne!(
+            bridge_route_policy("/localhost-demo"),
+            BridgeRoutePolicy::LocalData
+        );
+        assert_eq!(
+            bridge_route_policy("/localhost-demo"),
+            BridgeRoutePolicy::Protected
+        );
+    }
+
+    // ── 取数逻辑：学期分组 ────────────────────────────────────
+
+    #[test]
+    fn grades_are_grouped_by_term_in_ascending_order() {
+        let records = vec![
+            json!({"term": "2024-2025-1", "course_name": "B课程"}),
+            json!({"term": "2023-2024-2", "course_name": "A课程"}),
+            json!({"term": "2024-2025-1", "course_name": "C课程"}),
+            json!({"course_name": "无学期"}),
+        ];
+        let terms = group_grades_by_term(&records);
+        assert_eq!(terms.len(), 3);
+        assert_eq!(terms[0]["term"], "");
+        assert_eq!(terms[0]["courses"].as_array().unwrap().len(), 1);
+        assert_eq!(terms[1]["term"], "2023-2024-2");
+        assert_eq!(terms[2]["term"], "2024-2025-1");
+        assert_eq!(terms[2]["courses"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn grouping_empty_input_yields_empty_terms() {
+        assert!(group_grades_by_term(&[]).is_empty());
+    }
+
+    // ── 只读性冒烟：读前后缓存内容与 sync_time 完全不变 ────────
+
+    #[tokio::test]
+    async fn cache_reads_are_read_only_and_return_cached_payload() {
+        let db_path = temp_db("readonly");
+
+        // 预置成绩缓存（两个学期）与课表缓存
+        let grades_payload = json!({
+            "success": true,
+            "data": [
+                {"term": "2024-2025-1", "course_name": "高等数学", "kcbh": "K001"},
+                {"term": "2023-2024-2", "course_name": "大学英语", "kcbh": null}
+            ],
+            "sync_time": "2025-01-01T00:00:00+08:00",
+            "offline": false
+        });
+        crate::db::save_cache(&db_path, "grades_cache", "2510231001", &grades_payload)
+            .expect("预置成绩缓存失败");
+        let schedule_payload = json!({
+            "success": true,
+            "data": [{"name": "高等数学", "weekday": 1}],
+            "meta": {"semester": "2024-2025-1"},
+            "offline": false
+        });
+        crate::db::save_cache(&db_path, "schedule_cache", "2510231001", &schedule_payload)
+            .expect("预置课表缓存失败");
+
+        // 记录读取前的原始行内容
+        let before_grades = crate::db::get_cache(&db_path, "grades_cache", "2510231001")
+            .unwrap()
+            .unwrap();
+
+        // 读成绩：命中并携带 DB 层 sync_time / 原 offline 元数据
+        // （save_cache 写入时自行生成 sync_time 列，故只校验非空与一致性）
+        let (payload, sync_time) = read_local_cache(&db_path, "grades_cache", "2510231001")
+            .unwrap()
+            .expect("成绩缓存应存在");
+        assert_eq!((payload.clone(), sync_time.clone()), before_grades);
+        assert!(!sync_time.is_empty());
+        assert_eq!(payload["offline"], false);
+
+        // 读课表：命中
+        let (_, schedule_sync_time) = read_local_cache(&db_path, "schedule_cache", "2510231001")
+            .unwrap()
+            .expect("课表缓存应存在");
+        assert!(!schedule_sync_time.is_empty());
+
+        // 未缓存的 uid → None（端点据此回 NO_LOCAL_DATA）
+        assert!(read_local_cache(&db_path, "grades_cache", "nobody")
+            .unwrap()
+            .is_none());
+
+        // 只读性断言：多次读取后缓存内容与 sync_time 与读取前逐字节一致
+        let after_grades = crate::db::get_cache(&db_path, "grades_cache", "2510231001")
+            .unwrap()
+            .unwrap();
+        assert_eq!(after_grades, before_grades, "读取路径不得改动缓存行");
+
+        // 分组输出与缓存 data 一致
+        let records = payload["data"].as_array().unwrap().clone();
+        let terms = group_grades_by_term(&records);
+        assert_eq!(terms.len(), 2);
+        assert_eq!(terms[0]["term"], "2023-2024-2");
+        assert_eq!(terms[1]["term"], "2024-2025-1");
+
+        let dir = db_path.parent().unwrap();
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/apps/client/src-tauri/src/http_server/routes/mod.rs
+++ b/apps/client/src-tauri/src/http_server/routes/mod.rs
@@ -6,6 +6,7 @@ pub(super) mod auth;
 pub(super) mod course_selection;
 #[cfg(debug_assertions)]
 pub(super) mod debug;
+pub(super) mod local_data;
 pub(super) mod online_learning;
 pub(super) mod proxy;
 pub(super) mod schedule;

--- a/apps/client/src-tauri/src/http_server/state.rs
+++ b/apps/client/src-tauri/src/http_server/state.rs
@@ -7,11 +7,14 @@ use tokio::sync::RwLock;
 
 use crate::http_client::HbutClient;
 
-/// Bridge 路由共享状态（字段与拆分前完全一致）。
+/// Bridge 路由共享状态。
 #[derive(Clone)]
 pub(crate) struct HttpState {
     pub(crate) client: Arc<RwLock<HbutClient>>,
     pub(crate) local_api_key: Option<DecodingKey>,
     pub(crate) bridge_token: Arc<str>,
+    /// 本机 Agent 令牌（#698）：`/local/*` 只读端点族门禁；
+    /// None 表示令牌文件初始化失败，端点一律拒绝（fail closed）。
+    pub(crate) local_agent_token: Option<Arc<str>>,
     pub(crate) app: AppHandle,
 }


### PR DESCRIPTION
## TL;DR

本地数据线一期（Fixes #698，父 #697）：本机桥新增只读学业数据端点族（profile/grades/timetable）+ 本机令牌门禁，让同机 Agent 安全读取学业数据，数据不出电脑。

## 实现要点

| 文件 | 内容 |
|---|---|
| `http_server/local_token.rs`（新） | 令牌生命周期：`%APPDATA%/mini-hbut/local-agent-token`（64 hex），缺失生成/非法重置/tmp+rename 原子写入；支持 `HBUT_LOCAL_AGENT_TOKEN_PATH` 覆盖 |
| `http_server/routes/local_data.rs`（新，407 行） | GET /local/profile·grades·timetable——复用既有内部取数（登录内存快照、SQLite 成绩/课表缓存、教师缓存只读合并），零网络请求零写库 |
| `http_server/auth.rs` | 新增 LocalData 桥策略与可复用守卫：`Authorization: LocalToken <hex>`，错误统一 401 LOCAL_TOKEN_INVALID / NOT_LOGGED_IN / NO_LOCAL_DATA |
| mod/state/routes 注册 | HttpState 增令牌字段；服务保持仅绑定 127.0.0.1 |

## 验收证据

- cargo check --features bridge 零错误；cargo test --lib **319 passed**（含新增 http_server 11 用例）；fmt 干净
- 已知环境插曲（与本改动无关，已 stash 基线对照确认）：本机直接跑 bridge 测试二进制因 comctl32 manifest 缺失崩溃，属既有问题，建议另立 issue 给测试构建统一嵌 manifest

Fixes #698
关联 #697