### PR TITLE
fix(ci): Android 构建增加 SDK 许可非交互兜底接受

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,15 @@ jobs:
       - name: Setup Android NDK
         uses: ./.github/actions/setup-android-ndk
 
+      # 兜底接受 SDK 许可：2026-08-28 起 GitHub runner 预装 sdkmanager 版本错乱，
+      # setup-android@v3 的 accept licenses 步骤检出 6/7 许可未接受后要求交互确认
+      # （非 TTY 环境直接失败）。此处非交互式写入许可文件，失败不阻断（许可可能已存在）。
+      - name: Accept Android SDK licenses (non-interactive fallback)
+        run: |
+          set -uo pipefail
+          yes | sdkmanager --licenses > /dev/null 2>&1 || true
+          ls "$ANDROID_HOME/licenses" > /dev/null 2>&1 && echo "licenses dir present" || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 背景

v1.4.7 发布 run（33186014391）中 Android formal APK 失败：runner 预装 sdkmanager 版本错乱（Wrong version in preinstalled sdkmanager），setup-android@v3 的 accept-licenses 检出 6/7 许可未接受并要求交互确认（非 TTY 失败）。

## 修复

Setup Android NDK 后增加非交互许可接受兜底步骤（yes | sdkmanager --licenses，失败不阻断）。

## 计划

合并本 PR 后，删除 v1.4.7 已建 release 与旧 tag，重新打 tag 触发全新发布 run。
