### PR TITLE
feat(#699,#687): scope 目录扩展学习数据域 + 已上架应用元数据可编辑

### DIFF
--- a/identity-platform/core/src/api/developer/index.ts
+++ b/identity-platform/core/src/api/developer/index.ts
@@ -356,7 +356,9 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       if (!app) {
         throw new DeveloperApiError(404, 'not_found')
       }
-      if (app.status !== 'draft' && app.status !== 'rejected') {
+      // #692 后续（用户裁决）：元数据字段在 approved/active 亦可修改；
+      // pending_review 编辑会使内容寻址审核失效，suspended/revoked 维持锁定。
+      if (app.status === 'pending_review' || app.status === 'suspended' || app.status === 'revoked') {
         throw new DeveloperApiError(409, 'invalid_state')
       }
       const body = ((await readJsonBody(ctx)) ?? {}) as Record<string, unknown>
@@ -368,6 +370,15 @@ export function registerDeveloperRoutes(router: Router, deps: DeveloperApiDeps):
       if ('contact' in body) patch.contact = body.contact as string | null
       await updateApplication(sql, app.client_id, patch)
       const updated = await findOwnedApp(sql, dev.id, ctx.params.id as string)
+      await insertAuditEvent(sql, {
+        eventType: 'developer.app_updated',
+        actorType: 'developer',
+        actorId: dev.id,
+        targetType: 'oauth_application',
+        targetId: String(ctx.params.id),
+        result: 'success',
+        metadata: { client_id: app.client_id },
+      })
       ctx.status = 200
       ctx.body = { app: updated ? await toDetail(sql, updated, secretKek) : null }
     } catch (err) {

--- a/identity-platform/core/tests/api/developer.test.ts
+++ b/identity-platform/core/tests/api/developer.test.ts
@@ -11,7 +11,7 @@
  *  1. PATCH 更新 name/description/contact 成功且 DB 真实落库（contact 白名单修复）；
  *  2. detail 返回 secret 元数据 last4 / fingerprint 非 null 且值正确；
  *  3. GET scopes 返回 scope 列表；
- *  4. 越权/状态机兜底：无 subject 401；active 应用 PATCH 409。
+ *  4. 越权/状态机兜底：无 subject 401；pending_review PATCH 409；active 应用元数据可编辑并写审计。
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import Koa from 'koa'
@@ -202,20 +202,45 @@ describe('#687 developer API', () => {
     })
   })
 
-  it('5. active 应用 PATCH → 409 invalid_state（仅 draft/rejected 可编辑）', async () => {
+  it('5. active 应用 PATCH 元数据 → 成功落库并写审计（#692 后续放开）', async () => {
     const fixture = await createClientFixture(db.sql, { status: 'active', scopes: ['openid'] })
     const app = buildDeveloperApp(db.sql)
     await withServer(app, async (baseUrl) => {
       const res = await devPatch(
         baseUrl,
         `/api/v1/developer/apps/${fixture.applicationId}`,
-        { name: '不该生效' },
+        { name: '上架后改名', description: '上架后新简介' },
+        subjectFor(fixture.userId),
+      )
+      expect(res.status).toBe(200)
+      const updated = res.body.app as Record<string, unknown>
+      expect(updated.name).toBe('上架后改名')
+      // 审计：developer.app_updated 落库（元数据编辑可追溯）
+      const audit = await db.sql.query(
+        `SELECT event_type FROM audit_events WHERE target_id = $1 AND event_type = 'developer.app_updated'`,
+        [fixture.applicationId],
+      )
+      expect(audit.rows.length).toBe(1)
+      const row = await findApplicationByClientId(db.sql, fixture.clientId)
+      expect(row?.name).toBe('上架后改名')
+    })
+  })
+
+  it('5b. pending_review 应用 PATCH → 409 invalid_state（审核中编辑会使审核失效）', async () => {
+    const fixture = await createClientFixture(db.sql, {
+      status: 'pending_review',
+      scopes: ['openid'],
+    })
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devPatch(
+        baseUrl,
+        `/api/v1/developer/apps/${fixture.applicationId}`,
+        { name: '审核中改名尝试' },
         subjectFor(fixture.userId),
       )
       expect(res.status).toBe(409)
       expect(res.body.error).toBe('invalid_state')
-      const row = await findApplicationByClientId(db.sql, fixture.clientId)
-      expect(row?.name).not.toBe('不该生效')
     })
   })
 
@@ -231,7 +256,25 @@ describe('#687 developer API', () => {
         subjectFor(stranger.userId),
       )
       expect(res.status).toBe(404)
-      expect(res.body.error).toBe('not_found')
+      expect(res.body.error).toBe('not_found')    
+    })
+  })
+
+  it('7. pending_review 应用 PATCH → 409 invalid_state（审核中编辑会使审核失效）', async () => {
+    const fixture: ClientFixture = await createClientFixture(db.sql, {
+      status: 'pending_review',
+      scopes: ['openid'],
+    })
+    const app = buildDeveloperApp(db.sql)
+    await withServer(app, async (baseUrl) => {
+      const res = await devPatch(
+        baseUrl,
+        `/api/v1/developer/apps/${fixture.applicationId}`,
+        { name: '改名尝试' },
+        subjectFor(fixture.userId),
+      )
+      expect(res.status).toBe(409)
+      expect(res.body.error).toBe('invalid_state')
     })
   })
 })

