### PR TITLE
fix(#753): 空教室楼栋按钮显示 一教/二教…，教务查询值保持原文

### DIFF
--- a/apps/client/src/components/ClassroomView.spec.ts
+++ b/apps/client/src/components/ClassroomView.spec.ts
@@ -63,4 +63,16 @@ describe('ClassroomView display contract', () => {
     expect(vue).toMatch(/\.classroom-period-button\s*\{[^}]*min-width:\s*42px;/s)
     expect(vue).toMatch(/\.classroom-period-row-buttons\s*\{[^}]*grid-template-columns:\s*repeat\(4,\s*42px\);/s)
   })
+
+  it('displays buildings as 一教/二教… while keeping the original jxlmc query value (#753)', () => {
+    const vue = source()
+
+    // 显示：按钮文案经 displayBuildingName 映射（教务原文「N号教学楼」→「N教」）
+    expect(vue).toContain('{{ displayBuildingName(b.name) }}')
+    // 查询：filters.building 仍写入教务原始 name（jxlmc 语义不可变）
+    expect(vue).toContain('filters.building = b.name')
+    // 映射规则：数字转汉字 + 「教」后缀，兼容「N号教学楼/N号楼/N教」形态
+    expect(vue).toContain('CN_DIGITS')
+    expect(vue).toMatch(/\(\?:号教学\(\?:楼\)\?\|号楼\|教\)/)
+  })
 })

--- a/apps/client/src/components/ClassroomView.vue
+++ b/apps/client/src/components/ClassroomView.vue
@@ -22,6 +22,16 @@ const CLASSROOM_SNAPSHOT_FRESH_MS = 60 * 1000
 const CLASSROOM_AUTO_QUERY_COOLDOWN_MS = 20 * 1000
 const CLASSROOM_DEFERRED_REFRESH_MS = 2500
 
+// #753：楼栋显示名映射。教务接口返回「N号教学楼」等原文（同时是 jxlmc 查询值，
+// 不可改动），页面按校内习惯显示为「N教」（数字转汉字）。
+const CN_DIGITS = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九']
+const displayBuildingName = (name) => {
+  const m = String(name || '').trim().match(/^(\d+)(?:号教学(?:楼)?|号楼|教)$/)
+  if (!m) return name
+  const cn = m[1].split('').map((d) => CN_DIGITS[Number(d)] || d).join('')
+  return `${cn}教`
+}
+
 // 状态
 const loading = ref(false)
 const buildings = ref([])
@@ -811,7 +821,7 @@ onBeforeUnmount(() => {
                   'px-3 py-1.5 rounded-full text-xs font-medium shrink-0',
                   filters.building === b.name ? 'bg-primary/10 text-primary border border-primary/20' : 'bg-surface-container-lowest border border-outline-variant/50 text-on-surface-variant'
                 ]"
-              >{{ b.name }}</button>
+              >{{ displayBuildingName(b.name) }}</button>
             </div>
           </div>
 


### PR DESCRIPTION
## TL;DR

Closes #753

查空教室页楼栋按钮显示教务原文「1号教学楼/2号教学楼…」，改为校内习惯的「一教/二教/三教/四教」（其他楼栋原名显示）。

## 关键约束（查明结论）

- 楼栋列表来自**教务页面** `/admin/system/jxzy/jsxx/queryForXsd` 的 `jxldm` 下拉（`http_client/academic/schedule.rs::fetch_classroom_buildings`），`name` 同时用作查询参数 `jxlmc`——**不可改动**
- `modules/classroom.rs::get_buildings` 为无引用的死代码路径，未触碰
- 修复 = 前端显示层映射：`displayBuildingName(name)`——「N号教学楼/N号楼/N教」→「N教」（数字转汉字）；查询值 `filters.building = b.name` 保持教务原文

## 改动

- `ClassroomView.vue`：新增 `CN_DIGITS` + `displayBuildingName` 纯函数；楼栋按钮 `{{ displayBuildingName(b.name) }}`（:824），查询/选中判断仍用 `b.name`（:809/:812）
- `ClassroomView.spec.ts`：新增契约断言（显示走映射、查询写原文、映射规则形态）

## 验证

- 契约测试 8/8 ✓；`npm run typecheck` ✓；`npm run build` ✓
- 运行时复核项（issue 验收）：点「一教」查询结果与改前一致（jxlmc 未变）