### PR TITLE
fix(#721): dev 构建 keyring 库 DEBUG 日志降噪（level_for 降为 Warn）

### DIFF
--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -94,20 +94,26 @@ pub fn run() {
 
     // #671 线上可观测性：文件日志（LogDir）+ stdout（dev 可见）。release 版 stderr 被
     // windows_subsystem 丢弃，关键链路（identity / credential_store）必须有落盘日志。
-    // 级别策略：debug 全量 Debug；release 默认 Warn，identity/credential_store 模块放宽 Info。
-    // 第三方 keyring 每次 Entry::new/get_password 都打 DEBUG（#721），dev 启动期
-    // 信封主密钥批量读取会连发几十条刷屏；降为 Warn 只保留异常告警。
+    // 级别策略：release 默认 Warn（identity / credential_store 放宽 Info）；dev 全局
+    // 只开 Info —— 第三方 crate 的内部 DEBUG 是刷屏主源（#721 实测 selectors /
+    // html5ever / cookie_store / keyring 占文件日志 95% 左右，cookie_store 还会把
+    // Set-Cookie 明文落盘），统一压到 Info 上限；自家代码按最具体前缀优先原则，
+    // 通过 hbut_helper 前缀覆盖保持全量 Debug。
     // 单文件 1MB，保留最近 3 份（KeepSome）。
+    let mut log_plugin = tauri_plugin_log::Builder::new()
+        .level(if cfg!(debug_assertions) {
+            log::LevelFilter::Info
+        } else {
+            log::LevelFilter::Warn
+        })
+        .level_for("hbut_helper::identity", log::LevelFilter::Info)
+        .level_for("hbut_helper::credential_store", log::LevelFilter::Info);
+    #[cfg(debug_assertions)]
+    {
+        log_plugin = log_plugin.level_for("hbut_helper", log::LevelFilter::Debug);
+    }
     let builder = builder.plugin(
-        tauri_plugin_log::Builder::new()
-            .level(if cfg!(debug_assertions) {
-                log::LevelFilter::Debug
-            } else {
-                log::LevelFilter::Warn
-            })
-            .level_for("hbut_helper::identity", log::LevelFilter::Info)
-            .level_for("hbut_helper::credential_store", log::LevelFilter::Info)
-            .level_for("keyring", log::LevelFilter::Warn)
+        log_plugin
             .max_file_size(1_000_000)
             .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3))
             .targets([

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -95,6 +95,8 @@ pub fn run() {
     // #671 线上可观测性：文件日志（LogDir）+ stdout（dev 可见）。release 版 stderr 被
     // windows_subsystem 丢弃，关键链路（identity / credential_store）必须有落盘日志。
     // 级别策略：debug 全量 Debug；release 默认 Warn，identity/credential_store 模块放宽 Info。
+    // 第三方 keyring 每次 Entry::new/get_password 都打 DEBUG（#721），dev 启动期
+    // 信封主密钥批量读取会连发几十条刷屏；降为 Warn 只保留异常告警。
     // 单文件 1MB，保留最近 3 份（KeepSome）。
     let builder = builder.plugin(
         tauri_plugin_log::Builder::new()
@@ -105,6 +107,7 @@ pub fn run() {
             })
             .level_for("hbut_helper::identity", log::LevelFilter::Info)
             .level_for("hbut_helper::credential_store", log::LevelFilter::Info)
+            .level_for("keyring", log::LevelFilter::Warn)
             .max_file_size(1_000_000)
             .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(3))
             .targets([


### PR DESCRIPTION
## 概述

修复 #721：dev 构建（`npx tauri dev`）启动与运行期间，第三方 crate 的内部 DEBUG 日志刷屏控制台与文件日志。实测当前 `mini-hbut.log`（4430 行）中第三方 DEBUG 占比 95%+：

| 来源 | 条数 | 内容 |
|------|------|------|
| `selectors::matching` | 1760 | 网页抓取时逐元素 CSS 匹配日志 |
| `cookie_store::cookie_store` | 1248 | **每次插入 Cookie 打印完整 Set-Cookie 明文（含会话值落盘）** |
| `html5ever::tree_builder` | 1113 | HTML 解析逐 token 日志（含页面正文片段） |
| `keyring` | 186 | 每次凭据读写三行一组（issue 原始报告项） |

## 变更策略：反转黑白名单

与其对每个第三方 crate 逐一 `level_for` 点名（打地鼠、新依赖还会复发），改为：

- **dev 全局级别 Debug → Info**：所有第三方 crate 的内部 DEBUG 一次性静音（Info/Warn 以上仍可见）；
- **自家代码按最具体前缀优先原则放开**：debug 构建下追加 `.level_for("hbut_helper", Debug)`，自有模块可观测性与原先完全一致；`identity` / `credential_store` 维持既有 Info 收敛不变；
- release 策略完全不变（默认 Warn + 两模块 Info 放宽）。

## 测试

- [x] `cargo check` 通过（44 个警告均为 main 已存在）
- [x] PR Gate / test-rust / test-rust-windows / test-rust-macos 全绿
- [ ] dev 实测：下次 `npx tauri dev` 确认文件日志无第三方 DEBUG 刷屏、自有模块日志照常输出

Closes #721