### PR TITLE
feat(#732): 近期消息中电费监控卡片前移至考试与学校消息之间

### DIFF
--- a/apps/client/src/components/NotificationView.vue
+++ b/apps/client/src/components/NotificationView.vue
@@ -1144,6 +1144,23 @@ watch(
           </div>
         </div>
 
+        <!-- Electricity Card（#732：前移至上课提醒/考试与学校消息之间） -->
+        <div v-if="powerSummary?.quantity != null" class="notify-message-card">
+          <div class="notify-msg-left">
+            <div class="notify-msg-icon icon-teal">
+              <span class="material-symbols-outlined fill">bolt</span>
+            </div>
+            <div class="notify-msg-body">
+              <div class="notify-msg-head">
+                <h4 class="notify-msg-title">电费监控</h4>
+                <span class="notify-msg-time">{{ powerStatusText }}</span>
+              </div>
+              <p class="notify-msg-text">剩余电量：{{ powerQuantityText }}</p>
+              <p v-if="powerSummary?.isDual" class="notify-msg-text">空调电量：{{ acPowerQuantityText }}</p>
+            </div>
+          </div>
+        </div>
+
         <!-- School Inbox Card -->
         <div v-if="schoolInboxSummary?.enabled" class="notify-message-card">
           <div class="notify-msg-left">
@@ -1184,23 +1201,6 @@ watch(
                 共 {{ chaoxingInboxSummary?.total || 0 }} 条 · 本次新增 {{ chaoxingInboxSummary?.triggered || 0 }} 条
               </p>
               <p v-if="chaoxingInboxSummary?.error" class="notify-msg-text warn">{{ chaoxingInboxSummary.error }}</p>
-            </div>
-          </div>
-        </div>
-
-        <!-- Electricity Card -->
-        <div v-if="powerSummary?.quantity != null" class="notify-message-card">
-          <div class="notify-msg-left">
-            <div class="notify-msg-icon icon-teal">
-              <span class="material-symbols-outlined fill">bolt</span>
-            </div>
-            <div class="notify-msg-body">
-              <div class="notify-msg-head">
-                <h4 class="notify-msg-title">电费监控</h4>
-                <span class="notify-msg-time">{{ powerStatusText }}</span>
-              </div>
-              <p class="notify-msg-text">剩余电量：{{ powerQuantityText }}</p>
-              <p v-if="powerSummary?.isDual" class="notify-msg-text">空调电量：{{ acPowerQuantityText }}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概述

Closes #732

通知页「近期消息」区块中，电费监控卡片原先排在最末（学习通通知之后）。本 PR 将其前移至「考试」与「学校消息」之间——落在提议者指定的「上课提醒与学校消息」区间内，且对既有相对顺序扰动最小。

## 变更内容（1 文件，纯模板位移）

- `components/NotificationView.vue`：Electricity Card 块整体移动，无任何脚本/样式改动
- 移动后顺序：成绩 → 上课提醒 → 考试 → **电费监控** → 学校消息 → 学习通通知
- 卡片视觉与交互保持现状（复用共享的 `notify-message-card` 体系，未新增 CSS）

## 验证

- [x] 模板注释序列确认新顺序生效
- [x] `vue-tsc --noEmit` 通过、`vite build` 成功
- [x] `notification_delivery_contract.spec.ts` + `bottom_tab_bar_safe_area.spec.ts` 35/35 绿（全量 vitest 本地此前同基线全绿，无顺序断言类测试受影响）
- [x] 电费卡内容（状态文案 / 剩余电量 / 空调电量双行）逐字未动

## 关联

- Closes #732 · 同区块背景 #715、#706/#708