### PR TITLE
fix: 出口合规声明仅系统加密表达 + iOS 最低版本升 15.0

### DIFF
--- a/apps/client/src-tauri/tauri.conf.json
+++ b/apps/client/src-tauri/tauri.conf.json
@@ -39,6 +39,9 @@
       "icons/icon.ico",
       "icons/icon.png"
     ],
+    "iOS": {
+      "minimumSystemVersion": "15.0"
+    },
     "windows": {
       "nsis": {
         "compression": "lzma",

--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -188,11 +188,14 @@ export function createAppEncryptionDeclarationLookupPath({ appId, limit = 200 })
 }
 
 /**
- * 创建「不包含任何加密算法」的出口合规声明请求体。
- * 对应 TestFlight 网页上的 Export Compliance = No（标准免税声明）。
- * 注意 Apple 真实 schema：CREATE 操作不接受 usesEncryption（只读派生字段，
- * 由 contains* 两项推导），且 appDescription / availableOnFrenchStore 为必填
- * （实测 409：ENTITY_ERROR.ATTRIBUTE.NOT_ALLOWED / REQUIRED，2026-08-25 run 32792223891）。
+ * 创建「不包含任何（自研）加密算法」的出口合规声明请求体。
+ * 对应 TestFlight 网页上 Export Compliance 问卷回答 No（标准免税声明）。
+ * Apple 数据模型（实测 2026-08-25 run 32794289891 两次 409 校准）：
+ *  - CREATE 不接受 usesEncryption（只读派生字段）；
+ *  - 不允许 containsProprietaryCryptography 与 containsThirdPartyCryptography
+ *    同时为 false（iOS 应用必然使用系统级加密，归入 third-party 一类）；
+ *  - 「无自研加密」的正确表达 = 仅系统加密（third-party=true）+ 法国可分发，
+ *    即美国/欧盟出口豁免（exemption）路径，无需逐次人工回答问卷。
  */
 export function createAppEncryptionDeclarationBody({ appId }) {
   return {
@@ -200,10 +203,10 @@ export function createAppEncryptionDeclarationBody({ appId }) {
       type: 'appEncryptionDeclarations',
       attributes: {
         appDescription:
-          'This app does not implement any encryption algorithms and does not use cryptography beyond the standard iOS system libraries.',
+          'This app does not implement any proprietary encryption algorithms; it only uses the standard iOS system cryptography libraries (e.g. HTTPS/TLS).',
         availableOnFrenchStore: true,
         containsProprietaryCryptography: false,
-        containsThirdPartyCryptography: false,
+        containsThirdPartyCryptography: true,
       },
       relationships: { app: { data: { type: 'apps', id: appId } } },
     },

--- a/tools/ci/submit_testflight.test.mjs
+++ b/tools/ci/submit_testflight.test.mjs
@@ -48,15 +48,16 @@ test('createAppEncryptionDeclarationLookupPath 含 app 过滤与所需字段', (
   assert.match(limited, /limit=50/)
 })
 
-test('createAppEncryptionDeclarationBody 声明「不包含加密算法」（Apple 真实 schema）', () => {
+test('createAppEncryptionDeclarationBody 声明「无自研加密」（Apple 真实 schema）', () => {
   const body = createAppEncryptionDeclarationBody({ appId: 'app-1' })
   assert.equal(body.data.type, 'appEncryptionDeclarations')
   // usesEncryption 是只读派生字段，CREATE 时携带会被 409 拒绝
   assert.equal('usesEncryption' in body.data.attributes, false)
+  // Apple 不允许双 false（iOS 应用必然使用系统级加密）：仅系统加密 = 免税路径
   assert.equal(body.data.attributes.containsProprietaryCryptography, false)
-  assert.equal(body.data.attributes.containsThirdPartyCryptography, false)
-  assert.ok(body.data.attributes.appDescription.length > 0)
+  assert.equal(body.data.attributes.containsThirdPartyCryptography, true)
   assert.equal(body.data.attributes.availableOnFrenchStore, true)
+  assert.ok(body.data.attributes.appDescription.length > 0)
   assert.deepEqual(body.data.relationships.app.data, { type: 'apps', id: 'app-1' })
 })
 


### PR DESCRIPTION
两件事：

**1. 出口合规声明第三次校准**（run 32794289835 实测）
Apple 拒绝双 `contains*=false` 的 CREATE：`Cannot create appEncryptionDeclarations unless either containsProprietaryCryptography is True or containsThirdPartyCryptography and availableOnFrenchStore are both True`。
网页问卷回答 No 的真实数据模型 = 仅系统加密（third-party=true）+ availableOnFrenchStore=true，即标准出口豁免。已按此修正。

**2. ITMS-90068 修复**
Apple 通知：2027 年春起 MinimumOSVersion 必须 ≥15.0。`bundle.iOS.minimumSystemVersion = "15.0"`（映射 IPHONEOS_DEPLOYMENT_TARGET，tauri ios init 时写入生成工程）。iOS 15 覆盖 iPhone 6s 及之后全部机型。

验证：node 单测 22 绿、契约 spec 22 绿、JSON 校验通过。