### PR TITLE
feat(#699): 授权弹窗学习数据 scope 逐项勾选（含 Core 部分批准能力调查结论）

### DIFF
--- a/apps/client/src/features/identity/components/IdentityApprovalOverlay.scoped.css
+++ b/apps/client/src/features/identity/components/IdentityApprovalOverlay.scoped.css
@@ -245,3 +245,91 @@
 .identity-test-banner strong {
   color: #a16207;
 }
+
+/* #699 学习数据逐项勾选：分组卡片风格与 IdentityScopeList 一致 */
+.identity-learning-group {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in oklab, var(--ui-muted, #475569) 22%, transparent);
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--ui-surface, #ffffff) 72%, transparent);
+}
+
+.identity-learning-title {
+  padding: 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ui-muted, #475569);
+}
+
+.identity-learning-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 2px;
+  cursor: pointer;
+}
+
+.identity-learning-check {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  margin: 1px 0 0;
+  accent-color: var(--ui-primary, #2563eb);
+  cursor: pointer;
+}
+
+.identity-learning-text {
+  min-width: 0;
+}
+
+.identity-learning-text strong {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--ui-text, #0f172a);
+}
+
+.identity-learning-sid {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--ui-muted, #475569);
+  font-family: ui-monospace, 'SFMono-Regular', Consolas, monospace;
+  word-break: break-all;
+}
+
+/* 取消项阻断说明：非恐吓式但必须显式告知 */
+.identity-learning-notice {
+  margin: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in oklab, var(--ui-warning, #f59e0b) 52%, transparent);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--ui-warning, #f59e0b) 7%, transparent);
+  color: #854d0e;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.identity-learning-notice-icon {
+  flex: none;
+  font-size: 16px;
+}
+
+/* 其余 scope 为空时的非官方声明兜底行（样式对齐 IdentityScopeList） */
+.identity-nonofficial-fallback {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ui-muted, #475569);
+}
+
+.identity-nonofficial-fallback .identity-nonofficial-icon {
+  flex: none;
+  font-size: 15px;
+}

--- a/apps/client/src/features/identity/components/IdentityApprovalOverlay.vue
+++ b/apps/client/src/features/identity/components/IdentityApprovalOverlay.vue
@@ -23,6 +23,13 @@ import {
   overlayVisible
 } from '../identityStore'
 import { trapTabFocus, focusCard } from '../identityAccessibility'
+import { NON_OFFICIAL_NOTICE } from '../identityScopes'
+import {
+  defaultLearningConsent,
+  learningConsentNotice,
+  resolveLearningConsent,
+  splitLearningDataScopes
+} from '../learningDataConsent'
 import IdentityClientCard from './IdentityClientCard.vue'
 import IdentityScopeList from './IdentityScopeList.vue'
 import IdentityResultState from './IdentityResultState.vue'
@@ -100,6 +107,59 @@ const remainingText = computed(() => {
 })
 
 const expiryUrgent = computed(() => remainingSeconds.value > 0 && remainingSeconds.value <= 30)
+
+// ── #699 学习数据 scope 逐项勾选 ───────────────────────────────────────────
+// 勾选状态仅存本组件内存（默认全选，不持久化）；
+// 当前 Core 只接受全集批准（approve body 白名单 + 服务端快照 scope_hash + resume 全量
+// Grant），存在任何取消项时禁止提交批准，避免取消项随全集进入授权范围。
+/** 学习数据项（冻结文案）与其余 scope（维持现有展示方式） */
+const learningScopes = computed(() => splitLearningDataScopes(ui.requestDetail?.scopes ?? []).learning)
+const otherScopes = computed(() => splitLearningDataScopes(ui.requestDetail?.scopes ?? []).others)
+
+/** 已勾选的学习数据 scope id 集合（请求切换时重置为全选） */
+const selectedLearningScopes = ref<ReadonlySet<string>>(new Set())
+
+watch(
+  () => ui.requestDetail?.request_id,
+  () => {
+    selectedLearningScopes.value = defaultLearningConsent(learningScopes.value)
+  },
+  { immediate: true }
+)
+
+const toggleLearningScope = (id: string, checked: boolean): void => {
+  const next = new Set(selectedLearningScopes.value)
+  if (checked) {
+    next.add(id)
+  } else {
+    next.delete(id)
+  }
+  selectedLearningScopes.value = next
+}
+
+/** checkbox change 事件桥接（类型收窄留在 script，模板不做断言） */
+const handleLearningCheckChange = (id: string, event: Event): void => {
+  const target = event.target as HTMLInputElement | null
+  if (!target) return
+  toggleLearningScope(id, target.checked)
+}
+
+/** 勾选守卫：全部勾选才可批准；存在取消项时阻断并如实说明 */
+const learningConsent = computed(() => resolveLearningConsent(learningScopes.value, selectedLearningScopes.value))
+const learningNotice = computed(() =>
+  learningScopes.value.length ? learningConsentNotice(learningConsent.value) : ''
+)
+
+const allowDisabled = computed(
+  () => busy.value || (learningScopes.value.length > 0 && !learningConsent.value.canApprove)
+)
+
+const handleAllow = (): void => {
+  // 双重守卫：即使按钮态被绕过，存在取消项也绝不提交批准（不允许静默扩大授权）
+  if (allowDisabled.value) return
+  if (!learningConsent.value.canApprove) return
+  props.identity.approveActive()
+}
 
 // ── 键盘可达性 ──────────────────────────────────────────────────────────────
 const handleKeydown = (event: KeyboardEvent): void => {
@@ -220,7 +280,46 @@ onBeforeUnmount(() => {
               不会获取、保存或使用你的任何真实数据。
             </div>
             <IdentityClientCard :client="ui.requestDetail.client" />
-            <IdentityScopeList :scopes="ui.requestDetail.scopes" />
+            <!-- 其余 scope：维持现有风险分组展示 -->
+            <IdentityScopeList v-if="otherScopes.length" :scopes="otherScopes" />
+
+            <!-- #699 学习数据权限：逐项勾选（默认全选；取消任意一项即不可整体批准） -->
+            <fieldset v-if="learningScopes.length" class="identity-learning-group">
+              <legend class="identity-learning-title">学习数据</legend>
+              <label
+                v-for="item in learningScopes"
+                :key="item.id"
+                class="identity-learning-item"
+              >
+                <input
+                  type="checkbox"
+                  class="identity-learning-check"
+                  :checked="selectedLearningScopes.has(item.id)"
+                  @change="handleLearningCheckChange(item.id, $event)"
+                />
+                <span class="identity-learning-text">
+                  <strong>{{ item.label }}</strong>
+                  <span class="identity-learning-sid">{{ item.id }}</span>
+                </span>
+              </label>
+            </fieldset>
+
+            <!-- 取消项阻断说明（aria-live 让读屏用户感知状态变化） -->
+            <p
+              v-if="learningNotice"
+              class="identity-learning-notice"
+              role="status"
+              aria-live="polite"
+            >
+              <span class="material-symbols-outlined identity-learning-notice-icon" aria-hidden="true">block</span>
+              {{ learningNotice }}
+            </p>
+
+            <!-- 其余 scope 为空时仍保留非官方声明（安全信息不因拆分展示而丢失） -->
+            <p v-if="!otherScopes.length && learningScopes.length" class="identity-nonofficial-fallback" role="note">
+              <span class="material-symbols-outlined identity-nonofficial-icon" aria-hidden="true">verified_user</span>
+              {{ NON_OFFICIAL_NOTICE }}
+            </p>
 
             <section class="identity-current" aria-label="当前 Mini-HBUT 身份">
               <h4>当前 Mini-HBUT 身份</h4>
@@ -249,8 +348,8 @@ onBeforeUnmount(() => {
               <button
                 class="btn-primary btn-ripple identity-allow-btn"
                 type="button"
-                :disabled="busy"
-                @click="identity.approveActive()"
+                :disabled="allowDisabled"
+                @click="handleAllow"
               >
                 允许
               </button>

--- a/apps/client/src/features/identity/learningDataConsent.spec.ts
+++ b/apps/client/src/features/identity/learningDataConsent.spec.ts
@@ -1,0 +1,117 @@
+// src/features/identity/learningDataConsent.spec.ts
+//
+// #699：学习数据 scope 逐项勾选纯函数单测（选中集合计算 / 全部取消守卫）。
+
+import { describe, expect, it } from 'vitest'
+import {
+  LEARNING_DATA_SCOPE_IDS,
+  LEARNING_DATA_SCOPE_LABELS,
+  defaultLearningConsent,
+  learningConsentNotice,
+  resolveLearningConsent,
+  splitLearningDataScopes
+} from './learningDataConsent'
+import type { IdentityScopeInfo } from './types'
+
+const scope = (id: string): IdentityScopeInfo => ({ id, label: `label:${id}`, risk: 'basic' })
+
+const bothScopes = (): IdentityScopeInfo[] => [
+  scope('openid'),
+  scope('student.grades.read'),
+  scope('student.identity'),
+  scope('student.timetable.read')
+]
+
+describe('#699 学习数据 scope 拆分与冻结文案', () => {
+  it('拆分：学习数据项按冻结顺序输出冻结文案，其余 scope 保持原顺序', () => {
+    const result = splitLearningDataScopes(bothScopes())
+    // 学习数据项只含冻结 id，顺序 = 冻结顺序（与请求中的出现顺序无关）
+    expect(result.learning.map((item) => item.id)).toEqual([
+      'student.grades.read',
+      'student.timetable.read'
+    ])
+    // 冻结文案逐字遵守
+    expect(LEARNING_DATA_SCOPE_LABELS['student.grades.read']).toBe(
+      '全部成绩单（含各学期成绩与绩点）'
+    )
+    expect(LEARNING_DATA_SCOPE_LABELS['student.timetable.read']).toBe('完整课表')
+    expect(result.learning.every((item) => item.label === LEARNING_DATA_SCOPE_LABELS[item.id])).toBe(true)
+    // 其余 scope 维持现有展示方式：原样保留原顺序
+    expect(result.others.map((item) => item.id)).toEqual(['openid', 'student.identity'])
+  })
+
+  it('拆分：请求不含学习数据项时 learning 为空、others 为全量', () => {
+    const result = splitLearningDataScopes([scope('openid'), scope('profile')])
+    expect(result.learning).toEqual([])
+    expect(result.others.map((item) => item.id)).toEqual(['openid', 'profile'])
+  })
+
+  it('拆分：非数组输入防御性返回空结果；未知 id 不进入学习数据组', () => {
+    expect(splitLearningDataScopes(undefined as unknown as IdentityScopeInfo[])).toEqual({
+      learning: [],
+      others: []
+    })
+    const result = splitLearningDataScopes([scope('student.grades.read.only')])
+    expect(result.learning).toEqual([])
+    expect(result.others).toHaveLength(1)
+  })
+})
+
+describe('#699 勾选守卫：选中集合计算与全部取消阻断', () => {
+  const items = splitLearningDataScopes(bothScopes()).learning
+
+  it('默认全选：defaultLearningConsent 覆盖请求中全部学习数据项', () => {
+    const selected = defaultLearningConsent(items)
+    expect(selected.size).toBe(2)
+    for (const id of LEARNING_DATA_SCOPE_IDS) {
+      expect(selected.has(id)).toBe(true)
+    }
+    // 全选时可批准
+    expect(resolveLearningConsent(items, selected)).toEqual({
+      canApprove: true,
+      allRevoked: false,
+      someRevoked: false
+    })
+  })
+
+  it('部分取消：不可批准（Core 只接受全集，取消项不得进入批准范围）', () => {
+    const selected = defaultLearningConsent(items)
+    selected.delete('student.grades.read')
+    const state = resolveLearningConsent(items, selected)
+    expect(state.canApprove).toBe(false)
+    expect(state.someRevoked).toBe(true)
+    expect(state.allRevoked).toBe(false)
+    // 部分取消提示不含「仍会提交」类扩大授权表述
+    const notice = learningConsentNotice(state)
+    expect(notice).not.toContain('仍会')
+    expect(notice).toContain('整体授予')
+  })
+
+  it('全部取消：阻断守卫 + 冻结文案「该应用要求的数据权限已被取消，无法继续」', () => {
+    const state = resolveLearningConsent(items, new Set())
+    expect(state.canApprove).toBe(false)
+    expect(state.allRevoked).toBe(true)
+    expect(state.someRevoked).toBe(false)
+    expect(learningConsentNotice(state)).toBe('该应用要求的数据权限已被取消，无法继续')
+  })
+
+  it('请求不含学习数据项：不参与勾选逻辑，维持原有批准路径', () => {
+    expect(resolveLearningConsent([], new Set())).toEqual({
+      canApprove: true,
+      allRevoked: false,
+      someRevoked: false
+    })
+    expect(learningConsentNotice({ canApprove: true, allRevoked: false, someRevoked: false })).toBe('')
+  })
+
+  it('健壮性：选中集合包含未知 id 或非 Set 输入时不误判为已选', () => {
+    const polluted = new Set([...items.map((item) => item.id), 'unknown.scope'])
+    expect(resolveLearningConsent(items, polluted).canApprove).toBe(true)
+    // 全部未知 id：等于全部未勾选
+    expect(resolveLearningConsent(items, new Set(['unknown.scope'])).allRevoked).toBe(true)
+    // 非 Set 输入（如 undefined）：fail closed，视为全部取消
+    expect(
+      resolveLearningConsent(items, undefined as unknown as ReadonlySet<string>).canApprove
+    ).toBe(false)
+  })
+})

--- a/apps/client/src/features/identity/learningDataConsent.ts
+++ b/apps/client/src/features/identity/learningDataConsent.ts
@@ -1,0 +1,118 @@
+// src/features/identity/learningDataConsent.ts
+//
+// #699：授权弹窗「学习数据 scope 逐项勾选」纯函数（无 Vue 依赖，可单测）。
+//
+// 服务端能力约束（#699 调查结论，决定本模块守卫语义）：
+//   - Core approve API body 为 strict 白名单（device_id/issued_at/nonce/signature/
+//     canonical_version），不接受任何 scopes/rejected 字段；
+//   - canonical 的 scope_hash 由服务端从请求快照 requested_scopes 重算（不信任客户端），
+//     resume 阶段 Grant 也按快照全量下发 —— 即当前 Core 只支持「全集批准」。
+// 因此：只要存在被取消的学习数据项，就绝不能提交批准（否则取消项会随全集
+// 进入批准范围 = 静默扩大授权）。本模块把该约束实现为可单测的纯函数守卫。
+
+import type { IdentityScopeInfo } from './types'
+
+/** 学习数据 scope id（#699 冻结集合，顺序即展示顺序） */
+export const LEARNING_DATA_SCOPE_IDS = ['student.grades.read', 'student.timetable.read'] as const
+
+export type LearningDataScopeId = (typeof LEARNING_DATA_SCOPE_IDS)[number]
+
+/**
+ * #699 冻结文案映射（逐字遵守；App 端固定使用，不依赖服务端 label）。
+ */
+export const LEARNING_DATA_SCOPE_LABELS: Record<LearningDataScopeId, string> = {
+  'student.grades.read': '全部成绩单（含各学期成绩与绩点）',
+  'student.timetable.read': '完整课表'
+}
+
+/** 学习数据项的展示模型（id + 冻结文案） */
+export interface LearningDataScopeItem {
+  id: LearningDataScopeId
+  label: string
+}
+
+/** 拆分结果：学习数据项（按冻结顺序）与其余 scope（维持现有展示方式） */
+export interface SplitLearningDataScopesResult {
+  learning: LearningDataScopeItem[]
+  others: IdentityScopeInfo[]
+}
+
+/**
+ * 从请求 scopes 中拆出学习数据项与其余 scope：
+ * - 学习数据项只认冻结 id 集合，展示顺序按冻结顺序、文案用冻结映射（逐字遵守）；
+ * - 其余 scope 原样保留原顺序，交回现有 IdentityScopeList 展示。
+ */
+export const splitLearningDataScopes = (
+  scopes: IdentityScopeInfo[]
+): SplitLearningDataScopesResult => {
+  const list = Array.isArray(scopes) ? scopes : []
+  const requested = new Set(list.map((scope) => scope.id))
+  const learning: LearningDataScopeItem[] = []
+  for (const id of LEARNING_DATA_SCOPE_IDS) {
+    if (requested.has(id)) {
+      learning.push({ id, label: LEARNING_DATA_SCOPE_LABELS[id] })
+    }
+  }
+  const learningIds = new Set<string>(learning.map((item) => item.id))
+  return {
+    learning,
+    others: list.filter((scope) => !learningIds.has(scope.id))
+  }
+}
+
+/** 默认全选（#699：勾选状态仅存组件内存，不持久化） */
+export const defaultLearningConsent = (
+  learning: LearningDataScopeItem[]
+): Set<string> => new Set<string>(learning.map((item) => item.id))
+
+/** 勾选守卫状态（由选中集合计算得出） */
+export interface LearningConsentState {
+  /**
+   * 是否可提交批准：仅当请求不含学习数据项、或全部学习数据项均被勾选。
+   * 当前 Core 只接受全集批准（见文件头），存在任何取消项都不可提交。
+   */
+  canApprove: boolean
+  /** 请求含学习数据项且全部被取消 */
+  allRevoked: boolean
+  /** 请求含学习数据项且取消了部分（非全部） */
+  someRevoked: boolean
+}
+
+/**
+ * 选中集合计算 + 提交守卫：
+ * - 未勾选任何不存在于请求中的多余 id 不影响判定（健壮性：忽略未知 id）；
+ * - allRevoked 时 UI 应阻断提示「该应用要求的数据权限已被取消，无法继续」。
+ */
+export const resolveLearningConsent = (
+  requested: LearningDataScopeItem[],
+  selected: ReadonlySet<string>
+): LearningConsentState => {
+  const total = Array.isArray(requested) ? requested.length : 0
+  if (total === 0) {
+    // 请求不含学习数据项：勾选逻辑不参与，维持原有批准路径
+    return { canApprove: true, allRevoked: false, someRevoked: false }
+  }
+  let checkedCount = 0
+  for (const item of requested) {
+    if (selected instanceof Set && selected.has(item.id)) checkedCount += 1
+  }
+  return {
+    canApprove: checkedCount === total,
+    allRevoked: checkedCount === 0,
+    someRevoked: checkedCount > 0 && checkedCount < total
+  }
+}
+
+/**
+ * 取消项提示文案（UI 直接插值；与 resolveLearningConsent 一一对应）：
+ * - 全部取消：任务冻结文案，逐字遵守；
+ * - 部分取消：如实说明「需整体授予」，引导用户恢复勾选或拒绝整个授权，
+ *   绝不出现「仍会提交/未生效也会授予」类表述（不允许静默扩大授权）。
+ */
+export const learningConsentNotice = (state: LearningConsentState): string => {
+  if (state.allRevoked) return '该应用要求的数据权限已被取消，无法继续'
+  if (state.someRevoked) {
+    return '应用申请的学习数据权限需要整体授予：已取消的项目无法单独排除。请重新勾选，或选择「拒绝」取消本次授权。'
+  }
+  return ''
+}


### PR DESCRIPTION
## TL;DR

App 授权弹窗对学习数据 scope 支持「逐项勾选」（Refs #699 的 App 端部分，父 #697）。**重要产品决策说明见下。**

## 关键调查结论

经查 Core approve 提交体为 strict 白名单（device_id/issued_at/nonce/signature/canonical_version），scope_hash 由服务端从请求快照全量重算——**Core 不支持部分 scope 批准**，claims 的 rejected 参数只是 provider 标准签名、非上报通道。

## 所选实现（诚实替代路线）

勾选状态驱动真实可批准性：
- 默认全选；取消任意一项 → 「允许」按钮禁用并内联说明（全部取消：「该应用要求的数据权限已被取消，无法继续」；部分取消：「学习数据权限需整体授予……请重新勾选或拒绝」）
- **任何路径下都不会出现「取消了某项但该项被授予」的静默扩大授权**
- 未来 Core 若支持 subset 批准，仅需放开守卫函数

## 改动

- 新增 `features/identity/learningDataConsent.ts`：冻结文案映射/scope 拆分/默认全选/守卫（纯函数可单测）
- `IdentityApprovalOverlay.vue`：学习数据两项独立勾选区块；其余 scope 走现有列表
- 新增 spec 8 用例；identity 相关 **88 tests passed** 无回归；coordinators 40 passed

## 验收证据

vue-tsc 通过；vitest identity + coordinators 全绿；样式仅新增 scoped 类

Refs #699
关联 #697