### PR TITLE
fix(#762): eportal 认证响应不再误判成功——删除子串判成功、校验状态码、HTML 降级为可读摘要

### DIFF
--- a/apps/client/src-tauri/src/modules/campus_network/eportal.rs
+++ b/apps/client/src-tauri/src/modules/campus_network/eportal.rs
@@ -30,6 +30,110 @@ fn build_client() -> Result<Client, String> {
         .map_err(|e| e.to_string())
 }
 
+/// ASCII 大小写不敏感的子串查找，返回匹配起点（字节偏移）。
+///
+/// needle 须为 ASCII：匹配点必为 ASCII 字节，可安全用于 UTF-8 字符串切片。
+fn find_ignore_case(haystack: &str, needle: &str) -> Option<usize> {
+    let hay = haystack.as_bytes();
+    let pat = needle.as_bytes();
+    if pat.is_empty() || hay.len() < pat.len() {
+        return None;
+    }
+    (0..=hay.len() - pat.len()).find(|&i| hay[i..i + pat.len()].eq_ignore_ascii_case(pat))
+}
+
+/// 折叠连续空白为单个空格并截断至 max_chars 个字符；无有效文本时返回 None。
+fn collapse_and_truncate(text: &str, max_chars: usize) -> Option<String> {
+    let mut collapsed = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            // 已有内容时记录一个待写入的空格，避免首尾空白。
+            pending_space = !collapsed.is_empty();
+            continue;
+        }
+        if pending_space {
+            collapsed.push(' ');
+            pending_space = false;
+        }
+        collapsed.push(ch);
+    }
+    let collapsed = collapsed.trim();
+    if collapsed.is_empty() {
+        return None;
+    }
+    if collapsed.chars().count() <= max_chars {
+        return Some(collapsed.to_string());
+    }
+    let truncated: String = collapsed.chars().take(max_chars).collect();
+    Some(format!("{truncated}…"))
+}
+
+/// 提取 HTML `<title>` 标签文本（大小写不敏感），无有效 title 时返回 None。
+fn extract_html_title(body: &str) -> Option<String> {
+    const OPEN_TAG: &str = "<title";
+    let open = find_ignore_case(body, OPEN_TAG)?;
+    let after_open = &body[open + OPEN_TAG.len()..];
+    // 排除 <titlefoo> 这类前缀巧合：紧跟字符必须是 '>'、空白或 '/'。
+    match after_open.chars().next()? {
+        '>' | '/' => {}
+        c if c.is_whitespace() => {}
+        _ => return None,
+    }
+    let tag_end = after_open.find('>')?;
+    let content = &after_open[tag_end + 1..];
+    let close = find_ignore_case(content, "</title")?;
+    Some(content[..close].to_string())
+}
+
+/// 从非 JSON 响应（通常是 queryString 过期时 302 重定向回的认证页 HTML）中
+/// 提取可读文本作为失败原因：优先 `<title>`，否则去标签取正文；兜底通用文案。
+fn extract_readable_text(body: &str) -> String {
+    const MAX_LEN: usize = 120;
+    const FALLBACK: &str = "认证服务器返回异常响应，请稍后重试";
+
+    if let Some(title) = extract_html_title(body) {
+        if let Some(text) = collapse_and_truncate(&title, MAX_LEN) {
+            return text;
+        }
+    }
+
+    // 去除所有 HTML 标签后取正文文本；在标签边界补一个空格，
+    // 避免相邻块级标签的文本粘连（多余空格由 collapse_and_truncate 折叠）。
+    let mut plain = String::with_capacity(body.len());
+    let mut in_tag = false;
+    let mut pending_space = false;
+    for ch in body.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                pending_space = !plain.is_empty();
+            }
+            '>' => in_tag = false,
+            c if !in_tag => {
+                if pending_space {
+                    plain.push(' ');
+                    pending_space = false;
+                }
+                plain.push(c);
+            }
+            _ => {}
+        }
+    }
+    if let Some(text) = collapse_and_truncate(&plain, MAX_LEN) {
+        return text;
+    }
+
+    FALLBACK.to_string()
+}
+
+/// 解析 eportal 登录接口响应。
+///
+/// 判定规则（修复 #762 假成功）：
+/// - 仅当响应体为 JSON 且含结构化成功标志（`result: "success"` 等 eportal
+///   协议字段，或 `success: true` 布尔字段）才判成功；
+/// - 非 JSON 响应（如重定向回的认证页 HTML，几乎必含「认证成功」字样）
+///   一律判失败，禁止任何「包含 success/成功」的子串猜测。
 fn parse_login_message(body: &str) -> (bool, String) {
     let trimmed = body.trim();
     if trimmed.is_empty() {
@@ -42,21 +146,28 @@ fn parse_login_message(body: &str) -> (bool, String) {
             .or_else(|| json.get("Result"))
             .and_then(|v| v.as_str().or_else(|| v.as_i64().map(|_| "1")))
             .unwrap_or("");
+        let success = matches!(result, "success" | "1" | "ok")
+            || json.get("success").and_then(|v| v.as_bool()) == Some(true);
         let message = json
             .get("message")
             .or_else(|| json.get("msg"))
             .and_then(|v| v.as_str())
-            .unwrap_or(trimmed);
-        let success = matches!(result, "success" | "1" | "ok")
-            || json.get("success").and_then(|v| v.as_bool()) == Some(true);
-        return (success, message.to_string());
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                // 无 message/msg 字段时不透传 JSON 原文，改用通用文案。
+                if success {
+                    "登录成功".to_string()
+                } else {
+                    "登录失败".to_string()
+                }
+            });
+        return (success, message);
     }
 
