### PR TITLE
feat(#708): 三敏感写动作接入 Turnstile 人机验证

### DIFF
--- a/identity-platform/web/app/developer-site/_components/api-keys.tsx
+++ b/identity-platform/web/app/developer-site/_components/api-keys.tsx
@@ -12,6 +12,9 @@
  * - mutation 一律带 x-csrf-token（双提交 Cookie，与 developer API 同机制）。
  */
 'use client'
+import { TurnstileField } from './turnstile-field'
+
+import { consumeTurnstileToken } from '@/lib/developer/turnstile-client'
 
 import { useEffect, useState } from 'react'
 import { ClientApiError, fetchMe } from './api'
@@ -45,6 +48,11 @@ async function keysRequest<T>(path: string, init?: { method?: string; body?: unk
   }
   if (init?.csrf) {
     headers['x-csrf-token'] = init.csrf
+  }
+  // #708：创建密钥属敏感写动作，附带一次性 Turnstile 令牌
+  const tt = consumeTurnstileToken()
+  if (tt) {
+    headers['x-turnstile-token'] = tt
   }
   const res = await fetch(path, {
     method: init?.method ?? 'GET',
@@ -217,6 +225,8 @@ export function ApiKeys() {
       <div className="dev-card">
         <h2>创建新密钥</h2>
         <p className="dev-hint">起一个好认的名字（比如「办公电脑」「CI 服务器」），方便以后管理。</p>
+        {/* #708 人机验证（申请密钥属敏感写动作） */}
+        <TurnstileField />
         <form onSubmit={(e) => void handleCreate(e)}>
           <div className="dev-field">
             <label htmlFor="api-key-name">密钥名称（必填）</label>

--- a/identity-platform/web/app/developer-site/_components/api.ts
+++ b/identity-platform/web/app/developer-site/_components/api.ts
@@ -58,6 +58,11 @@ async function request<T>(path: string, init?: RequestInit & { csrf?: string }):
   if (init?.csrf) {
     headers['x-csrf-token'] = init.csrf
   }
+  // #708：存在未消费的 Turnstile 令牌则自动附带（消费后置空，防重放）
+  const tt = consumeTurnstileToken()
+  if (tt) {
+    headers['x-turnstile-token'] = tt
+  }
   const res = await fetch(path, { ...init, headers, credentials: 'same-origin' })
   if (!res.ok) {
     let code = 'internal'
@@ -100,6 +105,8 @@ export async function fetchApp(id: string): Promise<DeveloperAppDetailDTO> {
   const data = await request<{ app: DeveloperAppDetailDTO }>(`/api/v1/developer/apps/${encodeURIComponent(id)}`)
   return data.app
 }
+
+import { consumeTurnstileToken } from '@/lib/developer/turnstile-client'
 
 export async function createApp(input: CreateAppInput, csrf: string): Promise<{ id: string; client_id: string; client_secret: string | null }> {
   return request<{ id: string; client_id: string; client_secret: string | null }>(

--- a/identity-platform/web/app/developer-site/_components/app-form.tsx
+++ b/identity-platform/web/app/developer-site/_components/app-form.tsx
@@ -8,6 +8,7 @@
  * 创建成功 → 先落 Draft；client_secret 一次性展示（仅此一次，刷新即失）。
  */
 'use client'
+import { TurnstileField } from './turnstile-field'
 
 import { useState } from 'react'
 import type { DeveloperClientType, RedirectUriKind } from '@/lib/developer/contract'
@@ -365,6 +366,8 @@ export function AppForm() {
       </div>
       )}
 
+      {/* #708 人机验证（站点钥匙未配置时不渲染） */}
+      <TurnstileField />
       <button type="button" className="dev-btn dev-btn-primary" disabled={busy} onClick={() => void handleSubmit()}>
         {busy ? '提交中…' : '创建应用（草稿）'}
       </button>

--- a/identity-platform/web/app/developer-site/_components/tabs/review.tsx
+++ b/identity-platform/web/app/developer-site/_components/tabs/review.tsx
@@ -3,6 +3,7 @@
  * 需修改项目 / 重新提交按钮。被拒绝时必须展示可行动的 review note（不只红色失败）。
  */
 'use client'
+import { TurnstileField } from '../turnstile-field'
 
 import { useState } from 'react'
 import { ClientApiError, submitApp } from '../api'
@@ -108,6 +109,8 @@ export function ReviewTab({ app, me, setApp, reload }: TabProps) {
           ) : (
             '确认信息无误后提交审核：'
           )}
+          {/* #708 人机验证（提交审核属敏感写动作） */}
+          <TurnstileField />
           <button type="button" className="dev-btn dev-btn-primary" disabled={busy} onClick={() => void handleSubmit()}>
             {busy ? '提交中…' : app.status === 'rejected' ? '重新提交审核' : '提交审核'}
           </button>

--- a/identity-platform/web/app/developer-site/_components/turnstile-field.tsx
+++ b/identity-platform/web/app/developer-site/_components/turnstile-field.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+/**
+ * #708 Turnstile 隐式组件占位：api.js 会自动渲染 class="cf-turnstile" 的元素，
+ * 回调把令牌写入 lib/developer/turnstile-client 的令牌仓；站点钥匙未配置时不渲染。
+ */
+const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ''
+
+export function TurnstileField() {
+  if (!SITE_KEY) return null
+  return (
+    <div
+      className="cf-turnstile"
+      data-sitekey={SITE_KEY}
+      data-callback="__mhTtSet"
+      data-theme="auto"
+    />
+  )
+}

--- a/identity-platform/web/app/developer-site/api/v1/developer/apps/[id]/submit/route.ts
+++ b/identity-platform/web/app/developer-site/api/v1/developer/apps/[id]/submit/route.ts
@@ -5,7 +5,8 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getDeveloperApi } from '@/lib/developer-api/client'
-import { developerErrorResponse, errorJson, guardMutation, jsonOk } from '@/lib/developer-api/bff'
+import { assertTurnstileFromRequest } from '@/lib/turnstile-server'
+import { developerErrorResponse, errorJson, guardMutation, noStoreJsonHeaders, jsonOk } from '@/lib/developer-api/bff'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,6 +14,15 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ id: st
   const session = guardMutation(request)
   if (session instanceof NextResponse) {
     return session
+  }
+
+  // #708 人机验证：敏感写动作必须通过 Turnstile 核验（未配置钥匙时跳过）
+  const turnstile = await assertTurnstileFromRequest(request)
+  if (!turnstile.ok) {
+    return NextResponse.json(
+      { error: 'turnstile_failed', message: turnstile.message },
+      { status: 400, headers: noStoreJsonHeaders() },
+    )
   }
   const { id } = await ctx.params
   try {

--- a/identity-platform/web/app/developer-site/api/v1/developer/apps/route.ts
+++ b/identity-platform/web/app/developer-site/api/v1/developer/apps/route.ts
@@ -7,10 +7,12 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { getDeveloperApi } from '@/lib/developer-api/client'
+import { assertTurnstileFromRequest } from '@/lib/turnstile-server'
 import {
   developerErrorResponse,
   errorJson,
   guardMutation,
+  noStoreJsonHeaders,
   jsonOk,
   requireSession,
 } from '@/lib/developer-api/bff'
@@ -35,6 +37,15 @@ export async function POST(request: NextRequest) {
   const session = guardMutation(request)
   if (session instanceof NextResponse) {
     return session
+  }
+
+  // #708 人机验证：敏感写动作必须通过 Turnstile 核验（未配置钥匙时跳过）
+  const turnstile = await assertTurnstileFromRequest(request)
+  if (!turnstile.ok) {
+    return NextResponse.json(
+      { error: 'turnstile_failed', message: turnstile.message },
+      { status: 400, headers: noStoreJsonHeaders() },
+    )
   }
   let raw: unknown
   try {

--- a/identity-platform/web/app/developer-site/api/v1/developer/keys/route.ts
+++ b/identity-platform/web/app/developer-site/api/v1/developer/keys/route.ts
@@ -5,12 +5,14 @@
  */
 
 import type { NextRequest } from 'next/server'
+import { assertTurnstileFromRequest } from '@/lib/turnstile-server'
 import { NextResponse } from 'next/server'
 import { getDeveloperKeysApi } from '@/lib/developer-api/account-client'
 import {
   developerErrorResponse,
   errorJson,
   guardMutation,
+  noStoreJsonHeaders,
   jsonOk,
   requireSession,
 } from '@/lib/developer-api/bff'
@@ -34,6 +36,15 @@ export async function POST(request: NextRequest) {
   const session = guardMutation(request)
   if (session instanceof NextResponse) {
     return session
+  }
+
+  // #708 人机验证：敏感写动作必须通过 Turnstile 核验（未配置钥匙时跳过）
+  const turnstile = await assertTurnstileFromRequest(request)
+  if (!turnstile.ok) {
+    return NextResponse.json(
+      { error: 'turnstile_failed', message: turnstile.message },
+      { status: 400, headers: noStoreJsonHeaders() },
+    )
   }
   let raw: unknown
   try {

--- a/identity-platform/web/app/developer-site/layout.tsx
+++ b/identity-platform/web/app/developer-site/layout.tsx
@@ -9,6 +9,7 @@ import { SESSION_COOKIE_NAME, decryptSession, isSessionValid } from '@/lib/auth-
 import { environmentLabel } from '@/lib/developer/issuer'
 import { OFFICIAL_IDENTITY_DOCS_URL } from '@/lib/developer/docs'
 import { LogoutButton } from './_components/logout-button'
+import Script from 'next/script'
 import './developer.css'
 
 export const dynamic = 'force-dynamic'
@@ -21,6 +22,11 @@ export default async function DeveloperSiteLayout({ children }: { children: Reac
 
   return (
     <div className="dev-shell">
+      {/* #708：Turnstile 人机验证脚本（创建应用 / 提交审核 / 申请 Key 三个敏感写动作的表单暗哨） */}
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+        strategy="afterInteractive"
+      />
       <header className="dev-header">
         <div className="dev-header-left">
           <a className="dev-brand" href="/">

--- a/identity-platform/web/lib/developer/turnstile-client.ts
+++ b/identity-platform/web/lib/developer/turnstile-client.ts
@@ -1,0 +1,20 @@
+/** #708 Turnstile 前端令牌中转：隐式组件回调写入 window，提交时消费（一次性）。 */
+
+export function setTurnstileToken(t: string | null): void {
+  if (typeof window === 'undefined') return
+  ;(window as unknown as { __mhTurnstileToken?: string | undefined }).__mhTurnstileToken =
+    t ?? undefined
+}
+
+export function consumeTurnstileToken(): string | null {
+  if (typeof window === 'undefined') return null
+  const w = window as unknown as { __mhTurnstileToken?: string | undefined }
+  const t = w.__mhTurnstileToken ?? null
+  w.__mhTurnstileToken = undefined
+  return t
+}
+
+if (typeof window !== 'undefined') {
+  ;(window as unknown as { __mhTtSet: (t: string) => void }).__mhTtSet = (t: string) =>
+    setTurnstileToken(t)
+}

--- a/identity-platform/web/lib/turnstile-server.ts
+++ b/identity-platform/web/lib/turnstile-server.ts
@@ -1,0 +1,38 @@
+/**
+ * #708 后续：Turnstile 服务端核验（developer-site 三个敏感写动作调用）。
+ *
+ * 策略：
+ *  - 未配置 TURNSTILE_SECRET_KEY（本地/测试）→ 跳过校验，零摩擦；
+ *  - 配置后：无 token / 校验失败 → ok:false（fail closed，400 turnstile_failed）；
+ *  - CF siteverify 自身不可达 → ok:false（提示稍后重试），不静默放行生产流量。
+ */
+export interface TurnstileVerdict {
+  ok: boolean
+  skipped: boolean
+  message?: string
+}
+
+export async function assertTurnstileFromRequest(request: Request): Promise<TurnstileVerdict> {
+  const secret = process.env.TURNSTILE_SECRET_KEY
+  if (!secret) {
+    return { ok: true, skipped: true }
+  }
+  const token = request.headers.get('x-turnstile-token') ?? ''
+  if (!token) {
+    return { ok: false, skipped: false, message: '缺少人机验证结果，请刷新页面重试' }
+  }
+  try {
+    const body = new URLSearchParams({ secret, response: token })
+    const ip = request.headers.get('cf-connecting-ip')
+    if (ip) body.set('remoteip', ip)
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body,
+    })
+    const j = (await res.json()) as { success?: boolean; 'error-codes'?: string[] }
+    if (j.success) return { ok: true, skipped: false }
+    return { ok: false, skipped: false, message: '人机验证未通过，请刷新页面后重试' }
+  } catch {
+    return { ok: false, skipped: false, message: '人机验证服务暂不可用，请稍后重试' }
+  }
+}


### PR DESCRIPTION
## TL;DR

三个敏感写动作（创建应用 / 提交审核 / 申请 API Key）接入 Cloudflare Turnstile 人机验证（父 #697，衔接已上线的限流真实 IP 修复 #734）。正常用户无感通过，脚本刷取被挡在表单层。

## 实现

| 层 | 内容 |
|---|---|
| 组件 | `_components/turnstile-field.tsx`：隐式托管模式组件，站点钥匙未配置时不渲染（本地/测试零摩擦） |
| 前端中转 | `lib/developer/turnstile-client.ts`：回调写入一次性令牌仓；api.ts request() 自动附带 `x-turnstile-token` 头（消费后置空防重放）；api-keys 页创建请求同样附带 |
| BFF 守卫 | 三个 POST 处理器（apps 创建 / submit 审核 / keys 签发）调用 `assertTurnstileFromRequest`：未配置 SECRET 时跳过（dev/test 零摩擦）；配置后无 token/校验失败 → 400 turnstile_failed |
| 布局 | layout 注入 CF api.js 脚本 |

**生产钥匙已通过 API 创建并写入 Vercel 生产环境变量**（NEXT_PUBLIC_TURNSTILE_SITE_KEY / TURNSTILE_SECRET_KEY），合并部署后即强制生效。

## 验收证据

- tsc --noEmit 零错误；next build 成功
- 覆盖三处：创建应用表单、审核 Tab 提交、API 密钥创建

Refs #697、#686