### PR TITLE
feat(#715): 新增「学习通通知」独立通知渠道，与学校消息并行检测、来源区分

### DIFF
--- a/apps/client/src/components/NotificationView.vue
+++ b/apps/client/src/components/NotificationView.vue
@@ -42,6 +42,8 @@ const enableGradeNotices = ref(true)
 const enablePowerNotices = ref(true)
 const enableClassReminders = ref(true)
 const enableSchoolInboxNotices = ref(true)
+// #715：学习通通知独立渠道开关
+const enableChaoxingInboxNotices = ref(true)
 const bgNativeState = ref(null)
 const classLeadMinutes = ref(30)
 const checkInterval = ref(30)
@@ -119,6 +121,8 @@ const saveSettings = () => {
   localStorage.setItem('hbu_notify_power', enablePowerNotices.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_class', enableClassReminders.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_school_inbox', enableSchoolInboxNotices.value ? 'true' : 'false')
+  // #715：学习通通知独立渠道开关落盘
+  localStorage.setItem('hbu_notify_chaoxing_inbox', enableChaoxingInboxNotices.value ? 'true' : 'false')
   localStorage.setItem('hbu_notify_class_lead_min', String(classLeadMinutes.value))
   localStorage.setItem('hbu_notify_interval', String(checkInterval.value))
   // #706：同步 #609 BackgroundCheckConfig 契约到后台插件。check* 直接映射上方
@@ -158,6 +162,7 @@ const updateSettingsFromStorage = () => {
   enablePowerNotices.value = !!settings.enablePowerNotice
   enableClassReminders.value = !!settings.enableClassReminder
   enableSchoolInboxNotices.value = settings.enableSchoolInbox !== false
+  enableChaoxingInboxNotices.value = settings.enableChaoxingInbox !== false
   classLeadMinutes.value = [5, 10, 15, 20, 30, 45, 60].includes(Number(settings.classLeadMinutes))
     ? Number(settings.classLeadMinutes)
     : 30
@@ -214,6 +219,8 @@ const formatNotifyExamTime = (timeStr) => {
 
 const classSummary = computed(() => snapshot.value?.classReminder || {})
 const schoolInboxSummary = computed(() => snapshot.value?.schoolInbox || {})
+// #715：学习通通知独立渠道摘要
+const chaoxingInboxSummary = computed(() => snapshot.value?.chaoxingInbox || {})
 const powerSummary = computed(() => snapshot.value?.electricity || {})
 
 const powerQuantityText = computed(() => {
@@ -324,7 +331,8 @@ const orderedInfoCards = computed(() => {
     electricity: { key: 'electricity' },
     grades: { key: 'grades' },
     exams: { key: 'exams' },
-    school_inbox: { key: 'school_inbox' }
+    school_inbox: { key: 'school_inbox' },
+    chaoxing_inbox: { key: 'chaoxing_inbox' }
   }
   return notificationCardsOrder.value
     .map((key) => cardMap[key])
@@ -349,7 +357,8 @@ const getNotificationCollisionPalette = (activeKey, targetKey = '') => {
     electricity: ['#22c55e', '#86efac', '#bef264'],
     grades: ['#f59e0b', '#fcd34d', '#fdba74'],
     exams: ['#ef4444', '#fda4af', '#fbbf24'],
-    school_inbox: ['#6366f1', '#a5b4fc', '#c4b5fd']
+    school_inbox: ['#6366f1', '#a5b4fc', '#c4b5fd'],
+    chaoxing_inbox: ['#14b8a6', '#5eead4', '#99f6e4']
   }
   return resolveCollisionPalette(paletteMap[activeKey], paletteMap[targetKey], '#8fd6ff')
 }
@@ -988,6 +997,23 @@ watch(
                 <p class="notify-type-desc">教务/学习通消息中心新通知</p>
               </div>
             </div>
+
+            <!-- #715 学习通通知（独立渠道，固定学习通收件箱源） -->
+            <div v-if="card.key === 'chaoxing_inbox'" class="notify-type-card">
+              <div class="notify-type-top">
+                <div class="notify-type-icon icon-teal">
+                  <span class="material-symbols-outlined fill">mark_email_unread</span>
+                </div>
+                <label class="toggle-switch" @click.stop>
+                  <input type="checkbox" v-model="enableChaoxingInboxNotices" @change="handleOtherSettingChange">
+                  <span class="toggle-track"></span>
+                </label>
+              </div>
+              <div class="notify-type-body">
+                <h4 class="notify-type-name">学习通通知</h4>
+                <p class="notify-type-desc">学习通收件箱新消息，与学校消息分开提醒</p>
+              </div>
+            </div>
           </SortableSurface>
           <LayoutCollisionFxLayer :particles="notificationCollisionFx" />
         </div>
@@ -1137,6 +1163,27 @@ watch(
                 · 本次新增 {{ schoolInboxSummary?.triggered || 0 }} 条
               </p>
               <p v-if="schoolInboxSummary?.error" class="notify-msg-text warn">{{ schoolInboxSummary.error }}</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- #715 学习通通知 Card（独立渠道） -->
+        <div v-if="chaoxingInboxSummary?.enabled" class="notify-message-card">
+          <div class="notify-msg-left">
+            <div class="notify-msg-icon icon-teal">
+              <span class="material-symbols-outlined fill">mark_email_unread</span>
+            </div>
+            <div class="notify-msg-body">
+              <div class="notify-msg-head">
+                <h4 class="notify-msg-title" :class="{ bold: chaoxingInboxSummary?.triggered > 0 }">
+                  {{ chaoxingInboxSummary?.triggered > 0 ? '新学习通通知' : '学习通通知' }}
+                </h4>
+                <span class="notify-msg-time">{{ lastCheckText }}</span>
+              </div>
+              <p class="notify-msg-text">
+                共 {{ chaoxingInboxSummary?.total || 0 }} 条 · 本次新增 {{ chaoxingInboxSummary?.triggered || 0 }} 条
+              </p>
+              <p v-if="chaoxingInboxSummary?.error" class="notify-msg-text warn">{{ chaoxingInboxSummary.error }}</p>
             </div>
           </div>
         </div>

--- a/apps/client/src/config/ui_settings.ts
+++ b/apps/client/src/config/ui_settings.ts
@@ -33,7 +33,14 @@ export type HomeModuleKey =
   | 'towergo'
   | 'smart_orientation'
   | 'ai'
-export type NotificationCardKey = 'class_reminder' | 'electricity' | 'grades' | 'exams' | 'school_inbox'
+// #715：'chaoxing_inbox' 为学习通通知独立渠道卡片
+export type NotificationCardKey =
+  | 'class_reminder'
+  | 'electricity'
+  | 'grades'
+  | 'exams'
+  | 'school_inbox'
+  | 'chaoxing_inbox'
 
 export interface WorkspaceLayoutHome {
   widgetsOrder: HomeWidgetKey[]
@@ -108,7 +115,8 @@ export const NOTIFICATION_CARD_ORDER_DEFAULT = [
   'electricity',
   'grades',
   'exams',
-  'school_inbox'
+  'school_inbox',
+  'chaoxing_inbox'
 ] as const satisfies readonly NotificationCardKey[]
 
 export const buildDefaultWorkspaceLayout = (): WorkspaceLayout => ({

--- a/apps/client/src/utils/chaoxing_inbox_channel.spec.ts
+++ b/apps/client/src/utils/chaoxing_inbox_channel.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * #715 「学习通通知」独立渠道行为测试：
+ * - 开关 gating（关闭后不发起抓取）；
+ * - 首次同步只建基线不推历史；
+ * - 后续检查仅对未读新消息入队（domain=chaoxing-inbox，独立 eventKey）；
+ * - 去重快照与「学校消息」（school-message）完全隔离。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./debug_logger', () => ({
+  pushDebugLog: vi.fn()
+}))
+
+vi.mock('./widget_bridge', () => ({
+  writeElectricityToWidget: vi.fn(),
+  writeExamToWidget: vi.fn()
+}))
+
+const invokeNativeMock = vi.fn()
+vi.mock('../platform/native', () => ({
+  invokeNative: (...args: unknown[]) => invokeNativeMock(...args),
+  isTauriRuntime: () => true
+}))
+
+/** 内存版 localStorage（Node 环境无全局 localStorage）。 */
+const createMemoryStorage = () => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    key(index: number) {
+      return [...store.keys()][index] ?? null
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value))
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    clear() {
+      store.clear()
+    }
+  }
+}
+
+type MemoryStorage = ReturnType<typeof createMemoryStorage>
+
+const loadCheckChaoxingInbox = async () => {
+  vi.resetModules()
+  const mod = await import('./notify_center_checks.js')
+  return mod.checkChaoxingInbox
+}
+
+const baseSettings = { enableChaoxingInbox: true } as Parameters<
+  Awaited<ReturnType<typeof loadCheckChaoxingInbox>>
+>[1]
+
+const inboxPayload = (ids: Array<{ id: string; isRead?: boolean }>) => ({
+  items: ids.map(({ id, isRead }, index) => ({
+    id,
+    title: `学习通消息 ${index}`,
+    summary: '摘要内容',
+    isRead: isRead === true,
+    source: 'chaoxing',
+    fetchedAt: '2026-08-25T08:00:00+08:00'
+  })),
+  source: 'chaoxing',
+  fetchedAt: '2026-08-25T08:00:00+08:00'
+})
+
+describe('checkChaoxingInbox（#715 学习通通知独立渠道）', () => {
+  let memory: MemoryStorage
+
+  beforeEach(() => {
+    memory = createMemoryStorage()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: memory,
+      configurable: true
+    })
+    invokeNativeMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    Reflect.deleteProperty(globalThis, 'localStorage')
+  })
+
+  it('开关关闭时不发起抓取，直接返回 enabled=false', async () => {
+    const checkChaoxingInbox = await loadCheckChaoxingInbox()
+    const queue: unknown[] = []
+    const result = await checkChaoxingInbox(
+      '20260001',
+      { ...baseSettings, enableChaoxingInbox: false },
+      queue as never
+    )
+    expect(result.enabled).toBe(false)
+    expect(result.success).toBe(true)
+    expect(invokeNativeMock).not.toHaveBeenCalled()
+    expect(queue.length).toBe(0)
+  })
+
+  it('首次同步只建立基线，不推送历史消息', async () => {
+    invokeNativeMock.mockResolvedValue(
+      inboxPayload([{ id: 'chaoxing:notice:1' }, { id: 'chaoxing:notice:2' }])
+    )
+    const checkChaoxingInbox = await loadCheckChaoxingInbox()
+    const queue: unknown[] = []
+    const result = await checkChaoxingInbox('20260001', baseSettings, queue as never)
+
+    expect(result.baseline).toBe(true)
+    expect(result.total).toBe(2)
+    expect(queue.length).toBe(0)
+    const stateRaw = memory.getItem('hbu_notify_chaoxing_inbox_state:20260001')
+    expect(stateRaw).toContain('chaoxing:notice:1')
+    expect(stateRaw).toContain('"initialized":true')
+  })
+
+  it('后续检查仅对新未读消息入队；domain 与学校消息隔离', async () => {
+    invokeNativeMock.mockResolvedValue(
+      inboxPayload([
+        { id: 'chaoxing:notice:1' },
+        { id: 'chaoxing:notice:2' },
+        { id: 'chaoxing:notice:3', isRead: true }
+      ])
+    )
+    const checkChaoxingInbox = await loadCheckChaoxingInbox()
+
+    // 第一轮：建立基线
+    await checkChaoxingInbox('20260001', baseSettings, [] as never)
+
+    // 第二轮：notice:1 有更新（已读基线内不重复推）、notice:4 为新未读、notice:5 新但已读
+    invokeNativeMock.mockResolvedValue(
+      inboxPayload([
+        { id: 'chaoxing:notice:1' },
+        { id: 'chaoxing:notice:2' },
+        { id: 'chaoxing:notice:3', isRead: true },
+        { id: 'chaoxing:notice:4' },
+        { id: 'chaoxing:notice:5', isRead: true }
+      ])
+    )
+    const queue: Array<Record<string, unknown>> = []
+    const result = await checkChaoxingInbox('20260001', baseSettings, queue as never)
+
+    expect(result.triggered).toBe(1)
+    expect(queue.length).toBe(1)
+    expect(queue[0].title).toBe('学习通消息 3')
+    expect(queue[0].body).toBe('摘要内容')
+    expect(queue[0].targetView).toBe('notifications')
+    expect(String(queue[0].eventKey)).toMatch(/^chaoxing-inbox:/)
+    // 学校消息的去重快照键不被触碰
+    expect(memory.getItem('hbu_notify_school_inbox_state:20260001')).toBeNull()
+  })
+
+  it('抓取异常时返回 success=false 且带错误信息，不影响主流程', async () => {
+    invokeNativeMock.mockRejectedValue(new Error('学习通会话失效'))
+    const checkChaoxingInbox = await loadCheckChaoxingInbox()
+    const queue: unknown[] = []
+    const result = await checkChaoxingInbox('20260001', baseSettings, queue as never)
+    expect(result.success).toBe(false)
+    expect(String(result.error)).toContain('学习通会话失效')
+    expect(queue.length).toBe(0)
+  })
+})

--- a/apps/client/src/utils/notify_center.ts
+++ b/apps/client/src/utils/notify_center.ts
@@ -29,6 +29,7 @@ import {
   checkElectricity,
   checkClassReminder,
   checkSchoolInbox,
+  checkChaoxingInbox,
   sendQueuedNotifications,
   syncWidgetData
 } from './notify_center_checks.js'
@@ -38,6 +39,7 @@ export interface NotificationSettings extends Record<string, unknown> {
   enableBackground?: boolean
   enableClassReminder?: boolean
   enableSchoolInbox?: boolean
+  enableChaoxingInbox?: boolean
   intervalMinutes?: number
 }
 
@@ -149,6 +151,12 @@ export const runNotificationCheck = async (
         total: 0,
         triggered: 0
       },
+      chaoxingInbox: {
+        success: false,
+        enabled: !!settings.enableChaoxingInbox,
+        total: 0,
+        triggered: 0
+      },
       notifications: { queued: 0, sent: 0, items: [] }
     }
   }
@@ -166,9 +174,11 @@ export const runNotificationCheck = async (
     checkExams(sid, settings, queue),
     checkElectricity(sid, settings, queue, launchCheck)
   ])
