### PR TITLE
feat(#737): 用电趋势按时间升序排序并支持横向滚动查看全部历史月份

### DIFF
--- a/apps/client/src/components/ElectricityView.vue
+++ b/apps/client/src/components/ElectricityView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed, watch } from 'vue'
+import { ref, onMounted, computed, watch, nextTick } from 'vue'
 import axios from 'axios'
 import { setCachedData, fetchWithCache } from '../utils/api.js'
 import { qrToDataURL } from '../utils/qrcode.js'
@@ -468,9 +468,28 @@ const usageTab = ref('week')
 const selectedBarIdx = ref(-1)
 const chartReady = ref(false)
 
+// #737：一码通接口的周/月列表顺序不保证（月视图含电表开户以来全部月份），
+// 按标签中的数字段逐级数值比较做升序排序（如 2024-01 < 2024-10 < 2025-01），
+// 解析失败的字段保持原相对顺序（Array.sort 稳定）。
+const comparePointLabel = (a, b) => {
+  const extract = (p) =>
+    String(p?.label || p?.date || p?.fullLabel || '')
+      .match(/\d+/g)
+      ?.map(Number) ?? []
+  const na = extract(a)
+  const nb = extract(b)
+  const len = Math.max(na.length, nb.length)
+  for (let i = 0; i < len; i += 1) {
+    const va = na[i] ?? -1
+    const vb = nb[i] ?? -1
+    if (va !== vb) return va - vb
+  }
+  return 0
+}
+
 const mapPoints = (pts, short = true) => {
   if (!Array.isArray(pts)) return []
-  return pts.map((p) => {
+  return [...pts].sort(comparePointLabel).map((p) => {
     const full = String(p?.label || p?.date || p?.fullLabel || '—')
     const label = short
       ? full.replace(/^\d{4}-?/, '').slice(0, 5) || full
@@ -492,6 +511,15 @@ const monthPoints = computed(() =>
 const activePoints = computed(() =>
   usageTab.value === 'month' ? monthPoints.value : weekPoints.value
 )
+
+// #737：月视图数据多时图表横向滚动，加载/切换后默认停在最右（最新月份）
+const ibarRef = ref(null)
+watch([activePoints, chartReady], () => {
+  nextTick(() => {
+    const el = ibarRef.value
+    if (el) el.scrollLeft = el.scrollWidth
+  })
+})
 
 const chartMax = computed(() => {
   const vals = activePoints.value.map((p) => p.value)
@@ -1075,6 +1103,7 @@ watch(
             :class="{ ready: chartReady }"
             role="listbox"
             aria-label="用电柱图"
+            ref="ibarRef"
           >
             <button
               v-for="(p, i) in activePoints"

--- a/apps/client/src/styles/views/ElectricityView.scoped.css
+++ b/apps/client/src/styles/views/ElectricityView.scoped.css
@@ -147,10 +147,25 @@ html.dark .glass-card-warning {
   gap: 6px;
   height: 168px;
   padding-top: 4px;
+  /* #737：月视图含电表开户以来全部月份，数据多时横向滚动查看（柱子保最小宽不被压扁） */
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+.ibar::-webkit-scrollbar {
+  height: 6px;
+}
+.ibar::-webkit-scrollbar-thumb {
+  background: var(--md-sys-color-outline-variant, #c4c7c5);
+  border-radius: 3px;
+}
+.ibar::-webkit-scrollbar-track {
+  background: transparent;
 }
 .ibar-col {
-  flex: 1;
-  min-width: 0;
+  /* #737：flex-basis 保底 34px——空间富余时仍均分拉伸（周视图不出现滚动），不足时可滚动 */
+  flex: 1 0 34px;
+  min-width: 34px;
   border: 0;
   background: transparent;
   padding: 0;


### PR DESCRIPTION
## 概述

Closes #737

电费「用电趋势」月视图把一码通智能水电接口返回的电表开户以来全部月份（从 2024 年起）原样渲染：既无排序保证，容器也不可滚动——柱子被 flex 均分压扁、标签重叠，只能看清一小部分。本 PR 修复展示层：**按时间升序确定性排序 + 图表横向滚动**，全部教务侧历史数据可滑动清晰查看。

## 变更内容（2 文件）

- `ElectricityView.vue`：
  - 新增 `comparePointLabel`——按标签中的数字段逐级数值比较（`2024-01 < 2024-10 < 2025-01`），`mapPoints` 映射前对周/月数据统一升序排序（`Array.sort` 稳定，解析失败保持原相对顺序）
  - 新增 `ibarRef` + `watch`：数据/视图就绪后自动把滚动位置停在最右（最新月份可见），向左滑动回看历史
- `ElectricityView.scoped.css`：
  - `.ibar` 加 `overflow-x: auto` + 细滚动条样式（webkit + `scrollbar-width: thin`）
  - `.ibar-col` 由 `flex:1; min-width:0` 改为 `flex: 1 0 34px; min-width: 34px`——空间富余时仍均分拉伸（周视图 7 根柱不出现滚动），不足时保底 34px 触发滚动，柱宽与标签始终可读

## 行为说明

- 「从 2024 年开始」是电表开户的真实数据起点（一码通接口全量返回），非数据错误；排序后语义自然：最早在左、最新在右
- 周视图数据量小（7 天），空间富余时不出现滚动条，行为兼容

## 验证

- [x] `vue-tsc --noEmit` 通过、`vite build` 成功
- [x] 全量 vitest（CI 配置）1127/1127 通过
- [ ] 真机目检：月视图滚动流畅、默认停最右、标签可读（待 review）

## 关联

- Closes #737 · 数据来源：一码通智能水电