### PR TITLE
fix(#739): 冷启动收到已失效 identity 深链不再全屏阻塞弹「授权失败」

### DIFF
--- a/apps/client/src/app/contracts/runtime.ts
+++ b/apps/client/src/app/contracts/runtime.ts
@@ -17,6 +17,7 @@ import type {
   IdentityIntentSnapshot
 } from '../../features/identity/identityIntentStore'
 import type { AppState } from '../state/appState'
+import type { DeepLinkDelivery } from '../../platform/deep_link'
 
 export type AuthStore = ReturnType<typeof useAuthStore>
 export type NavigationStore = ReturnType<typeof useNavigationStore>
@@ -191,8 +192,12 @@ export interface NotificationCoordinator {
 // #621 + #623：Identity 授权请求调度与审批流程契约。
 // IdentityIntent 仅内存（request_id + handoff 不持久化、不打印）。
 export interface IdentityCoordinator {
-  /** 稳定入口：提交外部授权意图（minihbut://identity 深链 / 后续二维码扫描） */
-  submitIntent(intent: IdentityIntent): void
+  /**
+   * 稳定入口：提交外部授权意图（minihbut://identity 深链 / 后续二维码扫描）。
+   * delivery 标记投递时机（#739）：cold-start=进程启动参数带入，warm=运行中收到
+   * （缺省按 warm）；冷启动死信（过期/不存在/handoff 失效）静默丢弃，不弹阻塞结果页。
+   */
+  submitIntent(intent: IdentityIntent, delivery?: DeepLinkDelivery): void
   /** App shell bootstrap 完成后冲刷冷启动缓冲（由 useAppRuntime 调用） */
   flushPendingIntents(): void
   /** 完成/拒绝/过期当前请求：终态（done/error）后自动推进队列中的下一个 */

--- a/apps/client/src/app/coordinators/IdentityCoordinator.ts
+++ b/apps/client/src/app/coordinators/IdentityCoordinator.ts
@@ -57,6 +57,7 @@ import {
   getIdentityDeviceDisplayName,
   invokeNative
 } from '../../platform/native'
+import type { DeepLinkDelivery } from '../../platform/deep_link'
 import { IdentityServiceError } from '../../features/identity/types'
 import type {
   IdentityEnrollResult,
@@ -71,6 +72,17 @@ import { showToast } from '../../utils/toast'
 const BOOT_WAIT_INTERVAL_MS = 100
 const BOOT_WAIT_MAX_TICKS = 50
 
+/**
+ * 冷启动死信错误码（#739）：请求在服务器侧已终态死亡、重试无意义。
+ * 冷启动投递时用户未发起任何操作，这类死信静默丢弃；
+ * warm 投递（用户刚主动发起）维持显式错误反馈。网络类可重试错误不在此列。
+ */
+const COLD_START_DEAD_CODES: ReadonlySet<IdentityUserSafeErrorCode> = new Set([
+  'request_expired',
+  'request_not_found',
+  'invalid_handoff'
+])
+
 /** 登录恢复事件（AuthCoordinator.handleLoginSuccess 派发；#623 resume hook） */
 export const IDENTITY_LOGIN_RESUMED_EVENT = 'hbu-identity-login-resumed'
 
@@ -83,6 +95,8 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
   /** 冷启动缓冲：app shell 尚未 bootstrap 时收到的 Intent（仅内存，不持久化） */
   let pendingBuffer: IdentityIntent[] = []
   let bootWaitTimer: ReturnType<typeof setTimeout> | null = null
+  /** 冷启动投递的 request_id（#739：仅内存；终态后清除；死信静默降级的判定依据） */
+  const coldStartRequestIds = new Set<string>()
 
   // ── #623 流程状态（每实例） ──────────────────────────────────────────────
   /** 正在执行加载流程的 requestId（防同一请求重复触发；不同请求可交错推进） */
@@ -230,6 +244,16 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
     } catch (err) {
       if (!isCurrentActive(active.requestId)) return
       const mapped = toUserSafeError(err)
+      // #739 冷启动死信：请求在服务器侧已终态死亡（过期/不存在/handoff 失效），
+      // 用户此刻未发起任何操作 -> 静默丢弃（不写结果页、不弹阻塞 Overlay）。
+      // 先把 UI 置回 idle 再推进队列：若队列有下一个请求，complete 触发的订阅回调
+      // 会立即用它的加载流程接管 UI，不会被这里的 idle 覆盖。
+      if (COLD_START_DEAD_CODES.has(mapped.code) && coldStartRequestIds.has(active.requestId)) {
+        coldStartRequestIds.delete(active.requestId)
+        setIdentityApprovalPhase('idle', { requestId: null })
+        completeIdentityIntent(active.requestId, 'error', mapped.message)
+        return
+      }
       // 先记录 UI 结果；队列推进延后到用户确认结果页（confirmResult）
       finishIdentityRequest(active.requestId, 'error', {
         message: mapped.message,
@@ -398,6 +422,7 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
     const pending = pendingTerminal
     pendingTerminal = null
     if (pending) {
+      coldStartRequestIds.delete(pending.requestId)
       completeIdentityIntent(pending.requestId, pending.status, pending.error)
     }
   }
@@ -440,7 +465,11 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
     pendingBuffer = []
     for (const intent of batch) {
       const result = enqueueIdentityIntent(intent)
-      if (!result.accepted) showToast(result.message, 'warning')
+      if (!result.accepted) {
+        // recently-completed（#739 死链重放）静默忽略，不打扰用户；同时清理残留冷启动标记
+        if (result.reason === 'recently-completed') coldStartRequestIds.delete(intent.requestId)
+        else showToast(result.message, 'warning')
+      }
     }
   }
 
@@ -463,7 +492,7 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
     bootWaitTimer = setTimeout(tick, BOOT_WAIT_INTERVAL_MS)
   }
 
-  const submitIntent = (intent: IdentityIntent): void => {
+  const submitIntent = (intent: IdentityIntent, delivery?: DeepLinkDelivery): void => {
     if (!intent || typeof intent.requestId !== 'string' || intent.requestId === '') return
     if (typeof intent.handoff !== 'string' || intent.handoff === '') return
     // 只保留合同字段：任何 deep link 附加的展示资料（name/scope/student_id）一律丢弃
@@ -472,6 +501,10 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
       handoff: intent.handoff,
       arrivedAt: typeof intent.arrivedAt === 'number' ? intent.arrivedAt : Date.now()
     }
+    if (delivery === 'cold-start') {
+      // #739：记录投递时机（仅内存；该请求终态后清除）
+      coldStartRequestIds.add(normalized.requestId)
+    }
     if (!state.mutable.appBootstrapped) {
       // 冷启动：shell 未就绪前只写入内存缓冲，不操作 UI；bootstrap 后统一入队
       pendingBuffer.push(normalized)
@@ -479,7 +512,11 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
       return
     }
     const result = enqueueIdentityIntent(normalized)
-    if (!result.accepted) showToast(result.message, 'warning')
+    if (!result.accepted) {
+      // recently-completed（#739 死链重放）静默忽略，不打扰用户；同时清理残留冷启动标记
+      if (result.reason === 'recently-completed') coldStartRequestIds.delete(normalized.requestId)
+      else showToast(result.message, 'warning')
+    }
   }
 
   const handleLoginResumed = (): void => {
@@ -525,6 +562,7 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
     clearExpiryTimer()
     pendingBuffer = []
     pendingTerminal = null
+    coldStartRequestIds.clear()
     unsubscribeStore()
     uninstallGlobalListeners()
   }
@@ -533,8 +571,14 @@ export const createIdentityCoordinator = (runtime: AppRuntime): IdentityCoordina
     // #621 合同（原样保留）
     submitIntent,
     flushPendingIntents,
-    completeIntent: (requestId, status, error) => completeIdentityIntent(requestId, status, error),
-    dismissIntent: (requestId) => dismissIdentityIntent(requestId),
+    completeIntent: (requestId, status, error) => {
+      coldStartRequestIds.delete(requestId)
+      completeIdentityIntent(requestId, status, error)
+    },
+    dismissIntent: (requestId) => {
+      coldStartRequestIds.delete(requestId)
+      dismissIdentityIntent(requestId)
+    },
     setPhase: (requestId, nextPhase: Exclude<IdentityIntentPhase, 'done' | 'error'> | 'error', options) =>
       setIdentityIntentPhase(requestId, nextPhase, options),
     reset: () => {

--- a/apps/client/src/app/coordinators/NotificationCoordinator.ts
+++ b/apps/client/src/app/coordinators/NotificationCoordinator.ts
@@ -2,6 +2,7 @@ import type { AppRuntime, NotificationCoordinator } from '../contracts/runtime'
 import { platformBridge } from '../../platform'
 import {
   installMiniHbutDeepLinkListeners,
+  type DeepLinkDelivery,
   type MiniHbutDeepLink
 } from '../../platform/deep_link'
 import { resolveNotificationActionTarget } from '../../platform/notification_actions'
@@ -72,7 +73,7 @@ export const createNotificationCoordinator = (runtime: AppRuntime): Notification
 
   // #621：统一深链分发（widget / identity 共用同一 parser 与监听入口）。
   // 深链解析已迁移到 src/platform/deep_link.ts；widget 保持原行为，identity 进入 IdentityCoordinator。
-  const dispatchMiniHbutDeepLink = (link: MiniHbutDeepLink) => {
+  const dispatchMiniHbutDeepLink = (link: MiniHbutDeepLink, delivery: DeepLinkDelivery) => {
     if (link.kind === 'widget-schedule') {
       runAfterBoot(() =>
         handleWidgetDeeplinkPayload({
@@ -87,12 +88,15 @@ export const createNotificationCoordinator = (runtime: AppRuntime): Notification
       runAfterBoot(() => handleNavigatePayload({ view: link.view, source: link.source }))
       return
     }
-    // identity：交给 IdentityCoordinator（内部处理冷启动缓冲与队列调度）
-    runtime.identity.submitIntent({
-      requestId: link.requestId,
-      handoff: link.handoff,
-      arrivedAt: Date.now()
-    })
+    // identity：交给 IdentityCoordinator（内部处理冷启动缓冲、队列调度与 #739 死信降级）
+    runtime.identity.submitIntent(
+      {
+        requestId: link.requestId,
+        handoff: link.handoff,
+        arrivedAt: Date.now()
+      },
+      delivery
+    )
   }
 
   const installWidgetDeeplinkListeners = () => {

--- a/apps/client/src/app/coordinators/identityCoordinatorFlow.spec.ts
+++ b/apps/client/src/app/coordinators/identityCoordinatorFlow.spec.ts
@@ -31,6 +31,8 @@ import {
   resetIdentityUiState
 } from '../../features/identity/identityStore'
 import type { IdentityRequestDetail } from '../../features/identity/types'
+import { IdentityServiceError } from '../../features/identity/types'
+import { showToast } from '../../utils/toast'
 
 vi.mock('../../utils/toast', () => ({
   showToast: vi.fn()
@@ -570,5 +572,102 @@ describe('#623 安全边界：handoff 仅内存', () => {
     await coordinator.approveActive()
     expect(vi.mocked(submitApprove)).toHaveBeenCalledTimes(1)
     expect(getIdentityIntentSnapshot().active).toBeNull()
+  })
+})
+
+// ─── #739 冷启动死信：服务器侧已终态死亡的请求静默降级 ──────────────────────
+
+describe('#739 冷启动死信静默降级', () => {
+  it('冷启动 + request_expired：不写结果页、Overlay 不展示、无 toast', async () => {
+    vi.mocked(fetchRequestDetail).mockRejectedValueOnce(
+      new IdentityServiceError('request_expired', '应用请求已过期，请从网页重新发起')
+    )
+    const coordinator = createCoordinator(makeRuntime())
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'), 'cold-start')
+    await flushAsync()
+    // 意图已终态推进（不挂队列、不留结果页确认）
+    expect(getIdentityIntentSnapshot().active).toBeNull()
+    expect(getIdentityIntentSnapshot().phase).toBe('idle')
+    // UI 回 idle：无阻塞授权弹窗
+    expect(identityUiState.approvalPhase).toBe('idle')
+    expect(identityUiState.lastResult).toBeNull()
+    expect(overlayVisible.value).toBe(false)
+    expect(vi.mocked(showToast)).not.toHaveBeenCalled()
+  })
+
+  it('冷启动 + invalid_handoff 同样静默（死信码集合覆盖）', async () => {
+    vi.mocked(fetchRequestDetail).mockRejectedValueOnce(
+      new IdentityServiceError('invalid_handoff', '接力凭据无效，请从网页重新发起授权')
+    )
+    const coordinator = createCoordinator(makeRuntime())
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'), 'cold-start')
+    await flushAsync()
+    expect(identityUiState.approvalPhase).toBe('idle')
+    expect(identityUiState.lastResult).toBeNull()
+    expect(overlayVisible.value).toBe(false)
+  })
+
+  it('warm + request_expired：维持显式错误结果页（用户刚主动发起授权）', async () => {
+    vi.mocked(fetchRequestDetail).mockRejectedValueOnce(
+      new IdentityServiceError('request_expired', '应用请求已过期，请从网页重新发起')
+    )
+    const coordinator = createCoordinator(makeRuntime())
+    coordinator.submitIntent(makeIntent('ar_1111111111111111')) // 缺省 warm
+    await flushAsync()
+    expect(identityUiState.approvalPhase).toBe('error')
+    expect(identityUiState.lastResult?.errorCode).toBe('request_expired')
+    expect(overlayVisible.value).toBe(true)
+    coordinator.confirmResult()
+    expect(getIdentityIntentSnapshot().active).toBeNull()
+  })
+
+  it('冷启动 + 网络不可用（可重试）：维持现状显式提示，不静默', async () => {
+    vi.mocked(fetchRequestDetail).mockRejectedValueOnce(
+      new IdentityServiceError('network_unavailable', '网络不可用')
+    )
+    const coordinator = createCoordinator(makeRuntime())
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'), 'cold-start')
+    await flushAsync()
+    expect(identityUiState.approvalPhase).toBe('error')
+    expect(identityUiState.lastResult?.retryable).toBe(true)
+    expect(overlayVisible.value).toBe(true)
+  })
+
+  it('静默丢弃后同一死链会话内重放：不再入队、不再打扰；新请求不受影响', async () => {
+    vi.mocked(fetchRequestDetail).mockRejectedValueOnce(
+      new IdentityServiceError('request_expired', '应用请求已过期，请从网页重新发起')
+    )
+    const coordinator = createCoordinator(makeRuntime())
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'), 'cold-start')
+    await flushAsync()
+    expect(getIdentityIntentSnapshot().active).toBeNull()
+    // 同一死链重放（冷启动 / warm 均可）：入队被拒且无 toast
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'), 'cold-start')
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'))
+    await flushAsync()
+    expect(getIdentityIntentSnapshot().active).toBeNull()
+    expect(vi.mocked(showToast)).not.toHaveBeenCalled()
+    expect(identityUiState.approvalPhase).toBe('idle')
+    // 新请求正常走完整流程
+    detailByRequest.set('ar_2222222222222222', makeDetail({ request_id: 'ar_2222222222222222' }))
+    coordinator.submitIntent(makeIntent('ar_2222222222222222'))
+    await flushAsync()
+    expect(getIdentityIntentSnapshot().active?.requestId).toBe('ar_2222222222222222')
+    expect(identityUiState.approvalPhase).toBe('ready')
+  })
+
+  it('队列推进不受静默丢弃影响：冷启动死信后，队列中的下一个请求正常接管', async () => {
+    vi.mocked(fetchRequestDetail).mockRejectedValueOnce(
+      new IdentityServiceError('request_expired', '应用请求已过期，请从网页重新发起')
+    )
+    detailByRequest.set('ar_2222222222222222', makeDetail({ request_id: 'ar_2222222222222222' }))
+    const coordinator = createCoordinator(makeRuntime())
+    coordinator.submitIntent(makeIntent('ar_1111111111111111'), 'cold-start')
+    coordinator.submitIntent(makeIntent('ar_2222222222222222'))
+    await flushAsync()
+    // 第一个死信被静默丢弃，第二个正常 ready
+    expect(getIdentityIntentSnapshot().active?.requestId).toBe('ar_2222222222222222')
+    expect(identityUiState.approvalPhase).toBe('ready')
+    expect(overlayVisible.value).toBe(true)
   })
 })

--- a/apps/client/src/features/identity/identityIntentStore.spec.ts
+++ b/apps/client/src/features/identity/identityIntentStore.spec.ts
@@ -224,3 +224,42 @@ describe('identityIntentStore: 订阅与 handoff 内存边界', () => {
     }
   })
 })
+
+// ─── #739 会话级重放去重 ─────────────────────────────────────────────────────
+
+describe('identityIntentStore: #739 会话内已终态请求重放去重', () => {
+  it('终态请求同会话重放入队被拒（recently-completed），其他请求不受影响', () => {
+    enqueueIdentityIntent(makeIntent('ar_1111111111111111'))
+    completeIdentityIntent('ar_1111111111111111', 'done')
+    // 同 request_id 重放：拒绝且原因明确
+    const replay = enqueueIdentityIntent(makeIntent('ar_1111111111111111'))
+    expect(replay.accepted).toBe(false)
+    if (replay.accepted) return
+    expect(replay.reason).toBe('recently-completed')
+    // 不同 request_id 正常入队
+    expect(enqueueIdentityIntent(makeIntent('ar_2222222222222222')).accepted).toBe(true)
+    expect(getIdentityIntentSnapshot().active?.requestId).toBe('ar_2222222222222222')
+  })
+
+  it('error 终态同样记入重放去重（死链重放静默的 store 侧基础）', () => {
+    enqueueIdentityIntent(makeIntent('ar_1111111111111111'))
+    completeIdentityIntent('ar_1111111111111111', 'error', '应用请求已过期')
+    const replay = enqueueIdentityIntent(makeIntent('ar_1111111111111111'))
+    expect(replay.accepted).toBe(false)
+    if (replay.accepted) return
+    expect(replay.reason).toBe('recently-completed')
+  })
+
+  it('dismiss（未终态移除）不记入重放去重：同 id 仍可重新入队', () => {
+    enqueueIdentityIntent(makeIntent('ar_1111111111111111'))
+    dismissIdentityIntent('ar_1111111111111111')
+    expect(enqueueIdentityIntent(makeIntent('ar_1111111111111111')).accepted).toBe(true)
+  })
+
+  it('重置清空重放记录（登出/测试场景）', () => {
+    enqueueIdentityIntent(makeIntent('ar_1111111111111111'))
+    completeIdentityIntent('ar_1111111111111111', 'done')
+    resetIdentityIntentStore()
+    expect(enqueueIdentityIntent(makeIntent('ar_1111111111111111')).accepted).toBe(true)
+  })
+})

--- a/apps/client/src/features/identity/identityIntentStore.ts
+++ b/apps/client/src/features/identity/identityIntentStore.ts
@@ -52,7 +52,11 @@ export interface IdentityIntentSnapshot {
 
 export type IdentityEnqueueResult =
   | { accepted: true }
-  | { accepted: false; reason: 'duplicate' | 'queue-full'; message: string }
+  | {
+      accepted: false
+      reason: 'duplicate' | 'queue-full' | 'recently-completed'
+      message: string
+    }
 
 /** 内存队列上限：并发待处理授权请求不超过 3 个 */
 export const IDENTITY_QUEUE_MAX = 3
@@ -62,12 +66,20 @@ export const IDENTITY_QUEUE_FULL_MESSAGE = '已有多个待处理授权，请先
 
 const DUPLICATE_MESSAGE = '该授权请求已存在，请先完成当前请求'
 
+/** 会话内已终态请求的重放提示（#739：消费端对该 reason 静默处理，不 toast） */
+const RECENTLY_COMPLETED_MESSAGE = '该授权请求已完成，请从网页重新发起'
+
+/** 会话级已终态 request_id 记录上限（FIFO；防外部死链重放撑爆内存） */
+const RECENT_COMPLETED_MAX = 16
+
 // ─── 模块级内存状态（单一实例，不持久化） ────────────────────────────────────
 
 let phase: IdentityIntentPhase = 'idle'
 let activeIntent: PendingExternalIntent | null = null
 const queue: PendingExternalIntent[] = []
 let lastCompleted: PendingExternalIntent | null = null
+/** 会话级已终态 request_id（#739：同一死链重放不重复入队/弹窗；仅内存） */
+const recentCompletedIds: string[] = []
 
 type StoreListener = () => void
 const listeners = new Set<StoreListener>()
@@ -115,6 +127,7 @@ export const subscribeIdentityIntentStore = (listener: StoreListener): (() => vo
 /**
  * 提交外部授权意图（深链 / 后续二维码扫描的统一入口）。
  * - 同 request_id 去重（活跃 + 队列）；
+ * - 会话内已终态请求的重放拒绝（#739：外部死链反复重放不再入队）；
  * - 队列超限（>3）时拒绝并返回提示；
  * - 无活跃请求时立即成为 active。
  */
@@ -124,6 +137,9 @@ export const enqueueIdentityIntent = (intent: IdentityIntent): IdentityEnqueueRe
     queue.some((item) => item.requestId === intent.requestId)
   if (exists) {
     return { accepted: false, reason: 'duplicate', message: DUPLICATE_MESSAGE }
+  }
+  if (recentCompletedIds.includes(intent.requestId)) {
+    return { accepted: false, reason: 'recently-completed', message: RECENTLY_COMPLETED_MESSAGE }
   }
   if (queue.length >= IDENTITY_QUEUE_MAX) {
     return { accepted: false, reason: 'queue-full', message: IDENTITY_QUEUE_FULL_MESSAGE }
@@ -152,6 +168,7 @@ export const setIdentityIntentPhase = (
 
 /**
  * 完成/拒绝/过期当前请求：标记终态（done/error）后自动推进队列中的下一个。
+ * 终态 request_id 记入会话级重放去重（#739）。
  */
 export const completeIdentityIntent = (
   requestId: string,
@@ -162,6 +179,12 @@ export const completeIdentityIntent = (
   activeIntent.phase = status
   if (status === 'error') activeIntent.error = error || '授权请求处理失败'
   lastCompleted = { ...activeIntent }
+  if (!recentCompletedIds.includes(requestId)) {
+    recentCompletedIds.push(requestId)
+    if (recentCompletedIds.length > RECENT_COMPLETED_MAX) {
+      recentCompletedIds.shift()
+    }
+  }
   activeIntent = queue.shift() ?? null
   phase = activeIntent ? 'received' : 'idle'
   notify()
@@ -189,6 +212,7 @@ export const resetIdentityIntentStore = (): void => {
   queue.length = 0
   activeIntent = null
   lastCompleted = null
+  recentCompletedIds.length = 0
   phase = 'idle'
   notify()
 }

--- a/apps/client/src/platform/deep_link.spec.ts
+++ b/apps/client/src/platform/deep_link.spec.ts
@@ -374,19 +374,21 @@ describe('installMiniHbutDeepLinkListeners', () => {
     const { installMiniHbutDeepLinkListeners: install } = await import('./deep_link')
     const handler = vi.fn()
     const cleanup = await install(handler)
-    // 冷启动 URL 已派发
+    // 冷启动 URL 已派发，投递时机标记为 cold-start（#739）
     expect(handler).toHaveBeenCalledTimes(1)
     expect(handler.mock.calls[0][0]).toEqual({
       kind: 'identity',
       requestId: validRequestId,
       handoff: validHandoff
     })
+    expect(handler.mock.calls[0][1]).toBe('cold-start')
     // 热启动 URL 派发（warm start / single-instance 转发）
     expect(deepLinkControl.onOpenUrl).toHaveBeenCalledTimes(1)
     const onOpenUrlHandler = deepLinkControl.onOpenUrl.mock.calls[0][0] as (urls: string[]) => void
     onOpenUrlHandler([`minihbut://electricity`])
     expect(handler).toHaveBeenCalledTimes(2)
     expect(handler.mock.calls[1][0]).toEqual({ kind: 'navigate', view: 'electricity', source: 'widget' })
+    expect(handler.mock.calls[1][1]).toBe('warm')
     // 无效 URL 静默忽略
     onOpenUrlHandler(['https://evil.example/identity'])
     expect(handler).toHaveBeenCalledTimes(2)
@@ -423,6 +425,8 @@ describe('installMiniHbutDeepLinkListeners', () => {
       period: 0,
       source: 'widget'
     })
+    // Capacitor appUrlOpen 属运行中投递（#739）
+    expect(handler.mock.calls[0][1]).toBe('warm')
     appUrlOpenHandler({})
     expect(handler).toHaveBeenCalledTimes(1)
     expect(() => cleanup()).not.toThrow()

--- a/apps/client/src/platform/deep_link.ts
+++ b/apps/client/src/platform/deep_link.ts
@@ -33,6 +33,14 @@ export type MiniHbutDeepLink =
   | { kind: 'navigate'; view: 'electricity' | 'exams'; source: string }
   | { kind: 'identity'; requestId: string; handoff: string }
 
+/**
+ * 深链投递时机（#739）：
+ * - cold-start：进程启动参数自带的 URL（getCurrent），用户此刻未必主动发起过任何操作；
+ * - warm：运行中收到（onOpenUrl / single-instance 转发 / Capacitor appUrlOpen），用户刚有可感知动作。
+ * 消费端（IdentityCoordinator）据此决定死信（过期/不存在）是静默丢弃还是显式报错。
+ */
+export type DeepLinkDelivery = 'cold-start' | 'warm'
+
 export type MiniHbutDeepLinkErrorCode =
   | 'invalid-url'
   | 'wrong-scheme'
@@ -120,7 +128,7 @@ const parseIdentityDeepLink = (url: URL): MiniHbutDeepLinkResult => {
   return { ok: true, link: { kind: 'identity', requestId, handoff } }
 }
 
-export type MiniHbutDeepLinkHandler = (link: MiniHbutDeepLink) => void
+export type MiniHbutDeepLinkHandler = (link: MiniHbutDeepLink, delivery: DeepLinkDelivery) => void
 
 /**
  * 安装统一深链监听（唯一安装点）：
@@ -134,12 +142,12 @@ export const installMiniHbutDeepLinkListeners = async (
 ): Promise<() => void> => {
   const cleanups: Array<() => void> = []
 
-  const handleUrls = (urls: string[]): void => {
+  const handleUrls = (urls: string[], delivery: DeepLinkDelivery): void => {
     for (const raw of urls) {
       const result = parseMiniHbutDeepLink(raw)
       if (!result.ok) continue // 无效/恶意链接：静默忽略（通用错误不回显，也不落日志）
       try {
-        handler(result.link)
+        handler(result.link, delivery)
       } catch {
         // 消费者异常不阻断后续 URL 处理
       }
@@ -151,12 +159,12 @@ export const installMiniHbutDeepLinkListeners = async (
       const deepLink = await import('@tauri-apps/plugin-deep-link')
       try {
         const startUrls = await deepLink.getCurrent()
-        if (Array.isArray(startUrls) && startUrls.length > 0) handleUrls(startUrls)
+        if (Array.isArray(startUrls) && startUrls.length > 0) handleUrls(startUrls, 'cold-start')
       } catch {
         // 冷启动深链读取失败：按无启动 URL 处理（不阻断 onOpenUrl 安装）
       }
       try {
-        const unlisten = await deepLink.onOpenUrl(handleUrls)
+        const unlisten = await deepLink.onOpenUrl((urls) => handleUrls(urls, 'warm'))
         cleanups.push(unlisten)
       } catch {
         // 热启动监听不可用：Windows/Linux 由 single-instance 聚焦兜底，静默降级
@@ -169,7 +177,7 @@ export const installMiniHbutDeepLinkListeners = async (
       const app = await import('@capacitor/app')
       const listener = await app.App.addListener('appUrlOpen', (event) => {
         const url = event?.url
-        if (typeof url === 'string' && url) handleUrls([url])
+        if (typeof url === 'string' && url) handleUrls([url], 'warm')
       })
       cleanups.push(() => {
         void listener.remove()


### PR DESCRIPTION
Closes #739

## 问题

每次新打开软件就会弹全屏模态「Mini-HBUT 登录授权 / 授权失败 / 应用请求已过期，请从网页重新发起」。实证（见 issue 取证）：外部重放一条已失效的 `minihbut://identity` 深链（进程启动参数带入）时，客户端把"服务器侧已死亡"的请求当成需要用户处理的活跃请求，冷启动直接被阻塞错误页挡住。

## 修复（按 issue 决策点默认口径）

1. **深链投递分级**：`deep_link.ts` 的 handler 现在携带 `delivery` —— `cold-start`（`getCurrent()` 启动参数）vs `warm`（`onOpenUrl` / single-instance 转发 / Capacitor `appUrlOpen`）；`NotificationCoordinator` 透传给 `submitIntent(intent, delivery?)`（缺省 warm，QR 扫码入口无需改动）。
2. **冷启动死信静默丢弃**：`runActiveFlow` 拉取详情返回 `request_expired` / `request_not_found` / `invalid_handoff` 且该请求为冷启动投递时 → UI 置回 idle、不写结果页、不弹 Overlay、不 toast，直接终态并推进队列（队列中的下一个请求正常接管 UI）。
3. **维持不变的部分**：warm 投递（用户刚在网页主动发起）死信仍显示现有错误模态；网络类可重试错误维持现状；详情加载成功后本地倒计时过期的路径也维持现状（请求到达时是活的）。
4. **会话级重放去重**：`identityIntentStore` 记录终态 request_id（FIFO，上限 16，仅内存），同一死链会话内重放入队被拒（`reason: 'recently-completed'`），协调器对该 reason 静默不 toast。
5. **契约不变**：`IdentityIntent` 合同字段未动（pending 字段集合守卫测试原样通过）；handoff / request_id 仍仅内存，不落日志与 UI。

## 验证

- 新增 10 个用例：投递时机断言（cold-start / warm / Capacitor）、冷启动死信静默（expired + invalid_handoff）、warm 死信显式、网络错误维持现状、死链重放不再打扰、队列正常推进
- 本地全绿：`npm run test:ci` 165 文件 / 1137 用例；`vue-tsc --noEmit -p tsconfig.json`；`npm run build`；前端安全 / 设计令牌 / 架构守卫 / dist 边界四脚本
- 实机行为待 CI 构建产物或用户本机验证：此前带过期深链参数冷启动必弹（复现步骤见 issue），修复后预期无弹窗

## 范围外（建议另立 issue）

本机 `minihbut://` 协议注册被 dev 构建 `register_all()` 劫持、生产安装未注册的卫生问题（见 issue #739 取证记录）。