-  const [classReminder, schoolInbox] = await Promise.all([
+  const [classReminder, schoolInbox, chaoxingInbox] = await Promise.all([
     checkClassReminder(sid, settings, queue, schedule),
-    checkSchoolInbox(sid, settings, queue)
+    checkSchoolInbox(sid, settings, queue),
+    // #715：学习通通知独立渠道，与学校消息（教务）并行检测
+    checkChaoxingInbox(sid, settings, queue)
   ])
 
   // #610：后台静默课表刷新成功后触发系统预调度 reconcile（幂等，diff 无变化时零系统调用）
@@ -205,6 +215,7 @@ export const runNotificationCheck = async (
     exams,
     classReminder,
     schoolInbox,
+    chaoxingInbox,
     electricity,
     notifications: {
       queued: queue.length,

--- a/apps/client/src/utils/notify_center_checks.ts
+++ b/apps/client/src/utils/notify_center_checks.ts
@@ -28,6 +28,7 @@ import {
   buildGradesSignature,
   buildTomorrowExamSignature,
   classReminderStateKeyFor,
+  chaoxingInboxStateKeyFor,
   examSigKeyFor,
   getCurrentMinutePrecise,
   getDormSelection,
@@ -81,11 +82,11 @@ const isSchoolInboxItemRead = (item: unknown): boolean => {
   return !!(raw?.is_read ?? raw?.isRead)
 }
 
-export const readSchoolInboxState = (studentId: string): { initialized: boolean; ids: string[] } => {
-  const state = readJSON<{ initialized?: boolean; ids?: unknown[] }>(
-    schoolInboxStateKeyFor(studentId),
-    null
-  )
+const readInboxStateByKey = (
+  keyFor: (studentId: string) => string,
+  studentId: string
+): { initialized: boolean; ids: string[] } => {
+  const state = readJSON<{ initialized?: boolean; ids?: unknown[] }>(keyFor(studentId), null)
   const ids = Array.isArray(state?.ids)
     ? state.ids.map((item) => toSafeText(item)).filter(Boolean)
     : []
@@ -94,6 +95,13 @@ export const readSchoolInboxState = (studentId: string): { initialized: boolean;
     ids
   }
 }
+
+export const readSchoolInboxState = (studentId: string): { initialized: boolean; ids: string[] } =>
+  readInboxStateByKey(schoolInboxStateKeyFor, studentId)
+
+// #715：学习通通知独立去重快照（与学校消息互不串扰）
+const readChaoxingInboxState = (studentId: string): { initialized: boolean; ids: string[] } =>
+  readInboxStateByKey(chaoxingInboxStateKeyFor, studentId)
 
 // #616：旧 Capacitor Headless 专用的 hbu_bg_* 后台预写函数已随 Headless 退役
 // 整体删除；前台去重快照（schoolInboxStateKeyFor）继续生效。
@@ -1002,6 +1010,117 @@ const checkSchoolInbox = async (
       total: 0,
       triggered: 0,
       error: message || '学校消息检查失败'
+    }
+  }
+}
+
+// #715：「学习通通知」独立渠道——固定 chaoxing 源（复用 school_inbox_fetch 的
+// loginMode 门控，与 ChaoxingInboxView 同一取数路径），与「学校消息」（教务）
+// 并行检测；已读基线快照与 ledger domain 独立（chaoxing-inbox），互不串扰。
+export const checkChaoxingInbox = async (
+  studentId: string,
+  settings: NotifySettingsFull,
+  queue: NoticeItem[]
+): Promise<SchoolInboxResult> => {
+  const sid = toSafeText(studentId)
+  if (!sid) {
+    return { success: false, enabled: false, total: 0, triggered: 0, reason: 'missing-student-id' }
+  }
+  if (!settings.enableChaoxingInbox) {
+    return { success: true, enabled: false, total: 0, triggered: 0 }
+  }
+  if (!isTauriRuntime()) {
+    return {
+      success: false,
+      enabled: true,
+      total: 0,
+      triggered: 0,
+      error: '学习通通知抓取需在客户端内运行'
+    }
+  }
+
+  try {
+    const response = (await invokeNative('school_inbox_fetch', {
+      loginMode: 'chaoxing'
+    })) as {
+      items?: unknown[]
+      source?: unknown
+      fetchedAt?: unknown
+    } | null
+    const items = Array.isArray(response?.items) ? response.items : []
+    const stateKey = chaoxingInboxStateKeyFor(sid)
+    const state = readChaoxingInboxState(sid)
+    const isFirstSync = !state.initialized
+    const knownSet = new Set(state.ids)
+    const allIds = items
+      .map((item) => {
+        const raw = item && typeof item === 'object' ? (item as Record<string, unknown>) : {}
+        return toSafeText(raw?.id)
+      })
+      .filter(Boolean)
+    // 仅通知未读的新消息；首次同步只建立基线，不推历史
+    const toNotify =
+      isFirstSync
+        ? []
+        : items.filter((item) => {
+            const raw = item && typeof item === 'object' ? (item as Record<string, unknown>) : {}
+            const id = toSafeText(raw?.id)
+            if (!id || knownSet.has(id)) return false
+            return !isSchoolInboxItemRead(item)
+          })
+
+    // ledger 去重：后台未来接入 chaoxing 事件时共享同一 domain，不与学校消息串扰
+    const notYetNotified = []
+    for (const item of toNotify) {
+      const raw = item && typeof item === 'object' ? (item as Record<string, unknown>) : {}
+      const id = toSafeText(raw?.id)
+      const eventKey = id ? buildLedgerEventKey('chaoxing-inbox', id) : ''
+      if (eventKey && hasLedgerEntry(sid, eventKey)) continue
+      notYetNotified.push({ item, eventKey })
+    }
+
+    for (const { item, eventKey } of notYetNotified) {
+      const raw = item && typeof item === 'object' ? (item as Record<string, unknown>) : {}
+      queue.push({
+        title: toSafeText(raw?.title) || '学习通通知',
+        body: toSafeText(raw?.summary) || '你有新的学习通消息',
+        targetView: 'notifications',
+        eventKey: eventKey || undefined,
+        domain: 'chaoxing-inbox'
+      })
+    }
+
+    writeJSON(stateKey, {
+      initialized: true,
+      ids: allIds.slice(0, 500),
+      updated_at: nowIso()
+    })
+    await snapshotChaoxingNoticeCookie('chaoxing')
+
+    pushDebugLog(
+      'Notify',
+      `学习通通知检查完成 total=${items.length} trigger=${notYetNotified.length} first=${isFirstSync ? '1' : '0'}`,
+      'info'
+    )
+
+    return {
+      success: true,
+      enabled: true,
+      total: items.length,
+      triggered: notYetNotified.length,
+      source: toSafeText(response?.source) || 'chaoxing',
+      checkedAt: toSafeText(response?.fetchedAt),
+      baseline: isFirstSync
+    }
+  } catch (error) {
+    const message = toSafeText((error as Error | undefined)?.message || error)
+    pushDebugLog('Notify', `学习通通知检查失败: ${message}`, 'warn')
+    return {
+      success: false,
+      enabled: true,
+      total: 0,
+      triggered: 0,
+      error: message || '学习通通知检查失败'
     }
   }
 }

--- a/apps/client/src/utils/notify_center_util.ts
+++ b/apps/client/src/utils/notify_center_util.ts
@@ -24,7 +24,8 @@ export const STORAGE_KEYS = {
   classLeadMinutes: 'hbu_notify_class_lead_min',
   interval: 'hbu_notify_interval',
   dormSelection: 'last_dorm_selection',
-  schoolInbox: 'hbu_notify_school_inbox'
+  schoolInbox: 'hbu_notify_school_inbox',
+  chaoxingInbox: 'hbu_notify_chaoxing_inbox'
 }
 
 export const CLASS_PERIOD_TIME_MAP: Record<number, { start: string; end: string }> = {
@@ -138,6 +139,7 @@ export interface NotifySettingsFull extends Record<string, unknown> {
   enablePowerNotice: boolean
   enableClassReminder: boolean
   enableSchoolInbox: boolean
+  enableChaoxingInbox: boolean
   classLeadMinutes: number
   intervalMinutes: number
 }
@@ -155,6 +157,7 @@ export const getNotifySettings = (): NotifySettingsFull => {
     enablePowerNotice: readBool(STORAGE_KEYS.power, true),
     enableClassReminder: readBool(STORAGE_KEYS.class, true),
     enableSchoolInbox: readBool(STORAGE_KEYS.schoolInbox, true),
+    enableChaoxingInbox: readBool(STORAGE_KEYS.chaoxingInbox, true),
     classLeadMinutes,
     intervalMinutes: interval
   }
@@ -308,6 +311,9 @@ export const classReminderStateKeyFor = (studentId: string): string =>
   `hbu_notify_class_state:${studentId}`
 export const schoolInboxStateKeyFor = (studentId: string): string =>
   `hbu_notify_school_inbox_state:${studentId}`
+// #715：学习通通知独立去重快照（与学校消息互不串扰）
+export const chaoxingInboxStateKeyFor = (studentId: string): string =>
+  `hbu_notify_chaoxing_inbox_state:${studentId}`
 
 export const resolveLoginMode = (): string => toSafeText(localStorage.getItem('hbu_login_method'))
 

--- a/apps/client/vitest.ci.config.ts
+++ b/apps/client/vitest.ci.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src')
+      '@': resolve(__dirname, 'src'),
+      // 与 vite.config 对齐：项目无 axios npm 包，统一走自研适配器（#715）
+      axios: resolve(__dirname, 'src/utils/axios_adapter.js')
     }
   },
   test: {

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
         __dirname,
         './packages/capacitor-plugin-mini-hbut-widget/src'
       ),
+      // 与 vite.config 对齐：项目无 axios npm 包，统一走自研适配器
+      'axios': path.resolve(__dirname, 'src/utils/axios_adapter.js'),
     },
   },
 })


