### PR TITLE
fix(ci): Android APK 构建注入 VITE_EXCLUDE_HIDDEN_VIEWS（修复 boundary guard 失败）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,10 @@ jobs:
           NDK_HOME: ${{ env.NDK_HOME }}
           ANDROID_NDK_HOME: ${{ env.NDK_HOME }}
           ANDROID_NDK_ROOT: ${{ env.NDK_HOME }}
+          # 关键：tauri CLI 的 beforeBuildCommand 会重新执行 npm run build，
+          # env 不随步骤继承，必须在此注入，否则 dist 被重建为全功能版、
+          # ForumView 等隐藏视图 chunk 重新进入发布包（boundary guard 失败，#595/#591 回归）。
+          VITE_EXCLUDE_HIDDEN_VIEWS: "1"
 
       - name: Mobile boundary guard (hidden views excluded, kept capabilities intact)
         working-directory: apps/client


### PR DESCRIPTION
## 背景

v1.4.7 发布 run 第二轮：Android formal APK 构建成功，但 Mobile boundary guard 失败——`ForumView 重新进入 dist`。

根因（本地已复现）：`Build frontend for Android` 步骤带 `VITE_EXCLUDE_HIDDEN_VIEWS=1` 构建出无 ForumView 的 dist；但随后的 `tauri android build` 步骤的 beforeBuildCommand 会**重新执行 npm run build**，且该步骤未继承该 env → dist 被重建为全功能版，ForumView chunk 回归，guard 抓包。

本地验证：
- 带 env 构建：dist 无 ForumView chunk（guard 通过）
- 不带 env 构建：ForumView-REb7J4MR.js 出现（与 CI 失败 hash 前缀一致）

## 修复

APK 构建步骤 env 注入 `VITE_EXCLUDE_HIDDEN_VIEWS: "1"`（含注释说明原因）。

## 计划

合并后删除 v1.4.7 release 与旧 tag，重新打 tag 触发第三轮完整发布 run。