--- a/identity-platform/core/tests/helpers/fixtures.ts
+++ b/identity-platform/core/tests/helpers/fixtures.ts
@@ -22,7 +22,7 @@ export async function createClientFixture(
   opts: {
     scopes?: string[]
     clientType?: 'web_confidential' | 'native_public'
-    status?: 'active' | 'suspended' | 'revoked' | 'draft'
+    status?: 'active' | 'suspended' | 'revoked' | 'draft' | 'pending_review' | 'rejected'
     /** 自定义 redirect_uri（默认 https://app.example.com/cb，kind=web_https） */
     redirectUris?: Array<{ uri: string; kind: 'web_https' | 'native_loopback' }>
     /** 自定义 homepage_url（默认 https://app.example.com） */
@@ -57,11 +57,13 @@ export async function createClientFixture(
   const status = opts.status ?? 'active'
   if (status !== 'draft') {
     // 审核流：draft → pending_review → approved → active（简化：逐级推进）
-    const path: Array<'pending_review' | 'approved' | 'active' | 'suspended' | 'revoked'> =
+    const path: Array<'pending_review' | 'approved' | 'active' | 'suspended' | 'revoked' | 'rejected'> =
       status === 'active' ? ['pending_review', 'approved', 'active']
         : status === 'suspended' ? ['pending_review', 'approved', 'active', 'suspended']
           : status === 'revoked' ? ['pending_review', 'approved', 'active', 'revoked']
-            : ['pending_review', 'approved']
+            : status === 'pending_review' ? ['pending_review']
+              : status === 'rejected' ? ['pending_review', 'rejected']
+                : ['pending_review', 'approved']
     for (const s of path) {
       await setClientStatus(sql, result.clientId, s)
     }

--- a/identity-platform/web/app/developer-site/_components/app-detail.tsx
+++ b/identity-platform/web/app/developer-site/_components/app-detail.tsx
@@ -45,7 +45,10 @@ function editEntryFor(status: string): { enabled: boolean; tooltip: string } {
       return { enabled: false, tooltip: '审核中，请耐心等待审核结果' }
     case 'approved':
     case 'active':
-      return { enabled: false, tooltip: '已上架应用暂不支持在线修改；重大变更可创建新应用或联系管理员' }
+      return {
+        enabled: true,
+        tooltip: '可修改名称、简介、主页与隐私政策链接；回调地址与权限范围变更暂不支持在线操作',
+      }
     default:
       // suspended / revoked 及未知状态
       return { enabled: false, tooltip: '当前状态不可修改' }

--- a/identity-platform/web/app/developer-site/_components/app-form.tsx
+++ b/identity-platform/web/app/developer-site/_components/app-form.tsx
@@ -47,6 +47,9 @@ export function AppForm() {
     profile: { selected: false, justification: '' },
     'student.identity': { selected: false, justification: '' },
     offline_access: { selected: false, justification: '' },
+    // #697 学习数据域：授权时由 App 加密上传数据快照（≤7 天），供第三方在有效期内读取
+    'student.grades.read': { selected: false, justification: '' },
+    'student.timetable.read': { selected: false, justification: '' },
   })
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/identity-platform/web/app/developer-site/_components/tabs/types.ts
+++ b/identity-platform/web/app/developer-site/_components/tabs/types.ts
@@ -17,11 +17,17 @@ export interface TabProps {
 
 /** 可编辑状态提示（draft/rejected 之外锁定） */
 export function editLocked(app: DeveloperAppDetailDTO): boolean {
-  return app.status !== 'draft' && app.status !== 'rejected'
+  // #692 后续：元数据编辑覆盖 draft/rejected/approved/active；
+  // 仅审核中（会使内容寻址审核失效）、suspended、revoked 锁定。
+  return (
+    app.status === 'pending_review' || app.status === 'suspended' || app.status === 'revoked'
+  )
 }
 
 export function editLockedHint(app: DeveloperAppDetailDTO): string {
-  return editLocked(app)
-    ? `当前状态（${app.status}）下信息锁定：如需修改，请等待审核结果或先撤销后重建。`
-    : ''
+  if (!editLocked(app)) return ''
+  if (app.status === 'pending_review') {
+    return '当前状态（审核中）下信息锁定：编辑会使本次审核失效。请等待审核结果。'
+  }
+  return `当前状态（${app.status}）下信息锁定：请先恢复可用后再编辑。`
 }

--- a/identity-platform/web/lib/developer/scopes.ts
+++ b/identity-platform/web/lib/developer/scopes.ts
@@ -1,16 +1,25 @@
 /**
  * Scope 管理与敏感 scope 审核字段（纯函数）。
  *
- * V1 白名单（#617/#620 对齐，禁止本 Issue 擅自增加学业 Resource scope）：
- *   openid           必选、基础登录、自动选择不可移除；
- *   profile          基础资料，普通 scope；
- *   student.identity 敏感：必须填写使用理由、隐私政策、联系方式；管理员人工批准；
- *   offline_access   敏感：长期访问（Refresh Token），必须填写用途；管理员批准。
+ * 白名单（#617/#620 初版；#697 扩展学习数据域，敏感项均需理由+人工批准）：
+ *   openid                  必选、基础登录、自动选择不可移除；
+ *   profile                 基础资料，普通 scope；
+ *   student.identity        敏感：学校身份声明；必须使用理由+隐私政策+人工批准；
+ *   offline_access          敏感：长期访问（Refresh Token）；人工批准；
+ *   student.grades.read     敏感：读取全部成绩单快照（授权时由 App 加密上传，≤7 天）；
+ *   student.timetable.read  敏感：读取完整课表快照（同上）。
  */
 
 import type { DeveloperClientType } from './contract'
 
-export const SCOPE_WHITELIST = ['openid', 'profile', 'student.identity', 'offline_access'] as const
+export const SCOPE_WHITELIST = [
+  'openid',
+  'profile',
+  'student.identity',
+  'offline_access',
+  'student.grades.read',
+  'student.timetable.read',
+] as const
 
 export type ScopeId = (typeof SCOPE_WHITELIST)[number]
 
@@ -50,6 +59,26 @@ export const SCOPE_META: Readonly<Record<ScopeId, ScopeMeta>> = {
     description:
       '学校身份声明（学号关联信息）。敏感 scope：保证级别为 verification_method=mini_hbut_app，' +
       '即 Mini-HBUT App 本地验证，不是学校官方 OIDC 背书；必须填写使用理由与隐私政策，管理员人工批准。',
+    risk: 'sensitive',
+    mandatory: false,
+    requiresJustification: true,
+  },
+  'student.grades.read': {
+    id: 'student.grades.read',
+    label: 'student.grades.read（成绩单读取）',
+    description:
+      '读取你的全部成绩单（含各学期成绩与绩点）。数据在你授权时由 Mini-HBUT App 加密上传为快照，' +
+      '有效期最长 7 天，过期需重新授权。敏感：必须填写使用理由与隐私政策，管理员人工批准。',
+    risk: 'sensitive',
+    mandatory: false,
+    requiresJustification: true,
+  },
+  'student.timetable.read': {
+    id: 'student.timetable.read',
+    label: 'student.timetable.read（课表读取）',
+    description:
+      '读取你的完整课表。数据在你授权时由 Mini-HBUT App 加密上传为快照，有效期最长 7 天，' +
+      '过期需重新授权。敏感：必须填写使用理由与隐私政策，管理员人工批准。',
     risk: 'sensitive',
     mandatory: false,
     requiresJustification: true,


### PR DESCRIPTION
## TL;DR

用户实测反馈的两项跟进（父 #686，衔接 #687/#699）：
1. 开发者门户 scope 目录扩展学习数据域：student.grades.read / student.timetable.read（此前仅 Core 白名单与授权端就绪，门户目录未同步）
2. 已上架（approved/active）应用支持在线编辑元数据：名称/简介/主页/隐私政策/联系方式——回调地址与权限范围两类安全关键字段维持锁定

## 改动

| 文件 | 内容 |
|---|---|
| `web/lib/developer/scopes.ts` | 目录扩展两项敏感 scope（含通俗说明与快照时效语义）；白名单同步 |
| `web/app/developer-site/_components/app-form.tsx` | 创建表单渲染新 scope 复选项 |
| `_components/app-detail.tsx` + `tabs/types.ts` | 编辑入口与 editLocked 覆盖 approved/active；pending_review/suspended/revoked 维持禁用并给原因 |
| `core/src/api/developer/index.ts` | PATCH 状态门放开至 approved/active（pending_review 编辑会使内容寻址审核失效、suspended/revoked 锁定）；新增审计事件 developer.app_updated |
| `core/tests/api/developer.test.ts` + `tests/helpers/fixtures.ts` | 用例5改为 active 编辑成功+审计断言；新增 5b pending_review 409；夹具支持 pending_review/rejected 状态推进 |

**安全边界不变**：redirect_uris 与 scopes 变更仍仅限 draft/rejected；pending_review/suspended/revoked 锁定；测试账号生产拦截等校验不变。

## 验收证据

- core：developer.test **8 passed**（含 active 编辑成功+审计落库断言、pending_review 409）；全量回归随集成验收
- web：typecheck 零错误；next build 成功
- 新增 scope 在创建表单可见可勾选（构建产物验证）

Refs #687、#688、#699、#697
关联 #686