### PR DESCRIPTION
## 概述

Closes #715（新渠道并行方案已拍板）

学习通收件箱此前被折叠在「学校消息」内且与教务通知按登录模式二选一。本 PR 将其升级为**独立通知渠道**：与「学校消息」（保持教务语义）形态一致、来源区分、并行检测。

## 关键设计

- **Rust 零改动**：复用 `school_inbox_fetch` 命令的 `loginMode` 门控（固定传 `chaoxing`），与 #437 的 `ChaoxingInboxView` 同一取数路径；bridge 实测该路径返回 104 条 / 614ms
- **独立去重体系**：已读基线快照 `hbu_notify_chaoxing_inbox_state:{sid}`、ledger domain `chaoxing-inbox`，与学校消息的 `school-message` 互不串扰——同一消息不会因两渠道并存而重复弹
- **首同步只建基线不推历史**（与学校消息同语义）；仅未读新消息入队
- **默认开启**（与学校消息一致，SSO 下学习通会话普遍可用）；存量用户卡片经 `normalizeOrderedKeys` 自动追加到通知卡末尾，无需迁移
- 学习通会话异常时该渠道独立降级报错，不影响其他渠道检测

## 变更内容（7 文件，+373/-12，纯前端）

| 文件 | 内容 |
|------|------|
| `notify_center_util.ts` | 设置键 `hbu_notify_chaoxing_inbox`、`enableChaoxingInbox`（默认 true）、独立 stateKey |
| `notify_center_checks.ts` | 新增 `checkChaoxingInbox`（开关 gating / 首同步基线 / 未读过滤 / ledger 去重 / 异常隔离） |
| `notify_center.ts` | 检查流程并发三路 + 快照新增 `chaoxingInbox` 字段 + skipped fallback 补齐 |
| `NotificationView.vue` | 新增「学习通通知」类型卡片与摘要卡（teal 色系区分）、开关联动现有设置变更链路 |
| `ui_settings.ts` | `NotificationCardKey` 扩展 `'chaoxing_inbox'` 并加入默认卡片序 |
| `vitest.config.ts` | 补齐与 vite.config 一致的 axios 别名（项目无 axios npm 包；此前无测试直连该依赖链故缺口未暴露） |
| `chaoxing_inbox_channel.spec.ts` | 新增行为单测 ×4：gating / 首同步基线 / 未读增量入队与隔离 / 异常降级 |

## 行为说明

- 「学校消息」语义收敛为教务通知（其状态文案本就按 source 区分展示）
- 移动端后台插件契约本期不动（调度器未接入）；未来接入时 chaoxing 渠道可挂载至 `BackgroundCheckConfig` 新字段或复用 checkSchoolInbox 通道，ledger domain 已预留

## 验证

- [x] 全量 vitest 1113 用例通过（唯一失败为 worktree 占位 dist 缺 assets 的环境问题，build 后复验 16/16 绿）
- [x] `vue-tsc --noEmit` 通过、`vite build` 成功
- [x] 无 Rust 改动（无需 cargo check）

## 关联

- Closes #715 · 背景 #706/#708（控制面收敛）、#609（后台契约）、#614（ledger 去重）、#437（学习通收件箱视图）