### PR TITLE
fix(#749,#750): 课表划分线行距对齐 + 学期切换改为开学日期驱动（提前 3 天不回跳）

### DIFF
--- a/apps/client/src/components/ScheduleView.vue
+++ b/apps/client/src/components/ScheduleView.vue
@@ -30,7 +30,9 @@ import { useScheduleDetail } from '../features/schedule/composables/useScheduleD
 import { useScheduleEditor } from '../features/schedule/composables/useScheduleEditor'
 import { useScheduleIO } from '../features/schedule/composables/useScheduleIO'
 import { useScheduleSync } from '../features/schedule/composables/useScheduleSync'
+import { useScheduleTermStart } from '../features/schedule/composables/useScheduleTermStart'
 import { deriveSemesterByDate, readStoredSemester } from '../features/schedule/utils/semester'
+import { semesterIsNewer } from '../utils/semester.js'
 
 import ScheduleTopbar from '../features/schedule/components/ScheduleTopbar.vue'
 import ScheduleDrawer from '../features/schedule/components/ScheduleDrawer.vue'
@@ -63,6 +65,8 @@ const detail = useScheduleDetail({ data, semester: semesterApi })
 const editor = useScheduleEditor({ props, data, semester: semesterApi, detail, menu, confirmDialog })
 const io = useScheduleIO({ props, data, semester: semesterApi, editor, confirmDialog })
 const sync = useScheduleSync({ props, data, semester: semesterApi, editor, confirmDialog })
+// #750：开学日期驱动学期切换（时间应选学期判定/自动切换/横幅/回前台重探）
+const termStart = useScheduleTermStart({ props, data, semester: semesterApi })
 
 // 任一弹层打开时禁用周次滑动/键盘切换（与原始 shouldIgnoreWeekSwipe 一致）
 // #742：学期徽章/提示弹窗 UI 已移除，其状态不再参与门控
@@ -194,6 +198,8 @@ const handleEditManagedCourse = (course: any) => {
 }
 
 const handleSemesterChange = () => {
+  // #750：手动切换 = 会话内临时行为（manual-select 锁，重启后以时间驱动为准）
+  termStart.clearNoticeIfMatches(semesterDraft.value)
   void data.onSemesterChange()
 }
 
@@ -270,36 +276,65 @@ onMounted(async () => {
   window.addEventListener('hbu-session-online', data.handleSessionOnline)
   window.addEventListener('hbu-session-logout', data.handleSessionLogout)
   document.addEventListener('visibilitychange', sync.handleScheduleVisibilityChange)
+  // #750：回前台轻量重探（提前窗口内检查新学期发布状态，60s 节流）
+  document.addEventListener('visibilitychange', termStart.handleForegroundVisibility)
   sync.refreshCloudSyncCooldown()
   sync.ensureCloudSyncCooldownTimer()
   void data.fetchSemesterOptions()
 
+  // #750：时间驱动应选学期——学期开学日(start_date) <= 今天+3天 的最近一个；
+  // 本地无开学日数据时回退 deriveSemesterByDate() 月份推算（仅作 lock 比较基准，不用于自动切换）。
+  const timeDriven = termStart.resolveTimeDrivenSemester()
+
   // 下次进入自动切换：后台检测到新学期并已确认有课表数据时生效。
+  // #750：后台 pending 若早于时间驱动应选学期（后端 current 尚未推进）→ 丢弃，避免回跳旧学期。
   const switchSemester = consumeScheduleSwitchPending(props.studentId)
   if (switchSemester) {
-    writeScheduleLock(props.studentId, switchSemester, 'pending-switch')
-    semester.value = switchSemester
-    semesterDraft.value = switchSemester
+    const pendingStale =
+      !!timeDriven.target &&
+      timeDriven.target !== switchSemester &&
+      !semesterIsNewer(switchSemester, timeDriven.target)
+    if (pendingStale) {
+      pushDebugLog(
+        'Schedule',
+        `#750 后台切换 pending(${switchSemester}) 早于时间驱动应选学期(${timeDriven.target})，丢弃以避免回跳`,
+        'warn'
+      )
+    } else {
+      writeScheduleLock(props.studentId, switchSemester, 'pending-switch')
+      semester.value = switchSemester
+      semesterDraft.value = switchSemester
+    }
   }
 
+  // #750：lock 清理规则（替代原「lock ≠ deriveSemesterByDate() 即清」）：
+  // - manual-select：会话内临时行为，启动一律清除（重启后以时间驱动应选学期为准）；
+  // - auto 锁 == target：保留（term-start/pending-switch 等时间驱动锁定不被误清）；
+  // - auto 锁早于 target（时间推进）：清理并重探；
+  // - auto 锁晚于 target（本地开学日数据滞后）：保留，避免误清后台已确认的新学期。
   const lockDetail = readScheduleLockDetail(props.studentId) as {
     semester?: string
     reason?: string
   } | null
-  const todaySemester = deriveSemesterByDate()
-  if (
-    lockDetail?.semester &&
-    todaySemester &&
-    lockDetail.semester !== todaySemester &&
-    isAutoScheduleLockReason(lockDetail.reason)
-  ) {
-    const cleared = clearScheduleLock(props.studentId)
-    if (cleared) {
-      pushDebugLog(
-        'Schedule',
-        `检测到自动锁定学期(${lockDetail.semester})与当前日期学期(${todaySemester})冲突，已清理并重探测`,
-        'warn'
-      )
+  if (lockDetail?.semester) {
+    const lockIsManual = !isAutoScheduleLockReason(lockDetail.reason)
+    const lockNewerThanTarget = timeDriven.target
+      ? semesterIsNewer(lockDetail.semester, timeDriven.target)
+      : true
+    const shouldClearLock =
+      lockIsManual ||
+      (!!timeDriven.target && lockDetail.semester !== timeDriven.target && !lockNewerThanTarget)
+    if (shouldClearLock) {
+      const cleared = clearScheduleLock(props.studentId)
+      if (cleared) {
+        pushDebugLog(
+          'Schedule',
+          lockIsManual
+            ? `#750 手动锁定学期(${lockDetail.semester})为会话内临时，启动不延续，已清理`
+            : `#750 自动锁定学期(${lockDetail.semester})早于时间驱动应选学期(${timeDriven.target})，已清理并重探`,
+          'warn'
+        )
+      }
     }
   }
 
@@ -333,7 +368,10 @@ onMounted(async () => {
     const probeAndRefresh = async () => {
       const warmed = await warmupScheduleForStudent(props.studentId, {
         forceProbe: true,
-        reason: 'first-enter'
+        reason: 'first-enter',
+        // #750：传入时间驱动应选学期——探测命中且有课表 → term-start 锁定；
+        // picked 早于 target（窗口内新学期未发布）→ 不写锁，等待发布后自动切。
+        targetSemester: timeDriven.target || ''
       }) as {
         success?: boolean
         semester?: string
@@ -342,6 +380,7 @@ onMounted(async () => {
       if (warmed?.success && warmed?.semester) {
         semester.value = warmed.semester
         semesterDraft.value = warmed.semester
+        // #750：回跳保护路径返回 payload=null（保持锁定学期语义），回落 fetchSchedule 取数
         if (!data.applySchedulePayload(warmed.payload, warmed.semester)) {
           await data.fetchSchedule(warmed.semester)
         } else {
@@ -362,6 +401,9 @@ onMounted(async () => {
       await data.fetchSchedule()
     }
   }
+  // #750：时间驱动学期决策（异步，不阻塞首屏）：进入提前窗口 → 探测新学期发布状态，
+  // 已发布自动切换（term-start 锁定），未发布保持旧学期 + 顶部横幅提示。
+  void termStart.ensureTimeDrivenSemester('startup')
   // #742：学期徽章/提示弹窗 UI 已移除，原 popup 状态机会让 anyOverlayOpen 永久为真
   // 从而禁用滑动与键盘切换周次；清理后不再弹任何学期提示。
 })
@@ -373,6 +415,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('hbu-session-online', data.handleSessionOnline)
   window.removeEventListener('hbu-session-logout', data.handleSessionLogout)
   document.removeEventListener('visibilitychange', sync.handleScheduleVisibilityChange)
+  document.removeEventListener('visibilitychange', termStart.handleForegroundVisibility)
   sync.clearCloudSyncCooldownTimer()
   if (widgetHighlightTimer) {
     clearTimeout(widgetHighlightTimer)
@@ -448,6 +491,7 @@ onBeforeUnmount(() => {
       :error-msg="errorMsg"
       :current-week="currentWeek"
       :selected-week="selectedWeek"
+      :term-start-notice="termStart.termStartNotice.value"
       @jump-current="jumpToCurrentWeek"
     />
 

--- a/apps/client/src/features/schedule/components/ScheduleBanners.vue
+++ b/apps/client/src/features/schedule/components/ScheduleBanners.vue
@@ -2,6 +2,7 @@
 /**
  * 课表横幅区：离线/假期/错误提示 + 回到当前周按钮。
  * 自 ScheduleView.vue 拆分，DOM 结构/class 完全保留。
+ * #750：新增学期切换提示横幅（提前窗口内新学期课表未发布时展示）。
  */
 defineProps({
   offline: { type: Boolean, default: false },
@@ -12,6 +13,7 @@ defineProps({
   errorMsg: { type: String, default: '' },
   currentWeek: { type: Number, default: 0 },
   selectedWeek: { type: Number, default: 0 },
+  termStartNotice: { type: String, default: '' },
 })
 const emit = defineEmits(['jump-current'])
 </script>
@@ -24,6 +26,11 @@ const emit = defineEmits(['jump-current'])
 
   <div v-if="vacationNotice" class="vacation-banner">
     {{ vacationNotice }}
+  </div>
+
+  <!-- #750：提前窗口内新学期课表未发布，保持旧学期并提示将自动切换 -->
+  <div v-if="termStartNotice" class="term-start-banner">
+    {{ termStartNotice }}
   </div>
 
   <div v-if="errorMsg" class="error-banner">
@@ -57,6 +64,17 @@ const emit = defineEmits(['jump-current'])
   background: rgba(245, 158, 11, 0.16);
   border: 1px solid rgba(217, 119, 6, 0.35);
   color: #92400e;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+/* #750：学期切换提示（信息级，蓝色系与回当前周按钮呼应） */
+.term-start-banner {
+  margin: 12px 0 0;
+  padding: 10px 14px;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: #1d4ed8;
   border-radius: 12px;
   font-weight: 600;
 }

--- a/apps/client/src/features/schedule/components/ScheduleGrid.vue
+++ b/apps/client/src/features/schedule/components/ScheduleGrid.vue
@@ -1,9 +1,9 @@
 <script setup>
 /**
  * 课表主体：日期头 + 时间轴 + 课程网格（含周切换动画）。
- * 自 ScheduleView.vue 拆分，DOM 结构/class 完全保留。
+ * 自 ScheduleView.vue 拆分；#749 起划分线由 grid-lines 单元素背景绘制（不再逐节循环 DOM 行）。
  */
-import { MAX_PERIOD, timeSchedule } from '../constants'
+import { timeSchedule } from '../constants'
 
 const props = defineProps({
   weekDates: { type: Array, default: () => [] },
@@ -25,8 +25,6 @@ const isTodayColumn = (dayIndex) => {
   const date = props.weekDates[idx]
   return !!date?.isToday
 }
-
-const periodRows = Array.from({ length: MAX_PERIOD }, (_, i) => i + 1)
 </script>
 
 <template>
@@ -58,10 +56,9 @@ const periodRows = Array.from({ length: MAX_PERIOD }, (_, i) => i + 1)
 
         <!-- 课程网格 -->
         <div class="courses-grid" :key="`courses-grid-${scheduleCourseCardStyle}-${courseCardRefreshNonce}`">
-          <!-- 背景线 -->
-          <div class="grid-lines">
-            <div v-for="i in periodRows" :key="i" class="line-row"></div>
-          </div>
+          <!-- 背景划分线：单元素背景绘制（#749）。线距严格等于 var(--slot-height) 整数倍，
+               无可被 flex 压缩的 DOM 行，任何视口下都与时间轴/课程网格的第 k 节边界重合 -->
+          <div class="grid-lines" aria-hidden="true"></div>
 
           <!-- 每天一列 -->
           <div v-for="day in 7" :key="day" class="day-column" :class="{ 'is-today-column': isTodayColumn(day) }">
@@ -208,6 +205,8 @@ const periodRows = Array.from({ length: MAX_PERIOD }, (_, i) => i + 1)
 }
 
 .time-slot {
+  /* #749：flex 固定行高，禁止时间轴行被压缩/拉伸，行距恒等于 var(--slot-height) */
+  flex: 0 0 var(--slot-height);
   height: var(--slot-height);
   display: flex;
   flex-direction: column;
@@ -244,24 +243,33 @@ const periodRows = Array.from({ length: MAX_PERIOD }, (_, i) => i + 1)
   grid-template-columns: repeat(7, minmax(0, 1fr));
   position: relative;
   height: 100%;
+  /* #749：恢复 v1.4.6 高度保护——视口不足 11×slot 时容器不再被压缩，
+     课程网格 / 时间轴 / 划分线三套行距在任意视口下保持恒等 */
+  min-height: calc(var(--slot-height) * 11 + var(--schedule-bottom-gap));
   box-sizing: border-box;
 }
 
+/* 划分线：单元素背景绘制（#749 结构性免疫）。
+   repeating-linear-gradient 每个周期 = var(--slot-height)，仅周期底部 1px 着色，
+   线位置恒为 var(--slot-height) 的整数倍；background-size 限定 11 个完整周期，
+   即恰好 11 条线，与 11 个 time-slot / day-column 网格行一一对应。
+   原方案（11 个 line-row 行 DOM 循环）在容器高度不足时会被 flex 均匀压缩导致行距分叉，已移除 */
 .grid-lines {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
-  flex-direction: column;
   pointer-events: none;
-}
-
-.line-row {
-  height: var(--slot-height);
-  border-bottom: 1px dashed #e5e7eb;
-  box-sizing: border-box;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent calc(var(--slot-height) - 1px),
+    #e5e7eb calc(var(--slot-height) - 1px),
+    #e5e7eb var(--slot-height)
+  );
+  background-size: 100% calc(var(--slot-height) * 11);
+  background-repeat: no-repeat;
 }
 
 .day-column {
@@ -463,10 +471,6 @@ const periodRows = Array.from({ length: MAX_PERIOD }, (_, i) => i + 1)
 
   .day-column {
     grid-template-rows: repeat(11, var(--slot-height));
-  }
-
-  .line-row {
-    height: var(--slot-height);
   }
 
   .course-card {

--- a/apps/client/src/features/schedule/composables/useScheduleSemester.ts
+++ b/apps/client/src/features/schedule/composables/useScheduleSemester.ts
@@ -5,6 +5,7 @@
  */
 import { computed, ref, watch } from 'vue'
 import { isTestAccountSession } from '../../../utils/test_account.js'
+import { recordSemesterStartDate } from '../../../utils/schedule_prefetch.js'
 import { SCHEDULE_META_KEY, weekDays } from '../constants'
 import { readStoredSemester } from '../utils/semester'
 
@@ -107,6 +108,10 @@ export const useScheduleSemester = (options: ScheduleSemesterOptions) => {
         total_weeks: totalWeeks.value,
         vacation_notice: vacationNotice.value
       }))
+      // #750：同步「学期 → 开学日」映射，供时间驱动应选学期判定使用
+      if (resolvedSemester && startDateStr.value) {
+        recordSemesterStartDate(resolvedSemester, startDateStr.value)
+      }
     }
   }
 

--- a/apps/client/src/features/schedule/composables/useScheduleTermStart.ts
+++ b/apps/client/src/features/schedule/composables/useScheduleTermStart.ts
@@ -1,0 +1,286 @@
+/**
+ * 课表领域 - #750 开学日期驱动学期切换组合式函数。
+ *
+ * 产品语义（issue #750）：
+ * 1. 时间驱动：「应显示学期」= 学期列表中 start_date <= 今天 + 3 天 的最近一个（开学前 3 天自动切换）；
+ * 2. 切后不回跳：切到新学期后以 term-start reason 锁定，任何启动/探测/回前台路径不得改回更旧学期；
+ * 3. 提前窗口内新学期课表未发布：保持旧学期 + 顶部横幅提示，每次启动与 visibilitychange
+ *    回前台时重探（60s 节流），发布后自动再切；
+ * 4. 手动查看其他学期 = 会话内临时行为（manual-select lock），会话内自动路径不与其冲突，
+ *    重启后回到时间驱动应选学期；
+ * 5. start_date 缺失/映射为空 → 回退现有推算链（deriveSemesterByDate），行为不劣化。
+ *
+ * lock 生命周期行为矩阵（ semester 显示 × 各时机 ）：
+ * ┌────────────────┬─────────────────────────────┬──────────────────────────────┬───────────────┬────────────────────────────┐
+ * │ lock 状态       │ 启动 onMounted               │ 探测 warmup（无锁初始探测）     │ 手动切换学期    │ 回前台 visibilitychange     │
+ * ├────────────────┼─────────────────────────────┼──────────────────────────────┼───────────────┼────────────────────────────┤
+ * │ 无锁            │ 时间驱动判定；pending-switch  │ #745 就近探测；picked==target  │ 写 manual-     │ 时间驱动 target 更新→探测，  │
+ * │                │ 门槛消费；探测 picked==target │ 有课→term-start 锁；picked 早  │ select 锁      │ published→切+term-start 锁；│
+ * │                │ →term-start 锁               │ 于 target→不写锁（等发布）      │ (会话内临时)   │ 未发布→横幅                  │
+ * ├────────────────┼─────────────────────────────┼──────────────────────────────┼───────────────┼────────────────────────────┤
+ * │ auto 锁         │ lock==target→保留；lock 早于  │ forceProbe 时探测结果不晚于    │ 覆写为 manual- │ manual 之外：target 更新→    │
+ * │ (term-start/   │ target→清理重探；lock 晚于    │ 现有锁→不覆盖(回跳保护①)；     │ select 锁      │ 探测切换；否则保留           │
+ * │ pending-switch │ target(本地数据滞后)→保留     │ picked 早于 target→不写锁②     │               │                            │
+ * │ 等自动 reason) │                             │                              │               │                            │
+ * ├────────────────┼─────────────────────────────┼──────────────────────────────┼───────────────┼────────────────────────────┤
+ * │ manual-select  │ 启动即清（会话内临时，重启    │ warmup 非 forceProbe 尊重锁； │ 写 manual-     │ 会话内 manual 优先：整体     │
+ * │                │ 以时间驱动为准）              │ forceProbe 走保护①            │ select 锁      │ 跳过自动切换                 │
+ * └────────────────┴─────────────────────────────┴──────────────────────────────┴───────────────┴────────────────────────────┘
+ */
+import { ref } from 'vue'
+import {
+  isAutoScheduleLockReason,
+  probeSemesterSchedule,
+  readScheduleLockDetail,
+  readSemesterStartDates,
+  writeScheduleLock
+} from '../../../utils/schedule_prefetch.js'
+import { semesterIsNewer } from '../../../utils/semester.js'
+import { pushDebugLog } from '../../../utils/debug_logger'
+import {
+  SEMESTER_SWITCH_LEAD_DAYS,
+  deriveSemesterByDate,
+  getNextSemesterString,
+  isSemesterStartWithinLeadWindow,
+  readStoredSemesterMeta,
+  resolveSemesterByStartDate
+} from '../utils/semester'
+import type { SemesterStartDateEntry } from '../utils/semester'
+import type { ScheduleData } from './useScheduleData'
+import type { ScheduleSemester } from './useScheduleSemester'
+
+/** 回前台重探节流：60s 内只探一次，避免频繁切换前台时狂发请求 */
+const FOREGROUND_PROBE_COOLDOWN_MS = 60_000
+
+export interface ScheduleTermStartOptions {
+  props: any
+  data: ScheduleData
+  semester: ScheduleSemester
+}
+
+export const useScheduleTermStart = (options: ScheduleTermStartOptions) => {
+  const { props, data, semester } = options
+
+  /** 提前窗口内新学期未发布的顶部提示文案（空 = 不展示） */
+  const termStartNotice = ref('')
+
+  let ensureInflight: Promise<void> | null = null
+  let lastForegroundProbeAt = 0
+
+  /**
+   * 计算时间驱动应选学期（纯本地）：
+   * 输入 = 本地「学期 → 开学日」映射 + hbu_schedule_meta 兜底；映射为空/无合格学期时
+   * 回退 deriveSemesterByDate()（仅用于 lock 清理比较，不用于自动切换，保证不劣化）。
+   */
+  const resolveTimeDrivenSemester = () => {
+    const map = readSemesterStartDates()
+    const entries: SemesterStartDateEntry[] = Object.entries(map).map(([semesterKey, startDate]) => ({
+      semester: semesterKey,
+      start_date: startDate
+    }))
+    // meta 兜底：旧版本升级后映射可能缺失当前学期 start_date
+    const storedMeta = readStoredSemesterMeta()
+    const storedSemester = String(storedMeta?.semester || '').trim()
+    const storedStartDate = String(storedMeta?.start_date || '').trim()
+    if (storedSemester && storedStartDate && !map[storedSemester]) {
+      entries.push({ semester: storedSemester, start_date: storedStartDate })
+    }
+
+    const byStartDate = resolveSemesterByStartDate(entries, new Date(), SEMESTER_SWITCH_LEAD_DAYS)
+    const fallbackTarget = byStartDate ? '' : deriveSemesterByDate()
+    pushDebugLog(
+      'Schedule',
+      `#750 时间驱动应选学期判定 entries=${entries.length} target=${byStartDate || 'null'} fallback=${fallbackTarget || '无'}`,
+      'debug'
+    )
+    return {
+      target: byStartDate || fallbackTarget,
+      /** true = 由开学日期数据驱动；false = 回退月份推算 */
+      fromStartDate: !!byStartDate,
+      entryCount: entries.length
+    }
+  }
+
+  /** 最近更新学期候选：学期列表（降序）中第一个比当前学期新的；列表缺失时按学期键推算 */
+  const pickUpcomingSemesterCandidate = (currentSemester: string): string => {
+    const list = Array.isArray(data.semesterOptions.value) ? data.semesterOptions.value : []
+    for (const item of list) {
+      const sem = String(item || '').trim()
+      if (sem && sem !== currentSemester && semesterIsNewer(sem, currentSemester)) {
+        return sem
+      }
+    }
+    return getNextSemesterString(currentSemester)
+  }
+
+  const setTermStartNotice = (targetSemester: string, startDate: string) => {
+    const current = String(semester.semester.value || '').trim()
+    if (!current || targetSemester === current) return
+    const dateText = String(startDate || '').trim()
+    const next = dateText
+      ? `新学期（${targetSemester}）将于 ${dateText} 开学，课表发布后自动切换显示`
+      : `新学期（${targetSemester}）即将开始，课表发布后自动切换显示`
+    if (termStartNotice.value === next) return
+    termStartNotice.value = next
+    pushDebugLog(
+      'Schedule',
+      `#750 提前窗口内新学期课表未发布，保持学期 ${current}，等待 semester=${targetSemester} start_date=${dateText || '未知'}`,
+      'info'
+    )
+  }
+
+  /** 时间驱动切换落地：写 term-start 锁（启动不误清）+ 应用课表渲染 */
+  const switchToTimeDrivenSemester = async (targetSemester: string, probe: any, reason: string) => {
+    const sid = String(props.studentId || '').trim()
+    if (!sid || !targetSemester) return
+    const previous = String(semester.semester.value || '').trim()
+    if (previous === targetSemester) return
+    writeScheduleLock(sid, targetSemester, 'term-start')
+    termStartNotice.value = ''
+    pushDebugLog(
+      'Schedule',
+      `#750 时间驱动切换学期 ${previous || '无'}→${targetSemester}（reason=${reason}，探测课数=${Number(probe?.count ?? 0)}）`,
+      'info'
+    )
+    semester.semester.value = targetSemester
+    semester.semesterDraft.value = targetSemester
+    const appliedFromProbe = probe?.payload ? data.applySchedulePayload(probe.payload, targetSemester) : false
+    if (!appliedFromProbe) {
+      const cached = data.applyCachedScheduleImmediately(targetSemester)
+      if (!cached) {
+        await data.fetchSchedule(targetSemester)
+        return
+      }
+    }
+    await data.loadCustomCourses(targetSemester)
+  }
+
+  /**
+   * 发现型探测：本地尚无合格 target（映射缺新学期开学日）时，轻量探测「最近更新学期」
+   * 以发现其 start_date / 课表发布状态。仅当其开学日未知，或已知且已进提前窗口时才发起。
+   */
+  const discoverUpcomingSemester = async (sid: string, currentSemester: string, reason: string) => {
+    const upcoming = pickUpcomingSemesterCandidate(currentSemester)
+    if (!upcoming || upcoming === currentSemester) return
+    const knownStart = String(readSemesterStartDates()[upcoming] || '').trim()
+    if (knownStart && !isSemesterStartWithinLeadWindow(knownStart)) return // 已知开学日且窗口外：无需探测
+
+    const probe = await probeSemesterSchedule(sid, upcoming) as {
+      ok?: boolean
+      published?: boolean
+      count?: number
+      startDate?: string
+      needLogin?: boolean
+      payload?: any
+    }
+    if (probe?.needLogin) return
+    const startDate = String(probe?.startDate || knownStart || '').trim()
+    if (probe?.published) {
+      // 已发布：仅当进入提前窗口才切换（窗口外静默，等窗口到点由时间驱动接管）
+      if (startDate && isSemesterStartWithinLeadWindow(startDate)) {
+        await switchToTimeDrivenSemester(upcoming, probe, `${reason}/discovery`)
+      }
+      return
+    }
+    // 未发布：进入提前窗口 → 横幅提示；窗口外静默
+    if (startDate && isSemesterStartWithinLeadWindow(startDate)) {
+      setTermStartNotice(upcoming, startDate)
+    }
+  }
+
+  /**
+   * 时间驱动学期决策主入口（启动 / 回前台共用）。
+   * 只会「向前切」（target 必须比当前显示学期更新），绝不自动回退到更旧学期。
+   */
+  const ensureTimeDrivenSemester = async (reason: string): Promise<void> => {
+    const sid = String(props.studentId || '').trim()
+    if (!sid) return
+    if (ensureInflight) return ensureInflight
+
+    // 会话内 manual 优先：手动选择锁定期间不做任何自动切换（重启后 manual lock 被清除，恢复时间驱动）
+    const lockDetail = readScheduleLockDetail(sid) as { semester?: string; reason?: string } | null
+    if (lockDetail && !isAutoScheduleLockReason(lockDetail.reason)) {
+      pushDebugLog(
+        'Schedule',
+        `#750 会话内手动锁定(${lockDetail.semester})优先，跳过时间驱动自动切换 reason=${reason}`,
+        'debug'
+      )
+      return
+    }
+
+    const run = (async () => {
+      const decision = resolveTimeDrivenSemester()
+      const current = String(semester.semester.value || semester.semesterDraft.value || '').trim()
+
+      if (decision.fromStartDate && decision.target) {
+        if (decision.target === current) {
+          termStartNotice.value = ''
+        } else if (!semesterIsNewer(decision.target, current)) {
+          // target 早于当前显示：不回跳（时间驱动只向前切）
+          pushDebugLog(
+            'Schedule',
+            `#750 时间驱动 target(${decision.target}) 早于当前显示(${current || '无'})，跳过切换`,
+            'debug'
+          )
+          return
+        } else {
+          // 进入提前窗口：探测新学期课表是否已发布
+          const probe = await probeSemesterSchedule(sid, decision.target) as {
+            published?: boolean
+            count?: number
+            startDate?: string
+            needLogin?: boolean
+            payload?: any
+          }
+          if (probe?.needLogin) return
+          if (probe?.published) {
+            await switchToTimeDrivenSemester(decision.target, probe, reason)
+            return
+          }
+          // 窗口内但课表未发布：保持旧学期 + 横幅（启动/回前台会重探，发布后自动再切）
+          setTermStartNotice(decision.target, String(probe?.startDate || '').trim())
+          return
+        }
+      }
+
+      // 发现型探测（两种情况走到这里）：
+      // a) 无开学日期驱动的 target（映射为空/无合格学期）——补充数据；
+      // b) target==当前显示学期——本地可能尚不知「更更新学期」的开学日，
+      //    不探测会死锁（提前窗口内永远发现不了新学期 start_date）。
+      // discoverUpcomingSemester 自带节流：已知开学日且窗口外 → 零请求。
+      await discoverUpcomingSemester(sid, current, reason)
+    })().finally(() => {
+      ensureInflight = null
+    })
+
+    ensureInflight = run
+    return run
+  }
+
+  /** visibilitychange 回前台：节流后轻量重探（60s cooldown） */
+  const handleForegroundVisibility = () => {
+    if (document.hidden) return
+    const now = Date.now()
+    if (now - lastForegroundProbeAt < FOREGROUND_PROBE_COOLDOWN_MS) return
+    lastForegroundProbeAt = now
+    void ensureTimeDrivenSemester('visibility-foreground')
+  }
+
+  /** 手动切换到横幅所指的新学期时即时清除横幅 */
+  const clearNoticeIfMatches = (targetSemester: string) => {
+    const sem = String(targetSemester || '').trim()
+    if (sem && termStartNotice.value && termStartNotice.value.includes(sem)) {
+      termStartNotice.value = ''
+    }
+  }
+
+  return {
+    termStartNotice,
+    resolveTimeDrivenSemester,
+    ensureTimeDrivenSemester,
+    handleForegroundVisibility,
+    clearNoticeIfMatches
+  }
+}
+
+export type ScheduleTermStart = ReturnType<typeof useScheduleTermStart>

--- a/apps/client/src/features/schedule/schedule_grid_lines.spec.ts
+++ b/apps/client/src/features/schedule/schedule_grid_lines.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { readVueContractSource } from '../../utils/contract_source_test'
+
+/**
+ * #749 课表横向划分线与课程卡片逐节错位 —— 源码契约门闩。
+ *
+ * 根因回顾：.courses-grid 丢失 v1.4.6 的 min-height 保护后，视口不足 11×slot 时
+ * .grid-lines（inset:0 + flex column）高度跟随容器被压缩，11 个 .line-row 被 flex
+ * 均匀压缩（约 84px/行），而 time-slot / day-column 行距仍为 var(--slot-height)
+ * （约 86px/行），三套行距分叉且逐节累积（第 9 节偏 19px），虚线穿入课程方块。
+ *
+ * 失败条件（回归即挂）：
+ * 1. .courses-grid 丢失 min-height: calc(var(--slot-height) * 11 + var(--schedule-bottom-gap))
+ * 2. 划分线回退为 .line-row DOM 循环（可被 flex 压缩的实现）
+ * 3. 划分线尺寸不再绑定 var(--slot-height)（线位漂移）
+ * 4. .time-slot 丢失 flex: 0 0 固定（时间轴行被压缩/拉伸）
+ */
+const source = readVueContractSource('src/features/schedule/components/ScheduleGrid.vue')
+
+/** 按「选择器 {」定位 CSS 规则块并截取配对花括号内的声明，避免跨块/媒体查询误匹配 */
+const cssBlock = (selector: string): string => {
+  const start = source.indexOf(`${selector} {`)
+  expect(start, `ScheduleGrid.vue 缺少选择器 ${selector}`).toBeGreaterThan(-1)
+  const open = source.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(open + 1, i)
+    }
+  }
+  return ''
+}
+
+describe('schedule grid lines contract (#749)', () => {
+  it('courses-grid keeps v1.4.6 min-height guard (11×slot + bottom-gap)', () => {
+    const block = cssBlock('.courses-grid')
+    // A1：容器高度保护，视口不足时不再被压缩
+    expect(block).toContain('min-height: calc(var(--slot-height) * 11 + var(--schedule-bottom-gap))')
+    expect(block).toContain('height: 100%')
+  })
+
+  it('grid lines are painted as slot-height-bound background (no compressible line-row DOM)', () => {
+    // B：划分线为单元素背景绘制，线距 = var(--slot-height) 整数倍
+    const block = cssBlock('.grid-lines')
+    expect(block).toContain('repeating-linear-gradient')
+    expect(block).toContain('calc(var(--slot-height) - 1px)')
+    // background-size 限定 11 个完整周期 = 11 条线，底部留白不着色
+    expect(block).toContain('calc(var(--slot-height) * 11)')
+    // 禁止回归可被 flex 压缩的 line-row 行循环
+    expect(source).not.toContain('.line-row')
+    expect(source).not.toContain('class="line-row"')
+  })
+
+  it('time-slot rows are flex-fixed to slot-height', () => {
+    // A2：时间轴行禁止 flex 压缩/拉伸
+    const block = cssBlock('.time-slot')
+    expect(block).toContain('flex: 0 0 var(--slot-height)')
+    expect(block).toContain('height: var(--slot-height)')
+  })
+
+  it('day-column rows stay pinned to 11×slot-height', () => {
+    // 课程卡片网格行：固定 11 行 × slot 高，与划分线/时间轴同源
+    const block = cssBlock('.day-column')
+    expect(block).toContain('grid-template-rows: repeat(11, var(--slot-height))')
+    expect(block).toContain('min-height: calc(var(--slot-height) * 11)')
+  })
+
+  it('time-axis keeps min-height guard aligned with courses-grid', () => {
+    // 时间轴容器与课程网格容器共用同一 min-height 公式，保证两列等高对齐
+    const block = cssBlock('.time-axis')
+    expect(block).toContain('min-height: calc(var(--slot-height) * 11 + var(--schedule-bottom-gap))')
+  })
+})

--- a/apps/client/src/features/schedule/utils/semester.spec.ts
+++ b/apps/client/src/features/schedule/utils/semester.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * #750 开学日期驱动应选学期 —— 纯函数单测。
+ *
+ * 覆盖 resolveSemesterByStartDate 的产品语义：
+ * 「应显示学期」= 学期列表中 start_date <= 今天 + 3 天 的最近一个。
+ * - start−3 当天（应切）/ start−4（不切）/ start 当天（应切）
+ * - 多学期序列取最近（start_date 最大者）
+ * - 无 start_date / 空列表 → null（调用方回退 deriveSemesterByDate 推算链）
+ * - 非法/溢出日期忽略；并列 start_date 取列表靠前
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  SEMESTER_SWITCH_LEAD_DAYS,
+  getNextSemesterString,
+  isSemesterStartWithinLeadWindow,
+  parseSemesterLocalDate,
+  resolveSemesterByStartDate
+} from './semester'
+
+const at = (y: number, m: number, d: number) => new Date(y, m - 1, d, 12, 0, 0)
+
+describe('SEMESTER_SWITCH_LEAD_DAYS（#750 提前量契约）', () => {
+  it('提前量为 3 天', () => {
+    expect(SEMESTER_SWITCH_LEAD_DAYS).toBe(3)
+  })
+})
+
+describe('parseSemesterLocalDate（YYYY-MM-DD → 本地当日 00:00）', () => {
+  it('解析为本地时区当日零点（规避 UTC 解析偏移）', () => {
+    const d = parseSemesterLocalDate('2026-08-31')!
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(7)
+    expect(d.getDate()).toBe(31)
+    expect(d.getHours()).toBe(0)
+    expect(d.getMinutes()).toBe(0)
+  })
+
+  it('非法输入返回 null', () => {
+    expect(parseSemesterLocalDate('')).toBeNull()
+    expect(parseSemesterLocalDate('2026/08/31')).toBeNull()
+    expect(parseSemesterLocalDate('2026-13-01')).toBeNull()
+    expect(parseSemesterLocalDate('2026-02-31')).toBeNull() // 溢出日期拒绝
+    expect(parseSemesterLocalDate(null)).toBeNull()
+  })
+})
+
+describe('resolveSemesterByStartDate（#750 应选学期）', () => {
+  it('start−3 当天应切（提前窗口边界）', () => {
+    const entries = [{ semester: '2026-2027-1', start_date: '2026-08-31' }]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 28))).toBe('2026-2027-1')
+  })
+
+  it('start−4 不切：无其他合格学期 → null（回退推算链）', () => {
+    const entries = [{ semester: '2026-2027-1', start_date: '2026-08-31' }]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 27))).toBeNull()
+  })
+
+  it('start−4 不切：存在旧学期时保持旧学期', () => {
+    const entries = [
+      { semester: '2026-2027-1', start_date: '2026-08-31' },
+      { semester: '2025-2026-2', start_date: '2026-03-02' }
+    ]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 27))).toBe('2025-2026-2')
+  })
+
+  it('start 当天应切', () => {
+    const entries = [{ semester: '2026-2027-1', start_date: '2026-08-31' }]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 31))).toBe('2026-2027-1')
+  })
+
+  it('多学期序列取最近（start_date 最大的合格学期）', () => {
+    const entries = [
+      { semester: '2026-2027-1', start_date: '2026-08-31' },
+      { semester: '2025-2026-2', start_date: '2026-03-02' },
+      { semester: '2025-2026-1', start_date: '2025-09-01' }
+    ]
+    // 提前窗口内（cutoff=9/1）：新学期（8/31）与旧学期（3/2）都合格 → 取最近的新学期
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 29))).toBe('2026-2027-1')
+    // 暑假深处（7/15）：新学期未进窗口 → 最近合格者为 2025-2026-2
+    expect(resolveSemesterByStartDate(entries, at(2026, 7, 15))).toBe('2025-2026-2')
+    // 学期中：只有 2025-2026-2 合格
+    expect(resolveSemesterByStartDate(entries, at(2026, 5, 10))).toBe('2025-2026-2')
+    // 上学年期中：2025-2026-1 合格（2025-2026-2 尚未进窗口）
+    expect(resolveSemesterByStartDate(entries, at(2025, 10, 20))).toBe('2025-2026-1')
+  })
+
+  it('无 start_date（全部缺失/非法）→ null', () => {
+    expect(
+      resolveSemesterByStartDate([
+        { semester: '2026-2027-1' },
+        { semester: '2025-2026-2', start_date: '' },
+        { semester: '2025-2026-1', start_date: null },
+        { semester: '2024-2025-2', start_date: 'not-a-date' }
+      ], at(2026, 8, 30))
+    ).toBeNull()
+  })
+
+  it('空列表 → null', () => {
+    expect(resolveSemesterByStartDate([], at(2026, 8, 30))).toBeNull()
+  })
+
+  it('非法条目（semester 为空）被忽略', () => {
+    const entries = [
+      { semester: '', start_date: '2026-08-31' },
+      { semester: '2026-2027-1', start_date: '2026-08-31' }
+    ]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 30))).toBe('2026-2027-1')
+  })
+
+  it('并列 start_date 取列表靠前（约定新学期在前）', () => {
+    const entries = [
+      { semester: '2026-2027-1', start_date: '2026-08-31' },
+      { semester: '2025-2026-2', start_date: '2026-08-31' }
+    ]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 30))).toBe('2026-2027-1')
+  })
+
+  it('跨年边界：寒假期间未进窗口保持第一学期', () => {
+    const entries = [
+      { semester: '2025-2026-2', start_date: '2026-02-23' },
+      { semester: '2025-2026-1', start_date: '2025-09-01' }
+    ]
+    expect(resolveSemesterByStartDate(entries, at(2026, 1, 10))).toBe('2025-2026-1')
+    // 2/20（start−3）进入窗口 → 切第二学期
+    expect(resolveSemesterByStartDate(entries, at(2026, 2, 20))).toBe('2025-2026-2')
+  })
+
+  it('自定义提前量生效（leadDays=0 即开学当天才切）', () => {
+    const entries = [{ semester: '2026-2027-1', start_date: '2026-08-31' }]
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 30), 0)).toBeNull()
+    expect(resolveSemesterByStartDate(entries, at(2026, 8, 31), 0)).toBe('2026-2027-1')
+  })
+})
+
+describe('isSemesterStartWithinLeadWindow（#750 窗口判定）', () => {
+  it('窗口内/外/非法', () => {
+    expect(isSemesterStartWithinLeadWindow('2026-08-31', at(2026, 8, 28))).toBe(true)
+    expect(isSemesterStartWithinLeadWindow('2026-08-31', at(2026, 8, 27))).toBe(false)
+    expect(isSemesterStartWithinLeadWindow('bad-date', at(2026, 8, 28))).toBe(false)
+    expect(isSemesterStartWithinLeadWindow('', at(2026, 8, 28))).toBe(false)
+  })
+})
+
+describe('getNextSemesterString（#750 发现型探测候选推算）', () => {
+  it('term1 → 同学年 term2', () => {
+    expect(getNextSemesterString('2025-2026-1')).toBe('2025-2026-2')
+  })
+
+  it('term2 → 下一学年 term1', () => {
+    expect(getNextSemesterString('2025-2026-2')).toBe('2026-2027-1')
+  })
+
+  it('非法格式/学年不连续返回空串', () => {
+    expect(getNextSemesterString('2025-2025-1')).toBe('')
+    expect(getNextSemesterString('abc')).toBe('')
+    expect(getNextSemesterString('')).toBe('')
+  })
+})

