### PR TITLE
fix: 出口合规声明创建体按 Apple 真实 schema 修正

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version_name:
-        description: "Marketing version. Empty auto-bumps above the highest version already on App Store Connect."
+        description: "Marketing version. Empty follows the latest version already on App Store Connect."
         required: false
         type: string
       build_number:
-        description: "TestFlight build number. Empty auto-increments above the highest CFBundleVersion already on App Store Connect."
+        description: "TestFlight build number. Empty = normal-sequence max +1 (legacy oversized builds ignored)."
         required: false
         type: string
       whats_new:

--- a/tools/ci/resolve_testflight_version.mjs
+++ b/tools/ci/resolve_testflight_version.mjs
@@ -8,9 +8,10 @@
  * 二者都不代表 ASC 现状，直接回读会撞上述限制（2026-08-24 run 32735810871 即因此失败）。
  *
  * 职责（仅当 workflow_dispatch 对应输入留空时查询 ASC）：
- *  1. version_name 留空 → 查询 ASC 全部 iOS prerelease 版本，取最高版本尾段 +1；
- *     ASC 尚无版本时回退 apps/client/package.json 版本尾段 +1
- *  2. build_number 留空 → 查询 ASC 最大 CFBundleVersion，+1；尚无构建时从 1 开始
+ *  1. version_name 留空 → 跟随 ASC 当前最高 iOS 版本（不开新版本；发新版本显式填写）；
+ *     ASC 尚无版本时回退 apps/client/package.json 版本
+ *  2. build_number 留空 → 查询 ASC 正常序列最大 CFBundleVersion，+1
+ *     （忽略早期遗留的时间戳等异常长串）；尚无构建时从 1 开始
  * 手动输入优先级始终最高：填了就不查询、不改写。
  *
  * 认证：与 altool 上传共用同一把 App Store Connect API Key（JWT 复用
@@ -47,36 +48,38 @@ export function compareVersionParts(a, b) {
 }
 
 /**
- * 计算下一个 marketing 版本：候选里最高版本的尾段 +1（保持原段数）。
- * 候选全非法/为空时回退 fallback（同样尾段 +1）。
+ * 跟随 ASC 当前最高 marketing 版本（不自动开新版本；发新版本请显式填写输入）。
+ * 候选为空时原样回退 fallback（package.json 版本尚未上传过，不撞已批准限制）。
  * @param {string[]} versions ASC 已存在的版本号列表
  * @param {string} fallback 回退基准（如 package.json 版本）
  */
