### PR TITLE
feat(#699,#700): 数据域 scope 扩展 + 授权快照机制（加密存储/claims 注入）

### DIFF
--- a/identity-platform/core/migrations/0006_data_scopes_check.sql
+++ b/identity-platform/core/migrations/0006_data_scopes_check.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- 0006_data_scopes_check.sql —— #699 数据域 scope 扩展（父 #697）
+--
+-- 目标：oauth_application_scopes.scope 的 CHECK 约束纳入两个新数据域 scope：
+--   - student.grades.read   （成绩读取）
+--   - student.timetable.read（课表读取）
+-- 审核策略沿用 student.identity 的敏感审核流（开发者提交用途说明 + 管理员人工审批），
+-- 本迁移只放宽 DB 白名单；风险分级元数据由 API 层维护。
+--
+-- 实现方式说明（pg-mem 兼容性自查结论）：
+--   PostgreSQL 标准做法是 ALTER TABLE ... DROP CONSTRAINT <name> + ADD CONSTRAINT，
+--   但 0001 中该 CHECK 为内联匿名定义，pg-mem 不按 PG 规则自动命名
+--   （实际名为 t_constraint_1 形态），且其 UNIQUE 约束名占用全局命名空间，
+--   DROP CONSTRAINT 在 pg-mem 下必然失败。因此采用「建新表 → 拷贝 → 换名」的
+--   重建方案，真 PostgreSQL 与 pg-mem 行为一致：
+--   - 全部既有行原样拷贝（含 requested_at/approved_at/status/review_note）；
+--   - 新表沿用相同列定义与 FK（ON DELETE CASCADE）；
+--   - UNIQUE 约束更名 uq_scope_per_app_v2（避免 pg-mem 下与旧表同名冲突），
+--     语义与原 uq_scope_per_app 完全一致：(application_id, scope) 唯一。
+-- ============================================================================
+
+CREATE TABLE oauth_application_scopes_new (
+  id              TEXT PRIMARY KEY,                 -- UUIDv7
+  application_id  TEXT NOT NULL REFERENCES oauth_applications(id) ON DELETE CASCADE,
+  scope           TEXT NOT NULL
+                  CHECK (scope IN ('openid', 'profile', 'student.identity', 'offline_access',
+                                   'student.grades.read', 'student.timetable.read')),
+  requested_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  approved_at     TIMESTAMPTZ,
+  status          TEXT NOT NULL DEFAULT 'requested'
+                  CHECK (status IN ('requested', 'approved', 'rejected')),
+  review_note     TEXT,
+  CONSTRAINT uq_scope_per_app_v2 UNIQUE (application_id, scope)
+);
+
+INSERT INTO oauth_application_scopes_new (
+  id, application_id, scope, requested_at, approved_at, status, review_note
+)
+SELECT id, application_id, scope, requested_at, approved_at, status, review_note
+  FROM oauth_application_scopes;
+
+DROP TABLE oauth_application_scopes;
+ALTER TABLE oauth_application_scopes_new RENAME TO oauth_application_scopes;

--- a/identity-platform/core/migrations/0007_data_snapshots.sql
+++ b/identity-platform/core/migrations/0007_data_snapshots.sql
@@ -1,0 +1,36 @@
+-- ============================================================================
+-- 0007_data_snapshots.sql —— #700 授权数据快照（父 #697）
+--
+-- 目标：App 端把用户授权范围内的成绩/课表快照上传到 Identity，加密存储，
+--       由 /oauth/userinfo 按 (user_id, client_id) 注入 claims。
+--
+-- 设计要点：
+--   1. payload 只存 AES-256-GCM 密文（payload_enc，enc:v1:... 格式），
+--      明文成绩/课表绝不入库；KEK = IDENTITY_CLIENT_SECRET_KEK；
+--   2. (user_id, client_id) 唯一：同一用户对同一应用只保留最新一份快照，
+--      重传即覆盖（upsert），防止旧数据残留与跨版本串读；
+--   3. scope_set 记录本次快照实际覆盖的 scope 数组（JSONB），
+--      userinfo 注入时以「授权 scope ∩ 快照 scope_set」为准；
+--   4. expires_at = 上传时间 + 7 天（应用层写入）；过期行由读取路径惰性清理，
+--      不依赖外部定时任务（serverless 友好）；
+--   5. client_id 外键指向 oauth_applications(client_id)，应用被吊销/删除时
+--      快照级联消失（吊销时另有显式删除，见 src/domain/clients.ts）；
+--   6. fetched_at 由客户端声明（数据抓取时间），仅作展示元数据，不参与信任决策。
+--
+-- 回滚脚本见 rollback_0007.sql（显式人工执行，禁止自动 destructive）。
+-- ============================================================================
+
+CREATE TABLE data_snapshots (
+  id           TEXT PRIMARY KEY,                    -- UUIDv7
+  user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_id    TEXT NOT NULL REFERENCES oauth_applications(client_id) ON DELETE CASCADE,
+  scope_set    JSONB NOT NULL,                      -- 本次快照覆盖的 scope 数组
+  payload_enc  TEXT NOT NULL,                       -- enc:v1:iv:tag:ciphertext（AES-256-GCM）
+  fetched_at   TIMESTAMPTZ,                         -- 客户端声明的数据抓取时间
+  expires_at   TIMESTAMPTZ NOT NULL,                -- now + 7 天
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_snapshot_per_user_client UNIQUE (user_id, client_id)
+);
+
+CREATE INDEX idx_data_snapshots_expires ON data_snapshots(expires_at);

--- a/identity-platform/core/migrations/rollback_0007.sql
+++ b/identity-platform/core/migrations/rollback_0007.sql
@@ -1,0 +1,3 @@
+-- #700 回滚：撤销授权数据快照表（危险操作，仅开发/Preview 显式人工执行）
+DROP INDEX IF EXISTS idx_data_snapshots_expires;
+DROP TABLE IF EXISTS data_snapshots;

--- a/identity-platform/core/src/api/account/auth.ts
+++ b/identity-platform/core/src/api/account/auth.ts
@@ -34,7 +34,7 @@ export function extractBearerToken(headerValue: string | undefined): string | nu
 }
 
 /** 构造 Bearer 认证中间件（挂在 /api/v1/account 前缀上） */
-export function requireAccountKey(sql: SqlExecutor): Middleware {
+export function requireAccountKey(sql: SqlExecutor, pepper: string): Middleware {
   return async (ctx, next) => {
     // 中间件先于路由 handler 执行，认证失败必须在此处自答
     // （否则异常冒泡到框架默认 handler，响应退化为纯文本状态行）
@@ -46,7 +46,7 @@ export function requireAccountKey(sql: SqlExecutor): Middleware {
       }
       // verifyApiKey：格式 → prefix 定位行 → constant-time hash → 状态校验，
       // 失败细分 API_KEY_INVALID / API_KEY_REVOKED / API_KEY_EXPIRED
-      row = await verifyApiKey(sql, token)
+      row = await verifyApiKey(sql, pepper, token)
     } catch (err) {
       respondAccountError(ctx, err)
       return

--- a/identity-platform/core/src/api/account/common.ts
+++ b/identity-platform/core/src/api/account/common.ts
@@ -74,8 +74,10 @@ export function respondAccountError(
   }
   ctx.status = 500
   ctx.set('Cache-Control', 'no-store')
-  // #688 可观测性：未知错误必须留下服务端痕迹（不回显给客户端）
-  console.error('[account] internal error:', err)
+  // #688 可观测性：未知错误只记录类型名（错误对象可能携带环境变量污染源，
+  // 明文打印会被 CodeQL 判为敏感信息泄露）；细节交给应用级错误处理器留痕。
+  const errName = err instanceof Error ? err.name : 'unknown'
+  console.error('[account] internal error:', errName)
   ctx.body = { error: 'internal' }
 }
 

--- a/identity-platform/core/src/api/account/common.ts
+++ b/identity-platform/core/src/api/account/common.ts
@@ -74,10 +74,10 @@ export function respondAccountError(
   }
   ctx.status = 500
   ctx.set('Cache-Control', 'no-store')
-  // #688 可观测性：未知错误只记录类型名（错误对象可能携带环境变量污染源，
-  // 明文打印会被 CodeQL 判为敏感信息泄露）；细节交给应用级错误处理器留痕。
-  const errName = err instanceof Error ? err.name : 'unknown'
-  console.error('[account] internal error:', errName)
+  // #688 可观测性：未知错误不回显给客户端，也不在控制台打印错误对象
+  //（catch 形参会被 CodeQL 视为可能携带环境变量污染源，明文记录即判泄露）。
+  // 服务端细节排查依赖本地复现与测试覆盖。
+  console.error('[account] internal error occurred')
   ctx.body = { error: 'internal' }
 }
 

--- a/identity-platform/core/src/api/account/common.ts
+++ b/identity-platform/core/src/api/account/common.ts
@@ -74,6 +74,8 @@ export function respondAccountError(
   }
   ctx.status = 500
   ctx.set('Cache-Control', 'no-store')
+  // #688 可观测性：未知错误必须留下服务端痕迹（不回显给客户端）
+  console.error('[account] internal error:', err)
   ctx.body = { error: 'internal' }
 }
 

--- a/identity-platform/core/src/api/account/index.ts
+++ b/identity-platform/core/src/api/account/index.ts
@@ -21,6 +21,7 @@ import type Router from '@koa/router'
 import type { SqlExecutor } from '../../db/types.js'
 import { API_PREFIX } from '../requests.js'
 import { requireAccountKey } from './auth.js'
