### PR TITLE
fix(#745): 开学季自动切换学期——移除 anchor 有课即中止探测的提前收工逻辑

### DIFF
--- a/apps/client/src/utils/schedule_prefetch.d.ts
+++ b/apps/client/src/utils/schedule_prefetch.d.ts
@@ -2,6 +2,10 @@
 export const SCHEDULE_POPUP_PENDING_KEY: string
 export const SCHEDULE_SWITCH_PENDING_KEY: string
 
+export function buildNearestSemesterOrder(
+  semesterList: unknown,
+  anchorSemester?: string
+): string[]
 export function updateStoredScheduleMeta(meta: unknown, fallbackSemester?: string): unknown
 export function buildScheduleCacheKey(studentId: unknown, semester?: string): string
 export function readScheduleRenderSnapshot(studentId: unknown, semester?: string): unknown

--- a/apps/client/src/utils/schedule_prefetch.js
+++ b/apps/client/src/utils/schedule_prefetch.js
@@ -294,7 +294,8 @@ export const getCachedScheduleSnapshot = (studentId, semester = '') => {
   return null
 }
 
-const buildNearestSemesterOrder = (semesterList, anchorSemester = '') => {
+// #745：导出供单测（探测优先级契约：新学期先于旧学期）
+export const buildNearestSemesterOrder = (semesterList, anchorSemester = '') => {
   const list = normalizeSemesterList(semesterList)
   if (!list.length) return []
 
@@ -425,8 +426,9 @@ export const warmupScheduleForStudent = async (studentId, options = {}) => {
   const MAX_EXTRA_NEWER = 2
 
   for (const semester of limitedCandidates) {
-    // anchor 学期自身有课 → 直接采用，不再探测
-    if (picked && picked.semester === anchorSemester) break
+    // #745：开学季 anchor（后端 current / 本地存储）可能仍是旧学期且旧学期课表未下架，
+    // 不能让「anchor 有课」提前收工——继续探测由下方 picked 分支负责：
+    // 只投向更新的学期（最多 MAX_EXTRA_NEWER 次），有课才替换 picked，否则保持现状。
     // 已找到非 anchor 有课学期 → 只继续探测更新的学期（最多 MAX_EXTRA_NEWER 次）
     if (picked) {
       if (!semesterIsNewer(semester, picked.semester)) continue

--- a/apps/client/src/utils/schedule_prefetch_order.spec.ts
+++ b/apps/client/src/utils/schedule_prefetch_order.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * #745 开学季自动切换学期 —— 探测顺序契约测试。
+ *
+ * 回归点：warmupScheduleForStudent 曾因「anchor 学期有课即 break」而在
+ * 开学窗口期（旧学期课表未下架、新学期已出课表）永远停在旧学期。
+ * 本 spec 锁定探测候选顺序的关键不变量：
+ * 1. 以 anchor 为中心先更新后更旧交叉展开；
+ * 2. 新学期（anchor 的相邻更新学期）必须排在更旧学期之前；
+ * 3. 全量覆盖无遗漏。
+ */
+import { describe, expect, it } from 'vitest'
+import { buildNearestSemesterOrder } from './schedule_prefetch.js'
+
+// 教务学期列表为降序（新在前）
+const SEMESTERS = [
+  '2027-2028-1',
+  '2026-2027-1',
+  '2025-2026-2',
+  '2025-2026-1',
+  '2024-2025-2'
+]
+
+describe('buildNearestSemesterOrder（#745 开学季探测顺序）', () => {
+  it('以 anchor 为中心先更新后更旧交叉展开', () => {
+    const order = buildNearestSemesterOrder(SEMESTERS, '2025-2026-2')
+    expect(order[0]).toBe('2025-2026-2')
+    // 更新学期紧邻其后（开学季最关键：新学期必须是第二个候选）
+    expect(order[1]).toBe('2026-2027-1')
+    expect(order[2]).toBe('2025-2026-1')
+    expect(order[3]).toBe('2027-2028-1')
+  })
+
+  it('新学期排在所有更旧学期之前（探测优先级契约）', () => {
+    const order = buildNearestSemesterOrder(SEMESTERS, '2025-2026-2')
+    const nextIdx = order.indexOf('2026-2027-1')
+    const olderIdx = order.indexOf('2025-2026-1')
+    const oldestIdx = order.indexOf('2024-2025-2')
+    expect(nextIdx).toBeGreaterThan(-1)
+    expect(nextIdx).toBeLessThan(olderIdx)
+    expect(nextIdx).toBeLessThan(oldestIdx)
+  })
+
+  it('anchor 不在列表时返回原列表（降序）', () => {
+    const order = buildNearestSemesterOrder(SEMESTERS, '2099-2100-1')
+    expect(order).toEqual(SEMESTERS)
+  })
+
+  it('列表全覆盖无遗漏', () => {
+    const order = buildNearestSemesterOrder(SEMESTERS, '2025-2026-2')
+    expect([...order].sort()).toEqual([...SEMESTERS].sort())
+    expect(order.length).toBe(SEMESTERS.length)
+  })
+})


### PR DESCRIPTION
## 概述

Closes #745

开学季（新学期课表已上线、旧学期课表未下架）自动切换学期失效：进入课表页的学期探测（`warmupScheduleForStudent`）在「基准学期 anchor（后端 current 或本地缓存，此时仍是旧学期）自己也有课表」时**提前 break**，排在第二候选位的新学期从未被查询——于是每次进入都稳定停留在旧学期，即使新学期确有课表。

## 根因（代码级）

`schedule_prefetch.js` 探测循环内：

```js
// anchor 学期自身有课 → 直接采用，不再探测
if (picked && picked.semester === anchorSemester) break
```

- 候选顺序为「anchor → 更新的学期 → 更旧的学期」交叉排列，新学期恰是第 2 个候选；
- anchor（旧学期）有课 → picked=旧学期 → 第二轮循环被 break 掐断 → 新学期永不探测；
- 设计假设「anchor 有课 = 当前学期不需要切」在开学切换窗口期不成立（anchor 来自未更新的后端 current / 本地存储）。

## 变更内容（3 文件，+62/-3）

- `schedule_prefetch.js`：
  - 删除提前 break；探测继续交给下方 picked 分支——只投向**更新的**学期（`MAX_EXTRA_NEWER=2` 上界），`count>0` 才替换 picked，否则保持现状（非开学季零感知，仅多几个带缓存的查询）；
  - `buildNearestSemesterOrder` 改为导出（供契约测试）。
- `schedule_prefetch.d.ts`：同步新增 `buildNearestSemesterOrder` 声明。
- 新增 `schedule_prefetch_order.spec.ts` ×4：探测顺序契约——新学期必须是 anchor 后的第 2 个候选、新学期先于一切旧学期、anchor 不在列表时原样返回、全量覆盖无遗漏。

## 行为说明

- 开学窗口期：自动切到新学期（warmup 返回的新学期由 ScheduleView 直接应用，权威网络结果会同步更新本地存储 meta）；
- 无课表的新学期（未来学期/空）：探测到但不替换 picked，行为不变；
- 更旧学期在 picked 分支被 `semesterIsNewer` 过滤，仍不会回退。

## 验证

- [x] 新契约测试 4/4 通过（CI 配置）
- [x] `vue-tsc --noEmit`、`vite build` 通过
- [x] 全量 vitest 1141/1141 通过
- [ ] 真机目检（待发布）：8/28 进入课表页应自动切到 2026-2027-1（配合 #741 周次基线修复）

## 关联

- Closes #745 · 相邻：#743（#741/#742a）、#744（#742b 待合并）