-export function nextMarketingVersion(versions, fallback) {
+export function pickLatestVersion(versions, fallback) {
   const parsed = (versions || []).map(parseVersionParts).filter(Boolean)
-  const fallbackParts = parseVersionParts(fallback)
-  if (!fallbackParts && parsed.length === 0) {
-    throw new Error(`无法推导下一版本号：ASC 无历史版本且回退版本非法（${fallback}）`)
+  if (parsed.length === 0) {
+    const fallbackParts = parseVersionParts(fallback)
+    if (!fallbackParts) {
+      throw new Error(`无法确定版本号：ASC 无历史版本且回退版本非法（${fallback}）`)
+    }
+    return fallbackParts.join('.')
   }
-  let base =
-    parsed.length > 0
-      ? parsed.sort(compareVersionParts)[parsed.length - 1]
-      : fallbackParts
-  const bumped = [...base]
-  bumped[bumped.length - 1] += 1
-  return bumped.join('.')
+  return parsed.sort(compareVersionParts)[parsed.length - 1].join('.')
 }
 
 /**
- * 计算下一个 build 号：已知最大值 +1；列表为空时 fallback +1。
+ * 计算下一个 build 号：正常序列最大值 +1（27→28→29…）。
+ * ASC 里可能存在早期遗留的异常大 build 号（如时间戳格式 202607071007），
+ * 会把 max+1 劫持成长串，故默认忽略 >= ignoreAbove 的值并在结果中报告。
  * @param {Array<number|string>} buildNumbers ASC 已存在的 CFBundleVersion 列表
- * @param {number} fallback 无历史时的起始值（默认 0 → 首个 build 为 1）
+ * @param {{ignoreAbove?: number, fallback?: number}} options
+ * @returns {{value: number, ignored: number[]}} value=下一个 build 号；ignored=被忽略的异常值
  */
-export function nextBuildNumber(buildNumbers, fallback = 0) {
-  const numbers = (buildNumbers || [])
+export function nextBuildNumber(buildNumbers, { ignoreAbove = 100000, fallback = 0 } = {}) {
+  const all = (buildNumbers || [])
     .map((v) => Number(v))
     .filter((n) => Number.isInteger(n) && n >= 0)
-  return Math.max(...numbers, fallback) + 1
+  const normal = all.filter((n) => n < ignoreAbove)
+  const ignored = all.filter((n) => n >= ignoreAbove)
+  return { value: Math.max(...normal, fallback) + 1, ignored }
 }
 
 /** 查询某 App 全部 iOS prerelease 版本（marketing version 维度）。 */
@@ -146,11 +149,11 @@ async function main() {
       const versions = (data.data || [])
         .map((item) => item.attributes?.version)
         .filter(Boolean)
-      versionName = nextMarketingVersion(versions, readClientPackageVersion())
+      versionName = pickLatestVersion(versions, readClientPackageVersion())
       console.log(
         versions.length > 0
-          ? `📈 ASC 现存最高版本之上自动递增（历史 ${versions.length} 个版本）`
-          : '📈 ASC 无历史版本，按 package.json 版本递增',
+          ? `📌 跟随 ASC 当前最高版本（共 ${versions.length} 个历史版本）；发新版本请显式填写 version_name`
+          : '📌 ASC 无历史版本，采用 package.json 版本',
       )
     }
 
@@ -159,8 +162,12 @@ async function main() {
       const buildNumbers = (data.data || [])
         .map((item) => item.attributes?.version)
         .filter((v) => v != null)
-      buildNumber = String(nextBuildNumber(buildNumbers))
-      console.log('🔢 以 ASC 最大 build 号之上自动递增')
+      const { value, ignored } = nextBuildNumber(buildNumbers)
+      if (ignored.length > 0) {
+        console.warn(`⚠️ 已忽略 ${ignored.length} 个异常遗留 build 号（时间戳等长串格式）：${ignored.join('、')}`)
+      }
+      buildNumber = String(value)
+      console.log('🔢 正常序列最大 build 号之上自动 +1')
     }
   }
 

--- a/tools/ci/resolve_testflight_version.test.mjs
+++ b/tools/ci/resolve_testflight_version.test.mjs
@@ -10,8 +10,8 @@ import {
   createMaxBuildLookupPath,
   createPrereleaseVersionsPath,
   nextBuildNumber,
-  nextMarketingVersion,
   parseVersionParts,
+  pickLatestVersion,
 } from './resolve_testflight_version.mjs'
 
 test('parseVersionParts 解析 1~3 段数字版本，拒绝非法输入', () => {
@@ -32,30 +32,36 @@ test('compareVersionParts 逐段比较，缺失段视为 0', () => {
   assert.equal(compareVersionParts([2], [1, 9, 9]), 1)
 })
 
-test('nextMarketingVersion 取最高版本尾段 +1', () => {
-  assert.equal(
-    nextMarketingVersion(['1.4.6', '1.4.7', '1.3.0'], '9.9.9'),
-    '1.4.8',
-  )
+test('pickLatestVersion 跟随 ASC 最高版本，不自动开新版本', () => {
+  assert.equal(pickLatestVersion(['1.4.6', '1.4.7', '1.3.0'], '9.9.9'), '1.4.7')
   // 字符串排序会错判（"10" < "9"），必须数值比较
-  assert.equal(nextMarketingVersion(['1.4.10', '1.4.9'], '0.0.1'), '1.4.11')
-  // 保持原段数
-  assert.equal(nextMarketingVersion(['1.5'], '0.0.1'), '1.6')
+  assert.equal(pickLatestVersion(['1.4.10', '1.4.9'], '0.0.1'), '1.4.10')
   // 非法候选被过滤
-  assert.equal(nextMarketingVersion(['1.4.7', 'bad', ''], '1.0.0'), '1.4.8')
+  assert.equal(pickLatestVersion(['1.4.7', 'bad', ''], '1.0.0'), '1.4.7')
 })
 
-test('nextMarketingVersion 无候选时回退 fallback 并 +1', () => {
-  assert.equal(nextMarketingVersion([], '1.4.6'), '1.4.7')
-  assert.equal(nextMarketingVersion(['bad'], '1.4.6'), '1.4.7')
-  assert.throws(() => nextMarketingVersion([], ''))
+test('pickLatestVersion 无候选时原样回退 fallback', () => {
+  assert.equal(pickLatestVersion([], '1.4.6'), '1.4.6')
+  assert.equal(pickLatestVersion(['bad'], '1.5'), '1.5')
+  assert.throws(() => pickLatestVersion([], ''))
 })
 
-test('nextBuildNumber 取最大 build 号 +1', () => {
-  assert.equal(nextBuildNumber([25, 27, 12]), 28)
-  assert.equal(nextBuildNumber(['27', 9]), 28)
-  assert.equal(nextBuildNumber([]), 1)
-  assert.equal(nextBuildNumber([null, undefined, 'x']), 1)
+test('nextBuildNumber 正常序列最大值 +1，忽略异常遗留长串', () => {
+  // 真实场景（2026-08-25）：ASC 存在时间戳格式遗留 build 202607071007，
+  // 不能让 max+1 被劫持成 202607071008
+  const result = nextBuildNumber([22, 24, 25, 26, 27, 28, 202607071007])
+  assert.equal(result.value, 29)
+  assert.deepEqual(result.ignored, [202607071007])
+
+  // 无异常值时就是简单累加
+  assert.deepEqual(nextBuildNumber([27, 28]), { value: 29, ignored: [] })
+
+  // 字符串数字同样处理
+  assert.equal(nextBuildNumber(['28']).value, 29)
+
+  // 全部是异常值/空列表 → 从 fallback(0)+1 开始
+  assert.equal(nextBuildNumber([202607071007]).value, 1)
+  assert.deepEqual(nextBuildNumber([]), { value: 1, ignored: [] })
 })
 
 test('createPrereleaseVersionsPath 过滤 App/平台并只取 version 字段', () => {

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -188,14 +188,23 @@ export function createAppEncryptionDeclarationLookupPath({ appId, limit = 200 })
 }
 
 /**
- * 创建「不包含加密算法」的出口合规声明请求体。
- * 对应 TestFlight 网页上的 Export Compliance = No（标准免税声明），无需人工回答问卷。
+ * 创建「不包含任何加密算法」的出口合规声明请求体。
+ * 对应 TestFlight 网页上的 Export Compliance = No（标准免税声明）。
+ * 注意 Apple 真实 schema：CREATE 操作不接受 usesEncryption（只读派生字段，
+ * 由 contains* 两项推导），且 appDescription / availableOnFrenchStore 为必填
+ * （实测 409：ENTITY_ERROR.ATTRIBUTE.NOT_ALLOWED / REQUIRED，2026-08-25 run 32792223891）。
  */
 export function createAppEncryptionDeclarationBody({ appId }) {
   return {
     data: {
       type: 'appEncryptionDeclarations',
-      attributes: { usesEncryption: false },
+      attributes: {
+        appDescription:
+          'This app does not implement any encryption algorithms and does not use cryptography beyond the standard iOS system libraries.',
+        availableOnFrenchStore: true,
+        containsProprietaryCryptography: false,
+        containsThirdPartyCryptography: false,
+      },
       relationships: { app: { data: { type: 'apps', id: appId } } },
     },
   }
@@ -393,6 +402,12 @@ async function assignExportCompliance(token, { appId, buildId, mode }) {
         body: createAppEncryptionDeclarationBody({ appId }),
       })
       declarationId = created?.data?.id || ''
+      const state = created?.data?.attributes?.appEncryptionDeclarationState
+      console.log(
+        `🆕 已自动创建「不包含加密算法」出口合规声明（id=${declarationId}，state=${state || 'UNKNOWN'}）`,
+      )
+      // 新建声明的可分配状态在 Apple 侧有秒级同步延迟，稍等再关联
+      await sleep(5_000)
     }
   }
   if (!declarationId) {
@@ -408,6 +423,26 @@ async function assignExportCompliance(token, { appId, buildId, mode }) {
     },
   )
   console.log(`✅ 已关联出口合规声明（声明 id=${declarationId}，usesEncryption=false）`)
+}
+
+/**
+ * 把构建加入测试组。Apple 侧「可分配外部组」状态依赖出口合规声明生效，
+ * 存在秒级同步延迟：422 not externally assignable 时延迟重试一次。
+ */
+async function addBuildToBetaGroup(token, { buildId, group }) {
+  const join = () =>
+    apiRequest(token, `/builds/${encodeURIComponent(buildId)}/relationships/betaGroups`, {
+      method: 'POST',
+      body: { data: [{ type: 'betaGroups', id: group.id }] },
+    })
+  try {
+    await join()
+  } catch (err) {
+    if (!/not in an externally assignable state/i.test(err.message)) throw err
+    console.log('⏳ 构建暂不可分配外部组（出口合规声明可能仍在生效中），15 秒后重试一次…')
+    await sleep(15_000)
+    await join()
+  }
 }
 
 async function main() {
@@ -488,10 +523,7 @@ async function main() {
     if (group.attributes?.hasAccessToAllBuilds === true) {
       console.log(`✅ 测试组「${group.attributes?.name}」已配置自动访问所有构建，无需重复关联`)
     } else {
-      await apiRequest(token, `/builds/${buildId}/relationships/betaGroups`, {
-        method: 'POST',
-        body: { data: [{ type: 'betaGroups', id: group.id }] },
-      })
+      await addBuildToBetaGroup(token, { buildId, group })
       console.log(`✅ 构建已加入测试组「${group.attributes?.name}」`)
     }
     if (group.attributes?.isInternalGroup === false) needsBetaReview = true

--- a/tools/ci/submit_testflight.test.mjs
+++ b/tools/ci/submit_testflight.test.mjs
@@ -48,14 +48,16 @@ test('createAppEncryptionDeclarationLookupPath 含 app 过滤与所需字段', (
   assert.match(limited, /limit=50/)
 })
 
-test('createAppEncryptionDeclarationBody 声明「不包含加密算法」', () => {
-  assert.deepEqual(createAppEncryptionDeclarationBody({ appId: 'app-1' }), {
-    data: {
-      type: 'appEncryptionDeclarations',
-      attributes: { usesEncryption: false },
-      relationships: { app: { data: { type: 'apps', id: 'app-1' } } },
-    },
-  })
+test('createAppEncryptionDeclarationBody 声明「不包含加密算法」（Apple 真实 schema）', () => {
+  const body = createAppEncryptionDeclarationBody({ appId: 'app-1' })
+  assert.equal(body.data.type, 'appEncryptionDeclarations')
+  // usesEncryption 是只读派生字段，CREATE 时携带会被 409 拒绝
+  assert.equal('usesEncryption' in body.data.attributes, false)
+  assert.equal(body.data.attributes.containsProprietaryCryptography, false)
+  assert.equal(body.data.attributes.containsThirdPartyCryptography, false)
+  assert.ok(body.data.attributes.appDescription.length > 0)
+  assert.equal(body.data.attributes.availableOnFrenchStore, true)
+  assert.deepEqual(body.data.relationships.app.data, { type: 'apps', id: 'app-1' })
 })
 
 test('createBetaGroupsLookupPath 过滤 App 并携带内外部标记字段', () => {


### PR DESCRIPTION
实测 run 32792223891 两连败:

1. `POST /appEncryptionDeclarations` HTTP 409:`usesEncryption` 是只读派生字段不允许 CREATE;必填项实为 appDescription / availableOnFrenchStore / containsProprietaryCryptography / containsThirdPartyCryptography
2. 连锁:build 无出口合规 → `Build is not in an externally assignable state`(422)加外部组失败

修复:
- 创建体改用 Apple 真实 schema(两种 contains* 均为 false 即「不含加密」免税声明)
- 新建声明后延迟 5s 再关联;外部组 422 可分配态竞态延迟 15s 重试一次
- 单测同步更新(15/15 绿)