--- a/apps/client/src/features/schedule/utils/semester.ts
+++ b/apps/client/src/features/schedule/utils/semester.ts
@@ -1,6 +1,7 @@
 /**
  * 课表领域 - 学期派生/存储纯函数。
  * 原内联于 ScheduleView.vue（deriveSemesterByDate/resolveDisplayStudentId/readStoredSemester）。
+ * #750：新增开学日期驱动的应选学期纯函数（resolveSemesterByStartDate）。
  */
 import { SCHEDULE_META_KEY } from '../constants'
 
@@ -39,14 +40,121 @@ export const resolveDisplayStudentId = (studentId: string): string => {
   return /^\d{10}$/.test(fallback) ? fallback : ''
 }
 
-/** 读取本地存储的学期元信息 */
-export const readStoredSemester = (): string => {
+/** 读取本地存储的学期元信息（完整 meta：semester/start_date/current_week/total_weeks 等） */
+export const readStoredSemesterMeta = (): Record<string, unknown> | null => {
   try {
     const raw = localStorage.getItem(SCHEDULE_META_KEY)
-    if (!raw) return ''
+    if (!raw) return null
     const parsed = JSON.parse(raw)
-    return String(parsed?.semester || '').trim()
+    return parsed && typeof parsed === 'object' ? parsed : null
   } catch {
-    return ''
+    return null
   }
+}
+
+/** 读取本地存储的学期元信息中的学期键 */
+export const readStoredSemester = (): string => {
+  return String(readStoredSemesterMeta()?.semester || '').trim()
+}
+
+/**
+ * #750 推算下一学期：term1 → 同学年 term2；term2 → 下一学年 term1。
+ * 学期键格式非法返回 ''。
+ */
+export const getNextSemesterString = (semester: string): string => {
+  const m = String(semester || '').trim().match(/^(\d{4})-(\d{4})-([12])$/)
+  if (!m) return ''
+  const startYear = Number(m[1])
+  const endYear = Number(m[2])
+  const term = Number(m[3])
+  if (endYear !== startYear + 1) return ''
+  if (term === 1) return `${startYear}-${endYear}-2`
+  return `${endYear}-${endYear + 1}-1`
+}
+
+// ============ #750 开学日期驱动应选学期 ============
+
+/** 提前切换窗口：开学前 3 天自动切到新学期（产品语义） */
+export const SEMESTER_SWITCH_LEAD_DAYS = 3
+
+/** 学期条目：semester 为学期键（如 2025-2026-1），start_date 为开学日（YYYY-MM-DD，可缺省） */
+export interface SemesterStartDateEntry {
+  semester: string
+  start_date?: string | null
+}
+
+/**
+ * 将 YYYY-MM-DD 解析为「本地时区当日 00:00」的 Date。
+ * 仅接受日期字符串；非法输入返回 null。避免 new Date('YYYY-MM-DD') 被 UTC 解析导致的时区偏移。
+ */
+export const parseSemesterLocalDate = (text?: string | null): Date | null => {
+  const raw = String(text || '').trim()
+  const m = raw.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/)
+  if (!m) return null
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const day = Number(m[3])
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+  const date = new Date(year, month - 1, day)
+  if (Number.isNaN(date.getTime())) return null
+  // 防御 2026-02-31 这类溢出日期（构造后回滚到 3 月）
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null
+  }
+  return date
+}
+
+const startOfDay = (date: Date): Date => {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+/**
+ * #750 时间驱动应选学期（产品语义）：
+ * 「应显示学期」= 学期列表中 start_date <= 今天 + leadDays 的最近（最大 start_date）一个。
+ * - 开学前 3 天进入提前窗口自动切新学期；
+ * - 窗口内新学期未发布课表时，该学期仍会成为 target，由调用方保持旧学期 + 提示重探；
+ * - 列表为空 / 无任何有效 start_date / 所有 start_date 均晚于窗口 → 返回 null，调用方回退现有推算链。
+ * 并列 start_date 时取列表中靠前（调用方约定列表新学期在前）。
+ */
+export const resolveSemesterByStartDate = (
+  entries: readonly (SemesterStartDateEntry | null | undefined)[],
+  today: Date = new Date(),
+  leadDays: number = SEMESTER_SWITCH_LEAD_DAYS
+): string | null => {
+  if (!Array.isArray(entries) || entries.length === 0) return null
+  const baseDay = startOfDay(today instanceof Date && !Number.isNaN(today.getTime()) ? today : new Date())
+  const lead = Number.isFinite(leadDays) ? Math.max(0, Math.floor(Number(leadDays))) : SEMESTER_SWITCH_LEAD_DAYS
+  const cutoff = new Date(baseDay)
+  cutoff.setDate(cutoff.getDate() + lead)
+
+  let best: { semester: string; start: Date } | null = null
+  for (const entry of entries) {
+    const semester = String(entry?.semester || '').trim()
+    if (!semester) continue
+    const start = parseSemesterLocalDate(entry?.start_date)
+    if (!start) continue
+    if (start.getTime() > cutoff.getTime()) continue
+    if (!best || start.getTime() > best.start.getTime()) {
+      best = { semester, start }
+    }
+  }
+  return best ? best.semester : null
+}
+
+/**
+ * #750 判断给定开学日是否已进入提前切换窗口（start_date <= 今天 + leadDays）。
+ * start_date 非法时返回 false（调用方按「窗口外/未知」处理）。
+ */
+export const isSemesterStartWithinLeadWindow = (
+  startDate?: string | null,
+  today: Date = new Date(),
+  leadDays: number = SEMESTER_SWITCH_LEAD_DAYS
+): boolean => {
+  const start = parseSemesterLocalDate(startDate)
+  if (!start) return false
+  const baseDay = startOfDay(today instanceof Date && !Number.isNaN(today.getTime()) ? today : new Date())
+  const lead = Number.isFinite(leadDays) ? Math.max(0, Math.floor(Number(leadDays))) : SEMESTER_SWITCH_LEAD_DAYS
+  const cutoff = new Date(baseDay)
+  cutoff.setDate(cutoff.getDate() + lead)
+  return start.getTime() <= cutoff.getTime()
 }

--- a/apps/client/src/utils/schedule_prefetch.d.ts
+++ b/apps/client/src/utils/schedule_prefetch.d.ts
@@ -25,4 +25,20 @@ export function queueScheduleSemesterPopup(
   reason?: string
 ): void
 export function getCachedScheduleSnapshot(studentId: unknown, semester?: string): unknown
+export function readSemesterStartDates(): Record<string, string>
+export function recordSemesterStartDate(semester: unknown, startDate: unknown): boolean
+export function probeSemesterSchedule(
+  studentId: unknown,
+  semester?: string
+): Promise<{
+  ok: boolean
+  semester: string
+  published: boolean
+  count: number
+  startDate: string
+  fromCache?: boolean
+  stale?: boolean
+  needLogin?: boolean
+  payload?: unknown
+}>
 export function warmupScheduleForStudent(studentId: unknown, options?: Record<string, unknown>): Promise<unknown>

--- a/apps/client/src/utils/schedule_prefetch.js
+++ b/apps/client/src/utils/schedule_prefetch.js
@@ -2,10 +2,14 @@ import axios from 'axios'
 import { fetchWithCache, getCacheKey, setCachedData } from './api.js'
 import { normalizeSemesterList, resolveCurrentSemester, semesterIsNewer } from './semester.js'
 import { afterScheduleRefresh } from './widget_bridge'
+import { pushDebugLog } from './debug_logger'
 
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 const SCHEDULE_META_KEY = 'hbu_schedule_meta'
 const SCHEDULE_LOCK_KEY = 'hbu_schedule_lock'
+// #750：本地「学期 → 开学日(YYYY-MM-DD)」映射缓存，时间驱动应选学期的数据源
+const SCHEDULE_SEMESTER_START_DATES_KEY = 'hbu_semester_start_dates'
+const SEMESTER_START_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const SCHEDULE_RENDER_SNAPSHOT_SCHEMA = 1
 const SCHEDULE_RENDER_SNAPSHOT_PREFIX = 'hbu_schedule_render_snapshot_v1'
 export const SCHEDULE_POPUP_PENDING_KEY = 'hbu_schedule_popup_pending'
@@ -20,7 +24,9 @@ const AUTO_SCHEDULE_LOCK_REASONS = new Set([
   'pending-switch',
   'notify-background',
   'fallback-semester',
-  'locked-cache'
+  'locked-cache',
+  // #750：时间驱动（开学日期）锁定——语义为「按开学日期自动切入的学期，启动路径不误清」
+  'term-start'
 ])
 
 const toSafeText = (value) => String(value ?? '').trim()
@@ -79,6 +85,38 @@ export const buildScheduleCacheKey = (studentId, semester = '') => {
   const sem = toSafeText(semester)
   if (!sid) return ''
   return sem ? `schedule:${sid}:${sem}` : `schedule:${sid}`
+}
+
+// ============ #750 学期开学日映射缓存 ============
+
+/**
+ * #750 读取本地「学期 → 开学日」映射缓存。
+ * 数据来源：warmup 探测各学期 meta.start_date、当前学期 applyMeta 持久化。
+ */
+export const readSemesterStartDates = () => {
+  const raw = readJSON(SCHEDULE_SEMESTER_START_DATES_KEY, {})
+  const out = {}
+  for (const [sem, date] of Object.entries(raw && typeof raw === 'object' ? raw : {})) {
+    const semester = toSafeText(sem)
+    const startDate = toSafeText(date)
+    if (semester && SEMESTER_START_DATE_RE.test(startDate)) {
+      out[semester] = startDate
+    }
+  }
+  return out
+}
+
+/** #750 记录单个学期开学日（仅接受 YYYY-MM-DD；非法输入忽略） */
+export const recordSemesterStartDate = (semester, startDate) => {
+  const sem = toSafeText(semester)
+  const dateText = toSafeText(startDate)
+  if (!sem || !SEMESTER_START_DATE_RE.test(dateText)) return false
+  const map = readJSON(SCHEDULE_SEMESTER_START_DATES_KEY, {})
+  const cached = map && typeof map === 'object' ? map : {}
+  if (cached[sem] === dateText) return true
+  cached[sem] = dateText
+  writeJSON(SCHEDULE_SEMESTER_START_DATES_KEY, cached)
+  return true
 }
 
 const buildScheduleRenderSnapshotKey = (studentId) => {
@@ -364,6 +402,61 @@ const normalizeSemesterPayload = (payload) => {
   }
 }
 
+// #750 轻量探测指定学期课表（启动决策与回前台重探共用）：
+// - 无论课表是否发布，只要 meta 带该学期 start_date 就记录映射（支撑提前窗口判定）；
+// - inflight 去重：启动路径与回前台并发触发时只发一次请求。
+const probeSemesterInflight = new Map()
+
+export const probeSemesterSchedule = async (studentId, semester = '') => {
+  const sid = toSafeText(studentId)
+  const sem = toSafeText(semester)
+  if (!sid || !sem) {
+    return { ok: false, semester: sem, published: false, count: 0, startDate: '' }
+  }
+  const inflightKey = `${sid}:${sem}`
+  if (probeSemesterInflight.has(inflightKey)) {
+    return probeSemesterInflight.get(inflightKey)
+  }
+  const task = (async () => {
+    try {
+      const queryResult = await querySchedule(sid, sem)
+      const payload = queryResult?.data
+      if (payload?.need_login) {
+        return { ok: false, semester: sem, published: false, count: 0, startDate: '', needLogin: true }
+      }
+      const normalized = normalizeSemesterPayload(payload)
+      const startDate = toSafeText(payload?.meta?.start_date)
+      const payloadSemester = toSafeText(payload?.meta?.semester)
+      // meta.semester 与请求学期一致才记录开学日，防止后端回退到其他学期 meta 造成误记
+      if (normalized && payloadSemester === sem && startDate) {
+        recordSemesterStartDate(sem, startDate)
+      }
+      const published = !!normalized && normalized.count > 0
+      pushDebugLog(
+        'Schedule',
+        `#750 探测学期课表 semester=${sem} published=${published} count=${normalized?.count ?? 0} start_date=${startDate || '未知'}`,
+        'debug'
+      )
+      return {
+        ok: !!normalized,
+        semester: sem,
+        published,
+        count: normalized?.count ?? 0,
+        startDate,
+        fromCache: !!queryResult?.fromCache,
+        stale: !!queryResult?.stale,
+        payload: normalized ? normalized.payload : null
+      }
+    } catch {
+      return { ok: false, semester: sem, published: false, count: 0, startDate: '' }
+    } finally {
+      probeSemesterInflight.delete(inflightKey)
+    }
+  })()
+  probeSemesterInflight.set(inflightKey, task)
+  return task
+}
+
 const isAuthoritativeSchedulePayload = (payload, queryResult) => {
   if (!payload?.success) return false
   if (payload?.offline) return false
@@ -449,6 +542,12 @@ export const warmupScheduleForStudent = async (studentId, options = {}) => {
     const normalized = normalizeSemesterPayload(payload)
     if (!normalized) continue
 
+    // #750：记录各学期开学日（meta.start_date），即使该学期课表未发布，
+    // start_date 也可支撑提前窗口判定（开学前 3 天自动切新学期）。
+    if (payload?.meta?.start_date && normalized.semester) {
+      recordSemesterStartDate(normalized.semester, payload.meta.start_date)
+    }
+
     if (!firstSuccess) {
       firstSuccess = {
         semester: semester || normalized.semester,
@@ -508,6 +607,34 @@ export const warmupScheduleForStudent = async (studentId, options = {}) => {
   const previousStoredSemester = cachedSemester
   const payloadSemester = toSafeText(picked.payload?.meta?.semester || picked.semester)
   let selectedSemester = payloadSemester || previousStoredSemester || anchorSemester
+
+  // #750 回跳保护①：现有锁定学期比探测结果更新 → 不得把学期改回更旧学期。
+  // 不覆盖 lock / 不清 lock / 不更新 meta.semester / 不弹提示；payload 置空，
+  // 调用方按返回的锁定学期自行取数（fetchSchedule(锁定学期)），保持 UI 与锁定一致。
+  const existingLockDetail = readScheduleLockDetail(sid)
+  const existingLockSemester = toSafeText(existingLockDetail?.semester)
+  if (
+    existingLockSemester &&
+    selectedSemester !== existingLockSemester &&
+    !semesterIsNewer(selectedSemester, existingLockSemester)
+  ) {
+    pushDebugLog(
+      'Schedule',
+      `#750 探测学期(${selectedSemester}) 不晚于现有锁定(${existingLockSemester})，保持锁定不回跳`,
+      'info'
+    )
+    return {
+      success: true,
+      semester: existingLockSemester,
+      count: courseCount(picked.payload),
+      fromCache: true,
+      stale: !!picked.stale,
+      authoritative: false,
+      source: 'existing-lock-protected',
+      payload: null
+    }
+  }
+
   if (authoritative || !previousStoredSemester) {
     selectedSemester = updateStoredScheduleMeta(picked.payload?.meta, selectedSemester)
   }
@@ -518,21 +645,54 @@ export const warmupScheduleForStudent = async (studentId, options = {}) => {
     setCachedData(scopedKey, picked.payload)
   }
   setCachedData(buildScheduleCacheKey(sid), picked.payload)
-  if (authoritative || options?.forceLock) {
-    writeScheduleLock(sid, selectedSemester, reasonText)
+
+  // #750 回跳保护②：时间驱动应选学期(targetSemester)比探测结果更新（提前窗口内新学期
+  // 课表未发布，picked 仍为旧学期）→ 不把更旧学期写入 lock，保持「未锁定」状态，
+  // 等待新学期发布后的 authoritative 探测以 term-start 锁定，避免锁死旧学期。
+  const targetSemester = toSafeText(options?.targetSemester)
+  const pickedOlderThanTarget =
+    !!targetSemester &&
+    selectedSemester !== targetSemester &&
+    !semesterIsNewer(selectedSemester, targetSemester)
+
+  if (pickedOlderThanTarget) {
+    pushDebugLog(
+      'Schedule',
+      `#750 探测学期(${selectedSemester}) 早于时间驱动应选学期(${targetSemester})，跳过锁定以等待新学期发布`,
+      'info'
+    )
+  } else if (authoritative || options?.forceLock) {
+    // #750：探测命中时间驱动应选学期且有课表 → 以 term-start 锁定（启动路径不误清）。
+    const lockReason =
+      targetSemester && selectedSemester === targetSemester ? 'term-start' : reasonText
+    writeScheduleLock(sid, selectedSemester, lockReason)
+    if (lockReason === 'term-start') {
+      pushDebugLog(
+        'Schedule',
+        `#750 时间驱动锁定学期 ${selectedSemester}（reason=term-start，探测课数=${courseCount(picked.payload)}）`,
+        'info'
+      )
+    }
   } else {
     const lockDetail = readScheduleLockDetail(sid)
     if (lockDetail && isAutoScheduleLockReason(lockDetail.reason)) {
       clearScheduleLock(sid)
     }
   }
-  if (!options?.skipPopup) {
+  if (!pickedOlderThanTarget && !options?.skipPopup) {
     queueScheduleSemesterPopup(sid, selectedSemester, reasonText)
   }
 
   // Widget 快照写入（异步，不阻塞返回）
   const metaWeek = Number(picked.payload?.meta?.current_week) || 1
   afterScheduleRefresh(sid, picked.payload, { selectedWeek: metaWeek }).catch(() => {})
+
+  // #750 取证日志：探测 picked 学期/课数与锁定学期（旧值→新值）
+  pushDebugLog(
+    'Schedule',
+    `#750 探测 picked semester=${selectedSemester} count=${courseCount(picked.payload)} lock=${existingLockSemester || '无'}→${selectedSemester} authoritative=${authoritative}`,
+    'debug'
+  )
 
   return {
     success: true,

--- a/apps/client/src/utils/schedule_prefetch_lock_guard.spec.ts
+++ b/apps/client/src/utils/schedule_prefetch_lock_guard.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * #750 开学日期驱动学期切换 —— schedule_prefetch 锁保护/锁定契约测试。
+ *
+ * 回归点（issue #750）：
+ * 1. 回跳保护①：现有 auto 锁（如 term-start 的新学期）比探测 picked 更新时，
+ *    warmup 不得把学期改回更旧学期（不覆盖 lock、不清 lock、不更新 meta.semester、不弹提示）；
+ * 2. 回跳保护②：时间驱动应选学期（targetSemester）比探测 picked 更新（窗口内新学期课表
+ *    未发布）时，不把更旧学期写入 lock，保持可重探状态等待发布；
+ * 3. 探测命中时间驱动应选学期且有课表 → 以 term-start 锁定（启动路径不误清）；
+ * 4. probeSemesterSchedule：无论课表是否发布，meta.start_date 都记录进「学期→开学日」映射；
+ * 5. 'term-start' 必须被认定为 auto 锁 reason（isAutoScheduleLockReason）。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// hoisted 容器：按 fetchWithCache key 分发响应
+const responders = vi.hoisted(() => new Map<string, () => unknown>())
+
+vi.mock('./api.js', () => ({
+  fetchWithCache: vi.fn(async (key: string) => {
+    const responder = responders.get(key)
+    if (!responder) throw new Error(`unexpected fetchWithCache key: ${key}`)
+    return { data: responder(), fromCache: false, timestamp: Date.now() }
+  }),
+  getCacheKey: (key: string) => `zc:${key}`,
+  setCachedData: vi.fn()
+}))
+
+vi.mock('./widget_bridge', () => ({
+  afterScheduleRefresh: vi.fn(async () => {})
+}))
+
+vi.mock('./debug_logger', () => ({
+  pushDebugLog: vi.fn()
+}))
+
+vi.mock('axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() }
+}))
+
+// node 环境无 localStorage：内存实现
+const store = new Map<string, string>()
+const localStorageStub = {
+  getItem: (key: string) => (store.has(key) ? (store.get(key) as string) : null),
+  setItem: (key: string, value: string) => {
+    store.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    store.delete(key)
+  },
+  clear: () => store.clear()
+}
+vi.stubGlobal('localStorage', localStorageStub)
+
+import {
+  clearScheduleLock,
+  isAutoScheduleLockReason,
+  probeSemesterSchedule,
+  readScheduleLock,
+  readScheduleLockDetail,
+  readSemesterStartDates,
+  recordSemesterStartDate,
+  warmupScheduleForStudent
+} from './schedule_prefetch.js'
+
+const SID = 'S1'
+const OLD_SEM = '2025-2026-2'
+const NEW_SEM = '2026-2027-1'
+const OLD_START = '2026-03-02'
+const NEW_START = '2026-08-31'
+const SEMESTERS_KEY = 'semesters'
+const scheduleKey = (sem: string) => `schedule:${SID}:${sem}`
+
+const semestersPayload = () => ({
+  success: true,
+  current: OLD_SEM,
+  semesters: [NEW_SEM, OLD_SEM]
+})
+
+/** 旧学期（已上架，3 门课） */
+const oldSemesterPayload = () => ({
+  success: true,
+  data: [{ name: '课程A' }, { name: '课程B' }, { name: '课程C' }],
+  meta: { semester: OLD_SEM, start_date: OLD_START, current_week: 20, total_weeks: 25 }
+})
+
+/** 新学期载荷（count 由 courses 参数决定） */
+const newSemesterPayload = (courses: number) => ({
+  success: true,
+  data: Array.from({ length: courses }, (_, i) => ({ name: `新课${i + 1}` })),
+  meta: { semester: NEW_SEM, start_date: NEW_START, current_week: 1, total_weeks: 20 }
+})
+
+const setLockRecord = (semester: string, reason: string) => {
+  store.set('hbu_schedule_lock', JSON.stringify({ student_id: SID, semester, reason, at: Date.now() }))
+}
+
+const setStoredMeta = () => {
+  store.set(
+    'hbu_schedule_meta',
+    JSON.stringify({ semester: OLD_SEM, start_date: OLD_START, current_week: 20, total_weeks: 25 })
+  )
+}
+
+beforeEach(() => {
+  store.clear()
+  responders.clear()
+  responders.set(SEMESTERS_KEY, semestersPayload)
+  responders.set(scheduleKey(OLD_SEM), oldSemesterPayload)
+  responders.set(scheduleKey(NEW_SEM), () => newSemesterPayload(0))
+})
+
+describe('#750 isAutoScheduleLockReason：term-start 语义', () => {
+  it('term-start 属于 auto 锁（启动路径不误清）', () => {
+    expect(isAutoScheduleLockReason('term-start')).toBe(true)
+  })
+
+  it('manual-select 不是 auto 锁', () => {
+    expect(isAutoScheduleLockReason('manual-select')).toBe(false)
+  })
+})
+
+describe('#750 学期开学日映射缓存', () => {
+  it('记录与读取（YYYY-MM-DD 校验）', () => {
+    expect(recordSemesterStartDate(NEW_SEM, NEW_START)).toBe(true)
+    expect(readSemesterStartDates()[NEW_SEM]).toBe(NEW_START)
+    expect(recordSemesterStartDate('bad-sem', 'not-a-date')).toBe(false)
+    expect(recordSemesterStartDate('', NEW_START)).toBe(false)
+  })
+
+  it('读取时过滤非法条目', () => {
+    store.set('hbu_semester_start_dates', JSON.stringify({ [NEW_SEM]: NEW_START, bad: 'xx' }))
+    const map = readSemesterStartDates()
+    expect(map[NEW_SEM]).toBe(NEW_START)
+    expect(map.bad).toBeUndefined()
+  })
+})
+
+describe('#750 warmupScheduleForStudent 回跳保护①', () => {
+  it('现有 auto 锁（新学期）比探测 picked 更新 → 不改学期/不清锁/不改 meta', async () => {
+    // 现有锁定：时间驱动已锁新学期；新学期课表查询返回 0 门（异常下架场景），picked 落到旧学期
+    setLockRecord(NEW_SEM, 'term-start')
+    setStoredMeta()
+
+    const result = (await warmupScheduleForStudent(SID, {
+      forceProbe: true,
+      reason: 'first-enter'
+    })) as {
+      success?: boolean
+      semester?: string
+      source?: string
+      payload?: unknown
+    }
+
+    expect(result?.success).toBe(true)
+    expect(result?.semester).toBe(NEW_SEM)
+    expect(result?.source).toBe('existing-lock-protected')
+    expect(result?.payload).toBeNull()
+
+    // lock 未被覆盖/清除
+    expect(readScheduleLock(SID)).toBe(NEW_SEM)
+    expect((readScheduleLockDetail(SID) as { reason?: string })?.reason).toBe('term-start')
+    // meta.semester 未被探测结果污染
+    expect(JSON.parse(store.get('hbu_schedule_meta') || '{}').semester).toBe(OLD_SEM)
+    // 探测到的开学日仍入映射（供时间驱动判定）
+    expect(readSemesterStartDates()[NEW_SEM]).toBe(NEW_START)
+  })
+})
+
+describe('#750 warmupScheduleForStudent 回跳保护②', () => {
+  it('picked 早于 targetSemester（窗口内新学期未发布）→ 不写 lock，等待发布', async () => {
+    setStoredMeta() // 无 lock
+
+    const result = (await warmupScheduleForStudent(SID, {
+      forceProbe: true,
+      reason: 'first-enter',
+      targetSemester: NEW_SEM
+    })) as { success?: boolean; semester?: string }
+
+    // picked = 旧学期（新学期 0 门课），照常返回数据用于渲染
+    expect(result?.success).toBe(true)
+    expect(result?.semester).toBe(OLD_SEM)
+    // 但不得把更旧学期写进 lock（保持未锁定，等待新学期发布后的 authoritative 探测）
+    expect(readScheduleLock(SID)).toBe('')
+    // 新学期开学日已记录（下次启动时间驱动判定可用）
+    expect(readSemesterStartDates()[NEW_SEM]).toBe(NEW_START)
+  })
+})
+
+describe('#750 warmupScheduleForStudent term-start 锁定', () => {
+  it('探测命中 targetSemester 且有课表 → 以 term-start 锁定', async () => {
+    responders.set(scheduleKey(NEW_SEM), () => newSemesterPayload(5))
+    setStoredMeta() // 无 lock
+
+    const result = (await warmupScheduleForStudent(SID, {
+      forceProbe: true,
+      reason: 'first-enter',
+      targetSemester: NEW_SEM
+    })) as { success?: boolean; semester?: string }
+
+    expect(result?.semester).toBe(NEW_SEM)
+    expect(readScheduleLock(SID)).toBe(NEW_SEM)
+    expect((readScheduleLockDetail(SID) as { reason?: string })?.reason).toBe('term-start')
+  })
+})
+
+describe('#750 probeSemesterSchedule 轻量探测', () => {
+  it('未发布学期：记录 start_date 映射且 published=false', async () => {
+    const result = (await probeSemesterSchedule(SID, NEW_SEM)) as {
+      ok?: boolean
+      published?: boolean
+      count?: number
+      startDate?: string
+    }
+    expect(result?.ok).toBe(true)
+    expect(result?.published).toBe(false)
+    expect(result?.count).toBe(0)
+    expect(result?.startDate).toBe(NEW_START)
+    expect(readSemesterStartDates()[NEW_SEM]).toBe(NEW_START)
+  })
+
+  it('已发布学期：published=true 且课数正确', async () => {
+    responders.set(scheduleKey(NEW_SEM), () => newSemesterPayload(7))
+    const result = (await probeSemesterSchedule(SID, NEW_SEM)) as {
+      published?: boolean
+      count?: number
+    }
+    expect(result?.published).toBe(true)
+    expect(result?.count).toBe(7)
+  })
+
+  it('need_login 时返回 needLogin 标记', async () => {
+    responders.set(scheduleKey(NEW_SEM), () => ({ success: false, need_login: true }))
+    const result = (await probeSemesterSchedule(SID, NEW_SEM)) as { needLogin?: boolean }
+    expect(result?.needLogin).toBe(true)
+  })
+
+  it('参数缺失直接返回不可用结果', async () => {
+    const result = (await probeSemesterSchedule('', NEW_SEM)) as { ok?: boolean }
+    expect(result?.ok).toBe(false)
+  })
+})
+
+describe('#750 启动清理兜底', () => {
+  it('clearScheduleLock 移除锁定记录', () => {
+    setLockRecord(NEW_SEM, 'term-start')
+    expect(clearScheduleLock(SID)).toBe(true)
+    expect(readScheduleLock(SID)).toBe('')
+  })
+})


### PR DESCRIPTION
## TL;DR

Closes #749 · Closes #750

两个开学季课表问题的修复（双 Agent 并行实现，集成验收全绿）：

1. **#749 划分线与课程卡片逐节错位**：像素级实测虚线 84px/行 vs 卡片与时间轴 86px/行（每节累积 2px，第 9 节偏 19px）。根因 = 组件拆分时 `.courses-grid` 丢失 v1.4.6 的 `min-height` 保护，虚线行被 flex 均匀压缩。修复（A+B）：
   - A：恢复 `.courses-grid` 的 `min-height: calc(var(--slot-height) * 11 + var(--schedule-bottom-gap))`，`.time-slot` 补 `flex: 0 0 var(--slot-height)`
   - B：划分线改用 `repeating-linear-gradient` 背景绘制（每周期 = `var(--slot-height)`，`background-size` 限定 11 个周期），移除 11 个 `.line-row` DOM——结构上免疫 flex 压缩，线位恒为 slot 整数倍
2. **#750 学期切换改为开学日期驱动**（产品拍板：时间驱动取代手动优先）：
   - 新纯函数 `resolveSemesterByStartDate`：应显示学期 = `start_date <= 今天+3 天` 的最近一个（提前 3 天自动切，有提前量）；缺失回退现有推算链
   - **切后不回跳**：`term-start` 锁定 + warmup 探测「picked 不晚于现有锁则不覆盖/不清/不改 meta」双保护；lock 清理条件从「≠日期推算」改为「≠时间驱动判定」
   - 提前窗口内新学期课表未发布 → 保持旧学期 + `termStartNotice` 横幅，启动/回前台（60s 节流）重探，发布后自动切
   - 手动查看其他学期 = 会话内临时（重启回时间驱动应选学期）；`manual-select` 锁会话内优先不被自动路径拉回
   - 运行时取证日志：应选学期判定/lock 写入清除覆盖（旧值→新值）/探测 picked 全量 debug 日志
   - `useScheduleTermStart.ts` 文件头含完整 lock 生命周期行为表（锁定类型 × 启动/探测/手动/回前台）

## 测试结论（本地实测）

| 项目 | 结果 |
|---|---|
| `npm run typecheck`（vue-tsc） | 通过 |
| `npx vitest run` 全量 | **170 文件 / 1186 测试全部通过**（新增 semester.spec 18 例 + lock_guard 10 例 + grid_lines 5 例） |
| `npm run build` | 通过（7.96s） |

注：首轮全量曾出现 1 个网络模拟类测试偶发失败（sessionOnlineState，与本次改动无关的重跑即绿项），复跑全绿。

## 验收对照（issue 标准）

- #749：三套行距在视口 < / > 11×slot 下恒等（min-height + gradient 双保障）✓；新增 5 条源码契约断言防回归 ✓
- #750：start−3 当天切 / start−4 不切 / start 当天 / 无 start_date 回退 / 多学期取最近（18 例单测）✓；切新学期后重启不回跳（lock 生命周期矩阵）✓；无数据保持旧学期+横幅 ✓；取证日志 ✓

## 风险与说明

- 新学期 start_date 由客户端从课表 meta 累积缓存（/v2/semesters 不带日期），首次进入提前窗口当天靠发现型探测补齐（Agent 实现说明，最坏多一次 5min-TTL 缓存级查询）
- 全局 schedule 相关测试为重跑即绿项；若 CI 偶发可 rerun