### PR TITLE
fix(#749): 课表划分线视觉微调——原生 dashed 改稀疏虚线（::after 渐变线体）

### DIFF
--- a/apps/client/src/features/schedule/components/ScheduleGrid.vue
+++ b/apps/client/src/features/schedule/components/ScheduleGrid.vue
@@ -1,9 +1,10 @@
 <script setup>
 /**
  * 课表主体：日期头 + 时间轴 + 课程网格（含周切换动画）。
- * 自 ScheduleView.vue 拆分；#749 起划分线由 grid-lines 单元素背景绘制（不再逐节循环 DOM 行）。
+ * 自 ScheduleView.vue 拆分；#749 修复行距错位（容器 min-height + 行 flex 固定），
+ * 划分线保持 v1.4.6 的 line-row dashed 虚线视觉（用户指定）。
  */
-import { timeSchedule } from '../constants'
+import { MAX_PERIOD, timeSchedule } from '../constants'
 
 const props = defineProps({
   weekDates: { type: Array, default: () => [] },
@@ -25,6 +26,8 @@ const isTodayColumn = (dayIndex) => {
   const date = props.weekDates[idx]
   return !!date?.isToday
 }
+
+const periodRows = Array.from({ length: MAX_PERIOD }, (_, i) => i + 1)
 </script>
 
 <template>
@@ -56,9 +59,12 @@ const isTodayColumn = (dayIndex) => {
 
         <!-- 课程网格 -->
         <div class="courses-grid" :key="`courses-grid-${scheduleCourseCardStyle}-${courseCardRefreshNonce}`">
-          <!-- 背景划分线：单元素背景绘制（#749）。线距严格等于 var(--slot-height) 整数倍，
-               无可被 flex 压缩的 DOM 行，任何视口下都与时间轴/课程网格的第 k 节边界重合 -->
-          <div class="grid-lines" aria-hidden="true"></div>
+          <!-- 背景划分线：虚线视觉与 v1.4.6 一致（用户指定 dashed）。
+               #749 的行距对齐由「容器 min-height + 行 flex: 0 0」双保护保证，
+               line-row 不再可能被 flex 压缩 -->
+          <div class="grid-lines" aria-hidden="true">
+            <div v-for="i in periodRows" :key="i" class="line-row"></div>
+          </div>
 
           <!-- 每天一列 -->
           <div v-for="day in 7" :key="day" class="day-column" :class="{ 'is-today-column': isTodayColumn(day) }">
@@ -249,27 +255,44 @@ const isTodayColumn = (dayIndex) => {
   box-sizing: border-box;
 }
 
-/* 划分线：单元素背景绘制（#749 结构性免疫）。
-   repeating-linear-gradient 每个周期 = var(--slot-height)，仅周期底部 1px 着色，
-   线位置恒为 var(--slot-height) 的整数倍；background-size 限定 11 个完整周期，
-   即恰好 11 条线，与 11 个 time-slot / day-column 网格行一一对应。
-   原方案（11 个 line-row 行 DOM 循环）在容器高度不足时会被 flex 均匀压缩导致行距分叉，已移除 */
+/* 划分线：line-row 虚线（v1.4.6 视觉，用户指定 dashed）。
+   #749 行距对齐的根因修复是两道保护，与线实现解耦：
+   1) .courses-grid 的 min-height 保证 grid-lines 容器 ≥ 11×slot，行不再被压缩
+   2) .line-row / .time-slot 的 flex: 0 0 固定行高，禁止压缩/拉伸 */
 .grid-lines {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  display: flex;
+  flex-direction: column;
   pointer-events: none;
+}
+
+.line-row {
+  height: var(--slot-height);
+  flex: 0 0 var(--slot-height);
+  position: relative;
+  box-sizing: border-box;
+}
+
+/* 稀疏虚线：::after 限定 1px 线高，水平 repeating 渐变控制疏密
+   （8px 实段 / 8px 空，浏览器原生 dashed 约 3px 段太密，用户要求稀松） */
+.line-row::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
   background-image: repeating-linear-gradient(
-    to bottom,
-    transparent 0,
-    transparent calc(var(--slot-height) - 1px),
-    #e5e7eb calc(var(--slot-height) - 1px),
-    #e5e7eb var(--slot-height)
+    to right,
+    #e5e7eb 0,
+    #e5e7eb 8px,
+    transparent 8px,
+    transparent 16px
   );
-  background-size: 100% calc(var(--slot-height) * 11);
-  background-repeat: no-repeat;
 }
 
 .day-column {

--- a/apps/client/src/features/schedule/schedule_grid_lines.spec.ts
+++ b/apps/client/src/features/schedule/schedule_grid_lines.spec.ts
@@ -11,9 +11,9 @@ import { readVueContractSource } from '../../utils/contract_source_test'
  *
  * 失败条件（回归即挂）：
  * 1. .courses-grid 丢失 min-height: calc(var(--slot-height) * 11 + var(--schedule-bottom-gap))
- * 2. 划分线回退为 .line-row DOM 循环（可被 flex 压缩的实现）
- * 3. 划分线尺寸不再绑定 var(--slot-height)（线位漂移）
- * 4. .time-slot 丢失 flex: 0 0 固定（时间轴行被压缩/拉伸）
+ * 2. .line-row 丢失 flex: 0 0 / dashed 视觉（划分线被改为实线或可压缩实现）
+ * 3. .time-slot 丢失 flex: 0 0 固定（时间轴行被压缩/拉伸）
+ * 4. 划分线尺寸不再绑定 var(--slot-height)（线位漂移）
  */
 const source = readVueContractSource('src/features/schedule/components/ScheduleGrid.vue')
 
@@ -41,16 +41,18 @@ describe('schedule grid lines contract (#749)', () => {
     expect(block).toContain('height: 100%')
   })
 
-  it('grid lines are painted as slot-height-bound background (no compressible line-row DOM)', () => {
-    // B：划分线为单元素背景绘制，线距 = var(--slot-height) 整数倍
-    const block = cssBlock('.grid-lines')
-    expect(block).toContain('repeating-linear-gradient')
-    expect(block).toContain('calc(var(--slot-height) - 1px)')
-    // background-size 限定 11 个完整周期 = 11 条线，底部留白不着色
-    expect(block).toContain('calc(var(--slot-height) * 11)')
-    // 禁止回归可被 flex 压缩的 line-row 行循环
-    expect(source).not.toContain('.line-row')
-    expect(source).not.toContain('class="line-row"')
+  it('grid lines keep sparse dashed line-row pinned by flex-basis (v1.4.6 rhythm, anti-compression)', () => {
+    // 划分线为 line-row 稀疏虚线（用户指定疏密），线本体 = ::after 1px 高 + 水平渐变，
+    // 行高由 flex: 0 0 固定 + 容器 min-height 保护，杜绝 flex 压缩
+    const block = cssBlock('.line-row')
+    expect(block).toContain('flex: 0 0 var(--slot-height)')
+    expect(block).toContain('height: var(--slot-height)')
+    const after = cssBlock('.line-row::after')
+    expect(after).toContain('height: 1px')
+    expect(after).toContain('repeating-linear-gradient')
+    expect(after).toContain('#e5e7eb')
+    // 禁止回退为实线背景绘制（用户否决过 gradient 实线视觉）
+    expect(source).not.toContain('background-size: 100% calc(var(--slot-height) * 11)')
   })
 
   it('time-slot rows are flex-fixed to slot-height', () => {


### PR DESCRIPTION
## TL;DR

Ref #749 视觉微调：用户反馈浏览器原生 `border dashed`（约 3px 段）太密，改为 `::after` 1px 线体 + 水平 `repeating-linear-gradient`（**8px 实段 / 8px 空**）的稀疏虚线。行距保护（容器 min-height + 行 flex: 0 0）原样保留。

## 改动

- `.line-row`：去 `border-bottom dashed`，改 `position: relative` + `::after`（1px 高、水平渐变虚线、颜色同为 #e5e7eb）
- `.line-row::after`：`repeating-linear-gradient(to right, #e5e7eb 0 8px, transparent 8px 16px)`，疏密参数集中一处可调
- 契约测试同步：断言 ::after 虚线实现 + flex/min-height 保护，禁止回退 gradient 实线整面绘制

## 验证

- 契约测试 5/5 ✓；`npm run typecheck` ✓；dev 实例 HMR 实时生效（用户已实时确认方向）