### PR TITLE
fix(#759,#758): 小组件跨天日期滞后 + 背景半透明与颜色跟随应用模式

### DIFF
--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/ElectricityWidgetRenderer.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/ElectricityWidgetRenderer.kt
@@ -22,6 +22,8 @@ object ElectricityWidgetRenderer {
         val store = WidgetDataStore(context)
         val json = store.readElectricity()
         val data = parseJson(json)
+        // #758：应用强制 light/dark 时覆盖背景与中性文字色；system 模式零干预
+        val themeMode = WidgetThemeMode.resolve(context)
 
         val titleId = context.resources.getIdentifier("widget_elec_title", "id", packageName)
         val quantityId = context.resources.getIdentifier("widget_elec_quantity", "id", packageName)
@@ -65,6 +67,11 @@ object ElectricityWidgetRenderer {
         }
         val rootId = context.resources.getIdentifier("widget_elec_root", "id", packageName)
         if (rootId != 0) views.setOnClickPendingIntent(rootId, pi)
+        // #758：强制模式下覆盖背景与中性文字色（电量数值沿用品牌主题色）
+        WidgetThemeMode.applyBackground(context, themeMode, views, rootId)
+        WidgetThemeMode.bindTextColor(context, themeMode, views, titleId, "widget_text_primary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, roomId, "widget_text_secondary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, statusId, "widget_location_text")
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/ExamWidgetRenderer.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/ExamWidgetRenderer.kt
@@ -23,6 +23,8 @@ object ExamWidgetRenderer {
         val store = WidgetDataStore(context)
         val json = store.readExam()
         val data = parseJson(json)
+        // #758：应用强制 light/dark 时覆盖背景与中性文字色；system 模式零干预
+        val themeMode = WidgetThemeMode.resolve(context)
 
         val titleId = context.resources.getIdentifier("widget_exam_title", "id", packageName)
         val courseId = context.resources.getIdentifier("widget_exam_course", "id", packageName)
@@ -95,6 +97,12 @@ object ExamWidgetRenderer {
         }
         val rootId = context.resources.getIdentifier("widget_exam_root", "id", packageName)
         if (rootId != 0) views.setOnClickPendingIntent(rootId, pi)
+        // #758：强制模式下覆盖背景与中性文字色（倒计时沿用品牌主题色）
+        WidgetThemeMode.applyBackground(context, themeMode, views, rootId)
+        WidgetThemeMode.bindTextColor(context, themeMode, views, titleId, "widget_text_primary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, courseId, "widget_text_primary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, dateId, "widget_text_secondary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, locationId, "widget_location_text")
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesRemoteViewsService.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesRemoteViewsService.kt
@@ -78,6 +78,8 @@ class TodayCoursesRemoteViewsFactory(
         } catch (_: Exception) {
             android.graphics.Color.parseColor("#2563eb")
         }
+        // #758：应用强制 light/dark 时覆盖中性文字色；system 模式零干预
+        val themeMode = WidgetThemeMode.resolve(context)
 
         // 节次徽标（合并后显示范围，如 "3-4节"）
         val periodText = if (row.periodStart == row.periodEnd) {
@@ -90,20 +92,19 @@ class TodayCoursesRemoteViewsFactory(
         views.setTextColor(periodId, themeColor)
 
         // 时间
-        views.setTextViewText(
-            context.resources.getIdentifier("widget_item_time", "id", packageName),
-            "${row.timeStart}-${row.timeEnd}"
-        )
+        val timeId = context.resources.getIdentifier("widget_item_time", "id", packageName)
+        views.setTextViewText(timeId, "${row.timeStart}-${row.timeEnd}")
         // 课程名
-        views.setTextViewText(
-            context.resources.getIdentifier("widget_item_name", "id", packageName),
-            row.name
-        )
+        val nameId = context.resources.getIdentifier("widget_item_name", "id", packageName)
+        views.setTextViewText(nameId, row.name)
         // 教室
-        views.setTextViewText(
-            context.resources.getIdentifier("widget_item_location", "id", packageName),
-            row.location
-        )
+        val locationId = context.resources.getIdentifier("widget_item_location", "id", packageName)
+        views.setTextViewText(locationId, row.location)
+
+        // #758：强制模式下覆盖中性文字色（节次徽标沿用品牌主题色）
+        WidgetThemeMode.bindTextColor(context, themeMode, views, nameId, "widget_text_primary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, timeId, "widget_text_secondary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, locationId, "widget_location_text")
 
         // 无障碍 contentDescription — 对齐 a11yLabel 格式
         val contentDesc = "第 ${row.periodStart} 节 ${row.timeStart} 到 ${row.timeEnd} ${row.name} ${row.location}".trimEnd()
@@ -115,11 +116,7 @@ class TodayCoursesRemoteViewsFactory(
         // 行点击深链：携带节次参数（#759：快照过期时深链用今天，避免前端高亮到昨天）
         val snapshotJson = store.readSnapshot()
         val snapshotDateRaw = readSnapshotDate(snapshotJson)
-        val snapshotDate = if (isBeforeToday(snapshotDateRaw)) {
-            java.time.LocalDate.now().toString()
-        } else {
-            snapshotDateRaw
-        }
+        val snapshotDate = if (isBeforeToday(snapshotDateRaw)) todayString() else snapshotDateRaw
         if (snapshotDate.isNotEmpty() && row.periodStart >= 1) {
             val fillInIntent = Intent().apply {
                 data = WidgetDeepLink.scheduleUri(snapshotDate, row.periodStart)
@@ -148,14 +145,20 @@ class TodayCoursesRemoteViewsFactory(
         }
     }
 
-    /** #759：快照日期是否早于今天（解析失败按未过期处理，保持原行为） */
+    /**
+     * #759：快照日期是否早于今天（解析失败按未过期处理，保持原行为）。
+     * 用 "yyyy-MM-dd" 字典序比较（ISO 日期字符串字典序 = 时间序），
+     * 避免在本类引入 java.time（API 26+，minSdk 22 无 desugaring）依赖。
+     */
     private fun isBeforeToday(dateStr: String): Boolean {
-        if (dateStr.isBlank()) return false
-        return try {
-            java.time.LocalDate.parse(dateStr).isBefore(java.time.LocalDate.now())
-        } catch (_: Exception) {
-            false
-        }
+        if (!Regex("^\\d{4}-\\d{2}-\\d{2}$").matches(dateStr)) return false
+        return dateStr < todayString()
+    }
+
+    /** 今天的 "yyyy-MM-dd"（SimpleDateFormat API 1+，与 isBeforeToday 同源比较基准） */
+    private fun todayString(): String {
+        return java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US)
+            .format(java.util.Date())
     }
 
     override fun getLoadingView(): RemoteViews? = null

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesRemoteViewsService.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/TodayCoursesRemoteViewsService.kt
@@ -112,8 +112,14 @@ class TodayCoursesRemoteViewsFactory(
             contentDesc
         )
 
-        // 行点击深链：携带节次参数
-        val snapshotDate = readSnapshotDate(store.readSnapshot())
+        // 行点击深链：携带节次参数（#759：快照过期时深链用今天，避免前端高亮到昨天）
+        val snapshotJson = store.readSnapshot()
+        val snapshotDateRaw = readSnapshotDate(snapshotJson)
+        val snapshotDate = if (isBeforeToday(snapshotDateRaw)) {
+            java.time.LocalDate.now().toString()
+        } else {
+            snapshotDateRaw
+        }
         if (snapshotDate.isNotEmpty() && row.periodStart >= 1) {
             val fillInIntent = Intent().apply {
                 data = WidgetDeepLink.scheduleUri(snapshotDate, row.periodStart)
@@ -139,6 +145,16 @@ class TodayCoursesRemoteViewsFactory(
             JSONObject(json).optString("date", "")
         } catch (_: Exception) {
             ""
+        }
+    }
+
+    /** #759：快照日期是否早于今天（解析失败按未过期处理，保持原行为） */
+    private fun isBeforeToday(dateStr: String): Boolean {
+        if (dateStr.isBlank()) return false
+        return try {
+            java.time.LocalDate.parse(dateStr).isBefore(java.time.LocalDate.now())
+        } catch (_: Exception) {
+            false
         }
     }
 

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetDataStore.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetDataStore.kt
@@ -48,6 +48,14 @@ class WidgetDataStore(context: Context) {
             .commit()
     }
 
+    /**
+     * #758：读取应用写入的主题模式（system/light/dark，见 WidgetThemeMode）。
+     * 缺省/非法值由消费端兜底为 system（保持系统资源限定符行为）。
+     */
+    fun readThemeMode(): String {
+        return prefs.getString(KEY_THEME_MODE, THEME_MODE_SYSTEM) ?: THEME_MODE_SYSTEM
+    }
+
     fun readElectricity(): String? = prefs.getString(KEY_ELECTRICITY_JSON, null)
 
     fun writeElectricity(json: String): Boolean {
@@ -73,6 +81,9 @@ class WidgetDataStore(context: Context) {
         private const val KEY_ELECTRICITY_JSON = "electricity_json"
         private const val KEY_EXAM_JSON = "exam_json"
         private const val KEY_THEME_COLOR = "theme_color"
+        /** #758：应用内主题模式（system/light/dark），由前端经桥接写入 */
+        private const val KEY_THEME_MODE = "theme_mode"
         const val DEFAULT_THEME_COLOR = "#2563eb"
+        const val THEME_MODE_SYSTEM = "system"
     }
 }

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetLayoutHelper.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetLayoutHelper.kt
@@ -75,4 +75,24 @@ object WidgetLayoutHelper {
     fun staleHint(context: Context): String = context.getString(
         context.resources.getIdentifier("widget_stale_hint", "string", context.packageName)
     )
+
+    /**
+     * #759：跨天旧快照的陈旧标记文案 "数据更新于 X月X日"（snapshotDate 为 yyyy-MM-dd）。
+     * 资源缺失或日期格式异常时回退到通用 staleHint。
+     */
+    fun outdatedHint(context: Context, snapshotDate: String): String {
+        val id = context.resources.getIdentifier("widget_outdated_hint", "string", context.packageName)
+        if (id == 0) return staleHint(context)
+        val dateText = try {
+            val parts = snapshotDate.split("-")
+            if (parts.size == 3) "${parts[1].trimStart('0')}月${parts[2].trimStart('0')}日" else snapshotDate
+        } catch (_: Exception) {
+            snapshotDate
+        }
+        return try {
+            context.getString(id, dateText)
+        } catch (_: Exception) {
+            staleHint(context)
+        }
+    }
 }

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt
@@ -29,6 +29,8 @@ object WidgetRenderer {
         val store = WidgetDataStore(context)
         val snapshotJson = store.readSnapshot()
         val themeColor = parseColor(store.readThemeColor())
+        // #758：应用强制 light/dark 时覆盖背景与中性文字色；system 模式零干预
+        val themeMode = WidgetThemeMode.resolve(context)
         val snapshot = parseSnapshot(snapshotJson)
         val date = snapshot?.optString("date", "") ?: ""
         val weekIndex = snapshot?.optInt("week_index", 0) ?: 0
@@ -98,9 +100,14 @@ object WidgetRenderer {
         if (rootId != 0) {
             views.setOnClickPendingIntent(rootId, rootPendingIntent)
         }
+        // #758：强制模式下覆盖背景（system 模式保持布局默认的 @drawable/widget_background）
+        WidgetThemeMode.applyBackground(context, themeMode, views, rootId)
+        // #758：强制模式下覆盖标题/空态文案的中性色
+        WidgetThemeMode.bindTextColor(context, themeMode, views, titleId, "widget_text_primary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, emptyId, "widget_text_secondary")
 
         if (WidgetLayoutHelper.isCompactLayout(layoutName)) {
-            bindCompactCourse(context, views, courses, themeColor)
+            bindCompactCourse(context, views, courses, themeColor, themeMode)
             if (listId != 0) views.setViewVisibility(listId, View.GONE)
             if (emptyId != 0) views.setViewVisibility(emptyId, View.GONE)
         } else {
@@ -117,7 +124,8 @@ object WidgetRenderer {
         context: Context,
         views: RemoteViews,
         courses: JSONArray?,
-        themeColor: Int
+        themeColor: Int,
+        themeMode: String
     ) {
         val packageName = context.packageName
         val nameId = context.resources.getIdentifier("widget_next_course_name", "id", packageName)
@@ -153,6 +161,9 @@ object WidgetRenderer {
                 views.setViewVisibility(locationId, View.GONE)
             }
         }
+        // #758：强制模式下覆盖中性文字色（时间行沿用品牌主题色）
+        WidgetThemeMode.bindTextColor(context, themeMode, views, nameId, "widget_text_primary")
+        WidgetThemeMode.bindTextColor(context, themeMode, views, locationId, "widget_location_text")
     }
 
     private fun bindListCourse(

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetRenderer.kt
@@ -36,7 +36,13 @@ object WidgetRenderer {
         val courses = snapshot?.optJSONArray("courses")
         val courseCount = courses?.length() ?: 0
         val emptyMessage = WidgetLayoutHelper.emptyStateMessage(context, snapshot)
-        val stale = snapshot != null && WidgetLayoutHelper.isStale(snapshot)
+        // #759：快照 date 早于今天 = 跨天重写失败（WebView 冻结/进程被杀后前端定时器失效）。
+        // 兜底策略：标题日期显示今天 + 溢出位显示「数据更新于 X月X日」陈旧标记，
+        // 深链同样携带今天，避免点击后前端高亮到昨天。快照内容仍由前端主修路径重写。
+        val snapshotDate = try { java.time.LocalDate.parse(date) } catch (_: Exception) { null }
+        val today = java.time.LocalDate.now()
+        val outdated = snapshotDate != null && snapshotDate.isBefore(today)
+        val stale = (snapshot != null && WidgetLayoutHelper.isStale(snapshot)) || outdated
 
         val titleId = context.resources.getIdentifier("widget_title", "id", packageName)
         val overflowId = context.resources.getIdentifier("widget_overflow_tag", "id", packageName)
@@ -46,7 +52,8 @@ object WidgetRenderer {
         if (titleId != 0) {
             val titleText = when {
                 weekIndex > 0 && date.isNotEmpty() -> {
-                    val displayDate = formatDateChinese(date)
+                    // #759：快照过期时标题日期显示今天（列表内容仍为旧快照，由陈旧标记提示）
+                    val displayDate = formatDateChinese(if (outdated) today.toString() else date)
                     "今日课程 · $displayDate"
                 }
                 emptyMessage.isNotEmpty() -> emptyMessage
@@ -62,7 +69,13 @@ object WidgetRenderer {
                 views.setTextColor(overflowId, themeColor)
                 views.setViewVisibility(overflowId, View.VISIBLE)
             } else if (stale) {
-                views.setTextViewText(overflowId, WidgetLayoutHelper.staleHint(context))
+                // #759：跨天旧快照显示「数据更新于 X月X日」，其余陈旧沿用通用提示
+                val staleText = if (outdated && date.isNotEmpty()) {
+                    WidgetLayoutHelper.outdatedHint(context, date)
+                } else {
+                    WidgetLayoutHelper.staleHint(context)
+                }
+                views.setTextViewText(overflowId, staleText)
                 views.setTextColor(overflowId, themeColor)
                 views.setViewVisibility(overflowId, View.VISIBLE)
             } else {
@@ -70,7 +83,11 @@ object WidgetRenderer {
             }
         }
 
-        val deepLinkDate = if (date.isNotEmpty()) date else java.time.LocalDate.now().toString()
+        val deepLinkDate = when {
+            outdated -> today.toString()
+            date.isNotEmpty() -> date
+            else -> java.time.LocalDate.now().toString()
+        }
         val rootPendingIntent = WidgetDeepLink.pendingIntent(
             context,
             appWidgetId,

--- a/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetThemeMode.kt
+++ b/apps/client/android/app/src/main/java/com/hbut/mini/widget/WidgetThemeMode.kt
@@ -1,0 +1,81 @@
+package com.hbut.mini.widget
+
+import android.content.Context
+import android.content.res.Configuration
+import android.widget.RemoteViews
+import androidx.core.content.res.ResourcesCompat
+
+/**
+ * #758：应用内主题模式（system/light/dark）→ 小组件渲染适配。
+ *
+ * 模式值由前端经原生桥写入 SharedPreferences（key=theme_mode，见 WidgetDataStore）。
+ * - system：完全沿用系统资源限定符机制（values-night / Material You 动态色），渲染零干预；
+ * - light/dark：应用强制模式可能与系统深浅色相反，渲染时需覆盖背景与中性文字色，
+ *   否则会出现「浅底浅字 / 深底深字」。品牌主题色（theme_color）跨模式可用，保持不变。
+ */
+object WidgetThemeMode {
+    const val SYSTEM = "system"
+    const val LIGHT = "light"
+    const val DARK = "dark"
+
+    /** 读取应用写入的主题模式；缺省/非法值一律兜底为 system（与旧版行为一致，零回归） */
+    fun resolve(context: Context): String {
+        val mode = WidgetDataStore(context).readThemeMode().trim().lowercase()
+        return if (mode == LIGHT || mode == DARK) mode else SYSTEM
+    }
+
+    fun isForced(mode: String): Boolean = mode == LIGHT || mode == DARK
+
+    /** 强制模式下应使用的背景 drawable 资源名；system 返回 null（保持布局默认） */
+    fun backgroundResName(mode: String): String? = when (mode) {
+        LIGHT -> "widget_background_light"
+        DARK -> "widget_background_dark"
+        else -> null
+    }
+
+    /**
+     * 强制模式下覆盖 widget 根节点背景（setBackgroundResource 是 RemoteViews 支持的标准反射方法）。
+     * system 模式 / rootId 无效 / 资源缺失时不做任何事。
+     */
+    fun applyBackground(context: Context, mode: String, views: RemoteViews, rootId: Int) {
+        val resName = backgroundResName(mode) ?: return
+        if (rootId == 0) return
+        val resId = context.resources.getIdentifier(resName, "drawable", context.packageName)
+        if (resId != 0) {
+            views.setInt(rootId, "setBackgroundResource", resId)
+        }
+    }
+
+    /**
+     * 强制模式下按模式解析颜色并应用到指定 TextView。
+     * colorResName 与布局静态引用同名（widget_text_primary 等），经 uiMode 覆盖后的
+     * ConfigurationContext 解析，保证文字色与背景同一套深浅色。
+     * system 模式 / viewId 无效 / 解析失败时不做任何事（保持布局默认色）。
+     */
+    fun bindTextColor(context: Context, mode: String, views: RemoteViews, viewId: Int, colorResName: String) {
+        if (!isForced(mode) || viewId == 0) return
+        val color = resolveColor(context, mode, colorResName) ?: return
+        views.setTextColor(viewId, color)
+    }
+
+    /** 生成 uiMode 覆盖后的 Context：强制 light → NIGHT_NO，dark → NIGHT_YES（保留其余配置） */
+    private fun themedContext(context: Context, mode: String): Context {
+        val conf = Configuration(context.resources.configuration)
+        conf.uiMode = (conf.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+            if (mode == DARK) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO
+        return context.createConfigurationContext(conf)
+    }
+
+    /** 按模式解析颜色资源；失败返回 null（调用方保持布局默认色） */
+    private fun resolveColor(context: Context, mode: String, colorResName: String): Int? {
+        return try {
+            val themed = themedContext(context, mode)
+            val res = themed.resources
+            val id = res.getIdentifier(colorResName, "color", themed.packageName)
+            // ResourcesCompat 兼容 minSdk 22（res.getColor(id, theme) 需 API 23+）
+            if (id == 0) null else ResourcesCompat.getColor(res, id, null)
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/apps/client/android/app/src/main/res/drawable-v31/widget_background.xml
+++ b/apps/client/android/app/src/main/res/drawable-v31/widget_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    #758：API 31+ 的 widget 背景使用 Material You 动态色（@color/widget_bg 在
+    values-v31/values-night-v31 下解析为 system_accent1_50/900）。动态色是运行时
+    取色值，无法在颜色资源上静态叠加 alpha，故用 layer-list 的 item android:alpha
+    （API 23+ 支持，v31 限定保证安全）把整个 shape 调到 85% 不透明度，
+    与 < v31 的 #D9FFFFFF / #D91E293B 等效，且不破坏 Material You 取色。
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.85">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/widget_bg" />
+            <corners android:radius="20dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/apps/client/android/app/src/main/res/drawable/widget_background_dark.xml
+++ b/apps/client/android/app/src/main/res/drawable/widget_background_dark.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- #758：应用强制 dark 模式时的小组件背景（恒定深色 85% 不透明） -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_bg_forced_dark" />
+    <corners android:radius="20dp" />
+</shape>

--- a/apps/client/android/app/src/main/res/drawable/widget_background_light.xml
+++ b/apps/client/android/app/src/main/res/drawable/widget_background_light.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- #758：应用强制 light 模式时的小组件背景（恒定浅色 85% 不透明） -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_bg_forced_light" />
+    <corners android:radius="20dp" />
+</shape>

--- a/apps/client/android/app/src/main/res/values-night/colors_widget.xml
+++ b/apps/client/android/app/src/main/res/values-night/colors_widget.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Widget 深色主题 -->
-    <color name="widget_bg">#FF1E293B</color>
+    <!-- #758：背景默认 85% 不透明（D9），透出桌面壁纸 -->
+    <color name="widget_bg">#D91E293B</color>
     <color name="widget_text_primary">#FFF1F5F9</color>
     <color name="widget_text_secondary">#FF94A3B8</color>
     <color name="widget_accent">#FF34D399</color>

--- a/apps/client/android/app/src/main/res/values/colors_widget.xml
+++ b/apps/client/android/app/src/main/res/values/colors_widget.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Widget 浅色主题 -->
-    <color name="widget_bg">#FFFFFFFF</color>
+    <!-- #758：背景默认 85% 不透明（D9），透出桌面壁纸 -->
+    <color name="widget_bg">#D9FFFFFF</color>
+    <!-- #758：应用强制 light/dark 时的恒定背景色（不受 values-night 限定符影响） -->
+    <color name="widget_bg_forced_light">#D9FFFFFF</color>
+    <color name="widget_bg_forced_dark">#D91E293B</color>
     <color name="widget_text_primary">#FF1A2332</color>
     <color name="widget_text_secondary">#FF5C6B7A</color>
     <color name="widget_accent">#FF10B981</color>

--- a/apps/client/android/app/src/main/res/values/strings_widget.xml
+++ b/apps/client/android/app/src/main/res/values/strings_widget.xml
@@ -13,6 +13,8 @@
     <string name="widget_weekend">周末愉快</string>
     <string name="widget_login_required">请先在 Mini-HBUT 登录</string>
     <string name="widget_stale_hint">数据可能已过期，打开 App 刷新</string>
+    <!-- #759：跨天旧快照的陈旧标记（%1$s = 快照写入日期） -->
+    <string name="widget_outdated_hint">数据更新于 %1$s</string>
     <string name="widget_data_error">小组件数据异常，请打开 App</string>
     <string name="widget_open_app">打开 Mini-HBUT</string>
     

--- a/apps/client/src/app/coordinators/LifecycleCoordinator.spec.ts
+++ b/apps/client/src/app/coordinators/LifecycleCoordinator.spec.ts
@@ -1,0 +1,167 @@
+// src/app/coordinators/LifecycleCoordinator.spec.ts
+// #759：回前台（resume）时无条件补写小组件快照单测
+//
+// 背景：跨天定时器依赖 WebView 内存中的 setTimeout，WebView 冻结/进程被杀后失效，
+// 小组件全天显示昨天。修复：handleAppResume 在登录态下无条件调用
+// tryWriteSnapshotFromCache（与重排定时器并行，失败静默）。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('../../platform/native', () => ({
+  isCapacitorRuntime: vi.fn(() => false),
+  isTauriRuntime: vi.fn(() => false)
+}))
+
+vi.mock('../../platform/runtime', () => ({
+  isAndroidLike: vi.fn(() => false),
+  isDesktopLike: vi.fn(() => false),
+  isIOSLike: vi.fn(() => false)
+}))
+
+vi.mock('../../utils/campus_network_service', () => ({
+  runCampusNetworkAutoLogin: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('../../navigation/app_navigation', () => ({
+  normalizeViewName: (view: unknown) => String(view || 'home')
+}))
+
+vi.mock('../../utils/widget_bridge', () => ({
+  tryWriteSnapshotFromCache: vi.fn(async () => {})
+}))
+
+vi.mock('../../utils/local_reminder_scheduler', () => ({
+  reconcileLocalReminders: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('../../utils/background_notification', () => ({
+  consumeBackgroundEventsOnce: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('../../utils/school_website_embed.ts', () => ({
+  recoverSchoolWebsiteBridgeOnResume: vi.fn(() => Promise.resolve(true)),
+  invokeEnsureHttpBridge: vi.fn(() => Promise.resolve({ status: 'ok' }))
+}))
+
+import { createLifecycleCoordinator } from './LifecycleCoordinator'
+import { tryWriteSnapshotFromCache } from '../../utils/widget_bridge'
+
+const mockTryWrite = vi.mocked(tryWriteSnapshotFromCache)
+
+const SID = '2510231106'
+
+const makeRuntime = (studentId: string) => {
+  const state = {
+    studentId: ref(studentId),
+    currentView: ref('home'),
+    appShellRef: ref(null),
+    mutable: {
+      appBootstrapped: true,
+      lastResumeHandledAt: 0,
+      resumePendingSnapshot: null,
+      iosHardReloadCount: 0,
+      iosReloadFallbackAt: 0,
+      viewportResizeRaf: 0,
+      desktopResizePerfTimer: null,
+      capacitorAppStateListener: null,
+      removeHomeLayoutDiagnosticsErrorCapture: null
+    }
+  }
+  const runtime = {
+    state,
+    stores: {
+      lifecycle: {
+        markHidden: vi.fn(),
+        consumeHiddenDuration: vi.fn(() => 1000)
+      }
+    },
+    navigation: {
+      readWindowRouteSnapshot: vi.fn(() => ({ view: 'home' })),
+      collectCurrentViewSnapshot: vi.fn(() => ({ view: 'home' })),
+      restoreViewFromSnapshot: vi.fn(async () => {}),
+      forceScrollTop: vi.fn(),
+      goToView: vi.fn()
+    },
+    notification: {
+      scheduleWidgetCrossDayTimer: vi.fn(),
+      stopWidgetCrossDayTimer: vi.fn()
+    }
+  } as unknown as Parameters<typeof createLifecycleCoordinator>[0]
+  const coordinator = createLifecycleCoordinator(runtime)
+  return { state, runtime, coordinator }
+}
+
+/** 排空微任务队列；动态 import() 模块加载链较深，轮询等待是唯一可靠方式 */
+const flushAsync = async (times = 12) => {
+  for (let i = 0; i < times; i += 1) await Promise.resolve()
+}
+
+/** 等待异步补写链（动态 import → then → async mock）执行完成 */
+const waitForTryWrite = async (times: number) => {
+  await vi.waitFor(() => expect(mockTryWrite).toHaveBeenCalledTimes(times), { timeout: 2000 })
+}
+
+beforeEach(() => {
+  mockTryWrite.mockClear()
+  vi.stubGlobal(
+    'document',
+    {
+      hidden: false,
+      documentElement: {
+        clientHeight: 0,
+        style: {
+          setProperty: vi.fn(),
+          getPropertyValue: () => ''
+        },
+        classList: { add: vi.fn(), remove: vi.fn(), contains: vi.fn(() => false) }
+      },
+      body: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+  )
+  vi.stubGlobal('window', globalThis)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('#759 回前台补写小组件快照', () => {
+  it('登录态回前台：无条件调用 tryWriteSnapshotFromCache 并重排跨天定时器', async () => {
+    const { runtime, coordinator } = makeRuntime(SID)
+    coordinator.handleAppResume('visibilitychange')
+    await waitForTryWrite(1)
+
+    expect(mockTryWrite).toHaveBeenCalledWith(SID)
+    expect(runtime.notification.scheduleWidgetCrossDayTimer).toHaveBeenCalledTimes(1)
+  })
+
+  it('resume 连发（visibility/pageshow/focus）被 320ms 节流合并，只补写一次', async () => {
+    const { coordinator } = makeRuntime(SID)
+    coordinator.handleAppResume('visibilitychange')
+    coordinator.handleAppResume('pageshow')
+    coordinator.handleAppResume('focus')
+    await waitForTryWrite(1)
+    await flushAsync()
+
+    expect(mockTryWrite).toHaveBeenCalledTimes(1)
+  })
+
+  it('未登录（studentId 为空）：不补写快照、不重排定时器', async () => {
+    const { runtime, coordinator } = makeRuntime('')
+    coordinator.handleAppResume('visibilitychange')
+    await flushAsync()
+
+    expect(mockTryWrite).not.toHaveBeenCalled()
+    expect(runtime.notification.scheduleWidgetCrossDayTimer).not.toHaveBeenCalled()
+  })
+
+  it('补写失败被静默吞掉，不影响 resume 主流程', async () => {
+    mockTryWrite.mockRejectedValueOnce(new Error('bridge down'))
+    const { coordinator } = makeRuntime(SID)
+    expect(() => coordinator.handleAppResume('visibilitychange')).not.toThrow()
+    await waitForTryWrite(1)
+  })
+})

--- a/apps/client/src/app/coordinators/LifecycleCoordinator.ts
+++ b/apps/client/src/app/coordinators/LifecycleCoordinator.ts
@@ -299,9 +299,15 @@ export const createLifecycleCoordinator = (runtime: AppRuntime): LifecycleCoordi
     })
     // 回前台：探测 loopback bridge，并通知内嵌页恢复（官网/模块）
     void recoverEmbeddedWebAfterResume(targetView, idle)
-    // 回前台：重算跨天定时器剩余时间
+    // 回前台：重算跨天定时器剩余时间；并无条件补写小组件快照（#759）
     if (state.studentId.value) {
       runtime.notification.scheduleWidgetCrossDayTimer()
+      // #759：跨天定时器在 WebView 冻结/进程被杀后会失效，导致小组件全天显示昨天。
+      // 回前台时无条件用缓存重写一次快照（date/weekday/周次按当下重算），
+      // 与定时器重排并行执行；内部已全静默捕获，失败不影响 resume 主流程。
+      void import('../../utils/widget_bridge')
+        .then((mod) => mod.tryWriteSnapshotFromCache(state.studentId.value))
+        .catch(() => {})
       // #610：resume/跨天后第一次活跃 → 触发系统预调度 reconcile
       // （窗口随"今天"滚动，跨天自然重算；幂等 diff 保证无变化时零系统调用）
       void import('../../utils/local_reminder_scheduler').then((mod) =>

--- a/apps/client/src/app/coordinators/NotificationCoordinator.spec.ts
+++ b/apps/client/src/app/coordinators/NotificationCoordinator.spec.ts
@@ -1,0 +1,123 @@
+// src/app/coordinators/NotificationCoordinator.spec.ts
+// #759：小组件跨天定时器单测
+//
+// 覆盖：
+// 1. scheduleWidgetCrossDayTimer 按「下一个 00:01（Asia/Shanghai）」调度
+// 2. 定时器触发时调用 tryWriteSnapshotFromCache（内部按当下重算 date/weekday/周次）
+// 3. 触发后自动重排下一次（每 24h 持续触发）
+// 4. stopWidgetCrossDayTimer 清理后不再触发
+// 5. 未登录（studentId 为空）不调度
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('../../utils/widget_bridge', () => ({
+  tryWriteSnapshotFromCache: vi.fn(async () => {})
+}))
+
+vi.mock('../../utils/test_account.js', () => ({
+  isTestAccountSession: vi.fn(() => false)
+}))
+
+vi.mock('../../platform', () => ({
+  platformBridge: {
+    addNotificationActionListener: vi.fn(async () => () => {})
+  }
+}))
+
+vi.mock('../../platform/deep_link', () => ({
+  installMiniHbutDeepLinkListeners: vi.fn()
+}))
+
+vi.mock('../../platform/notification_actions', () => ({
+  resolveNotificationActionTarget: vi.fn(() => ({ view: 'home' }))
+}))
+
+vi.mock('../../navigation/app_navigation', () => ({
+  normalizeViewName: (view: unknown) => String(view || '')
+}))
+
+import { createNotificationCoordinator, msUntilNextDayCrossover } from './NotificationCoordinator'
+import { tryWriteSnapshotFromCache } from '../../utils/widget_bridge'
+
+const mockTryWrite = vi.mocked(tryWriteSnapshotFromCache)
+
+const SID = '2510231106'
+
+const makeRuntime = (studentId: string) => {
+  const state = {
+    studentId: ref(studentId),
+    currentView: ref('home'),
+    widgetDeeplinkDate: ref(''),
+    widgetDeeplinkPeriod: ref(0),
+    mutable: {
+      appBootstrapped: true,
+      widgetCrossDayTimer: null as number | null,
+      removeNotificationActionListener: null as (() => void) | null
+    }
+  }
+  const runtime = {
+    state,
+    navigation: { goToView: vi.fn() },
+    identity: { submitIntent: vi.fn() }
+  } as unknown as Parameters<typeof createNotificationCoordinator>[0]
+  const coordinator = createNotificationCoordinator(runtime)
+  return { state, coordinator }
+}
+
+beforeEach(() => {
+  mockTryWrite.mockClear()
+  vi.useFakeTimers()
+  // node 环境无 window：与 globalThis 共享（fake timers 替换的是 globalThis 上的定时器）
+  vi.stubGlobal('window', globalThis)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('#759 小组件跨天定时器', () => {
+  it('按「下一个 00:01（Asia/Shanghai）」的剩余毫秒数调度', () => {
+    const { coordinator } = makeRuntime(SID)
+    coordinator.scheduleWidgetCrossDayTimer()
+    const crossover = msUntilNextDayCrossover()
+    expect(crossover).toBeGreaterThan(60 * 1000)
+    expect(crossover).toBeLessThanOrEqual((24 * 3600 + 60) * 1000)
+    // 定时器在 crossover 前不应触发
+    vi.advanceTimersByTime(crossover - 1000)
+    expect(mockTryWrite).not.toHaveBeenCalled()
+  })
+
+  it('触发时调用 tryWriteSnapshotFromCache 并自动重排下一次', () => {
+    const { coordinator } = makeRuntime(SID)
+    coordinator.scheduleWidgetCrossDayTimer()
+
+    const firstDelay = msUntilNextDayCrossover()
+    vi.advanceTimersByTime(firstDelay)
+    expect(mockTryWrite).toHaveBeenCalledTimes(1)
+    expect(mockTryWrite).toHaveBeenCalledWith(SID)
+
+    // 重排后的 delay = 到下一个 00:01（推进后恰好处于 00:01:00 → 24h）
+    vi.advanceTimersByTime(24 * 3600 * 1000 - 1000)
+    expect(mockTryWrite).toHaveBeenCalledTimes(1) // 未到点不触发
+    vi.advanceTimersByTime(1000)
+    expect(mockTryWrite).toHaveBeenCalledTimes(2)
+  })
+
+  it('stopWidgetCrossDayTimer 清理后不再触发', () => {
+    const { coordinator } = makeRuntime(SID)
+    coordinator.scheduleWidgetCrossDayTimer()
+    coordinator.stopWidgetCrossDayTimer()
+
+    vi.advanceTimersByTime((24 * 3600 + 60) * 1000)
+    expect(mockTryWrite).not.toHaveBeenCalled()
+  })
+
+  it('studentId 为空时不调度', () => {
+    const { coordinator } = makeRuntime('')
+    coordinator.scheduleWidgetCrossDayTimer()
+    vi.advanceTimersByTime((24 * 3600 + 60) * 1000)
+    expect(mockTryWrite).not.toHaveBeenCalled()
+  })
+})

--- a/apps/client/src/app/coordinators/NotificationCoordinator.ts
+++ b/apps/client/src/app/coordinators/NotificationCoordinator.ts
@@ -10,7 +10,8 @@ import { tryWriteSnapshotFromCache } from '../../utils/widget_bridge'
 import { isTestAccountSession } from '../../utils/test_account.js'
 import { normalizeViewName } from '../../navigation/app_navigation'
 
-const msUntilNextDayCrossover = () => {
+/** 导出供单测：计算距离下一个「00:01」（Asia/Shanghai）的毫秒数 */
+export const msUntilNextDayCrossover = () => {
   const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: 'Asia/Shanghai',
     hour: '2-digit',
@@ -37,6 +38,8 @@ export const createNotificationCoordinator = (runtime: AppRuntime): Notification
     state.mutable.widgetCrossDayTimer = window.setTimeout(() => {
       state.mutable.widgetCrossDayTimer = null
       if (state.studentId.value && !isTestAccountSession()) {
+        // #759：tryWriteSnapshotFromCache 内部按当下时间重算 date/weekday，
+        // 并优先用开学锚点推算当前真实周次（不再信任前一天缓存的 current_week）
         void tryWriteSnapshotFromCache(state.studentId.value)
         scheduleWidgetCrossDayTimer()
       }

--- a/apps/client/src/platform/capacitor/widget.ts
+++ b/apps/client/src/platform/capacitor/widget.ts
@@ -16,6 +16,12 @@ import { isTauriRuntime, isCapacitorRuntime, invokeNative } from '@/platform/nat
 /** 最大 snapshot 字节数：32 KB */
 const MAX_SNAPSHOT_BYTES = 32 * 1024
 
+/**
+ * #758：应用内主题模式（与线A #757 三态对应）。
+ * Kotlin 端 WidgetThemeMode 按此值覆盖小组件深浅色。
+ */
+export type WidgetThemeMode = 'system' | 'light' | 'dark'
+
 /** 自定义错误，携带 code 字段便于上层判断 */
 export class WidgetBridgeError extends Error {
   constructor(
@@ -183,6 +189,34 @@ export async function writeExamSnapshot(data: ExamWidgetSnapshot): Promise<void>
 
 export async function writeWidgetThemeColor(color: string): Promise<void> {
   await getWidgetBridge().writeThemeColor({ color })
+}
+
+/**
+ * #758：将应用当前主题模式写入原生 Widget 存储（SharedPreferences key=theme_mode）。
+ * 写入通路：
+ * - Tauri Android：invokeNative('write_widget_theme_mode')（原生命令尚未注册时 reject）
+ * - Capacitor：MiniHbutWidget.writeThemeMode（插件尚未实现该方法时 reject）
+ * - 桌面/Web：不支持，reject
+ * 调用方（widget_bridge.writeWidgetThemeMode）必须静默捕获失败——通路未就绪时
+ * Kotlin 端按 "system" 渲染，与旧版行为完全一致。
+ */
+export async function writeThemeMode(mode: WidgetThemeMode): Promise<void> {
+  if (isTauriAndroid()) {
+    await invokeNative('write_widget_theme_mode', { mode })
+    return
+  }
+  if (isCapacitorRuntime()) {
+    const cap = typeof window === 'undefined' ? undefined : (window as any).Capacitor
+    const plugin = cap?.Plugins?.MiniHbutWidget as
+      | { writeThemeMode?: (options: { mode: string }) => Promise<void> }
+      | undefined
+    if (plugin && typeof plugin.writeThemeMode === 'function') {
+      await plugin.writeThemeMode({ mode })
+      return
+    }
+    throw new Error('MiniHbutWidget.writeThemeMode not implemented')
+  }
+  throw new Error('theme mode sync is unavailable on this runtime')
 }
 
 /**

--- a/apps/client/src/platform/capacitor/widget_theme_mode.spec.ts
+++ b/apps/client/src/platform/capacitor/widget_theme_mode.spec.ts
@@ -1,0 +1,70 @@
+// src/platform/capacitor/widget_theme_mode.spec.ts
+// #758：writeThemeMode（应用主题模式 → 原生 Widget 存储）平台通路单测
+//
+// 通路设计：
+// - Tauri Android：invokeNative('write_widget_theme_mode')（Rust 命令待补齐，未注册时 reject）
+// - Capacitor：MiniHbutWidget.writeThemeMode（插件未实现该方法时 reject）
+// - 桌面/Web：reject
+// 调用方 widget_bridge.writeWidgetThemeMode 静默捕获全部失败。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/platform/native', () => ({
+  isTauriRuntime: vi.fn(() => false),
+  isCapacitorRuntime: vi.fn(() => false),
+  invokeNative: vi.fn(async () => ({}))
+}))
+
+import { writeThemeMode } from './widget'
+import { invokeNative, isCapacitorRuntime, isTauriRuntime } from '@/platform/native'
+
+const mockTauri = vi.mocked(isTauriRuntime)
+const mockCapacitor = vi.mocked(isCapacitorRuntime)
+const mockInvoke = vi.mocked(invokeNative)
+
+const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Mobile Safari/537.36'
+
+beforeEach(() => {
+  mockTauri.mockReturnValue(false)
+  mockCapacitor.mockReturnValue(false)
+  mockInvoke.mockClear()
+  vi.stubGlobal('navigator', { userAgent: ANDROID_UA })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('#758 writeThemeMode 平台通路', () => {
+  it('Tauri Android：走 invokeNative("write_widget_theme_mode")', async () => {
+    mockTauri.mockReturnValue(true)
+    await expect(writeThemeMode('dark')).resolves.toBeUndefined()
+    expect(mockInvoke).toHaveBeenCalledWith('write_widget_theme_mode', { mode: 'dark' })
+  })
+
+  it('Capacitor 且插件已实现 writeThemeMode：透传调用', async () => {
+    mockCapacitor.mockReturnValue(true)
+    const pluginWrite = vi.fn(async () => {})
+    vi.stubGlobal('window', {
+      Capacitor: { Plugins: { MiniHbutWidget: { writeThemeMode: pluginWrite } } }
+    })
+    await expect(writeThemeMode('light')).resolves.toBeUndefined()
+    expect(pluginWrite).toHaveBeenCalledWith({ mode: 'light' })
+  })
+
+  it('Capacitor 但插件未实现 writeThemeMode：reject（由上层静默）', async () => {
+    mockCapacitor.mockReturnValue(true)
+    vi.stubGlobal('window', { Capacitor: { Plugins: { MiniHbutWidget: {} } } })
+    await expect(writeThemeMode('light')).rejects.toThrow(/not implemented/)
+  })
+
+  it('window 未定义（SSR/Node）：reject', async () => {
+    vi.stubGlobal('window', undefined)
+    mockCapacitor.mockReturnValue(true)
+    await expect(writeThemeMode('system')).rejects.toThrow(/not implemented|unavailable/)
+  })
+
+  it('桌面/Web 运行时：reject（由上层静默）', async () => {
+    await expect(writeThemeMode('system')).rejects.toThrow(/unavailable/)
+  })
+})

--- a/apps/client/src/utils/widget_bridge.spec.ts
+++ b/apps/client/src/utils/widget_bridge.spec.ts
@@ -1,0 +1,156 @@
+// src/utils/widget_bridge.spec.ts
+// #759：Widget 快照周次重算与「真实周优先」单测
+//
+// 覆盖：
+// 1. tryWriteSnapshotFromCache：跨天触发时用开学锚点重算周次（不再信任前一天缓存的 current_week）
+// 2. tryWriteSnapshotFromCache：无锚点时回退 meta.current_week；均缺失时回退 1
+// 3. tryWriteSnapshotFromCache：snapshot.date/weekday 始终按当下时间重算
+// 4. afterScheduleRefresh：meta.current_week 可用 → 用真实周；缺失 → 退回 selectedWeek
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/platform/capacitor/widget', () => ({
+  writeSnapshotWithRetry: vi.fn(async () => {}),
+  clearSnapshot: vi.fn(async () => {}),
+  writeElectricitySnapshot: vi.fn(async () => {}),
+  writeExamSnapshot: vi.fn(async () => {}),
+  writeWidgetThemeColor: vi.fn(async () => {}),
+  requestRefresh: vi.fn(async () => {})
+}))
+
+vi.mock('@/platform/native', () => ({
+  isTauriRuntime: vi.fn(() => false),
+  invokeNative: vi.fn(async () => ({}))
+}))
+
+vi.mock('./api.js', () => ({
+  getCacheKey: (key: string) => `ck:${key}`
+}))
+
+vi.mock('./debug_logger', () => ({
+  pushDebugLog: vi.fn()
+}))
+
+import { afterScheduleRefresh, tryWriteSnapshotFromCache } from './widget_bridge'
+import { writeSnapshotWithRetry } from '@/platform/capacitor/widget'
+import { getCacheKey } from './api.js'
+
+const mockWrite = vi.mocked(writeSnapshotWithRetry)
+
+// ─── localStorage stub（node 环境无全局 localStorage） ──────────────────────
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear()
+}
+vi.stubGlobal('localStorage', stubStorage)
+
+const SID = '2510231106'
+
+/** 写入课表缓存（结构与 schedule_prefetch 写入一致：{ data: { data: [...] } }） */
+const seedScheduleCache = (courses: unknown[]) => {
+  storageMap.set(getCacheKey(`schedule:${SID}`), JSON.stringify({ data: { data: courses } }))
+}
+
+/** 写入课表 meta */
+const seedMeta = (meta: Record<string, unknown>) => {
+  storageMap.set('hbu_schedule_meta', JSON.stringify(meta))
+}
+
+const lastSnapshot = () => {
+  const calls = mockWrite.mock.calls
+  expect(calls.length, 'writeSnapshotWithRetry 应被调用').toBeGreaterThan(0)
+  return calls[calls.length - 1]![0] as { date: string; weekday: number; week_index: number; courses: unknown[] }
+}
+
+beforeEach(() => {
+  storageMap.clear()
+  mockWrite.mockClear()
+})
+
+describe('#759 tryWriteSnapshotFromCache 周次重算', () => {
+  it('有 start_date 锚点：周一凌晨跨天触发时用推算周次（而非前一天缓存的 current_week）', async () => {
+    // 开学 2026-03-02，meta 缓存的 current_week=5（上周日写入），
+    // 现在（真实时钟）推算结果由 mock 时钟决定 → 用真实当前时间即可：
+    // 锚点推算只依赖 meta.start_date 与当下，此处断言「结果与锚点推算一致」
+    seedMeta({ semester: '2025-2026-2', start_date: '2026-03-02', current_week: 5, total_weeks: 25 })
+    seedScheduleCache([])
+    await tryWriteSnapshotFromCache(SID)
+
+    const snapshot = lastSnapshot()
+    // 锚点推算语义：floor((今天 - 开学日) / 7) + 1（Asia/Shanghai）
+    const todayCst = snapshot.date
+    const days = Math.floor(
+      (Date.parse(`${todayCst}T00:00:00Z`) - Date.parse('2026-03-02T00:00:00Z')) / 86_400_000
+    )
+    const expected = Math.min(Math.floor(Math.max(days, 0) / 7) + 1, 25)
+    expect(snapshot.week_index).toBe(Math.max(expected, 1))
+  })
+
+  it('无 start_date：回退 meta.current_week 缓存值', async () => {
+    seedMeta({ semester: '2025-2026-2', current_week: 7, total_weeks: 25 })
+    seedScheduleCache([])
+    await tryWriteSnapshotFromCache(SID)
+    expect(lastSnapshot().week_index).toBe(7)
+  })
+
+  it('meta 完全缺失：回退第 1 周', async () => {
+    seedScheduleCache([])
+    await tryWriteSnapshotFromCache(SID)
+    expect(lastSnapshot().week_index).toBe(1)
+  })
+
+  it('date/weekday 始终按当下时间重算（跨天后不残留昨日日期）', async () => {
+    seedMeta({ start_date: '2026-03-02', current_week: 3, total_weeks: 25 })
+    seedScheduleCache([])
+    await tryWriteSnapshotFromCache(SID)
+
+    const snapshot = lastSnapshot()
+    const now = new Date()
+    const fmt = new Intl.DateTimeFormat('zh-CN', {
+      timeZone: 'Asia/Shanghai',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    })
+    const parts = fmt.formatToParts(now)
+    const y = parts.find((p) => p.type === 'year')?.value ?? ''
+    const m = parts.find((p) => p.type === 'month')?.value ?? ''
+    const d = parts.find((p) => p.type === 'day')?.value ?? ''
+    expect(snapshot.date).toBe(`${y}-${m}-${d}`)
+    expect(snapshot.weekday).toBeGreaterThanOrEqual(1)
+    expect(snapshot.weekday).toBeLessThanOrEqual(7)
+  })
+
+  it('无课表缓存时静默返回（不写入、不抛错）', async () => {
+    seedMeta({ start_date: '2026-03-02', current_week: 3 })
+    await expect(tryWriteSnapshotFromCache(SID)).resolves.toBeUndefined()
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+})
+
+describe('#759 afterScheduleRefresh 真实周优先', () => {
+  it('meta.current_week 可用 → 使用真实周（忽略界面手动选中的 selectedWeek）', async () => {
+    seedMeta({ semester: '2025-2026-2', start_date: '2026-03-02', current_week: 3, total_weeks: 25 })
+    await afterScheduleRefresh(SID, { data: [] }, { selectedWeek: 7 })
+    expect(lastSnapshot().week_index).toBe(3)
+  })
+
+  it('meta 缺失 current_week → 退回 selectedWeek', async () => {
+    seedMeta({ semester: '2025-2026-2' })
+    await afterScheduleRefresh(SID, { data: [] }, { selectedWeek: 7 })
+    expect(lastSnapshot().week_index).toBe(7)
+  })
+
+  it('payload 缺少 data 数组时不写快照', async () => {
+    await afterScheduleRefresh(SID, { foo: 'bar' }, { selectedWeek: 2 })
+    expect(mockWrite).not.toHaveBeenCalled()
+  })
+})

--- a/apps/client/src/utils/widget_bridge.spec.ts
+++ b/apps/client/src/utils/widget_bridge.spec.ts
@@ -15,6 +15,7 @@ vi.mock('@/platform/capacitor/widget', () => ({
   writeElectricitySnapshot: vi.fn(async () => {}),
   writeExamSnapshot: vi.fn(async () => {}),
   writeWidgetThemeColor: vi.fn(async () => {}),
+  writeThemeMode: vi.fn(async () => {}),
   requestRefresh: vi.fn(async () => {})
 }))
 
@@ -31,11 +32,12 @@ vi.mock('./debug_logger', () => ({
   pushDebugLog: vi.fn()
 }))
 
-import { afterScheduleRefresh, tryWriteSnapshotFromCache } from './widget_bridge'
-import { writeSnapshotWithRetry } from '@/platform/capacitor/widget'
+import { afterScheduleRefresh, tryWriteSnapshotFromCache, writeWidgetThemeMode } from './widget_bridge'
+import { writeSnapshotWithRetry, writeThemeMode } from '@/platform/capacitor/widget'
 import { getCacheKey } from './api.js'
 
 const mockWrite = vi.mocked(writeSnapshotWithRetry)
+const mockWriteThemeMode = vi.mocked(writeThemeMode)
 
 // ─── localStorage stub（node 环境无全局 localStorage） ──────────────────────
 
@@ -73,6 +75,20 @@ const lastSnapshot = () => {
 beforeEach(() => {
   storageMap.clear()
   mockWrite.mockClear()
+  mockWriteThemeMode.mockClear()
+})
+
+describe('#758 writeWidgetThemeMode 主题模式通路', () => {
+  it('通路就绪时把模式透传给 platform 层', async () => {
+    await expect(writeWidgetThemeMode('dark')).resolves.toBeUndefined()
+    expect(mockWriteThemeMode).toHaveBeenCalledWith('dark')
+  })
+
+  it('通路未就绪（原生命令/插件未实现 reject）时静默吞错，不抛出', async () => {
+    mockWriteThemeMode.mockRejectedValueOnce(new Error('unimplemented'))
+    await expect(writeWidgetThemeMode('light')).resolves.toBeUndefined()
+    await expect(writeWidgetThemeMode('system')).resolves.toBeUndefined()
+  })
 })
 
 describe('#759 tryWriteSnapshotFromCache 周次重算', () => {

--- a/apps/client/src/utils/widget_bridge.ts
+++ b/apps/client/src/utils/widget_bridge.ts
@@ -12,7 +12,9 @@ import {
   writeElectricitySnapshot,
   writeExamSnapshot,
   writeWidgetThemeColor as writeNativeWidgetThemeColor,
-  requestRefresh as requestWidgetRefresh
+  writeThemeMode as writeNativeWidgetThemeMode,
+  requestRefresh as requestWidgetRefresh,
+  type WidgetThemeMode as NativeWidgetThemeMode
 } from '@/platform/capacitor/widget'
 import { pushDebugLog } from './debug_logger'
 import { getCacheKey } from './api.js'
@@ -319,5 +321,27 @@ export async function writeWidgetThemeColor(color: string): Promise<void> {
   } catch (err: unknown) {
     console.warn('[widget] writeWidgetThemeColor failed:', err)
     pushDebugLog('widget', 'widget_write_failed', 'warn', { source: 'writeWidgetThemeColor' })
+  }
+}
+
+/**
+ * #758：将应用当前主题模式（system/light/dark）写入小组件，Kotlin 渲染时据此
+ * 覆盖深浅色资源（system = 维持 values-night / Material You 机制）。
+ *
+ * 接入时机（待线A #757 三态合并后接入）：主题初始化与应用内深浅色切换处调用
+ * `writeWidgetThemeMode(resolvedMode)`，与 writeWidgetThemeColor 同点触发。
+ * 当前不自动接入的原因：现有 night_mode 信号只有二态（html.dark），无法区分
+ * system 与 light，误写会破坏「跟随系统」用户。
+ *
+ * 失败静默：写入通路未就绪（Tauri 原生命令 / Capacitor 插件方法尚未实现）时
+ * Kotlin 端按 "system" 渲染，与旧版行为完全一致。
+ */
+export async function writeWidgetThemeMode(mode: NativeWidgetThemeMode): Promise<void> {
+  try {
+    await writeNativeWidgetThemeMode(mode)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.warn(`[widget] writeWidgetThemeMode(${mode}) unavailable: ${message}`)
+    pushDebugLog('widget', 'widget_write_failed', 'warn', { source: 'writeWidgetThemeMode' })
   }
 }

--- a/apps/client/src/utils/widget_bridge.ts
+++ b/apps/client/src/utils/widget_bridge.ts
@@ -5,7 +5,7 @@
 // 注意：本文件不得从 schedule_prefetch.js 导入，避免循环依赖。
 // schedule_prefetch.js 导入了本文件的 afterScheduleRefresh。
 
-import { buildTodayCourseSnapshot } from './widget_snapshot'
+import { buildTodayCourseSnapshot, resolveWeekIndexFromAnchor } from './widget_snapshot'
 import {
   writeSnapshotWithRetry,
   clearSnapshot,
@@ -21,6 +21,7 @@ import { isTauriRuntime, invokeNative } from '@/platform/native'
 // ─── 内联的缓存读取逻辑（避免循环依赖 schedule_prefetch ↔ widget_bridge） ───
 
 const SCHEDULE_LOCK_KEY = 'hbu_schedule_lock'
+const SCHEDULE_META_KEY = 'hbu_schedule_meta'
 
 function readJson(key: string): unknown {
   try {
@@ -107,7 +108,7 @@ function readCustomCoursesInline(studentId: string, _semester: string): unknown[
  */
 function readCurrentWeekFromMeta(): number {
   try {
-    const raw = localStorage.getItem('hbu_schedule_meta')
+    const raw = localStorage.getItem(SCHEDULE_META_KEY)
     if (!raw) return 1
     const parsed = JSON.parse(raw)
     const week = Number(parsed?.current_week)
@@ -115,6 +116,54 @@ function readCurrentWeekFromMeta(): number {
   } catch {
     return 1
   }
+}
+
+/**
+ * 从 schedule meta（localStorage）读取 current_week，缺失/非法时返回 0
+ * 用于区分「meta 没有 current_week」与「真实周次 = 1」
+ */
+function readMetaCurrentWeek(): number {
+  try {
+    const raw = localStorage.getItem(SCHEDULE_META_KEY)
+    if (!raw) return 0
+    const parsed = JSON.parse(raw)
+    const week = Number(parsed?.current_week)
+    return Number.isFinite(week) && week >= 1 ? Math.floor(week) : 0
+  } catch {
+    return 0
+  }
+}
+
+/** #759：meta.current_week 可用则用真实周，否则退回给定的回退值 */
+function readMetaCurrentWeekOr(fallback: number): number {
+  const week = readMetaCurrentWeek()
+  return week >= 1 ? week : fallback
+}
+
+/**
+ * 从 localStorage 读取课表 meta（内联版）：
+ * 结构 { semester, start_date, current_week, total_weeks, vacation_notice }
+ */
+function readScheduleMetaInline(): Record<string, unknown> | null {
+  const raw = readJson(SCHEDULE_META_KEY)
+  if (!raw || typeof raw !== 'object') return null
+  return raw as Record<string, unknown>
+}
+
+/**
+ * #759：解析写入 Widget 快照应使用的「当前真实周次」。
+ * 优先级：meta.start_date 开学锚点推算（跨天后依然正确，修复周一凌晨写错周次）
+ * → meta.current_week 缓存（无锚点时回退，此时周次可能滞后一天，已写入提交说明限制）
+ * → 1（readCurrentWeekFromMeta 的兜底语义）。
+ */
+export function resolveWeekIndexForSnapshot(now: Date = new Date()): number {
+  const meta = readScheduleMetaInline()
+  const startDate = toSafeText(meta?.start_date)
+  const totalWeeksRaw = Number(meta?.total_weeks)
+  const totalWeeks = Number.isFinite(totalWeeksRaw) && totalWeeksRaw >= 1 ? Math.floor(totalWeeksRaw) : 25
+  const anchorWeek = startDate ? resolveWeekIndexFromAnchor(startDate, now, totalWeeks) : 0
+  if (anchorWeek >= 1) return anchorWeek
+  return readCurrentWeekFromMeta()
 }
 
 /**
@@ -143,7 +192,9 @@ export async function afterScheduleRefresh(
     const snapshot = buildTodayCourseSnapshot({
       cache: allCourses,
       studentId: sid,
-      weekIndex: opts.selectedWeek
+      // #759：真实周优先（meta.current_week 是服务端权威值）；缺失时才退回界面选中周，
+      // 避免用户手动翻周污染小组件快照
+      weekIndex: readMetaCurrentWeekOr(opts.selectedWeek)
     })
 
     await writeSnapshotWithRetry(snapshot)
@@ -176,7 +227,10 @@ export async function tryWriteSnapshotFromCache(sid: string): Promise<void> {
     const customCourses = readCustomCoursesInline(sid, lockedSemester)
     const allCourses = [...remoteCourses, ...customCourses]
 
-    const weekIndex = readCurrentWeekFromMeta()
+    // #759：跨天定时器/回前台触发时重算当前真实周次（优先开学锚点推算），
+    // 不再直接信任前一天缓存写入的 current_week；date/weekday 由
+    // buildTodayCourseSnapshot 用当下时间计算，天然正确
+    const weekIndex = resolveWeekIndexForSnapshot()
 
     const snapshot = buildTodayCourseSnapshot({
       cache: allCourses,

--- a/apps/client/src/utils/widget_snapshot.ts
+++ b/apps/client/src/utils/widget_snapshot.ts
@@ -80,6 +80,39 @@ export function getIsoWeekday(now: Date): number {
 }
 
 /**
+ * 解析 "YYYY-MM-DD" 为 UTC 午夜毫秒时间戳（非法输入返回 null）
+ * 统一用 UTC 午夜对齐，避免时区/夏令时对「天数差」计算的干扰
+ */
+function parseUtcMidnightMs(dateStr: string): number | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr.trim())
+  if (!m) return null
+  const ms = Date.parse(`${m[1]}-${m[2]}-${m[3]}T00:00:00Z`)
+  return Number.isFinite(ms) ? ms : null
+}
+
+/**
+ * #759：按开学日期锚点推算「当前真实周次」（Asia/Shanghai 日期语义）
+ * - 第 1 周 = start_date 起始的 7 天（与课表 week_index 契约语义一致）
+ * - 今天早于开学日（未开学）→ 返回 0，由调用方回退到缓存周次
+ * - 结果钳制到 [1, totalWeeks]；start_date 非法/解析失败 → 返回 0
+ */
+export function resolveWeekIndexFromAnchor(
+  startDate: string,
+  now: Date,
+  totalWeeks = 25,
+): number {
+  const startMs = parseUtcMidnightMs(startDate)
+  if (startMs == null) return 0
+  const todayMs = parseUtcMidnightMs(formatLocalDate(now))
+  if (todayMs == null) return 0
+  const DAY_MS = 24 * 60 * 60 * 1000
+  const days = Math.floor((todayMs - startMs) / DAY_MS)
+  if (days < 0) return 0
+  const maxWeek = Number.isFinite(totalWeeks) && totalWeeks >= 1 ? Math.floor(totalWeeks) : 25
+  return Math.min(Math.floor(days / 7) + 1, maxWeek)
+}
+
+/**
  * 从 cache 数组中提取指定 weekIndex + weekday 的课程
  * - 按 week_index（或 weeks 数组）+ weekday 过滤
  * - 跨周重复实例去重（按 name+period_start+period_end+location 组合）

--- a/apps/client/src/utils/widget_snapshot_week_anchor.spec.ts
+++ b/apps/client/src/utils/widget_snapshot_week_anchor.spec.ts
@@ -1,0 +1,73 @@
+// src/utils/widget_snapshot_week_anchor.spec.ts
+// #759：resolveWeekIndexFromAnchor（开学日期锚点推算当前周次）纯函数单测
+//
+// 语义约定（与课表 week_index 契约一致）：
+// - 第 1 周 = start_date 起始的 7 天
+// - 今天早于开学日（未开学）→ 0（调用方回退缓存周次）
+// - 结果钳制到 [1, totalWeeks]
+
+import { describe, expect, it } from 'vitest'
+import { resolveWeekIndexFromAnchor } from './widget_snapshot'
+
+/** 构造一个 Asia/Shanghai 下确定日期的时刻（避免测试机器本地时区影响） */
+const sh = (isoCst: string): Date => new Date(isoCst)
+
+describe('resolveWeekIndexFromAnchor', () => {
+  it('开学当天 → 第 1 周', () => {
+    const now = sh('2026-03-02T08:00:00+08:00') // 2026-03-02（周一）开学日当天
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(1)
+  })
+
+  it('开学后第 6 天（第 1 周内）→ 第 1 周', () => {
+    const now = sh('2026-03-08T23:30:00+08:00')
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(1)
+  })
+
+  it('开学后第 7 天（新一周开始）→ 第 2 周', () => {
+    const now = sh('2026-03-09T00:01:00+08:00')
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(2)
+  })
+
+  it('#759 跨天定时器场景：周一凌晨 00:01 周次从 N 推进到 N+1', () => {
+    // 第 5 周周日 23:59 仍是第 5 周；00:01 进入第 6 周
+    const start = '2026-02-23'
+    expect(resolveWeekIndexFromAnchor(start, sh('2026-03-29T23:59:00+08:00'), 25)).toBe(5)
+    expect(resolveWeekIndexFromAnchor(start, sh('2026-03-30T00:01:00+08:00'), 25)).toBe(6)
+  })
+
+  it('多周跨度推算正确（手机长期未打开 App 后）', () => {
+    const now = sh('2026-05-04T12:00:00+08:00') // 开学后 63 天 = 第 10 周
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(10)
+  })
+
+  it('未开学（今天早于开学日）→ 0，由调用方回退', () => {
+    const now = sh('2026-02-20T12:00:00+08:00')
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(0)
+  })
+
+  it('超过 totalWeeks 时钳制到上限', () => {
+    const now = sh('2026-12-01T12:00:00+08:00') // 远超 25 周
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(25)
+  })
+
+  it('start_date 非法（空串/格式错误）→ 0', () => {
+    const now = sh('2026-03-05T12:00:00+08:00')
+    expect(resolveWeekIndexFromAnchor('', now, 25)).toBe(0)
+    expect(resolveWeekIndexFromAnchor('2026/03/02', now, 25)).toBe(0)
+    expect(resolveWeekIndexFromAnchor('not-a-date', now, 25)).toBe(0)
+  })
+
+  it('totalWeeks 缺省/非法时按 25 处理', () => {
+    const now = sh('2026-05-04T12:00:00+08:00') // 第 10 周
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now)).toBe(10)
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, Number.NaN)).toBe(10)
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 0)).toBe(10)
+  })
+
+  it('now 的 Asia/Shanghai 日期与本地时区无关（UTC+8 换日边界）', () => {
+    // 同一时刻：UTC 2026-03-08T16:01:00Z = 上海 2026-03-09T00:01:00 → 第 2 周；
+    // 若误用 UTC 日期（03-08）会得到第 1 周
+    const now = sh('2026-03-08T16:01:00Z')
+    expect(resolveWeekIndexFromAnchor('2026-03-02', now, 25)).toBe(2)
+  })
+})


### PR DESCRIPTION
## TL;DR

修复桌面课表小组件比实际慢一天（快照固化 + 回前台不补写），并将小组件背景默认改 85% 半透明、预留颜色跟随应用内主题模式的完整管道。

## #759 慢一天修复

- **回前台补写**：`LifecycleCoordinator` 在登录态下回前台无条件 `tryWriteSnapshotFromCache`（此前只重排定时器不补写，冻结的跨天定时器被清除后当天无任何重写——直接根因）
- **周次锚点重算**：新增 `resolveWeekIndexFromAnchor`（`hbu_schedule_meta.start_date` 锚点、Asia/Shanghai、钳制 [1, total_weeks]）；跨天定时器周一凌晨不再写错周次
- **手动翻周污染消除**：`afterScheduleRefresh` 改为 meta 真实周优先，用户手动选中的周不再写入快照
- **原生陈旧兜底**：快照 `date` 早于今天时标题显示今天 + 溢出位「数据更新于 X月X日」，课程行深链携带今天；刻意不引入 java.time 到 RemoteViewsService（minSdk=22 无 desugaring）

## #758 半透明 + 颜色跟随

- 浅色 `#D9FFFFFF` / 深色 `#D91E293B`（85% 不透明）；API 31+ 动态色经 `drawable-v31/widget_background.xml` layer-list alpha=0.85，保留 Material You 取色
- 三个小组件（今日课程/电费/考试）统一走 `widget_background` 自动生效
- **颜色跟随应用内模式管道就绪**：前端 `writeThemeMode`（Tauri/Capacitor 双路径）→ Kotlin `theme_mode`（缺省 system 零干预与旧版一致）→ `WidgetThemeMode.kt` createConfigurationContext + ResourcesCompat 强制 light/dark 覆盖
- ⚠️ 前端接入点待 #757（三态主题）合并后一行调用接入，将在后续小 PR 完成——现有 night_mode 二态信号无法区分 system/light，自动接入会破坏「跟随系统」用户

## 测试

- 新增 5 个 spec 共 33 用例全绿；`npm run typecheck` 通过
- 全量 `test:ci` 1228/1229（唯一失败 `bottom_tab_bar_safe_area.spec` 在基点 4e2c6846 同样失败，环境性 pre-existing）
- Rust/Kotlin：Kotlin 改动无法本地编译，CI Android job 为准；已自查资源引用/包名/API 兼容（ResourcesCompat 替代 getColor(id, theme)）

Closes #759
Related #758