-    let lower = trimmed.to_lowercase();
-    if lower.contains("success") || lower.contains("成功") {
-        return (true, trimmed.to_string());
-    }
-    (false, trimmed.to_string())
+    // 非 JSON 响应一律判失败，message 取 HTML 可读摘要而非整段原文。
+    (false, extract_readable_text(trimmed))
 }
 
 /// 执行 eportal 登录。
@@ -78,11 +189,9 @@ pub async fn eportal_login(
 
     let client = build_client()?;
     let index_url = format!("{gateway}{INDEX_JSP_PATH}?{query}");
-    client
-        .get(&index_url)
-        .send()
-        .await
-        .map_err(|e| format!("打开认证页失败: {e}"))?;
+    // 打开认证页仅用于预热会话 Cookie（best-effort）：
+    // 失败或非 2xx 都不阻断登录提交，最终以 InterFace.do 的响应为准。
+    let _ = client.get(&index_url).send().await;
 
     let login_url = format!("{gateway}{INTERFACE_DO_PATH}?method={LOGIN_METHOD}");
     let resp = client
@@ -98,7 +207,20 @@ pub async fn eportal_login(
         .await
         .map_err(|e| format!("提交认证失败: {e}"))?;
 
-    let body = resp.text().await.map_err(|e| e.to_string())?;
+    // 非 2xx（网关异常页/重定向残留）直接判结构化失败并携带状态码，
+    // 不读取响应体，避免把异常页面内容误当登录结果。
+    let status = resp.status();
+    if !status.is_success() {
+        return Ok((
+            false,
+            format!("认证服务器响应异常（HTTP {}），请稍后重试", status.as_u16()),
+        ));
+    }
+
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("读取认证响应失败: {e}"))?;
     let (success, message) = parse_login_message(&body);
     Ok((success, message))
 }
