### PR TITLE
fix: build 豁免标记兜底出口合规（声明 CREATED 不会自动审批）

### DIFF
--- a/tools/ci/submit_testflight.mjs
+++ b/tools/ci/submit_testflight.mjs
@@ -196,6 +196,22 @@ export function createAppEncryptionDeclarationGetPath(declarationId) {
 }
 
 /**
+ * 把 build 标记为「仅使用非豁免加密之外的系统加密」（usesNonExemptEncryption=false）。
+ * 这是 ASC 网页上回答 Export Compliance = No 的直接等价动作：声明资源本身停在
+ * CREATED 不会被自动审批（实测 2026-08-25 run 32797202004 轮询 3 分钟无变化），
+ * 而 build 打上该标记后才满足「可分配外部组」状态。
+ */
+export function createBuildExemptionPatchBody({ buildId }) {
+  return {
+    data: {
+      type: 'builds',
+      id: buildId,
+      attributes: { usesNonExemptEncryption: false },
+    },
+  }
+}
+
+/**
  * 创建「不包含任何（自研）加密算法」的出口合规声明请求体。
  * 对应 TestFlight 网页上 Export Compliance 问卷回答 No（标准免税声明）。
  * Apple 数据模型（实测 2026-08-25 run 32794289891 两次 409 校准）：
@@ -426,21 +442,21 @@ async function assignExportCompliance(token, { appId, buildId, mode }) {
     return
   }
 
-  // Apple 对标准豁免声明自动审批：新建声明初始为 CREATED，需等它进入
-  // APPROVED 后 build 才满足「可分配外部组」状态（实测 2026-08-25 run 32796747072）
-  for (let attempt = 1; attempt <= 18; attempt++) {
+  // Apple 对新建声明不做自动审批（实测 run 32797202004 轮询 3 分钟恒为 CREATED），
+  // 短暂重查几次即可；真正让 build 可分配外部组的是下方对 build 的豁免标记。
+  for (let attempt = 1; attempt <= 6; attempt++) {
     const detail = await apiRequest(token, createAppEncryptionDeclarationGetPath(declarationId))
     const state = detail?.data?.attributes?.appEncryptionDeclarationState
     if (state === 'APPROVED') {
       console.log(`✅ 出口合规声明已生效（APPROVED，第 ${attempt} 次查询）`)
       break
     }
-    if (attempt === 18) {
-      console.warn(`⚠️ 声明状态仍为 ${state || 'UNKNOWN'}（等待超时），仍将尝试关联`)
-      break
+    if (attempt < 6) {
+      console.log(`⏳ 出口合规声明状态 ${state || 'UNKNOWN'}，10 秒后重查（${attempt}/6）…`)
+      await sleep(10_000)
+    } else {
+      console.warn(`⚠️ 声明状态仍为 ${state || 'UNKNOWN'}，改用 build 豁免标记兜底`)
     }
-    console.log(`⏳ 出口合规声明状态 ${state || 'UNKNOWN'}，10 秒后重查（${attempt}/18）…`)
-    await sleep(10_000)
   }
 
   await apiRequest(
@@ -452,6 +468,18 @@ async function assignExportCompliance(token, { appId, buildId, mode }) {
     },
   )
   console.log(`✅ 已关联出口合规声明（声明 id=${declarationId}）`)
+
+  // 网页问卷「不使用加密」的等价动作：直接给 build 打非豁免加密=false 标记
+  try {
+    await apiRequest(token, `/builds/${encodeURIComponent(buildId)}`, {
+      method: 'PATCH',
+      body: createBuildExemptionPatchBody({ buildId }),
+    })
+    console.log('✅ 已标记构建仅使用系统加密（usesNonExemptEncryption=false）')
+  } catch (err) {
+    // 个别账号/状态下 Apple 可能拒绝直改，降级告警：外部组投递会再给出明确报错
+    console.warn(`⚠️ 构建豁免标记失败：${err.message}`)
+  }
 }
 
 /**

--- a/tools/ci/submit_testflight.test.mjs
+++ b/tools/ci/submit_testflight.test.mjs
@@ -13,6 +13,7 @@ import {
   createBetaBuildLocalizationBody,
   createBetaGroupsLookupPath,
   createBuildEncryptionDeclarationLinkageBody,
+  createBuildExemptionPatchBody,
   createJwt,
   createPrereleaseBuildsPath,
   createPrereleaseLookupPath,
@@ -71,6 +72,16 @@ test('createAppEncryptionDeclarationGetPath 只取审批状态字段', () => {
     url.searchParams.get('fields[appEncryptionDeclarations]'),
     'appEncryptionDeclarationState',
   )
+})
+
+test('createBuildExemptionPatchBody 给 build 打「仅系统加密」豁免标记', () => {
+  assert.deepEqual(createBuildExemptionPatchBody({ buildId: 'b-7' }), {
+    data: {
+      type: 'builds',
+      id: 'b-7',
+      attributes: { usesNonExemptEncryption: false },
+    },
+  })
 })
 
 test('createBetaGroupsLookupPath 过滤 App 并携带内外部标记字段', () => {


### PR DESCRIPTION
run 32797202004 实测:新建 AppEncryptionDeclaration 轮询 3 分钟恒为 `CREATED`——Apple 不自动审批声明资源,加外部组仍 422。

修复:
- 关联声明后追加 `PATCH /builds/{id}` 设 `usesNonExemptEncryption=false`(网页问卷答 No 的直接等价动作,让 build 立即满足外部组可分配状态)
- 声明轮询缩短为 6 次(60s),超时降级为告警并走兜底
- 单测补 body 断言(node --test 全绿)