### PR TITLE
fix(#708): 限流真实访客 IP——小黄云下优先读 CF-Connecting-IP

### DIFF
--- a/identity-platform/core/src/security/rate-limit.ts
+++ b/identity-platform/core/src/security/rate-limit.ts
@@ -198,7 +198,13 @@ export function rateLimitMiddleware(options: RateLimiterOptions): Middleware {
       return
     }
     try {
-      const decision = await checkRateLimit(options.sql, group, ctx.ip)
+      // #708：小黄云开启后 ctx.ip 是 Cloudflare 边缘 IP（全体访客共用），
+      // 必须优先读取 CF 附带的真实访客地址，否则限流会把所有人算成同一拨人误伤。
+      const realIp =
+        ctx.get('cf-connecting-ip') ||
+        (ctx.get('x-forwarded-for') || '').split(',')[0]?.trim() ||
+        ctx.ip
+      const decision = await checkRateLimit(options.sql, group, realIp)
       if (!decision.allowed) {
         ctx.status = 429
         ctx.set('Retry-After', String(decision.retryAfterSeconds))


### PR DESCRIPTION
## TL;DR

生产域名已开启 Cloudflare 小黄云（代理），后端限流此时看到的 `ctx.ip` 是 CF 边缘 IP（全体访客共用少数几个）——按 IP 分桶的限流会把所有真人算成同一拨人集体误伤。本修复让限流优先读取 CF 附带的真实访客地址。

## 改动

`security/rate-limit.ts` 限流取 IP 处：优先级 `CF-Connecting-IP` → `X-Forwarded-For` 首段 → `ctx.ip` 兜底。灰云/dev 场景无该头时行为与原先完全一致。

## 安全说明

- 直连源站伪造该头可绕过限流：当前架构请求必经 CF 代理（三域名均已点亮），实际暴露面可接受；后续可在边缘层校验来源网段
- 哈希截断 16 hex 不落原始 IP 的既有隐私约定不变

## 验收证据

- security 测试 **45 passed**；tsc 干净
- 集成树全量随最终验收报告

Refs #697（学习数据开放 epic 的前置依赖）、#686