@@ -120,6 +242,114 @@ mod tests {
     fn parses_failure_json() {
         let (ok, _) = parse_login_message(r#"{"result":"fail","message":"密码错误"}"#);
         assert!(!ok);
+    }
+
+    /// #762 回归：认证页 HTML 几乎必含「认证成功」等文案，绝不能据此判成功。
+    #[test]
+    fn html_with_success_keyword_is_failure() {
+        let html = r#"<html><head><title>校园网认证</title></head><body>
+            <h3>登录成功后即可访问互联网</h3><form action="/eportal/InterFace.do"></form>
+        </body></html>"#;
+        let (ok, msg) = parse_login_message(html);
+        assert!(!ok);
+        // message 应为 <title> 提取结果，而非整段 HTML。
+        assert_eq!(msg, "校园网认证");
+        assert!(!msg.contains('<'));
+    }
+
+    /// 无 <title> 时应去标签提取正文文本。
+    #[test]
+    fn html_without_title_extracts_plain_text() {
+        let html = r#"<html><body><div>网络异常</div><p>请重新登录</p></body></html>"#;
+        let (ok, msg) = parse_login_message(html);
+        assert!(!ok);
+        assert_eq!(msg, "网络异常 请重新登录");
+    }
+
+    /// HTML 无任何可读文本时使用通用中文文案兜底。
+    #[test]
+    fn html_without_readable_text_uses_fallback() {
+        let (ok, msg) = parse_login_message("   <div>   </div>   ");
+        assert!(!ok);
+        assert_eq!(msg, "认证服务器返回异常响应，请稍后重试");
+    }
+
+    /// 提取文本应截断至约 120 字符（含省略号）。
+    #[test]
+    fn long_html_message_is_truncated() {
+        let body = format!("<html><body>{}</body></html>", "超".repeat(300));
+        let (ok, msg) = parse_login_message(&body);
+        assert!(!ok);
+        assert_eq!(msg.chars().count(), 121);
+        assert!(msg.ends_with('…'));
+    }
+
+    /// 纯文本（非 JSON、非 HTML）响应判失败并原样（截断后）返回。
+    #[test]
+    fn plain_text_response_is_failure() {
+        let (ok, msg) = parse_login_message("请重新登录");
+        assert!(!ok);
+        assert_eq!(msg, "请重新登录");
+    }
+
+    /// 有效 JSON 但无 message/msg 字段时不得透传 JSON 原文。
+    #[test]
+    fn success_json_without_message_uses_generic_text() {
+        let (ok, msg) = parse_login_message(r#"{"result":"success"}"#);
+        assert!(ok);
+        assert_eq!(msg, "登录成功");
+        assert!(!msg.contains("result"));
+    }
+
+    #[test]
+    fn failure_json_without_message_uses_generic_text() {
+        let (ok, msg) = parse_login_message(r#"{"result":"fail"}"#);
+        assert!(!ok);
+        assert_eq!(msg, "登录失败");
+        assert!(!msg.contains("result"));
+    }
+
+    /// <title> 提取的边界：大小写不敏感、带属性、前缀巧合不算 title。
+    #[test]
+    fn extract_html_title_edge_cases() {
+        assert_eq!(
+            extract_html_title("<HTML><TITLE>登录页</TITLE></HTML>").as_deref(),
+            Some("登录页")
+        );
+        assert_eq!(
+            extract_html_title(r#"<title lang="zh-CN">校园网</title>"#).as_deref(),
+            Some("校园网")
+        );
+        // <titlefoo> 不是 title 标签，应返回 None。
+        assert_eq!(extract_html_title("<titlefoo>x</titlefoo>"), None);
+        // 有开无闭不提取。
+        assert_eq!(extract_html_title("<title>未闭合"), None);
+    }
+
+    /// 登录接口返回非 2xx 时应得到结构化失败（含状态码），而不是 Err 或解析异常页。
+    #[tokio::test]
+    async fn eportal_login_non_2xx_is_structured_failure() {
+        let server = MockServer::start().await;
+        // 故意不挂 GET index.jsp 的 mock：验证 best-effort 不因 404 阻断。
+        Mock::given(method("POST"))
+            .and(path("/eportal/InterFace.do"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+            .mount(&server)
+            .await;
+
+        let password = format!("secret-{}", std::process::id());
+        let (ok, message) = eportal_login(
+            server.uri().as_str(),
+            "wlanuserip=10.0.0.2&wlanacname=logic",
+            "2024123456",
+            &password,
+            "default",
+        )
+        .await
+        .expect("非 2xx 应为结构化失败而非 Err");
+        assert!(!ok);
+        assert!(message.contains("500"), "失败文案应含状态码: {message}");
+        assert!(!message.contains("server error"));
     }
 
     #[tokio::test]

--- a/apps/client/src-tauri/src/modules/campus_network/mod.rs
+++ b/apps/client/src-tauri/src/modules/campus_network/mod.rs
@@ -65,6 +65,9 @@ pub async fn login_campus_network(
 
     let service = carrier.eportal_service();
     let srun_username = carrier.srun_username(student_id);
+    // 记录最后一次 eportal 失败原因（已由适配器清洗为可读短文本），
+    // 全部网关失败时反馈给用户，避免只剩一句无信息量的通用文案。
+    let mut last_eportal_message = String::new();
 
     if let Some(ref q) = query {
         let eportal_gateways: Vec<String> = preferred_gateway
@@ -86,9 +89,8 @@ pub async fn login_campus_network(
                     };
                 }
                 Ok((false, message)) => {
-                    if preferred_gateway.as_deref() == Some(gw.as_str()) {
-                        // 记录首选网关失败原因，继续尝试 Srun
-                        let _ = message;
+                    if !message.trim().is_empty() {
+                        last_eportal_message = message;
                     }
                 }
                 Err(_) => continue,
@@ -112,9 +114,15 @@ pub async fn login_campus_network(
         }
     }
 
+    // eportal 与 Srun 全部失败：优先透出 eportal 的具体失败原因。
+    let message = if last_eportal_message.is_empty() {
+        "所有网关认证均失败，请检查账号密码或在校内网络重试".to_string()
+    } else {
+        format!("所有网关认证均失败（{last_eportal_message}），请检查账号密码或在校内网络重试")
+    };
     CampusNetworkLoginResult {
         success: false,
-        message: "所有网关认证均失败，请检查账号密码或在校内网络重试".to_string(),
+        message,
         adapter_used: None,
     }
 }

--- a/apps/client/src/utils/toast.js
+++ b/apps/client/src/utils/toast.js
@@ -7,12 +7,24 @@ export const toastState = reactive({
     timer: null
 })
 
+// Toast 文案最大长度：超出部分截断并加省略号，
+// 防止后端异常长文本（如整段 HTML）撑爆弹窗（issue #762 前端兜底）。
+const MAX_TOAST_LENGTH = 200
+
+const truncateToastMessage = (message) => {
+    const text = String(message ?? '')
+    if (text.length <= MAX_TOAST_LENGTH) {
+        return text
+    }
+    return `${text.slice(0, MAX_TOAST_LENGTH)}…`
+}
+
 export const showToast = (message, type = 'info', duration = 2000) => {
     if (toastState.timer) {
         clearTimeout(toastState.timer)
     }
 
-    toastState.message = message
+    toastState.message = truncateToastMessage(message)
     toastState.type = type
     toastState.show = true
 


### PR DESCRIPTION
## TL;DR

校园网「立即认证」弹整段 HTML 且假成功的根因修复：eportal 响应解析删除「success/成功」子串判成功逻辑，非 JSON 一律判失败；登录 POST 非 2xx 直接结构化失败；HTML 响应降级为可读摘要；前端 toast 截断兜底。

## 修复内容

- `eportal.rs parse_login_message` 重写：仅当响应为 JSON 且含结构化成功标志（`result: "success"|"1"|"ok"` 或 `success: true`，沿用仓库既有协议字段）才判成功；**非 JSON 一律失败**
- 失败 message 从 HTML 提取：优先 `<title>`，否则去标签（边界补空格防粘连）折叠空白截断 120 字符，兜底通用中文文案
- 登录 POST 非 2xx 直接返回 `认证服务器响应异常（HTTP {code}）`，不读异常页响应体；GET index.jsp 改 best-effort 不再中断登录
- JSON 无 `message/msg` 字段时用通用文案，不再透传 JSON 原文
- `mod.rs`：记录最后一次 eportal 失败原因（修正 `let _ = message;` 死代码），全部网关失败时透出具体原因；fallback Srun 链路不破坏
- 前端 `toast.js`：message 超 200 字符截断加省略号

## 测试

- `cargo test --lib campus_network`：18/18 绿（含回归：含「认证成功」的 HTML 判失败且 message 为提取文本、正常 JSON 成功、无 message 字段不透传、title/去标签/截断、wiremock 非 2xx 契约）
- `cargo fmt --all -- --check` 绿；`cargo clippy --lib` 改动文件无新增告警；`npm run typecheck` 绿

## 已知取舍

- 数字 `result` 任意非零映射成功的既有行为未收紧（避免扩大改动面，`{result: 0}` 理论上仍判成功——属历史行为）
- eportal 真实网关的成功字段离线无法验证；方向安全（宁可失败不假成功），未知成功形态将走 Srun fallback

Closes #762