### PR TITLE
fix(#729): 学校消息页登录方式键缺失时降级 portal，不再误报要求重登

### DIFF
--- a/apps/client/src/components/SchoolInboxView.vue
+++ b/apps/client/src/components/SchoolInboxView.vue
@@ -9,6 +9,12 @@ import { TPageHeader, TEmptyState } from './templates'
 
 const LOGIN_METHOD_KEY = 'hbu_login_method'
 
+// #729：登录方式键仅由账号密码登录（LoginV3）/测试账号路径写入，OIDC 认证会话、
+// 设备授权等直登路径不产生该键但会话完全有效。键缺失时降级为 portal（教务通知，
+// 与 Rust 端空 login_mode 的默认分流一致），不再误报「请重新登录」阻断页面。
+const resolveInboxLoginMode = () =>
+  String(localStorage.getItem(LOGIN_METHOD_KEY) || '').trim() || 'portal'
+
 const props = defineProps({
   studentId: { type: String, required: true }
 })
@@ -111,11 +117,7 @@ const fetchMessages = async ({ force = false } = {}) => {
     return
   }
 
-  const loginMode = String(localStorage.getItem(LOGIN_METHOD_KEY) || '').trim()
-  if (!loginMode) {
-    error.value = '缺少登录方式，请重新登录'
-    return
-  }
+  const loginMode = resolveInboxLoginMode()
 
   if (force) {
     refreshing.value = true
@@ -144,8 +146,7 @@ const fetchMessages = async ({ force = false } = {}) => {
 const loadDetail = async (item) => {
   if (!isTauriRuntime() || !item?.id) return
 
-  const loginMode = String(localStorage.getItem(LOGIN_METHOD_KEY) || '').trim()
-  if (!loginMode) return
+  const loginMode = resolveInboxLoginMode()
 
   detailLoading.value = true
   markReadHint.value = ''
@@ -218,11 +219,7 @@ const markSelectedAsRead = async () => {
   if (!selectedItem.value || selectedItem.value.isRead || markingRead.value) return
   if (!isTauriRuntime()) return
 
-  const loginMode = String(localStorage.getItem(LOGIN_METHOD_KEY) || '').trim()
-  if (!loginMode) {
-    markReadHint.value = '缺少登录方式，请重新登录'
-    return
-  }
+  const loginMode = resolveInboxLoginMode()
 
   const itemId = selectedItem.value.id
   markingRead.value = true


### PR DESCRIPTION
## 概述

Closes #729

学校消息页把「localStorage 是否记录了登录方式（`hbu_login_method`）」当作「是否已登录」的判据，但该键仅在账号密码登录（LoginV3）/测试账号路径写入；经 OIDC 认证会话、多设备自绑定（#680）等直登路径进入的用户从不产生该键——会话与 cookie 完全正常却被误报「缺少登录方式，请重新登录」，且按提示重走非 LoginV3 登录也无法消除。

## 根因与修复（1 文件，+9/-12）

- **根因**：`SchoolInboxView.vue` 三处（列表 / 详情 / 标记已读）在键为空时直接阻断；而下游 Rust `fetch_school_inbox_ex` 对空 `login_mode` 本就容错（`unwrap_or_default()` → 教务通知源），前端拦截属多余防御
- **修复**：新增 `resolveInboxLoginMode()`——键存在时行为完全不变（chaoxing_* → 学习通源，其余 → 教务源）；缺失时降级 `'portal'` 继续执行，三处阻断与误导性文案移除
- 不改动登录/恢复链路本身（`attemptAutoRelogin` 的模式分支逻辑不受影响）

## 验证

- [x] `vue-tsc --noEmit` 通过、`vite build` 成功
- [x] `notification_delivery_contract.spec.ts` 19/19 绿（断言的是 invokeNative 调用结构，与本次改动兼容）
- [x] 键存在路径零改动：仅替换取值方式，分流逻辑未动

## 关联

- Closes #729 · 背景 #680（OIDC 直登）、#659（登录态解耦）