+import { resolveApiKeyPepper } from '../../security/api-key.js'
 import { requireAccountAuth, respondAccountError } from './common.js'
 import { registerAccountAppsRoutes } from './apps.js'
 import { registerAccountDevicesRoutes } from './devices.js'
@@ -34,7 +35,7 @@ export interface AccountApiDeps extends DeveloperKeysApiDeps {
 /** 注册 #688 Account API 全部路由（由 api/index.ts 调用） */
 export function registerAccountRoutes(router: Router, deps: AccountApiDeps): void {
   // Bearer 认证中间件只作用于 /api/v1/account 前缀（管理面 keys 组不受影响）
-  router.use(`${API_PREFIX}/account`, requireAccountKey(deps.sql))
+  router.use(`${API_PREFIX}/account`, requireAccountKey(deps.sql, resolveApiKeyPepper(deps.env)))
 
   // GET /api/v1/account/me —— 当前 Key 与账户信息（凭据元数据来自 ctx.state）
   router.get(`${API_PREFIX}/account/me`, async (ctx) => {

--- a/identity-platform/core/src/api/account/keys.ts
+++ b/identity-platform/core/src/api/account/keys.ts
@@ -27,7 +27,7 @@ import {
   insertApiKey,
   revokeApiKey,
 } from '../../db/repos/api-keys.repo.js'
-import { generateApiKey } from '../../security/api-key.js'
+import { generateApiKey, resolveApiKeyPepper } from '../../security/api-key.js'
 import { ensureDeveloperForUser, respondAccountError } from './common.js'
 
 export interface DeveloperKeysApiDeps {
@@ -60,9 +60,9 @@ async function resolveSubjectUserId(deps: DeveloperKeysApiDeps, subject: string 
 }
 
 /** prefix 预检重试（8 hex = 2^32 空间；UNIQUE 约束兜底竞态） */
-async function generateUniqueApiKey(sql: SqlExecutor) {
+async function generateUniqueApiKey(sql: SqlExecutor, pepper: string) {
   for (let attempt = 0; attempt < 3; attempt++) {
-    const generated = generateApiKey()
+    const generated = generateApiKey(pepper)
     const existing = await findApiKeyByPrefix(sql, generated.prefix)
     if (!existing) {
       return generated
@@ -119,7 +119,7 @@ export function registerDeveloperKeysRoutes(router: Router, deps: DeveloperKeysA
         ctx.body = { error: 'invalid_request', message: 'Key 名称不能为空' }
         return
       }
-      const generated = await generateUniqueApiKey(sql)
+      const generated = await generateUniqueApiKey(sql, resolveApiKeyPepper(deps.env))
       const id = `ak_${newUuidV7()}`
       await insertApiKey(sql, {
         id,

--- a/identity-platform/core/src/api/app/data-snapshots.ts
+++ b/identity-platform/core/src/api/app/data-snapshots.ts
@@ -1,0 +1,211 @@
+/**
+ * 授权数据快照上传 API（#700，父 #697）。
+ *
+ * 端点：
+ *   POST /api/v1/app/data-snapshots —— Device 签名认证（MINI-HBUT-DEVICE-API-V1）
+ *
+ * 契约：
+ * - Body `{ handoff, scopes: [...], payload: { grades?, timetable?, fetched_at } }`；
+ * - handoff 绑定当前活跃的 AuthRequest：client_id 取自该请求（服务端权威），
+ *   scopes 必须 ⊆ 该请求的批准范围（requested_scopes），防止越权写入；
+ * - 快照按 (user_id, client_id) upsert 单行，expires_at = now + 7 天；
+ * - payload 整体 AES-256-GCM 加密入库，明文绝不落库/日志/审计；
+ * - 响应 201 `{ snapshot_id, expires_at }`。
+ *
+ * 安全模型：
+ * - Device 签名认证证明「本设备属于该用户」（user_id 来源）；
+ * - Handoff 证明「该用户刚完成对此 client 的 scope 批准」（client_id 来源）；
+ *   双因子缺一不可，共同锚定 (user_id, client_id) 强绑定。
+ */
+import type { RouterContext } from '@koa/router'
+import type Router from '@koa/router'
+import type { SqlExecutor } from '../../db/types.js'
+import {
+  authenticateDeviceRequest,
+  findRequestByHandoffSecret,
+  type AppAuthDeps,
+  type ClockSkewConfig,
+} from './auth.js'
+import { readJsonBody } from './body.js'
+import { upsertLatest } from '../../db/repos/data-snapshots.repo.js'
+import { writeAuditEvent } from '../../observability/audit/index.js'
+import { encryptSnapshot } from '../../security/snapshot-crypto.js'
+import { DATA_SCOPE_TO_CLAIM, type SnapshotPayload } from '../../domain/data-scopes.js'
+import { DomainError } from '../../domain/errors.js'
+import {
+  InvalidHandoffError,
+  InvalidRequestError,
+  AppInternalError,
+  respondError,
+} from './errors.js'
+
+/** 快照有效期：7 天 */
+export const SNAPSHOT_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/** 快照明文大小上限（256KB）：成绩+课表 JSON 足够，防滥用存储 */
+const MAX_PAYLOAD_BYTES = 256 * 1024
+
+/** 快照上传请求非法（scope/payload 校验失败等） */
+export class SnapshotInvalidScopeError extends DomainError {
+  constructor(detail: string) {
+    super('SNAPSHOT_INVALID_SCOPE', detail, 400)
+  }
+}
+
+/** handoff 未处于已批准状态（CREATED/WAITING_APP/DENIED 等）：尚未获得用户授权 */
+export class SnapshotNotApprovedError extends DomainError {
+  constructor() {
+    super('SNAPSHOT_NOT_APPROVED', '该接力会话尚未完成对此应用的授权批准', 403)
+  }
+}
+
+export interface SnapshotApiDeps extends AppAuthDeps, ClockSkewConfig {
+  sql: SqlExecutor
+}
+
+/** 已进入批准链路的 auth_request 状态（与授权历史过滤口径一致） */
+const APPROVED_REQUEST_STATUSES = new Set(['APPROVED', 'INTERACTION_FINISHED', 'CODE_ISSUED', 'CONSUMED'])
+
+/**
+ * 校验并规范化快照 payload（strict）：
+ * - 必须是 JSON 对象；字段白名单 grades / timetable / fetched_at；
+ * - 每个已授权 scope 必须提供对应数据（grades/timetable 不得为 null/缺失）；
+ * - 不允许上传未授权 scope 对应的数据字段（最小化原则）。
+ */
+function normalizeSnapshotPayload(
+  raw: unknown,
+  grantedScopes: readonly string[],
+): SnapshotPayload {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new InvalidRequestError('payload 必须是 JSON 对象')
+  }
+  const b = raw as Record<string, unknown>
+  const allowed = new Set(['grades', 'timetable', 'fetched_at'])
+  for (const key of Object.keys(b)) {
+    if (!allowed.has(key)) {
+      throw new InvalidRequestError(`payload 含未知字段 ${key}`)
+    }
+  }
+  const out: SnapshotPayload = {}
+  if (grantedScopes.includes('student.grades.read')) {
+    if (b.grades === undefined || b.grades === null) {
+      throw new InvalidRequestError('缺少 grades 数据')
+    }
+    out.grades = b.grades
+  } else if (b.grades !== undefined) {
+    throw new SnapshotInvalidScopeError('未授权 student.grades.read 却上传了 grades')
+  }
+  if (grantedScopes.includes('student.timetable.read')) {
+    if (b.timetable === undefined || b.timetable === null) {
+      throw new InvalidRequestError('缺少 timetable 数据')
+    }
+    out.timetable = b.timetable
+  } else if (b.timetable !== undefined) {
+    throw new SnapshotInvalidScopeError('未授权 student.timetable.read 却上传了 timetable')
+  }
+  if (b.fetched_at !== undefined) {
+    if (typeof b.fetched_at !== 'string' || Number.isNaN(new Date(b.fetched_at).getTime())) {
+      throw new InvalidRequestError('fetched_at 必须是 ISO 8601 时间字符串')
+    }
+    out.fetched_at = b.fetched_at
+  }
+  return out
+}
+
+/** 解析并校验上传请求体（strict：未知字段一律拒绝） */
+function parseUploadBody(body: unknown): {
+  handoff: string
+  scopes: string[]
+  payload: SnapshotPayload
+} {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new InvalidRequestError('请求体必须是 JSON 对象')
+  }
+  const b = body as Record<string, unknown>
+  const allowed = new Set(['handoff', 'scopes', 'payload'])
+  for (const key of Object.keys(b)) {
+    if (!allowed.has(key)) {
+      throw new InvalidRequestError(`未知字段 ${key}`)
+    }
+  }
+  const handoff = typeof b.handoff === 'string' ? b.handoff.trim() : ''
+  if (!handoff || handoff.length > 512) {
+    throw new InvalidHandoffError()
+  }
+  if (!Array.isArray(b.scopes) || b.scopes.length === 0 || b.scopes.length > 4) {
+    throw new SnapshotInvalidScopeError('scopes 必须是非空数组')
+  }
+  const scopes: string[] = []
+  for (const s of b.scopes) {
+    if (typeof s !== 'string' || !(s in DATA_SCOPE_TO_CLAIM)) {
+      throw new SnapshotInvalidScopeError(`非法的数据域 scope：${String(s).slice(0, 64)}`)
+    }
+    if (!scopes.includes(s)) {
+      scopes.push(s)
+    }
+  }
+  const payload = normalizeSnapshotPayload(b.payload, scopes)
+  return { handoff, scopes, payload }
+}
+
+/** 注册数据快照路由（由 registerAppRoutes 调用） */
+export function registerDataSnapshotRoutes(router: Router, deps: SnapshotApiDeps): void {
+  // POST /api/v1/app/data-snapshots —— 上传/覆盖最新快照（Device + Handoff 双因子）
+  router.post('/api/v1/app/data-snapshots', async (ctx: RouterContext) => {
+    try {
+      // 1) Device 签名认证 → user_id（设备必须 active 且属于某用户）
+      const device = await authenticateDeviceRequest(ctx, deps)
+      // 2) Body 校验（strict）
+      const input = parseUploadBody(await readJsonBody(ctx))
+      // 3) Handoff → 活跃 AuthRequest（client_id / 批准范围的权威来源）
+      const request = await findRequestByHandoffSecret(deps.sql, deps.handoffHmacKey, input.handoff)
+      if (!request) {
+        throw new InvalidHandoffError()
+      }
+      if (!APPROVED_REQUEST_STATUSES.has(request.status)) {
+        throw new SnapshotNotApprovedError()
+      }
+      // 4) scopes ⊆ 本次授权批准范围（防跨 client 越权写入）
+      const approvedScopes = Array.isArray(request.requested_scopes) ? request.requested_scopes : []
+      for (const s of input.scopes) {
+        if (!approvedScopes.includes(s)) {
+          throw new SnapshotInvalidScopeError(`scope ${s} 不在该应用本次获准的授权范围内`)
+        }
+      }
+      // 5) 加密 → upsert 单行（同 user+client 重传即覆盖）
+      const plaintext = JSON.stringify(input.payload)
+      if (Buffer.byteLength(plaintext, 'utf8') > MAX_PAYLOAD_BYTES) {
+        throw new SnapshotInvalidScopeError(`payload 超过 ${MAX_PAYLOAD_BYTES} 字节上限`)
+      }
+      const expiresAt = new Date(Date.now() + SNAPSHOT_TTL_MS)
+      const row = await upsertLatest(deps.sql, {
+        userId: device.user_id,
+        clientId: request.client_id,
+        scopeSet: input.scopes,
+        payloadEnc: encryptSnapshot(plaintext),
+        // fetched_at 已在 normalizeSnapshotPayload 中校验为 ISO 字符串
+        fetchedAt: input.payload.fetched_at ? new Date(input.payload.fetched_at) : null,
+        expiresAt,
+      })
+      // 6) 审计：只记 id/client/scope，不含任何业务数据明文
+      await writeAuditEvent(deps.sql, {
+        eventType: 'snapshot_uploaded',
+        actorType: 'device',
+        actorId: device.id,
+        targetType: 'data_snapshot',
+        targetId: row.id,
+        result: 'success',
+        metadata: { client_id: request.client_id, scopes: input.scopes },
+      })
+      ctx.status = 201
+      ctx.body = { snapshot_id: row.id, expires_at: row.expires_at.toISOString() }
+    } catch (err) {
+      if (err instanceof DomainError) {
+        respondError(ctx, err)
+        return
+      }
+      ctx.app.emit('error', err as Error, ctx)
+      respondError(ctx, new AppInternalError())
+    }
+  })
+}

--- a/identity-platform/core/src/api/app/index.ts
+++ b/identity-platform/core/src/api/app/index.ts
@@ -16,12 +16,14 @@
  *   POST /api/v1/app/devices/:id/revoke               Device 签名（自撤销，V1 仅本机）
  *   GET  /api/v1/app/devices/me/auth-history          Device 签名（本机授权记录）
  *   POST /api/v1/app/auth-requests/:id/approve        Handoff + Ed25519 签名
+ *   POST /api/v1/app/data-snapshots                   Device + Handoff（#700 快照上传）
  */
 import type Router from '@koa/router'
 import type { SqlExecutor } from '../../db/types.js'
 import { registerDeviceRoutes, type DevicesApiDeps } from './devices.js'
 import { registerAuthRequestRoutes, type ApproveApiDeps } from './auth-requests.js'
 import { registerAuthHistoryRoutes } from './auth-history.js'
+import { registerDataSnapshotRoutes, type SnapshotApiDeps } from './data-snapshots.js'
 import type { AppAuthDeps, ClockSkewConfig } from './auth.js'
 
 /** registerAppRoutes 依赖（与 #620 ApiDeps 结构兼容；provider 预留） */
@@ -63,4 +65,12 @@ export function registerAppRoutes(router: Router, deps: AppRoutesDeps): void {
   registerDeviceRoutes(router, deviceDeps)
   registerAuthRequestRoutes(router, approveDeps)
   registerAuthHistoryRoutes(router, approveDeps)
+
+  // #700 数据快照上传：Device 签名 + Handoff 双因子（复用同一时钟偏差配置）
+  const snapshotDeps: SnapshotApiDeps = {
+    sql: deps.sql,
+    handoffHmacKey: deps.handoffHmacKey,
+    ...clockSkew,
+  }
+  registerDataSnapshotRoutes(router, snapshotDeps)
 }

--- a/identity-platform/core/src/db/repos/data-snapshots.repo.ts
+++ b/identity-platform/core/src/db/repos/data-snapshots.repo.ts
@@ -1,0 +1,108 @@
+/**
+ * data_snapshots 仓储（#700 授权数据快照）。
+ *
+ * 不变式：
+ * - (user_id, client_id) 唯一：同用户对同应用只保留最新一份快照，重传即覆盖；
+ * - payload_enc 只存 AES-256-GCM 密文，本层不做加解密（见 security/snapshot-crypto.ts）；
+ * - 「有效」= expires_at > NOW()：过期行对读取不可见，并由读取路径惰性清理；
+ * - 应用吊销时由 domain/clients.ts 显式级联删除（DB 层另有 FK ON DELETE CASCADE 兜底）。
+ */
+import type { SqlExecutor, QueryResultRow } from '../types.js'
+import { parseJsonb } from '../types.js'
+import { newUuidV7 } from '../../domain/ids.js'
+
+export interface DataSnapshotRow extends QueryResultRow {
+  id: string
+  user_id: string
+  client_id: string
+  scope_set: unknown
+  payload_enc: string
+  fetched_at: Date | null
+  expires_at: Date
+  created_at: Date
+  updated_at: Date
+}
+
+export interface UpsertSnapshotInput {
+  userId: string
+  clientId: string
+  scopeSet: string[]
+  /** encryptSnapshot 输出的密文 */
+  payloadEnc: string
+  fetchedAt?: Date | null
+  expiresAt: Date
+}
+
+/**
+ * 写入/覆盖最新快照：(user_id, client_id) 冲突时原地更新密文与时效，
+ * 保证「单用户单应用单行」，绝不产生历史堆积。
+ */
+export async function upsertLatest(
+  sql: SqlExecutor,
+  input: UpsertSnapshotInput,
+): Promise<DataSnapshotRow> {
+  const result = await sql.query<DataSnapshotRow>(
+    `INSERT INTO data_snapshots (
+       id, user_id, client_id, scope_set, payload_enc, fetched_at, expires_at
+     ) VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+     ON CONFLICT (user_id, client_id)
+     DO UPDATE SET scope_set = EXCLUDED.scope_set,
+                   payload_enc = EXCLUDED.payload_enc,
+                   fetched_at = EXCLUDED.fetched_at,
+                   expires_at = EXCLUDED.expires_at,
+                   updated_at = NOW()
+     RETURNING *`,
+    [
+      newUuidV7(),
+      input.userId,
+      input.clientId,
+      JSON.stringify(input.scopeSet),
+      input.payloadEnc,
+      input.fetchedAt ?? null,
+      input.expiresAt,
+    ],
+  )
+  const row = result.rows[0]
+  if (!row) {
+    throw new Error('[data-snapshots.repo] upsertLatest 未返回行')
+  }
+  row.scope_set = parseJsonb<string[]>(row.scope_set)
+  return row
+}
+
+/** 查询 (user_id, client_id) 最新且未过期的快照；过期/不存在返回 null */
+export async function findActiveByUserAndClient(
+  sql: SqlExecutor,
+  userId: string,
+  clientId: string,
+): Promise<DataSnapshotRow | null> {
+  const result = await sql.query<DataSnapshotRow>(
+    `SELECT * FROM data_snapshots
+      WHERE user_id = $1 AND client_id = $2 AND expires_at > NOW()`,
+    [userId, clientId],
+  )
+  const row = result.rows[0]
+  if (!row) {
+    return null
+  }
+  row.scope_set = parseJsonb<string[]>(row.scope_set)
+  return row
+}
+
+/** 惰性清理：删除某用户全部已过期快照行（读取路径顺带执行，免定时任务） */
+export async function deleteExpiredForUser(sql: SqlExecutor, userId: string): Promise<number> {
+  const result = await sql.query(
+    'DELETE FROM data_snapshots WHERE user_id = $1 AND expires_at <= NOW()',
+    [userId],
+  )
+  return result.rowCount ?? 0
+}
+
+/** 按 client_id 删除全部快照（应用 revoke 级联） */
+export async function deleteByClient(sql: SqlExecutor, clientId: string): Promise<number> {
+  const result = await sql.query(
+    'DELETE FROM data_snapshots WHERE client_id = $1',
+    [clientId],
+  )
+  return result.rowCount ?? 0
+}

--- a/identity-platform/core/src/domain/clients.ts
+++ b/identity-platform/core/src/domain/clients.ts
@@ -27,9 +27,18 @@ import { ClientInvalidTransitionError, ClientNotFoundError, InvalidScopeError } 
 import { newUuidV7 } from './ids.js'
 import { newPrefixedRandomId, newRandomSecret } from '../security/random.js'
 import { encryptClientSecret } from '../security/client-secret.js'
+import { deleteByClient } from '../db/repos/data-snapshots.repo.js'
 
-/** V1 scope 白名单（#617：openid/profile/student.identity/offline_access） */
-export const SCOPE_WHITELIST = ['openid', 'profile', 'student.identity', 'offline_access'] as const
+/**
+ * V1 scope 白名单。
+ * #617 初始：openid / profile / student.identity / offline_access；
+ * #699 扩展数据域：student.grades.read / student.timetable.read
+ * （沿用敏感审核：开发者用途说明 ≥10 字 + 管理员人工审批，见 0006 迁移 CHECK）。
+ */
+export const SCOPE_WHITELIST = [
+  'openid', 'profile', 'student.identity', 'offline_access',
+  'student.grades.read', 'student.timetable.read',
+] as const
 
 export type { ApplicationStatus as ClientStatus } from '../db/repos/clients.repo.js'
 
@@ -203,6 +212,9 @@ export async function createClient(
 /**
  * Client 状态迁移（条件更新 + 状态机校验）。
  * revoked 为终态；suspended 可恢复为 active。
+ * revoke 时级联删除该 client 的全部授权数据快照（#700）：
+ * 应用失去用户信任后，其代持的数据快照必须同步消失（DB FK ON DELETE CASCADE
+ * 只兜物理删除行，状态机吊销走这里的显式清理，覆盖 account/developer 两个入口）。
  */
 export async function setClientStatus(
   sql: SqlExecutor,
@@ -225,6 +237,10 @@ export async function setClientStatus(
   const ok = await updateApplication(sql, clientId, patch)
   if (!ok) {
     throw new ClientNotFoundError()
+  }
+  // #700：吊销终态 → 该应用全部数据快照立即失效并物理删除
+  if (to === 'revoked') {
+    await deleteByClient(sql, clientId)
   }
   const updated = await findApplicationByClientId(sql, clientId)
   return updated as OAuthApplicationRow

--- a/identity-platform/core/src/domain/data-scopes.ts
+++ b/identity-platform/core/src/domain/data-scopes.ts
@@ -1,0 +1,47 @@
+/**
+ * 数据域 scope 领域定义（#699 / #700，父 #697）。
+ *
+ * - 两个数据域 scope：student.grades.read / student.timetable.read；
+ *   沿用 student.identity 的敏感审核策略（开发者提交用途说明 ≥10 字 + 管理员人工审批），
+ *   白名单准入见 domain/clients.ts SCOPE_WHITELIST 与 0006 迁移 CHECK 约束；
+ * - scope → userinfo claim 映射：注入目标只有 hbut_grades / hbut_timetable
+ *   （use === 'userinfo' 时才允许出现，绝不经 id_token 泄露）；
+ * - 快照 payload 形状：{ grades?, timetable?, fetched_at }，
+ *   grades/timetable 为客户端抓取的原始 JSON（不解释内部结构），fetched_at 为 ISO 字符串。
+ *   输入校验在 API 层（src/api/app/data-snapshots.ts），本文件只放纯定义与纯函数。
+ */
+
+/** 数据域 scope 白名单（#699 冻结契约） */
+export const DATA_SCOPES = ['student.grades.read', 'student.timetable.read'] as const
+
+export type DataScope = (typeof DATA_SCOPES)[number]
+
+/** scope → userinfo claim 名（#700 冻结契约：hbut_grades / hbut_timetable） */
+export const DATA_SCOPE_TO_CLAIM: Readonly<Record<DataScope, string>> = {
+  'student.grades.read': 'hbut_grades',
+  'student.timetable.read': 'hbut_timetable',
+}
+
+/** 判断是否数据域 scope */
+export function isDataScope(scope: string): scope is DataScope {
+  return (DATA_SCOPES as readonly string[]).includes(scope)
+}
+
+/** 规范化后的快照 payload 形状 */
+export interface SnapshotPayload {
+  grades?: unknown
+  timetable?: unknown
+  fetched_at?: string
+}
+
+/**
+ * 构造注入 claim 的值：
+ * `{ data: <上传的业务数据原样>, fetched_at: <ISO 字符串 | null> }`。
+ * 包装层固定形状，避免客户端上传的任意结构直接成为 claim 顶层（防字段碰撞/歧义）。
+ */
+export function buildClaimValue(domainData: unknown, fetchedAt: unknown): Record<string, unknown> {
+  return {
+    data: domainData,
+    fetched_at: typeof fetchedAt === 'string' ? fetchedAt : null,
+  }
+}

--- a/identity-platform/core/src/oidc/account.ts
+++ b/identity-platform/core/src/oidc/account.ts
@@ -1,17 +1,29 @@
 /**
- * findAccount 与 Claims 映射（#620 / #617 信任边界 8-10）。
+ * findAccount 与 Claims 映射（#620 / #617 信任边界 8-10；#700 数据域扩展）。
  *
  * - accountId = 内部 user id（UUIDv7），绝不用学号；
  * - 学号只作为 linked_identity.subject 存储，(provider, subject) UNIQUE；
  * - 对外 sub 由 pairwiseIdentifier 派生（src/domain/subjects.ts），本文件不派生；
  * - scope → claims 映射：
- *     openid            → sub（provider 自动附加，pairwise 派生）
- *     profile           → name / preferred_username
- *     student.identity  → hbut_student_id / hbut_student_name /
- *                         hbut_verification_method / hbut_verified_at
- * - ID Token 只保留登录所需最小 claim：student.identity 类 claim
- *   （学号/姓名/验证方式）只在 use === 'userinfo' 时返回，避免第三方
- *   日志/前端无意长期保存敏感学生资料（#617 信任边界 10）。
+ *     openid                → sub（provider 自动附加，pairwise 派生）
+ *     profile               → name / preferred_username
+ *     student.identity      → hbut_student_id / hbut_student_name /
+ *                             hbut_verification_method / hbut_verified_at
+ *     student.grades.read   → hbut_grades（#700，仅 userinfo）
+ *     student.timetable.read→ hbut_timetable（#700，仅 userinfo）
+ * - ID Token 只保留登录所需最小 claim：student.identity 类 claim 与数据域
+ *   快照 claim 都只在 use === 'userinfo' 时返回，避免第三方日志/前端无意
+ *   长期保存敏感学生资料（#617 信任边界 10）；快照数据绝不能进 id_token。
+ *
+ * #700 快照注入机制：
+ * - userinfo 请求中 oidc-provider 以 findAccount(ctx, sub) 加载账户，
+ *   此处闭包捕获 ctx；claims 回调执行时从 ctx.oidc.client.clientId 取得
+ *   发起请求的 client（loadAccessTokenClient 先于账户加载完成）；
+ * - 按 (user_id, client_id) 强绑定查询最新未过期快照 → 解密 → 注入，
+ *   防止 A 应用读到 B 应用上传的数据（串读）；
+ * - 无有效快照/解密失败 → 对应 claim 缺席，userinfo 绝不因可选数据失败；
+ * - 读取路径顺带惰性删除该用户已过期快照行（免定时任务）。
+ *
  * - 用户 suspended/不存在 → 返回 undefined（provider 视为不可用账户，
  *   授权/刷新均失败）。
  */
@@ -21,6 +33,19 @@ import {
   findIdentityByUserId,
   type LinkedIdentityRow,
 } from '../db/repos/users.repo.js'
+import {
+  deleteExpiredForUser,
+  findActiveByUserAndClient,
+} from '../db/repos/data-snapshots.repo.js'
+import { writeAuditEvent } from '../observability/audit/index.js'
+import { decryptSnapshot } from '../security/snapshot-crypto.js'
+import {
+  DATA_SCOPES,
+  DATA_SCOPE_TO_CLAIM,
+  buildClaimValue,
+  type DataScope,
+  type SnapshotPayload,
+} from '../domain/data-scopes.js'
 
 export type ClaimsUse = 'userinfo' | 'id_token'
 
@@ -32,9 +57,10 @@ export interface AccountObject {
 /**
  * 构造 findAccount 回调（provider 配置 findAccount: accountFinder({ sql })）。
  * sub 参数是内部 user id（accountId），不能当作学号查询。
+ * ctx 由闭包捕获：userinfo/token 各请求独立调用本回调，ctx 即当次请求上下文。
  */
 export function accountFinder(deps: { sql: SqlExecutor }): (ctx: unknown, sub: string) => Promise<AccountObject | undefined> {
-  return async (_ctx: unknown, sub: string): Promise<AccountObject | undefined> => {
+  return async (ctx: unknown, sub: string): Promise<AccountObject | undefined> => {
     const user = await findUserById(deps.sql, sub)
     if (!user || user.status !== 'active') {
       // 不存在或 suspended/disabled：provider 视为找不到账户（安全失败）
@@ -43,8 +69,14 @@ export function accountFinder(deps: { sql: SqlExecutor }): (ctx: unknown, sub: s
     const identity = await findIdentityByUserId(deps.sql, sub)
     return {
       accountId: sub,
-      claims: async (use, _scope, _claims, _rejected) =>
-        buildClaims(identity, use),
+      claims: async (use, scope, _claims, _rejected) => {
+        const out = buildClaims(identity, use)
+        if (use === 'userinfo') {
+          // #700：数据域快照 claim 只在 UserInfo 注入（绝不经 ID Token 泄露）
+          await injectSnapshotClaims(deps.sql, sub, ctx, scope, out)
+        }
+        return out
+      },
     }
   }
 }
@@ -70,4 +102,100 @@ function buildClaims(identity: LinkedIdentityRow | null, use: ClaimsUse): Record
     out.hbut_verified_at = identity.verified_at.toISOString()
   }
   return out
+}
+
+/**
+ * #700：按 (user_id, client_id) 强绑定注入数据域快照 claims。
+ * - 只处理本次 access token 已授权 ∧ 属于数据域的 scope；
+ * - 快照必须同时覆盖该 scope（snapshot.scope_set）才注入对应字段；
+ * - 任何异常（解密失败/格式非法）→ claim 缺席 + error 审计，绝不抛出。
+ */
+async function injectSnapshotClaims(
+  sql: SqlExecutor,
+  userId: string,
+  ctx: unknown,
+  scope: Iterable<unknown>,
+  out: Record<string, unknown>,
+): Promise<void> {
+  const granted = normalizeScope(scope).filter((s): s is DataScope =>
+    (DATA_SCOPES as readonly string[]).includes(s),
+  )
+  if (granted.length === 0) {
+    return
+  }
+  const clientId = extractClientId(ctx)
+  if (!clientId) {
+    // 无法确定 client（非 userinfo 形态的装配）：安全缺省，绝不注入
+    return
+  }
+  try {
+    // 惰性清理：顺手删掉该用户全部已过期快照（读取路径兜底，免定时任务）
+    await deleteExpiredForUser(sql, userId)
+    const snapshot = await findActiveByUserAndClient(sql, userId, clientId)
+    if (!snapshot) {
+      // 无有效快照：claim 缺席（契约行为）
+      return
+    }
+    const payload = JSON.parse(decryptSnapshot(snapshot.payload_enc)) as SnapshotPayload
+    const snapshotScopes = Array.isArray(snapshot.scope_set)
+      ? snapshot.scope_set.filter((s): s is string => typeof s === 'string')
+      : []
+    const injected: string[] = []
+    for (const ds of granted) {
+      if (!snapshotScopes.includes(ds)) {
+        continue
+      }
+      if (ds === 'student.grades.read' && payload.grades !== undefined) {
+        out[DATA_SCOPE_TO_CLAIM[ds]] = buildClaimValue(payload.grades, payload.fetched_at)
+        injected.push(DATA_SCOPE_TO_CLAIM[ds])
+      }
+      if (ds === 'student.timetable.read' && payload.timetable !== undefined) {
+        out[DATA_SCOPE_TO_CLAIM[ds]] = buildClaimValue(payload.timetable, payload.fetched_at)
+        injected.push(DATA_SCOPE_TO_CLAIM[ds])
+      }
+    }
+    // 审计快照读取（不含任何业务数据明文）
+    await writeAuditEvent(sql, {
+      eventType: 'snapshot_read',
+      actorType: 'client',
+      actorId: clientId,
+      targetType: 'data_snapshot',
+      targetId: snapshot.id,
+      result: 'success',
+      metadata: { injected_claims: injected },
+    })
+  } catch {
+    // 密文损坏 / KEK 不符 / 格式非法：fail closed 为「缺席」而非报错，
+    // userinfo 响应绝不因可选增强数据而失败；留 error 审计供排查。
+    try {
+      await writeAuditEvent(sql, {
+        eventType: 'snapshot_read',
+        actorType: 'client',
+        actorId: clientId,
+        targetType: 'data_snapshot',
+        targetId: null,
+        result: 'error',
+        metadata: {},
+      })
+    } catch {
+      // 审计失败也不影响主流程
+    }
+  }
+}
+
+/** scope 参数防御性归一化（Set / 数组 / 空白分隔字符串均接受） */
+function normalizeScope(scope: Iterable<unknown>): string[] {
+  if (typeof scope === 'string') {
+    return scope.split(/\s+/).filter(Boolean)
+  }
+  return [...scope].filter((s): s is string => typeof s === 'string')
+}
+
+/** 从请求上下文提取发起 userinfo 请求的 client_id（服务端权威值，非客户端传参） */
+function extractClientId(ctx: unknown): string | null {
+  if (!ctx || typeof ctx !== 'object') {
+    return null
+  }
+  const clientId = (ctx as { oidc?: { client?: { clientId?: unknown } } }).oidc?.client?.clientId
+  return typeof clientId === 'string' && clientId.length > 0 ? clientId : null
 }

--- a/identity-platform/core/src/oidc/provider.ts
+++ b/identity-platform/core/src/oidc/provider.ts
@@ -36,8 +36,11 @@ import {
   toProviderJwks,
 } from './keys.js'
 
-/** V1 scope 白名单（#617 初始 Scope，与 domain/clients.ts SCOPE_WHITELIST 一致） */
-export const OIDC_SCOPES = ['openid', 'profile', 'student.identity', 'offline_access'] as const
+/** V1 scope 白名单（#617 初始 + #699 数据域扩展，与 domain/clients.ts SCOPE_WHITELIST 一致） */
+export const OIDC_SCOPES = [
+  'openid', 'profile', 'student.identity', 'offline_access',
+  'student.grades.read', 'student.timetable.read',
+] as const
 
 /**
  * scope → claims 映射（#620 Claims 章节；collectClaims 会把新 scope 注册进 provider）。
@@ -62,6 +65,9 @@ export const OIDC_CLAIMS = {
     'hbut_verification_method',
     'hbut_verified_at',
   ],
+  // #700 数据域 scope → 快照注入 claim（只在 userinfo 出现，绝不进 ID Token）
+  'student.grades.read': ['hbut_grades'],
+  'student.timetable.read': ['hbut_timetable'],
 }
 
 export interface IdentityProviderDeps {

--- a/identity-platform/core/src/security/api-key.ts
+++ b/identity-platform/core/src/security/api-key.ts
@@ -47,13 +47,21 @@ export interface GeneratedApiKey {
 }
 
 /**
- * 存储哈希的 pepper：复用 KEK 环境变量派生，避免静态常量。
- * - production 缺失/非法 → fail closed（与 client-secret 同策略）；
- * - 非生产回退开发常量并告警（便于本地/测试跑通）。
+ * 存储哈希 pepper 的解析来源：
+ *   1) 注入 env 的 IDENTITY_CLIENT_SECRET_KEK（测试/装配优先，如 TEST_KEK）；
+ *   2) 进程 env 同名变量（生产运行时）；
+ *   3) production 缺失/不足 32 字节 → fail closed 抛错；
+ *      非生产回退开发常量并告警（严禁用于生产）。
  */
-function getPepper(): string {
-  const raw = process.env.IDENTITY_CLIENT_SECRET_KEK
-  if (raw && Buffer.from(raw, 'utf8').length >= 32) return raw
+export function resolveApiKeyPepper(env?: Record<string, string | undefined>): string {
+  const injected = env?.IDENTITY_CLIENT_SECRET_KEK
+  if (injected && Buffer.from(injected, 'utf8').length >= 32) {
+    return injected
+  }
+  const fromProcess = process.env.IDENTITY_CLIENT_SECRET_KEK
+  if (fromProcess && Buffer.from(fromProcess, 'utf8').length >= 32) {
+    return fromProcess
+  }
   if (process.env.IDENTITY_ENVIRONMENT === 'production') {
     throw new Error(
       '[security] IDENTITY_CLIENT_SECRET_KEK 缺失或不足 32 字节，API Key 无法安全存储（fail closed）',
@@ -61,7 +69,7 @@ function getPepper(): string {
   }
   // eslint-disable-next-line no-console
   console.error('[security] 开发/测试环境使用固定 API Key pepper——严禁用于生产')
-  return 'mini-hbut-dev-api-key-pepper'
+  return 'mini-hbut-dev-api-key-pepper::fallback::0000'
 }
 
 /**
@@ -71,19 +79,23 @@ function getPepper(): string {
  * 存储哈希用 HMAC-SHA256(pepper)：对高熵随机 Key 而言防碰撞足够，
  * 引入服务端 pepper 同时满足 CodeQL 对「快速哈希存密码类凭据」的红线（#688）。
  */
-export function generateApiKey(): GeneratedApiKey {
+export function generateApiKey(pepper: string): GeneratedApiKey {
   const hexPrefix = randomBytes(HEX_PREFIX_LENGTH / 2).toString('hex')
   const prefix = `${API_KEY_PREFIX}${hexPrefix}`
   const body = randomBytes(SECRET_BYTES).toString('base64url')
   const full = `${prefix}_${body}`
-  return { full, prefix, hash: hmacSha256Base64url(getPepper(), full) }
+  return { full, prefix, hash: hmacSha256Base64url(pepper, full) }
 }
 
 /**
  * 校验 Bearer 凭据并返回对应 api_keys 行（含 user_id，供后续 owner 解析）。
  * 失败按契约细分三种 DomainError；成功后由调用方负责 touch last_used_at。
  */
-export async function verifyApiKey(sql: SqlExecutor, token: string): Promise<ApiKeyRow> {
+export async function verifyApiKey(
+  sql: SqlExecutor,
+  pepper: string,
+  token: string,
+): Promise<ApiKeyRow> {
   // 1) 形态校验：任何格式偏差一律 invalid（不区分缺头/截断/篡改）
   if (token.length !== API_KEY_FULL_LENGTH || !API_KEY_FULL_RE.test(token)) {
     throw new ApiKeyInvalidError()
@@ -94,7 +106,7 @@ export async function verifyApiKey(sql: SqlExecutor, token: string): Promise<Api
     throw new ApiKeyInvalidError()
   }
   // 2) constant-time 比对 HMAC-SHA256(整串, pepper)；长度相同（43 字符）才进比对
-  const computed = Buffer.from(hmacSha256Base64url(getPepper(), token), 'utf8')
+  const computed = Buffer.from(hmacSha256Base64url(pepper, token), 'utf8')
   const stored = Buffer.from(row.secret_hash, 'utf8')
   if (computed.length !== stored.length || !timingSafeEqual(computed, stored)) {
     throw new ApiKeyInvalidError()

--- a/identity-platform/core/src/security/snapshot-crypto.ts
+++ b/identity-platform/core/src/security/snapshot-crypto.ts
@@ -1,0 +1,75 @@
+/**
+ * 授权数据快照加解密（#700，父 #697）。
+ *
+ * 方案：application-layer AES-256-GCM 整体加密（与 client-secret.ts 同范式）
+ * - 数据库只存密文（data_snapshots.payload_enc），明文成绩/课表绝不落库；
+ * - KEK 复用 IDENTITY_CLIENT_SECRET_KEK：
+ *   - production 缺失/不足 32 字节 → fail closed（抛错拒绝服务，绝不静默降级）；
+ *   - development/test 缺失 → 固定开发常量回退 + 告警（照 api-key.ts getPepper 风格）；
+ * - 密文格式：enc:v1:<base64url(iv)>:<base64url(tag)>:<base64url(ciphertext)>；
+ * - AAD 固定为 'minihbut:data_snapshot:v1'，防止 client_secret 等其他用途的
+ *   密文被跨用途重放到快照字段（反之亦然）。
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+
+const ALGO = 'aes-256-gcm'
+const VERSION = 'v1'
+const AAD = Buffer.from('minihbut:data_snapshot:v1', 'utf8')
+const IV_LENGTH = 12
+const TAG_LENGTH = 16
+
+/**
+ * 快照 KEK：复用 KEK 环境变量。
+ * - production：缺失/不足 32 字节直接抛错（fail closed）；
+ * - 非生产：回退开发常量并告警（便于本地/测试跑通）。
+ */
+function getSnapshotKek(): Buffer {
+  const raw = process.env.IDENTITY_CLIENT_SECRET_KEK
+  if (raw && Buffer.from(raw, 'utf8').length === 32) {
+    return Buffer.from(raw, 'utf8')
+  }
+  if ((process.env.IDENTITY_ENVIRONMENT ?? 'development').trim().toLowerCase() === 'production') {
+    throw new Error(
+      '[security] IDENTITY_CLIENT_SECRET_KEK 必须是 32 字节，数据快照无法安全加密（fail closed）',
+    )
+  }
+  // eslint-disable-next-line no-console
+  console.error('[security] 开发/测试环境使用固定数据快照密钥——严禁用于生产')
+  return Buffer.from('mini-hbut-dev-data-snapshot-kek!!', 'utf8').subarray(0, 32)
+}
+
+/** 加密快照 JSON 明文，返回 enc:v1:... 格式密文 */
+export function encryptSnapshot(plaintextJson: string): string {
+  const iv = randomBytes(IV_LENGTH)
+  const cipher = createCipheriv(ALGO, getSnapshotKek(), iv)
+  cipher.setAAD(AAD)
+  const ciphertext = Buffer.concat([cipher.update(plaintextJson, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return [
+    'enc',
+    VERSION,
+    iv.toString('base64url'),
+    tag.toString('base64url'),
+    ciphertext.toString('base64url'),
+  ].join(':')
+}
+
+/** 解密快照；格式非法 / 篡改 / KEK 不符都会抛错（fail closed，调用方按内部错误处理） */
+export function decryptSnapshot(encrypted: string): string {
+  const parts = encrypted.split(':')
+  if (parts.length !== 5 || parts[0] !== 'enc' || parts[1] !== VERSION) {
+    throw new Error('[security] 数据快照密文格式非法')
+  }
+  const [, , ivB64, tagB64, ctB64] = parts as [string, string, string, string, string]
+  const iv = Buffer.from(ivB64, 'base64url')
+  const tag = Buffer.from(tagB64, 'base64url')
+  const ciphertext = Buffer.from(ctB64, 'base64url')
+  if (iv.length !== IV_LENGTH || tag.length !== TAG_LENGTH) {
+    throw new Error('[security] 数据快照密文参数长度非法')
+  }
+  const decipher = createDecipheriv(ALGO, getSnapshotKek(), iv)
+  decipher.setAAD(AAD)
+  decipher.setAuthTag(tag)
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  return plaintext.toString('utf8')
+}

--- a/identity-platform/core/tests/api/account.test.ts
+++ b/identity-platform/core/tests/api/account.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../helpers/keys.js'
 import { registerAccountRoutes } from '../../src/api/account/index.js'
 import { insertApiKey } from '../../src/db/repos/api-keys.repo.js'
-import { sha256Base64url } from '../../src/security/hash.js'
+import { hmacSha256Base64url } from '../../src/security/hash.js'
 import { DEFAULT_RATE_LIMIT_GROUPS } from '../../src/security/rate-limit.js'
 import { derivePairwiseSubject } from '../../src/domain/subjects.js'
 
@@ -149,7 +149,7 @@ describe('#688 账户级 API Key（签发/Bearer 认证/account 端点）', () =
         'SELECT secret_hash FROM api_keys WHERE prefix = $1',
         [full.slice(0, 14)],
       )
-      expect(row.rows[0]?.secret_hash).toBe(sha256Base64url(full))
+      expect(row.rows[0]?.secret_hash).toBe(hmacSha256Base64url(TEST_KEK, full))
       expect(row.rows[0]?.secret_hash).not.toContain(full)
 
       // 管理面 GET：无明文/无 hash
@@ -164,7 +164,7 @@ describe('#688 账户级 API Key（签发/Bearer 认证/account 端点）', () =
       const serialized = JSON.stringify(listBody)
       expect(serialized).not.toContain('secret_hash')
       expect(serialized).not.toContain(full)
-      expect(serialized).not.toContain(sha256Base64url(full))
+      expect(serialized).not.toContain(hmacSha256Base64url(TEST_KEK, full))
     })
   })
 
@@ -339,7 +339,7 @@ describe('#688 账户级 API Key（签发/Bearer 认证/account 端点）', () =
         userId: fx.userId,
         name: '过期 Key',
         prefix: 'mhbat_deadbeef',
-        secretHash: sha256Base64url(expiredFull),
+        secretHash: hmacSha256Base64url(TEST_KEK, expiredFull),
       })
       await db.sql.query("UPDATE api_keys SET expires_at = NOW() - INTERVAL '1 day' WHERE id = 'ak_expired_fixture'")
       const expiredRes = await bearerRequest(baseUrl, 'GET', '/api/v1/account/me', expiredFull)

--- a/identity-platform/core/tests/api/app-data-snapshots.test.ts
+++ b/identity-platform/core/tests/api/app-data-snapshots.test.ts
@@ -1,0 +1,523 @@
+/**
+ * #700 授权数据快照 API 测试（父 #697）：
+ * - 上传 201：响应 { snapshot_id, expires_at=now+7d }，DB 只存密文（明文不落库）；
+ * - 无效 handoff / 缺失 Device 签名 → 401；
+ * - 同 user+client 重传 → 覆盖单行（不堆积历史）；
+ * - 不同 client 不串读：(user_id, client_id) 强绑定；
+ * - claims 注入成功与缺席（use='userinfo' 才注入；scope/快照双重门控）；
+ * - revoked 设备签名拒；
+ * - scope 越权（超出本次批准范围）→ 400；
+ * - 应用 revoke → 快照级联删除。
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import { createTestDatabase, type TestDatabase } from '../helpers/pg.js'
+import { withServer } from '../helpers.js'
+import {
+  buildApp,
+  buildEnrollBody,
+  newTestDeviceKey,
+  postJson,
+  type TestDeviceKey,
+} from './helpers.js'
+import { createClientFixture } from '../helpers/fixtures.js'
+import { TEST_KEK, TEST_HANDOFF_HMAC_KEY } from '../helpers/keys.js'
+import { createAuthRequest } from '../../src/domain/auth-requests/service.js'
+import { createEnrollmentChallenge, revokeDevice } from '../../src/domain/devices.js'
+import { buildDeviceApiCanonical } from '../../src/api/app/canonical.js'
+import { setClientStatus } from '../../src/domain/clients.js'
+import { accountFinder } from '../../src/oidc/account.js'
+import { findActiveByUserAndClient } from '../../src/db/repos/data-snapshots.repo.js'
+
+const SNAPSHOT_PATH = '/api/v1/app/data-snapshots'
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+describe('#700 data-snapshots API', () => {
+  let db: TestDatabase
+  let previousKek: string | undefined
+
+  beforeEach(async () => {
+    db = await createTestDatabase()
+    // 快照加解密统一走 TEST_KEK（与生产同路径，仅环境变量值不同）
+    previousKek = process.env.IDENTITY_CLIENT_SECRET_KEK
+    process.env.IDENTITY_CLIENT_SECRET_KEK = TEST_KEK
+  })
+  afterEach(async () => {
+    if (previousKek === undefined) {
+      delete process.env.IDENTITY_CLIENT_SECRET_KEK
+    } else {
+      process.env.IDENTITY_CLIENT_SECRET_KEK = previousKek
+    }
+    await db.cleanup()
+  })
+
+  /** 通过 enroll API 注册一台设备，返回 device_id / user_id */
+  async function enrollDevice(key: TestDeviceKey, studentId = '2023010101'): Promise<{
+    deviceId: string
+    userId: string
+  }> {
+    // enroll 只需有效 handoff（绑定任意活跃 client fixture 即可，与 scope 无关）
+    const fixture = await createClientFixture(db.sql, { scopes: ['openid', 'profile'] })
+    const request = await createAuthRequest(db.sql, {
+      interactionUid: `iu_${randomUUID().replaceAll('-', '')}`,
+      clientId: fixture.clientId,
+      requestedScopes: ['openid', 'profile'],
+      handoffHmacKey: TEST_HANDOFF_HMAC_KEY,
+    })
+    const { challenge } = await createEnrollmentChallenge(db.sql, {
+      purpose: 'device_enrollment',
+      ttlSeconds: 300,
+    })
+    const app = buildApp(db.sql)
+    let result: { status: number; body: Record<string, unknown> } = { status: 0, body: {} }
+    await withServer(app, async (baseUrl) => {
+      result = await postJson(
+        baseUrl,
+        '/api/v1/app/devices/enroll',
+        buildEnrollBody({
+          key,
+          challenge,
+          studentId,
+          studentName: '张三',
+        }),
+        { authorization: `Handoff ${request.handoffSecret}` },
+      )
+    })
+    expect(result.status).toBe(201)
+    return {
+      deviceId: String(result.body.device_id),
+      userId: String(result.body.user_id),
+    }
+  }
+
+  /**
+   * 创建一条已批准的 auth_request（含数据域 scope），返回 handoff secret 与 client_id。
+   * 快照上传的 Handoff 双因子要求该会话处于已批准链路状态。
+   */
+  async function createApprovedHandoff(opts: {
+    userId: string
+    deviceId: string
+    scopes?: string[]
+    /** 复用既有 client（同一应用再次授权） */
+    clientId?: string
+  }): Promise<{ clientId: string; handoffSecret: string }> {
+    const scopes = opts.scopes ?? ['openid', 'student.grades.read']
+    const fixture = opts.clientId ? null : await createClientFixture(db.sql, { scopes })
+    const clientId = opts.clientId ?? fixture!.clientId
+    const request = await createAuthRequest(db.sql, {
+      interactionUid: `iu_${randomUUID().replaceAll('-', '')}`,
+      clientId,
+      requestedScopes: scopes,
+      handoffHmacKey: TEST_HANDOFF_HMAC_KEY,
+    })
+    await db.sql.query(
+      `UPDATE auth_requests
+          SET status = 'APPROVED', opened_at = NOW(), approved_at = NOW(),
+              approved_user_id = $1, approved_device_id = $2
+        WHERE id = $3`,
+      [opts.userId, opts.deviceId, request.requestId],
+    )
+    return { clientId, handoffSecret: request.handoffSecret }
+  }
+
+  /** 构造 POST data-snapshots 的 Device 签名认证头 */
+  function deviceAuthHeader(key: TestDeviceKey, deviceId: string): string {
+    const issuedAt = Math.floor(Date.now() / 1000)
+    const nonce = randomUUID().replaceAll('-', '')
+    const canonical = buildDeviceApiCanonical({
+      method: 'POST',
+      path: SNAPSHOT_PATH,
+      deviceId,
+      issuedAt,
+      nonce,
+    })
+    return `Device ${deviceId} ${issuedAt} ${nonce} ${key.sign(canonical)}`
+  }
+
+  async function uploadSnapshot(
+    baseUrl: string,
+    headers: Record<string, string>,
+    body: unknown,
+  ): Promise<{ status: number; body: Record<string, unknown> }> {
+    return postJson(baseUrl, SNAPSHOT_PATH, body, headers)
+  }
+
+  function buildUploadBody(opts: {
+    handoffSecret: string
+    scopes?: string[]
+    grades?: unknown
+    timetable?: unknown
+    fetchedAt?: string
+  }): Record<string, unknown> {
+    const payload: Record<string, unknown> = {}
+    if (opts.grades !== undefined) payload.grades = opts.grades
+    if (opts.timetable !== undefined) payload.timetable = opts.timetable
+    if (opts.fetchedAt !== undefined || opts.grades !== undefined || opts.timetable !== undefined) {
+      payload.fetched_at = opts.fetchedAt ?? new Date().toISOString()
+    }
+    return {
+      handoff: opts.handoffSecret,
+      scopes: opts.scopes ?? ['student.grades.read'],
+      payload,
+    }
+  }
+
+  it('1. 上传 201：响应 snapshot_id/expires_at(+7d)，DB 只存密文且审计留痕', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key)
+    const { clientId, handoffSecret } = await createApprovedHandoff({ userId, deviceId })
+
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const before = Date.now()
+      const res = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({
+          handoffSecret,
+          grades: [{ course: '高等数学', score: 95 }],
+          fetchedAt: '2026-08-24T08:00:00.000Z',
+        }),
+      )
+      const after = Date.now()
+      expect(res.status).toBe(201)
+      expect(String(res.body.snapshot_id)).toMatch(/^[0-9a-f-]{36}$/)
+      const expiresAt = new Date(String(res.body.expires_at)).getTime()
+      // expires_at = now + 7 天（±5s 时钟容差）
+      expect(expiresAt).toBeGreaterThanOrEqual(before + SEVEN_DAYS_MS - 5000)
+      expect(expiresAt).toBeLessThanOrEqual(after + SEVEN_DAYS_MS + 5000)
+    })
+
+    // DB 断言：只存密文，明文绝不出现在任何列
+    const rows = await db.sql.query<{ payload_enc: string; scope_set: unknown; client_id: string; user_id: string; fetched_at: Date | null }>(
+      'SELECT * FROM data_snapshots WHERE user_id = $1',
+      [userId],
+    )
+    expect(rows.rows.length).toBe(1)
+    const row = rows.rows[0]!
+    expect(row.client_id).toBe(clientId)
+    expect(row.payload_enc).toMatch(/^enc:v1:[A-Za-z0-9_-]+:[A-Za-z0-9_-]+:[A-Za-z0-9_-]+$/)
+    expect(row.payload_enc).not.toContain('高等数学')
+    expect(row.payload_enc).not.toContain('course')
+    expect(row.fetched_at).not.toBeNull()
+
+    // 审计：snapshot_uploaded 留痕（不含业务数据）
+    const audit = await db.sql.query<{ event_type: string; metadata_json: unknown }>(
+      "SELECT event_type, metadata_json FROM audit_events WHERE event_type = 'snapshot_uploaded'",
+    )
+    expect(audit.rows.length).toBe(1)
+    const meta = JSON.stringify(audit.rows[0]!.metadata_json)
+    expect(meta).not.toContain('高等数学')
+  })
+
+  it('2. 无效凭据拒绝：伪造/缺失 handoff → 401；缺失 Device 签名 → 401', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key)
+    const { handoffSecret } = await createApprovedHandoff({ userId, deviceId })
+
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      // 完全没有 Authorization 头
+      const noAuth = await uploadSnapshot(
+        baseUrl,
+        {},
+        buildUploadBody({ handoffSecret, grades: { gpa: 3.8 } }),
+      )
+      expect(noAuth.status).toBe(401)
+      expect((noAuth.body.error as { code: string }).code).toBe('DEVICE_AUTH_FAILED')
+
+      // 有效 Device 签名 + 无效 handoff
+      const badHandoff = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret: 'A'.repeat(64), grades: { gpa: 3.8 } }),
+      )
+      expect(badHandoff.status).toBe(401)
+      expect((badHandoff.body.error as { code: string }).code).toBe('INVALID_HANDOFF')
+
+      // DB 无写入
+      const rows = await db.sql.query('SELECT * FROM data_snapshots')
+      expect(rows.rows.length).toBe(0)
+    })
+  })
+
+  it('3. 同 user+client 重传覆盖单行：DB 始终一行，内容为最新一次', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key)
+    const { handoffSecret } = await createApprovedHandoff({ userId, deviceId })
+
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const first = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, grades: { term: '2024-1', gpa: 3.1 } }),
+      )
+      expect(first.status).toBe(201)
+      const second = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, grades: { term: '2024-2', gpa: 3.9 } }),
+      )
+      expect(second.status).toBe(201)
+
+      const rows = await db.sql.query<{ id: string }>('SELECT id FROM data_snapshots')
+      expect(rows.rows.length).toBe(1)
+      // 覆盖语义：(user_id, client_id) 单行 upsert，两次返回同一个 snapshot_id
+      expect(String(second.body.snapshot_id)).toBe(String(first.body.snapshot_id))
+    })
+
+    const stored = await db.sql.query<{ payload_enc: string }>('SELECT payload_enc FROM data_snapshots')
+    // 用同一 KEK 解开验证是第二份数据（走 security 层）
+    const { decryptSnapshot } = await import('../../src/security/snapshot-crypto.js')
+    const plain = JSON.parse(decryptSnapshot(stored.rows[0]!.payload_enc)) as { grades: { gpa: number } }
+    expect(plain.grades.gpa).toBe(3.9)
+  })
+
+  it('4. 不同 client 不串读：clientB 无法读到 user 上传给 clientA 的快照', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key, '2023010102')
+    const a = await createApprovedHandoff({ userId, deviceId, scopes: ['openid', 'student.grades.read'] })
+    const b = await createApprovedHandoff({ userId, deviceId, scopes: ['openid', 'student.grades.read'] })
+    expect(a.clientId).not.toBe(b.clientId)
+
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret: a.handoffSecret, grades: { secret: 'only-for-A' } }),
+      )
+      expect(res.status).toBe(201)
+    })
+
+    // repo 层：(user, clientB) 查不到
+    expect(await findActiveByUserAndClient(db.sql, userId, a.clientId)).not.toBeNull()
+    expect(await findActiveByUserAndClient(db.sql, userId, b.clientId)).toBeNull()
+
+    // claims 层：clientB 的 userinfo 不含 hbut_grades
+    const finder = accountFinder({ sql: db.sql })
+    const accountB = await finder({ oidc: { client: { clientId: b.clientId } } }, userId)
+    expect(accountB).toBeDefined()
+    const claimsB = await accountB!.claims(
+      'userinfo',
+      new Set(['openid', 'student.grades.read']),
+      {},
+      [],
+    )
+    expect(claimsB.hbut_grades).toBeUndefined()
+
+    // clientA 正常读到
+    const accountA = await finder({ oidc: { client: { clientId: a.clientId } } }, userId)
+    const claimsA = await accountA!.claims(
+      'userinfo',
+      new Set(['openid', 'student.grades.read']),
+      {},
+      [],
+    )
+    expect((claimsA.hbut_grades as { data: { secret: string } }).data.secret).toBe('only-for-A')
+  })
+
+  it('5. claims 注入成功与缺席：use=userinfo 注入；id_token/scope 缺失/无快照均缺席', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key, '2023010103')
+    const { clientId, handoffSecret } = await createApprovedHandoff({
+      userId,
+      deviceId,
+      scopes: ['openid', 'student.grades.read', 'student.timetable.read'],
+    })
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({
+          handoffSecret,
+          scopes: ['student.grades.read', 'student.timetable.read'],
+          grades: [{ course: '数据结构', score: 88 }],
+          timetable: { mon: ['高等数学'] },
+        }),
+      )
+      expect(res.status).toBe(201)
+    })
+
+    const finder = accountFinder({ sql: db.sql })
+    // a) userinfo + 全部数据域 scope → 两个 claim 都注入
+    const account = await finder({ oidc: { client: { clientId } } }, userId)
+    const full = await account!.claims(
+      'userinfo',
+      new Set(['openid', 'student.grades.read', 'student.timetable.read']),
+      {},
+      [],
+    )
+    expect((full.hbut_grades as { data: Array<Record<string, unknown>> }).data[0]).toEqual({
+      course: '数据结构',
+      score: 88,
+    })
+    expect((full.hbut_grades as { fetched_at: string | null }).fetched_at).toBeTruthy()
+    expect((full.hbut_timetable as { data: { mon: string[] } }).data.mon).toEqual(['高等数学'])
+
+    // b) use=id_token：绝不注入（快照数据不能进 ID Token）
+    const forIdToken = await accountFinder({ sql: db.sql })(
+      { oidc: { client: { clientId } } },
+      userId,
+    )
+    const idTokenClaims = await forIdToken!.claims(
+      'id_token',
+      new Set(['openid', 'student.grades.read']),
+      {},
+      [],
+    )
+    expect(idTokenClaims.hbut_grades).toBeUndefined()
+    expect(idTokenClaims.hbut_timetable).toBeUndefined()
+
+    // c) scope 不含数据域：即使有快照也缺席
+    const narrow = await account!.claims('userinfo', new Set(['openid']), {}, [])
+    expect(narrow.hbut_grades).toBeUndefined()
+
+    // d) 无快照的用户：缺席且不报错
+    const other = await createClientFixture(db.sql, { scopes: ['openid', 'student.grades.read'] })
+    const emptyAccount = await finder({ oidc: { client: { clientId: other.clientId } } }, userId)
+    const empty = await emptyAccount!.claims(
+      'userinfo',
+      new Set(['openid', 'student.grades.read']),
+      {},
+      [],
+    )
+    expect(empty.hbut_grades).toBeUndefined()
+  })
+
+  it('6. revoked 设备签名拒：吊销后上传 401，且无新快照写入', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key, '2023010104')
+    const { handoffSecret } = await createApprovedHandoff({ userId, deviceId })
+
+    // 先成功上传一次
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const ok = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, grades: { n: 1 } }),
+      )
+      expect(ok.status).toBe(201)
+    })
+
+    // 吊销设备后再上传
+    await revokeDevice(db.sql, deviceId, 'user_revoked')
+    await withServer(app, async (baseUrl) => {
+      const res = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, grades: { n: 2 } }),
+      )
+      expect(res.status).toBe(401)
+      expect((res.body.error as { code: string }).code).toBe('DEVICE_AUTH_FAILED')
+    })
+
+    // 快照内容仍是第一份（n 加密后不可直接断言，行数不变即可 + 解密验证）
+    const rows = await db.sql.query<{ payload_enc: string }>('SELECT payload_enc FROM data_snapshots')
+    expect(rows.rows.length).toBe(1)
+    const { decryptSnapshot } = await import('../../src/security/snapshot-crypto.js')
+    const plain = JSON.parse(decryptSnapshot(rows.rows[0]!.payload_enc)) as { grades: { n: number } }
+    expect(plain.grades.n).toBe(1)
+  })
+
+  it('7. 越权防护：scope 超出本次批准范围 / payload 与 scope 不匹配 → 400', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key, '2023010105')
+    // 本次只批了 grades，没批 timetable
+    const { handoffSecret } = await createApprovedHandoff({ userId, deviceId, scopes: ['openid', 'student.grades.read'] })
+
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      // a) 声称未批准的 timetable scope
+      const resScope = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({
+          handoffSecret,
+          scopes: ['student.grades.read', 'student.timetable.read'],
+          grades: { gpa: 3.2 },
+          timetable: { mon: [] },
+        }),
+      )
+      expect(resScope.status).toBe(400)
+      expect((resScope.body.error as { code: string }).code).toBe('SNAPSHOT_INVALID_SCOPE')
+
+      // b) 已批 grades 但缺 grades 数据
+      const resMissing = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, grades: undefined }),
+      )
+      expect(resMissing.status).toBe(400)
+
+      // c) 非法 scope 名
+      const resBad = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, scopes: ['admin.all'], grades: {} }),
+      )
+      expect(resBad.status).toBe(400)
+
+      // d) 未授权字段混入 payload（只批 grades 却带 timetable 字段）
+      const resExtra = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        {
+          handoff: handoffSecret,
+          scopes: ['student.grades.read'],
+          payload: { grades: { gpa: 3.2 }, timetable: { mon: [] }, fetched_at: new Date().toISOString() },
+        },
+      )
+      expect(resExtra.status).toBe(400)
+
+      expect((await db.sql.query('SELECT * FROM data_snapshots')).rows.length).toBe(0)
+    })
+  })
+
+  it('8. 应用 revoke → 快照级联删除；过期快照读取缺席并被惰性清理', async () => {
+    const key = newTestDeviceKey()
+    const { deviceId, userId } = await enrollDevice(key, '2023010106')
+    const { clientId, handoffSecret } = await createApprovedHandoff({ userId, deviceId })
+
+    const app = buildApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret, grades: { v: 'will-vanish' } }),
+      )
+      expect(res.status).toBe(201)
+    })
+
+    // a) 过期：expires_at 改到过去 → repo 读不到 + 惰性删除生效
+    await db.sql.query('UPDATE data_snapshots SET expires_at = NOW() - interval \'1 hour\' WHERE user_id = $1', [userId])
+    expect(await findActiveByUserAndClient(db.sql, userId, clientId)).toBeNull()
+    const finder = accountFinder({ sql: db.sql })
+    const account = await finder({ oidc: { client: { clientId } } }, userId)
+    await account!.claims('userinfo', new Set(['openid', 'student.grades.read']), {}, [])
+    const afterLazy = await db.sql.query('SELECT * FROM data_snapshots WHERE user_id = $1', [userId])
+    expect(afterLazy.rows.length).toBe(0)
+
+    // b) 重新上传一份（同一 client）再 revoke 应用 → 快照被级联删除
+    const handoff2 = await createApprovedHandoff({
+      userId,
+      deviceId,
+      clientId,
+      scopes: ['openid', 'student.grades.read'],
+    })
+    await withServer(app, async (baseUrl) => {
+      const res = await uploadSnapshot(
+        baseUrl,
+        { authorization: deviceAuthHeader(key, deviceId) },
+        buildUploadBody({ handoffSecret: handoff2.handoffSecret, grades: { v: 2 } }),
+      )
+      expect(res.status).toBe(201)
+    })
+    await setClientStatus(db.sql, clientId, 'revoked')
+    const afterRevoke = await db.sql.query('SELECT * FROM data_snapshots WHERE client_id = $1', [clientId])
+    expect(afterRevoke.rows.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## TL;DR

OIDC 数据域 scope 扩展 + 授权快照机制后端（Refs #699 core 部分；Fixes #700，父 #697）。

## 行为对照契约 v1 全部落地

- SCOPE_WHITELIST + OIDC_SCOPES/OIDC_CLAIMS 纳入 student.grades.read / student.timetable.read；迁移 `0006_data_scopes_check.sql` 更新 DB CHECK（采用「重建表」方案保证真 PG 与 pg-mem 一致）
- POST /api/v1/app/data-snapshots：Device 签名 + handoff 双因子；scopes ⊆ 批准范围校验；payload strict 白名单+256KB 上限；AES-256-GCM 加密入库（KEK 派生，production 缺失 fail closed）；(user_id, client_id) UNIQUE upsert 仅存最新份；201 {snapshot_id, expires_at=now+7d}
- userinfo claims 注入：scope 含数据域且存在有效快照 → 解密注入 hbut_grades / hbut_timetable（包装为 {data, fetched_at} 固定形状）；无快照/解密失败 → claim 缺席绝不报错；**id_token 绝不注入**；client_id 取自 ctx.oidc.client（服务端权威值）
- 时效与清理：读取惰性删过期行；应用 revoke 级联物理删除快照（覆盖 account/developer 两入口）
- 审计：snapshot_uploaded / snapshot_read（不含任何明文）

## 验收证据

- app-data-snapshots.test.ts **8 passed**：上传201+密文断言 / 无效handoff拒 / 重传覆盖单行 / 跨client不串读 / claims注入与缺席 / revoked签名拒
- 集成树全量回归通过（见验收报告）

Fixes #700
Refs #699、#697