### PR TITLE
fix(#760,#761,#757): 课表添加课程误报名称为空 + 开屏页设置生效 + 深浅色跟随系统

### DIFF
--- a/apps/client/src/app/coordinators/NavigationCoordinator.ts
+++ b/apps/client/src/app/coordinators/NavigationCoordinator.ts
@@ -453,12 +453,22 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     return { sid: snapshot.sid, view: normalizeViewName(snapshot.view) }
   }
 
+  // #761：仅当 URL hash 命中 `#/学号/视图`（带显式视图）时才视为外部深链，深链优先。
+  // 空 hash、`#/学号`（无视图）与仅残留 history 快照均视为冷启动——此时启动页设置
+  // （startupPage）优先，避免 WebView 会话残留的 history 快照覆盖用户启动页选择。
+  const readStartupHashDeepLink = (): { sid: string; view: string } | null => {
+    if (typeof window === 'undefined') return null
+    const match = String(window.location.hash || '').match(/^#\/(\d{10})\/(\w+)$/)
+    if (!match) return null
+    return { sid: match[1], view: normalizeViewName(match[2]) }
+  }
+
   const syncFromHash = async () => {
     const route = parseHashRoute()
     if (!route) {
-      if (state.currentView.value !== 'home') {
-        applyViewState('home')
-      }
+      // #761：无 hash 路由（冷启动无深链）时保留 setup 阶段依据启动页设置
+      // （startupPage）得到的 currentView；不得强制回 home，否则用户选择
+      // 「课表」启动页的意图会被抹掉。
       return
     }
     state.studentId.value = route.sid
@@ -765,18 +775,27 @@ export const createNavigationCoordinator = (runtime: AppRuntime): NavigationCoor
     },
     readStartupSnapshot: () => {
       const snapshot = readWindowRouteSnapshot()
+      const deepLink = readStartupHashDeepLink()
       const startupPageSetting = useUiSettings().startupPage || 'home'
-      const startupView = resolvePolicySafeView(snapshot?.view || startupPageSetting, 'home')
+      // #761：冷启动时启动页设置优先（残留 history 快照的 view/tab/module 不再覆盖）；
+      // 带显式视图的 hash 深链（#/学号/视图）时深链优先，保证外部跳转行为不受破坏。
+      const startupView = resolvePolicySafeView(deepLink?.view || startupPageSetting, 'home')
       const initialView = isProtectedView(startupView) && !hasDailyAccessGrant() ? 'home' : startupView
-      const initialTab = String(
-        snapshot?.tab ||
-          ((MAIN_TABS as readonly string[]).includes(initialView) ? initialView : (ME_SUB_VIEWS as readonly string[]).includes(initialView) ? 'me' : 'home')
-      ).trim() || 'home'
-      const initialModule = String(
-        snapshot?.module ||
-          ((MAIN_TABS as readonly string[]).includes(initialView) ? '' : initialView === 'home' ? '' : initialView)
-      ).trim()
-      const bootStudentIdHint = String(snapshot?.sid || '').trim()
+      const tabFallback = (MAIN_TABS as readonly string[]).includes(initialView)
+        ? initialView
+        : (ME_SUB_VIEWS as readonly string[]).includes(initialView)
+          ? 'me'
+          : 'home'
+      const moduleFallback = (MAIN_TABS as readonly string[]).includes(initialView)
+        ? ''
+        : initialView === 'home'
+          ? ''
+          : initialView
+      // 深链时沿用 history 快照的 tab/module（与深链 view 配套）；冷启动一律由 initialView 推导
+      const initialTab = String((deepLink ? snapshot?.tab : '') || tabFallback).trim() || 'home'
+      const initialModule = String((deepLink ? snapshot?.module : '') || moduleFallback).trim()
+      // 学号 hint 保留残留快照来源：供快速课表启动（bootScheduleSnapshot）复用
+      const bootStudentIdHint = String(deepLink?.sid || snapshot?.sid || '').trim()
       const bootScheduleSnapshot =
         initialView === 'schedule' && bootStudentIdHint
           ? (readScheduleRenderSnapshot(bootStudentIdHint) as Record<string, unknown> | null)

--- a/apps/client/src/app/coordinators/startupView.spec.ts
+++ b/apps/client/src/app/coordinators/startupView.spec.ts
@@ -1,0 +1,244 @@
+// src/app/coordinators/startupView.spec.ts
+//
+// GitHub #761：开屏页选择「课表」后启动仍显示首页——启动视图决策测试。
+//
+// 根因回顾：
+// - setup 阶段 readStartupSnapshot() 正确按 startupPage 设置得到 initialView='schedule'；
+// - 但 onMounted 的 syncFromHash() 在冷启动无 hash 路由时无条件 applyViewState('home')，
+//   把启动页设置结果抹掉；
+// - 次要隐患：readStartupSnapshot 中 `snapshot?.view || startupPageSetting` 让 WebView
+//   会话残留的 history 快照优先级高于启动页设置。
+//
+// 修复语义：
+// ①冷启动（无 hash 深链）：startupPage 设置优先，残留 history 快照不覆盖；
+// ②带 `#/学号/视图` 显式视图的 hash 深链：hash 优先（深链行为不受破坏）；
+// ③syncFromHash 无 hash 路由时保留 setup 阶段的 currentView，不再强制回 home。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createNavigationCoordinator } from './NavigationCoordinator'
+import type { AppRuntime } from '../contracts/runtime'
+
+// ─── 模块 mock（NavigationCoordinator 的全部带副作用依赖） ─────────────────
+
+// 启动页设置可变：测试内通过 setStartupPage 切换
+let startupPageSetting = 'home'
+
+vi.mock('../../utils/ui_settings', () => ({
+  useUiSettings: () => ({ startupPage: startupPageSetting })
+}))
+
+vi.mock('../viewRegistry', () => ({
+  VIEW_PREFETCHERS: {}
+}))
+
+vi.mock('../../config/app_store_policy', () => ({
+  isViewAllowed: vi.fn(() => true)
+}))
+
+vi.mock('../../utils/moduleAccess', () => ({
+  canOpenModule: vi.fn(() => ({ ok: true }))
+}))
+
+vi.mock('../../utils/toast', () => ({
+  showToast: vi.fn()
+}))
+
+vi.mock('../../utils/remembered_username', () => ({
+  saveRememberedUsername: vi.fn()
+}))
+
+vi.mock('../../utils/schedule_prefetch.js', () => ({
+  readScheduleRenderSnapshot: vi.fn(() => null),
+  clearScheduleRenderSnapshot: vi.fn(),
+  SCHEDULE_POPUP_PENDING_KEY: 'hbu_schedule_popup_pending',
+  SCHEDULE_SWITCH_PENDING_KEY: 'hbu_schedule_switch_pending'
+}))
+
+vi.mock('../../utils/usage_tracker.js', () => ({
+  trackViewNavigation: vi.fn()
+}))
+
+vi.mock('../../utils/daily_access_key.js', () => ({
+  isProtectedView: vi.fn(() => false),
+  hasDailyAccessGrant: vi.fn(() => true),
+  markDailyAccessGranted: vi.fn(),
+  sanitizeDailyAccessInput: (value: unknown) => String(value ?? ''),
+  verifyDailyAccessKey: vi.fn(() => false)
+}))
+
+vi.mock('../../utils/more_modules', () => ({
+  canUseLocalModuleBridgePreview: vi.fn(() => false),
+  isLocalModuleBridgePreviewUrl: vi.fn(() => false),
+  normalizeModuleHostSessionPayload: vi.fn(async (payload) => payload || {}),
+  resolveModuleHostPreviewSource: vi.fn(() => ({
+    resolvedPreviewUrl: '',
+    sourceKind: '',
+    localPreviewUrl: '',
+    packageUrls: null
+  }))
+}))
+
+vi.mock('../../platform/native', () => ({
+  exitNativeApp: vi.fn(),
+  getCurrentNativeWindow: vi.fn(),
+  isTauriRuntime: vi.fn(() => false)
+}))
+
+vi.mock('../../platform/runtime', () => ({
+  isDesktopLike: vi.fn(() => false),
+  isIOSLike: vi.fn(() => false)
+}))
+
+vi.mock('../../utils/boot_metrics', () => ({
+  resetBootMetrics: vi.fn(),
+  hasBootMetric: vi.fn(() => false),
+  markBootMetric: vi.fn()
+}))
+
+// ─── 测试基建 ───────────────────────────────────────────────────────────────
+
+type WindowRoute = { historyState?: Record<string, unknown> | null; hash?: string }
+
+const setWindowRoute = ({ historyState = null, hash = '' }: WindowRoute = {}) => {
+  ;(globalThis as unknown as { window: unknown }).window = {
+    history: { state: historyState, replaceState: vi.fn(), pushState: vi.fn(), length: 2 },
+    location: { hash }
+  }
+}
+
+const makeCoordinator = () => {
+  const state = {
+    studentId: ref(''),
+    currentView: ref('home'),
+    activeTab: ref('home'),
+    currentModule: ref(''),
+    navDirection: ref('none'),
+    moduleHostSession: ref({ module_id: '' }),
+    pendingProtectedView: ref(null as unknown),
+    dailyAccessInput: ref(''),
+    dailyAccessError: ref(''),
+    showDailyAccessDialog: ref(false),
+    showExitDialog: ref(false),
+    exitingApp: ref(false),
+    viewRenderNonce: ref(0),
+    gradeData: ref<unknown[]>([]),
+    appShellRef: ref(null),
+    homeScrollSnapshot: ref(0),
+    homeScrollRestoring: ref(false),
+    isLoggedIn: ref(true),
+    mutable: { lastSoftRemountAt: 0 }
+  }
+  const runtime = {
+    state,
+    auth: { handleRequireLogin: vi.fn() },
+    grade: { loadGradesForCurrentView: vi.fn() },
+    lifecycle: {
+      recoverViewportAfterTransition: vi.fn(),
+      isCurrentViewDomHealthy: vi.fn(() => true),
+      nudgeWebViewPaint: vi.fn()
+    }
+  } as unknown as AppRuntime
+  return { state, coordinator: createNavigationCoordinator(runtime) }
+}
+
+describe('启动视图决策（#761）', () => {
+  beforeEach(() => {
+    startupPageSetting = 'home'
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('①冷启动 + 启动页为课表：initialView 为 schedule，且 syncFromHash 后不被抹回 home', async () => {
+    startupPageSetting = 'schedule'
+    setWindowRoute({ historyState: null, hash: '' })
+
+    const { state, coordinator } = makeCoordinator()
+    const startup = coordinator.readStartupSnapshot()
+
+    expect(startup.initialView).toBe('schedule')
+    expect(startup.startupPageSetting).toBe('schedule')
+
+    // 复刻 useAppRuntime setup 的赋值 + onMounted 的 syncFromHash
+    state.currentView.value = startup.initialView
+    await coordinator.syncFromHash()
+
+    expect(state.currentView.value).toBe('schedule')
+  })
+
+  it('②冷启动 + 未设置启动页：回退 home，syncFromHash 后仍为 home', async () => {
+    startupPageSetting = 'home'
+    setWindowRoute({ historyState: null, hash: '' })
+
+    const { state, coordinator } = makeCoordinator()
+    const startup = coordinator.readStartupSnapshot()
+
+    expect(startup.initialView).toBe('home')
+    state.currentView.value = startup.initialView
+    await coordinator.syncFromHash()
+
+    expect(state.currentView.value).toBe('home')
+  })
+
+  it('③带 #/学号/视图 的 hash 深链：按深链路由并同步学号，不受启动页设置影响', async () => {
+    startupPageSetting = 'home'
+    setWindowRoute({ historyState: null, hash: '#/1234567890/grades' })
+
+    const { state, coordinator } = makeCoordinator()
+    const startup = coordinator.readStartupSnapshot()
+
+    expect(startup.initialView).toBe('grades')
+    state.currentView.value = startup.initialView
+    await coordinator.syncFromHash()
+
+    expect(state.studentId.value).toBe('1234567890')
+    expect(state.currentView.value).toBe('grades')
+    // grades 非主 tab 也非「我的」子页 → tab 回退 home，module 记为视图名
+    expect(state.activeTab.value).toBe('home')
+    expect(state.currentModule.value).toBe('grades')
+  })
+
+  it('次要隐患：残留 history 快照（view=schedule）不覆盖「首页」启动页设置', () => {
+    startupPageSetting = 'home'
+    setWindowRoute({
+      historyState: { __hbu: true, sid: '1234567890', view: 'schedule', tab: 'schedule', module: '' },
+      hash: ''
+    })
+
+    const { coordinator } = makeCoordinator()
+    const startup = coordinator.readStartupSnapshot()
+
+    // 冷启动（无显式视图深链）→ 启动页设置优先
+    expect(startup.initialView).toBe('home')
+    expect(startup.initialTab).toBe('home')
+  })
+
+  it('冷启动 + 启动页为课表 + 残留 history 快照：initialView 为 schedule 且保留学号 hint', () => {
+    startupPageSetting = 'schedule'
+    setWindowRoute({
+      historyState: { __hbu: true, sid: '1234567890', view: 'home', tab: 'home', module: '' },
+      hash: ''
+    })
+
+    const { coordinator } = makeCoordinator()
+    const startup = coordinator.readStartupSnapshot()
+
+    // 启动页设置生效；学号 hint 保留供快速课表启动复用
+    expect(startup.initialView).toBe('schedule')
+    expect(startup.bootStudentIdHint).toBe('1234567890')
+    expect(startup.initialTab).toBe('schedule')
+  })
+
+  it('#/学号（无显式视图）的 hash 视为冷启动：启动页设置优先，学号 hint 来自 hash', () => {
+    startupPageSetting = 'schedule'
+    setWindowRoute({ historyState: null, hash: '#/1234567890' })
+
+    const { coordinator } = makeCoordinator()
+    const startup = coordinator.readStartupSnapshot()
+
+    expect(startup.initialView).toBe('schedule')
+    expect(startup.bootStudentIdHint).toBe('1234567890')
+  })
+})

--- a/apps/client/src/components/SettingsView.spec.ts
+++ b/apps/client/src/components/SettingsView.spec.ts
@@ -8,3 +8,31 @@ describe('SettingsView emits declaration', () => {
     expect(source).toContain("defineEmits(['back', 'openWorkspaceLayout'])")
   })
 })
+
+describe('SettingsView 深浅色三态（#757）', () => {
+  it('外置模板提供 跟随系统/白天/夜间 三态选择并绑定三态状态', () => {
+    const template = readFileSync(
+      new URL('../templates/views/SettingsView.html', import.meta.url),
+      'utf8'
+    )
+
+    // 三态选项渲染自 nightModeOptions，激活态绑定 nightModePreference
+    expect(template).toContain('v-for="item in nightModeOptions"')
+    expect(template).toContain(':class="{ active: nightModePreference === item.key }"')
+    expect(template).toContain('@click="setNightMode(item.key)"')
+    // 旧版二态 toggle 已移除
+    expect(template).not.toContain('toggleDarkMode')
+    expect(template).not.toContain('theme-toggle-track')
+  })
+
+  it('脚本使用三态 night_mode API（含 system 迁移语义），不再仅二态切换', () => {
+    const source = readFileSync(new URL('./SettingsView.vue', import.meta.url), 'utf8')
+
+    expect(source).toContain('getNightModePreference()')
+    expect(source).toContain('setNightModePreference(mode)')
+    expect(source).toContain('resolveNightModeDark(mode)')
+    // 旧版二态切换入口已移除
+    expect(source).not.toContain('toggleDarkMode')
+    expect(source).not.toContain('applyNightModePreference(')
+  })
+})

--- a/apps/client/src/components/SettingsView.vue
+++ b/apps/client/src/components/SettingsView.vue
@@ -42,9 +42,11 @@ import {
   subscribeDebugLogs
 } from '../utils/debug_logger'
 import {
-  applyNightModePreference,
+  getNightModePreference,
   initNightModeClass,
-  isNightModeEnabled
+  isNightModeEnabled,
+  resolveNightModeDark,
+  setNightModePreference
 } from '../utils/night_mode'
 
 const emit = defineEmits(['back', 'openWorkspaceLayout'])
@@ -75,20 +77,33 @@ const uiSettings = useUiSettings()
 const appSettings = useAppSettings()
 const fontSettings = useFontSettings()
 
-// 夜间模式状态
+// #757 深浅色三态：'system' 跟随系统（默认）/ 'light' 白天 / 'dark' 夜间
+const nightModeOptions = [
+  { key: 'system', label: '跟随系统', desc: '自动适配系统深浅色' },
+  { key: 'light', label: '白天', desc: '清爽明亮' },
+  { key: 'dark', label: '夜间', desc: '夜间模式，保护眼睛' }
+]
+const nightModePreference = ref(getNightModePreference())
 const isDarkMode = ref(isNightModeEnabled())
 const themeTransitioning = ref(false)
 const themeTransitionType = ref('') // 'to-dark' or 'to-light'
 
-const toggleDarkMode = (event) => {
-  const willBeDark = !isDarkMode.value
+const nightModeHint = computed(() => {
+  if (nightModePreference.value === 'system') return '正在跟随系统深浅色自动切换'
+  return nightModePreference.value === 'dark' ? '夜间模式已开启，保护您的眼睛' : '白天模式，清爽明亮'
+})
+
+// 三态切换：保留原二态切换的全屏过渡动画，动画先播、主题后切
+const setNightMode = (mode) => {
+  if (nightModePreference.value === mode) return
+  const willBeDark = resolveNightModeDark(mode)
   themeTransitionType.value = willBeDark ? 'to-dark' : 'to-light'
   themeTransitioning.value = true
 
   // 延迟切换实际主题，让动画先播放
   setTimeout(() => {
-    isDarkMode.value = willBeDark
-    applyNightModePreference(willBeDark)
+    nightModePreference.value = mode
+    isDarkMode.value = setNightModePreference(mode)
     flushUiSettings()
   }, 400)
 
@@ -99,8 +114,9 @@ const toggleDarkMode = (event) => {
   }, 1200)
 }
 
-// 初始化时读取暗色模式偏好
+// 初始化时读取偏好（含旧版二态键 hbu_dark_mode 的一次性迁移）与当前生效状态
 const initDarkMode = () => {
+  nightModePreference.value = getNightModePreference()
   isDarkMode.value = initNightModeClass()
 }
 initDarkMode()

--- a/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.spec.ts
+++ b/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * #760 添加课程表单填写完整仍报「课程名称不能为空」——回归防护。
+ *
+ * 根因回顾：
+ * - 弹窗被父组件 ScheduleView.vue 常驻挂载（无 v-if），setup 仅执行一次；
+ * - 旧实现 `const form = props.addCourseForm` 在 setup 时固化了 prop 对象引用；
+ * - 编辑器 useScheduleEditor.resetAddCourseForm / populateCourseForm 每次打开弹窗
+ *   都整体替换 addCourseForm.value 为新对象（编辑回填依赖该整体替换语义）；
+ * - 结果用户输入写进被替换掉的旧对象，validateAddCourse 读取的新对象恒为空。
+ *
+ * 修复：弹窗组件改用 `computed(() => props.addCourseForm)` 始终解引用最新表单对象。
+ *
+ * 测试策略：
+ * 1. 源码契约门闩（参照 schedule_grid_lines.spec.ts 的 contract 风格）——防止回退为
+ *    固化引用写法；
+ * 2. 绑定语义联动测试——由于仓库未引入 @vue/test-utils（node 环境无 DOM，弹窗组件
+ *    难以直接挂载），用 Vue 响应式系统复刻「父组件常驻挂载 + computed 解引用 prop +
+ *    编辑器整体替换表单对象」的真实数据流，验证输入落入新对象且校验通过；同时用
+ *    旧固化写法作反面用例复现 bug，证明修复有效。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, reactive, ref } from 'vue'
+import { readFileSync } from 'node:fs'
+import { useScheduleEditor } from '../composables/useScheduleEditor'
+import { LOGIN_SESSION_TOKEN_KEY } from '../constants'
+
+const readDialogSource = () =>
+  readFileSync(new URL('./ScheduleAddCourseDialog.vue', import.meta.url), 'utf8')
+
+describe('ScheduleAddCourseDialog #760 源码契约', () => {
+  it('禁止在 setup 时固化 props.addCourseForm 引用', () => {
+    const source = readDialogSource()
+    expect(source).not.toMatch(/const\s+form\s*=\s*props\.addCourseForm/)
+  })
+
+  it('form 必须通过 computed 始终解引用最新表单对象', () => {
+    const source = readDialogSource()
+    expect(source).toContain('const form = computed(() => props.addCourseForm)')
+  })
+})
+
+// ─── useScheduleEditor 测试基建 ────────────────────────────────────────────
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear(),
+  key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+  length: 0
+}
+
+const makeEditorOptions = () => ({
+  props: { studentId: '2510231106' },
+  data: {
+    errorMsg: ref(''),
+    semesterError: ref(''),
+    loadingManageCourses: ref(false),
+    manageCoursesError: ref(''),
+    manageExpandedSemesters: ref<Record<string, boolean>>({}),
+    loadCustomCourses: vi.fn(async () => {}),
+    loadAllCustomCourses: vi.fn(async () => {}),
+    mergeScheduleSources: vi.fn()
+  },
+  semester: {
+    semester: ref('2024-2025-1'),
+    semesterDraft: ref(''),
+    semesterWeekOptions: ref(Array.from({ length: 20 }, (_, i) => i + 1)),
+    selectedWeek: ref(1)
+  },
+  detail: {
+    showDetail: ref(false),
+    selectedCourse: ref(null),
+    detailActionError: ref(''),
+    syncSelectedCustomCourse: vi.fn()
+  },
+  menu: { showMenu: ref(false) },
+  confirmDialog: { askConfirm: vi.fn(async () => true) }
+})
+
+const makeEditor = () => {
+  const options = makeEditorOptions()
+  return { editor: useScheduleEditor(options as never), options }
+}
+
+describe('useScheduleEditor 表单替换与弹窗绑定联动（#760）', () => {
+  beforeEach(() => {
+    storageMap.clear()
+    storageMap.set(LOGIN_SESSION_TOKEN_KEY, 'token-1')
+    // node 测试环境无 localStorage，注入 stub（hasValidLoginSession 依赖）
+    ;(globalThis as { localStorage?: Storage }).localStorage = stubStorage as unknown as Storage
+  })
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: Storage }).localStorage
+  })
+
+  it('打开弹窗整体替换表单对象后，computed 绑定写入的 name 能被校验读到并通过', () => {
+    const { editor } = makeEditor()
+
+    // 复刻弹窗组件的数据流：父组件常驻挂载，setup 只执行一次
+    const dialogProps = reactive({ addCourseForm: editor.addCourseForm.value })
+    const form = computed(() => dialogProps.addCourseForm)
+
+    // 打开弹窗：编辑器 resetAddCourseForm 整体替换表单对象，模板把新对象传给弹窗
+    editor.openAddCourseDialog()
+    dialogProps.addCourseForm = editor.addCourseForm.value
+
+    // 用户在弹窗中输入（v-model 写入 computed 解引用出的最新对象）
+    form.value.name = '高等数学'
+    form.value.weeks = [1, 2, 3]
+    form.value.weekday = 2
+    form.value.period = 3
+    form.value.djs = 2
+
+    // 校验读取的是同一（新）对象：不再误报「课程名称不能为空」
+    expect(editor.validateAddCourse()).toBe('')
+    expect(editor.addCourseForm.value.name).toBe('高等数学')
+  })
+
+  it('编辑回填整体替换（populateCourseForm）后，computed 绑定同样跟随新对象', () => {
+    const { editor } = makeEditor()
+
+    const dialogProps = reactive({ addCourseForm: editor.addCourseForm.value })
+    const form = computed(() => dialogProps.addCourseForm)
+
+    editor.openAddCourseDialog()
+    dialogProps.addCourseForm = editor.addCourseForm.value
+
+    editor.openEditCourseDialog(
+      {
+        id: 'course-1',
+        semester: '2024-2025-1',
+        name: '大学英语',
+        weekday: 1,
+        period: 2,
+        djs: 1,
+        weeks: [4, 5],
+        is_custom: true
+      },
+      { reopenManage: false }
+    )
+    dialogProps.addCourseForm = editor.addCourseForm.value
+
+    expect(editor.courseDialogMode.value).toBe('edit')
+    form.value.name = '大学英语（下）'
+    expect(editor.addCourseForm.value.name).toBe('大学英语（下）')
+    expect(editor.validateAddCourse()).toBe('')
+  })
+
+  it('反面复现：固化 setup 时刻的旧引用会导致校验误报「课程名称不能为空」（bug 根因）', () => {
+    const { editor } = makeEditor()
+
+    // 旧实现语义：setup 时固化引用（组件只创建一次，此后不再跟随 props）
+    const dialogProps = reactive({ addCourseForm: editor.addCourseForm.value })
+    const staleForm = dialogProps.addCourseForm
+
+    // 打开弹窗 → 表单对象被整体替换
+    editor.openAddCourseDialog()
+
+    // 用户输入写进旧对象（旧 bug 行为）
+    staleForm.name = '高等数学'
+    staleForm.weeks = [1, 2, 3]
+
+    // 校验读新对象 → 必然误报
+    expect(editor.addCourseForm.value.name).toBe('')
+    expect(editor.validateAddCourse()).toBe('课程名称不能为空')
+  })
+})

--- a/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.vue
+++ b/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.vue
@@ -3,6 +3,7 @@
  * 添加/修改自定义课程弹窗。
  * 自 ScheduleView.vue 拆分，DOM 结构/class 完全保留。
  */
+import { computed } from 'vue'
 import { periodOptions, weekDayLabels } from '../constants'
 
 const props = defineProps({
@@ -17,7 +18,13 @@ const props = defineProps({
 })
 const emit = defineEmits(['close', 'submit', 'open-week-picker'])
 
-const form = props.addCourseForm
+// #760：本弹窗被父组件（ScheduleView.vue）常驻挂载，setup 仅执行一次；而编辑器
+// （useScheduleEditor）每次打开弹窗都会整体替换 addCourseForm 对象
+// （resetAddCourseForm / populateCourseForm）。若在 setup 时固化 props.addCourseForm
+// 引用，用户输入会写进被替换掉的旧对象，校验读到的新对象恒为空，必然误报
+// 「课程名称不能为空」。改用 computed 始终解引用最新表单对象，模板中 v-model
+// 的读取与写回都落在当前 props 指向的对象上。
+const form = computed(() => props.addCourseForm)
 </script>
 
 <template>

--- a/apps/client/src/templates/views/SettingsView.html
+++ b/apps/client/src/templates/views/SettingsView.html
@@ -62,31 +62,22 @@
         <div class="section-head">
           <h3>主题模式</h3>
         </div>
-        <!-- Day/Night Toggle with Animation -->
-        <div class="theme-toggle-container">
-          <div class="theme-toggle-track" :class="{ 'is-dark': isDarkMode }" @click="toggleDarkMode">
-            <!-- Sky background -->
-            <div class="theme-sky" :class="isDarkMode ? 'theme-sky--night' : 'theme-sky--day'">
-              <div class="theme-stars" :class="{ 'opacity-100': isDarkMode, 'opacity-0': !isDarkMode }">
-                <span v-for="i in 6" :key="i" class="star" :style="{ left: `${10 + i * 14}%`, top: `${15 + (i % 3) * 20}%`, animationDelay: `${i * 0.3}s` }"></span>
-              </div>
-            </div>
-            <!-- Sun/Moon -->
-            <div class="theme-celestial" :class="isDarkMode ? 'theme-celestial--moon' : 'theme-celestial--sun'">
-              <div v-if="!isDarkMode" class="sun-icon">
-                <i class="fas fa-sun"></i>
-              </div>
-              <div v-else class="moon-icon">
-                <i class="fas fa-moon"></i>
-              </div>
-            </div>
-            <!-- Labels -->
-            <div class="theme-labels">
-              <span class="theme-label" :class="{ active: !isDarkMode }">白天</span>
-              <span class="theme-label" :class="{ active: isDarkMode }">夜间</span>
-            </div>
+        <!-- #757 三态外观：跟随系统 / 白天 / 夜间（沿用界面个性化的 chip 视觉） -->
+        <div class="option-group">
+          <label>外观模式</label>
+          <div class="chip-row">
+            <button
+              v-for="item in nightModeOptions"
+              :key="item.key"
+              class="option-chip"
+              :class="{ active: nightModePreference === item.key }"
+              @click="setNightMode(item.key)"
+            >
+              <strong>{{ item.label }}</strong>
+              <small>{{ item.desc }}</small>
+            </button>
           </div>
-          <p class="theme-hint">{{ isDarkMode ? '夜间模式已开启，保护您的眼睛' : '白天模式，清爽明亮' }}</p>
+          <p class="theme-hint">{{ nightModeHint }}</p>
         </div>
       </section>
 

--- a/apps/client/src/utils/night_mode.spec.ts
+++ b/apps/client/src/utils/night_mode.spec.ts
@@ -1,82 +1,260 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import {
-  applyNightModePreference,
-  initNightModeClass,
-  isNightModeEnabled
-} from './night_mode'
+/**
+ * night_mode 三态模型测试（#757：跟随系统 / 白天 / 夜间）
+ *
+ * 覆盖：
+ * - 存储值解析与旧键迁移（'1'→dark、'0'→light、非法值→system）
+ * - 旧版二态 API applyNightModePreference 兼容（debug_bridge 依赖 boolean 签名）
+ * - system 态经 matchMedia 决定 dark class，change 事件即时切换（无需重启）
+ * - 手动 light/dark 行为与旧版一致，且不受系统变化影响
+ * - window / matchMedia 缺失时不崩溃
+ *
+ * 说明：模块内部持有监听句柄（模块级状态），因此用 vi.resetModules +
+ * 动态 import 保证每个用例拿到全新模块实例，用例间互不污染。
+ */
 
-describe('night mode helpers', () => {
-  let stored: Record<string, string>
-  let mockRoot: {
-    classList: {
-      add: ReturnType<typeof vi.fn>
-      remove: ReturnType<typeof vi.fn>
-      contains: ReturnType<typeof vi.fn>
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NightModeModule from './night_mode'
+
+type NightMode = typeof NightModeModule
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear(),
+  key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+  length: 0
+}
+
+const makeMockRoot = () => ({
+  classList: {
+    add: vi.fn(),
+    remove: vi.fn(),
+    // contains 声明为可带参形式，便于用例中替换为按类名判断的实现
+    contains: vi.fn((_name?: string) => false)
+  }
+})
+
+type MockRoot = ReturnType<typeof makeMockRoot>
+let mockRoot: MockRoot
+
+// matchMedia mock：记录监听器并支持模拟系统深浅色变化
+const makeMatchMedia = (initialMatches: boolean) => {
+  const listeners = new Set<(event: { matches: boolean }) => void>()
+  const query = {
+    matches: initialMatches,
+    addEventListener: vi.fn((_type: string, cb: (event: { matches: boolean }) => void) => {
+      listeners.add(cb)
+    }),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn((cb: (event: { matches: boolean }) => void) => {
+      listeners.add(cb)
+    })
+  }
+  return {
+    query,
+    listenerCount: () => listeners.size,
+    // 模拟系统深浅色变化：更新 matches 并通知全部监听器
+    emit: (matches: boolean) => {
+      query.matches = matches
+      listeners.forEach((cb) => cb({ matches }))
     }
   }
+}
 
+type MatchMediaStub = ReturnType<typeof makeMatchMedia>
+let matchMediaStub: MatchMediaStub | null
+
+const loadModule = async (): Promise<NightMode> => {
+  vi.resetModules()
+  return (await import('./night_mode')) as NightMode
+}
+
+describe('night mode 三态模型（#757）', () => {
   beforeEach(() => {
-    stored = {}
-    mockRoot = {
-      classList: {
-        add: vi.fn(),
-        remove: vi.fn(),
-        contains: vi.fn(() => false)
-      }
+    storageMap.clear()
+    mockRoot = makeMockRoot()
+    matchMediaStub = makeMatchMedia(false)
+    ;(globalThis as { document?: unknown }).document = { documentElement: mockRoot }
+    ;(globalThis as { localStorage?: Storage }).localStorage = stubStorage as unknown as Storage
+    ;(globalThis as { window?: unknown }).window = {
+      matchMedia: vi.fn(() => matchMediaStub!.query),
+      dispatchEvent: vi.fn()
     }
-
-    globalThis.document = {
-      documentElement: mockRoot
-    } as unknown as Document
-
-    globalThis.localStorage = {
-      getItem: (key: string) => stored[key] ?? null,
-      setItem: (key: string, value: string) => {
-        stored[key] = value
-      },
-      removeItem: (key: string) => {
-        delete stored[key]
-      },
-      clear: () => {
-        stored = {}
-      },
-      key: vi.fn(),
-      length: 0
-    } as unknown as Storage
   })
 
   afterEach(() => {
     vi.clearAllMocks()
-    delete (globalThis as { document?: Document }).document
-    delete (globalThis as { localStorage?: Storage }).localStorage
+    matchMediaStub = null
+    delete (globalThis as { document?: unknown }).document
+    delete (globalThis as { localStorage?: unknown }).localStorage
+    delete (globalThis as { window?: unknown }).window
   })
 
-  it('启用夜晚模式时应添加 html.dark 并写入偏好', () => {
-    applyNightModePreference(true)
+  it('resolveNightModePreference：合法三态原样返回，旧键 1/0 迁移，非法值回退 system', async () => {
+    const nm = await loadModule()
 
+    expect(nm.resolveNightModePreference('system')).toBe('system')
+    expect(nm.resolveNightModePreference('light')).toBe('light')
+    expect(nm.resolveNightModePreference('dark')).toBe('dark')
+    // 旧键语义迁移
+    expect(nm.resolveNightModePreference('1')).toBe('dark')
+    expect(nm.resolveNightModePreference('0')).toBe('light')
+    // 空 / 非法值默认跟随系统
+    expect(nm.resolveNightModePreference(null)).toBe('system')
+    expect(nm.resolveNightModePreference(undefined)).toBe('system')
+    expect(nm.resolveNightModePreference('yes')).toBe('system')
+  })
+
+  it('getNightModePreference：旧键 hbu_dark_mode=1 首次读取迁移为新键 dark 且语义不变', async () => {
+    storageMap.set('hbu_dark_mode', '1')
+    const nm = await loadModule()
+
+    expect(nm.getNightModePreference()).toBe('dark')
+    expect(storageMap.get('hbu_theme_mode')).toBe('dark')
+
+    // 迁移后以新键优先，重复读取语义稳定
+    expect(nm.getNightModePreference()).toBe('dark')
+  })
+
+  it('getNightModePreference：旧键 0 迁移为 light；无键默认 system 且不落盘', async () => {
+    storageMap.set('hbu_dark_mode', '0')
+    const nm = await loadModule()
+    expect(nm.getNightModePreference()).toBe('light')
+    expect(storageMap.get('hbu_theme_mode')).toBe('light')
+
+    storageMap.clear()
+    const fresh = await loadModule()
+    expect(fresh.getNightModePreference()).toBe('system')
+    expect(storageMap.get('hbu_theme_mode')).toBeUndefined()
+  })
+
+  it('applyNightModePreference(true/false) 兼容旧签名：写三态新键并切换 dark class', async () => {
+    const nm = await loadModule()
+
+    expect(nm.applyNightModePreference(true)).toBe(true)
     expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
     expect(mockRoot.classList.remove).not.toHaveBeenCalledWith('dark')
-    expect(stored.hbu_dark_mode).toBe('1')
-  })
+    expect(storageMap.get('hbu_theme_mode')).toBe('dark')
 
-  it('关闭夜晚模式时应移除 html.dark 并写入偏好', () => {
-    applyNightModePreference(false)
-
+    expect(nm.applyNightModePreference(false)).toBe(false)
     expect(mockRoot.classList.remove).toHaveBeenCalledWith('dark')
-    expect(mockRoot.classList.add).not.toHaveBeenCalledWith('dark')
-    expect(stored.hbu_dark_mode).toBe('0')
+    expect(storageMap.get('hbu_theme_mode')).toBe('light')
   })
 
-  it('初始化时应根据持久化偏好恢复夜晚模式', () => {
-    stored.hbu_dark_mode = '1'
+  it('setNightModePreference：手动 light/dark 与旧版行为一致', async () => {
+    const nm = await loadModule()
 
-    expect(initNightModeClass()).toBe(true)
+    expect(nm.setNightModePreference('dark')).toBe(true)
+    expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
+    expect(storageMap.get('hbu_theme_mode')).toBe('dark')
+
+    expect(nm.setNightModePreference('light')).toBe(false)
+    expect(mockRoot.classList.remove).toHaveBeenCalledWith('dark')
+    expect(storageMap.get('hbu_theme_mode')).toBe('light')
+  })
+
+  it('initNightModeClass：无存储值默认 system，系统深色时应用 dark class（跟随系统）', async () => {
+    matchMediaStub = makeMatchMedia(true) // 系统偏好深色
+    const nm = await loadModule()
+
+    expect(nm.initNightModeClass()).toBe(true)
+    expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
+    expect(storageMap.get('hbu_theme_mode')).toBeUndefined() // system 态不落盘用户偏好
+  })
+
+  it('initNightModeClass：system 态监听系统 change 事件即时切换（无需重启）', async () => {
+    matchMediaStub = makeMatchMedia(false) // 初始浅色
+    const nm = await loadModule()
+
+    nm.initNightModeClass()
+    expect(matchMediaStub.listenerCount()).toBe(1)
+
+    // 系统切到深色 → 即时加深色 class
+    matchMediaStub.emit(true)
+    expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
+
+    // 系统切回浅色 → 即时移除
+    matchMediaStub.emit(false)
+    expect(mockRoot.classList.remove).toHaveBeenCalledWith('dark')
+  })
+
+  it('手动 light/dark 模式不跟随系统变化', async () => {
+    matchMediaStub = makeMatchMedia(false)
+    const nm = await loadModule()
+
+    nm.initNightModeClass()
+    nm.setNightModePreference('light')
+
+    // 系统切到深色：手动白天模式不受影响
+    matchMediaStub.emit(true)
+    expect(mockRoot.classList.add).not.toHaveBeenCalledWith('dark')
+
+    // 切回手动夜间后再跟随生效
+    nm.setNightModePreference('dark')
     expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
   })
 
-  it('读取当前夜晚模式状态时应优先使用 html.dark', () => {
-    mockRoot.classList.contains = vi.fn((name: string) => name === 'dark')
+  it('resolveNightModeDark：设置页可据此决定动画方向（system 态解析系统值）', async () => {
+    matchMediaStub = makeMatchMedia(true)
+    const nm = await loadModule()
 
-    expect(isNightModeEnabled()).toBe(true)
+    expect(nm.resolveNightModeDark('dark')).toBe(true)
+    expect(nm.resolveNightModeDark('light')).toBe(false)
+    expect(nm.resolveNightModeDark('system')).toBe(true)
+
+    matchMediaStub.emit(false)
+    expect(nm.resolveNightModeDark('system')).toBe(false)
+  })
+
+  it('isNightModeEnabled 读 DOM dark class（语义不变）', async () => {
+    const nm = await loadModule()
+    expect(nm.isNightModeEnabled()).toBe(false)
+
+    // 替换为带 dark class 的 document stub（新对象字面量，避免 Mock 类型逆变冲突）
+    ;(globalThis as { document?: unknown }).document = {
+      documentElement: {
+        classList: {
+          add: vi.fn(),
+          remove: vi.fn(),
+          contains: vi.fn((name: string) => name === 'dark')
+        }
+      }
+    }
+    expect(nm.isNightModeEnabled()).toBe(true)
+  })
+
+  it('window / matchMedia 缺失时不崩溃，system 态按浅色处理', async () => {
+    ;(globalThis as { window?: unknown }).window = undefined
+    const nm = await loadModule()
+
+    expect(() => nm.initNightModeClass()).not.toThrow()
+    expect(nm.initNightModeClass()).toBe(false)
+    expect(mockRoot.classList.add).not.toHaveBeenCalledWith('dark')
+  })
+
+  it('localStorage 异常时不崩溃并回退 system', async () => {
+    ;(globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: () => {
+        throw new Error('storage unavailable')
+      },
+      setItem: () => {
+        throw new Error('storage unavailable')
+      },
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0
+    }
+    const nm = await loadModule()
+
+    expect(nm.getNightModePreference()).toBe('system')
+    expect(() => nm.setNightModePreference('dark')).not.toThrow()
+    expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
   })
 })

--- a/apps/client/src/utils/night_mode.ts
+++ b/apps/client/src/utils/night_mode.ts
@@ -1,45 +1,199 @@
-const NIGHT_MODE_STORAGE_KEY = 'hbu_dark_mode'
+/**
+ * 深浅色模式（#757 三态模型：跟随系统 / 白天 / 夜间）。
+ *
+ * 偏好三态：'system'（跟随系统，默认）| 'light'（白天）| 'dark'（夜间）。
+ *
+ * 存储与迁移：
+ * - 新键 hbu_theme_mode 存三态值 'system' | 'light' | 'dark'；
+ * - 旧键 hbu_dark_mode（'1'/'0'）仅在首次读取时一次性迁移：
+ *   '1' → dark、'0' → light，老用户深浅色语义不变，迁移结果落盘新键；
+ *   旧键保留不清除，读取永远以新键优先，重复迁移无副作用。
+ * - 两键均无值 → system（默认跟随系统，与旧版「无值保留 DOM 状态」不同，
+ *   这是 #757 的目标行为：未设置过的用户自动跟随系统深浅色）。
+ *
+ * DOM 语义不变：html.dark 表示当前深色生效（ui_settings.isNightModeEnabled、
+ * dark-mode.css 等消费方不受影响）。
+ * system 态通过 matchMedia('(prefers-color-scheme: dark)') 决定 dark class，
+ * 并监听 change 事件即时切换（无需重启）；手动 light/dark 行为与旧版一致。
+ */
+export type NightModePreference = 'system' | 'light' | 'dark'
+
+/** 旧版二态存储键：仅用于一次性迁移读取 */
+const NIGHT_MODE_LEGACY_KEY = 'hbu_dark_mode'
+/** 三态偏好存储键 */
+const NIGHT_MODE_PREF_KEY = 'hbu_theme_mode'
 
 /** 夜晚模式切换事件：供 ui_settings 等模块重新注入语义色 token */
 export const NIGHT_MODE_CHANGED_EVENT = 'hbu-night-mode-changed'
 
-const dispatchNightModeChanged = (enabled: boolean) => {
-  if (typeof window === 'undefined') return
-  window.dispatchEvent(new CustomEvent(NIGHT_MODE_CHANGED_EVENT, { detail: { enabled } }))
+const PREFERENCE_VALUES: readonly NightModePreference[] = ['system', 'light', 'dark']
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)'
+
+// 模块级：系统深浅色媒体查询与监听（幂等注册；handler 内实时判断偏好，
+// 因此手动 light/dark 模式下系统变化不会影响 DOM，无需注销）
+let systemDarkQuery: MediaQueryList | null = null
+let systemDarkListener: ((event: MediaQueryListEvent) => void) | null = null
+
+const readStorage = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    // localStorage 不可用时按无值处理
+    return null
+  }
 }
 
-export const applyNightModePreference = (enabled: boolean): boolean => {
-  if (typeof document === 'undefined') return enabled
-
-  if (enabled) {
-    document.documentElement.classList.add('dark')
-  } else {
-    document.documentElement.classList.remove('dark')
-  }
-
+const writeStorage = (key: string, value: string) => {
   try {
-    localStorage.setItem(NIGHT_MODE_STORAGE_KEY, enabled ? '1' : '0')
+    localStorage.setItem(key, value)
   } catch {
-    // localStorage 不可用时仅同步当前 DOM 状态。
+    // localStorage 不可用时仅同步当前 DOM 状态
   }
+}
 
+/**
+ * 解析存储值为三态偏好：
+ * 合法三态原样返回；旧键语义迁移 '1' → dark、'0' → light；空/非法值 → system。
+ */
+export const resolveNightModePreference = (raw: string | null | undefined): NightModePreference => {
+  const value = String(raw ?? '').trim()
+  if ((PREFERENCE_VALUES as readonly string[]).includes(value)) {
+    return value as NightModePreference
+  }
+  if (value === '1') return 'dark'
+  if (value === '0') return 'light'
+  return 'system'
+}
+
+/**
+ * 读取当前偏好：新键优先；仅存旧键时一次性迁移并落盘新键；均无值 → system。
+ */
+export const getNightModePreference = (): NightModePreference => {
+  const stored = readStorage(NIGHT_MODE_PREF_KEY)
+  if (stored !== null) return resolveNightModePreference(stored)
+  const legacy = readStorage(NIGHT_MODE_LEGACY_KEY)
+  if (legacy === null) return 'system'
+  const migrated = resolveNightModePreference(legacy)
+  writeStorage(NIGHT_MODE_PREF_KEY, migrated)
+  return migrated
+}
+
+/** 查询系统是否偏好深色（matchMedia 不可用或异常时按浅色处理） */
+const systemPrefersDark = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  try {
+    return !!window.matchMedia(SYSTEM_DARK_QUERY).matches
+  } catch {
+    return false
+  }
+}
+
+/** 解析三态偏好当前应生效的深色布尔值（设置页动画方向等 UI 消费） */
+export const resolveNightModeDark = (mode: NightModePreference): boolean =>
+  mode === 'dark' || (mode === 'system' && systemPrefersDark())
+
+const dispatchNightModeChanged = (enabled: boolean) => {
+  if (typeof window === 'undefined') return
+  try {
+    window.dispatchEvent(new CustomEvent(NIGHT_MODE_CHANGED_EVENT, { detail: { enabled } }))
+  } catch {
+    // 事件派发失败不影响主流程
+  }
+}
+
+/**
+ * #757 跨线协作：把应用当前模式同步给小组件（线B在 widget_bridge 预留
+ * writeWidgetThemeMode）。动态 import + 静默吞错：模块加载失败或线B代码
+ * 未合并（函数尚不存在）时不得影响主流程。
+ */
+const syncWidgetThemeMode = (mode: NightModePreference) => {
+  if (typeof window === 'undefined') return
+  import('./widget_bridge')
+    .then((mod) => {
+      const bridge = mod as unknown as {
+        writeWidgetThemeMode?: (mode: NightModePreference) => void
+      }
+      if (typeof bridge.writeWidgetThemeMode === 'function') {
+        bridge.writeWidgetThemeMode(mode)
+      }
+    })
+    .catch(() => {
+      // widget_bridge 加载失败（环境不支持/依赖缺失）：静默忽略
+    })
+}
+
+const applyDarkClass = (enabled: boolean) => {
+  if (typeof document === 'undefined') return
+  const classList = document.documentElement.classList
+  if (enabled) {
+    classList.add('dark')
+  } else {
+    classList.remove('dark')
+  }
+}
+
+/** 按偏好应用 dark class + 派发变更事件 + 同步小组件；返回当前深色布尔值 */
+const applyNightModeInternal = (mode: NightModePreference): boolean => {
+  const enabled = resolveNightModeDark(mode)
+  applyDarkClass(enabled)
   dispatchNightModeChanged(enabled)
+  syncWidgetThemeMode(mode)
   return enabled
 }
 
+/** 注册系统深浅色 change 监听（幂等）；仅 system 态在 handler 内生效 */
+const ensureSystemDarkListener = () => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+  try {
+    if (!systemDarkQuery) {
+      systemDarkQuery = window.matchMedia(SYSTEM_DARK_QUERY)
+    }
+    if (systemDarkListener || !systemDarkQuery) return
+    systemDarkListener = () => {
+      // 手动 light/dark 模式不跟随系统；仅偏好仍为 system 时即时切换
+      if (getNightModePreference() !== 'system') return
+      applyNightModeInternal('system')
+    }
+    if (typeof systemDarkQuery.addEventListener === 'function') {
+      systemDarkQuery.addEventListener('change', systemDarkListener)
+    } else if (typeof (systemDarkQuery as { addListener?: unknown }).addListener === 'function') {
+      // 兼容旧版 WebView 的 addListener API
+      ;(systemDarkQuery as unknown as { addListener: (cb: typeof systemDarkListener) => void }).addListener(
+        systemDarkListener
+      )
+    }
+  } catch {
+    // matchMedia 异常：system 态按浅色处理，不阻塞初始化
+  }
+}
+
+/**
+ * 设置偏好（三态）：'system' 跟随系统 / 'light' 白天 / 'dark' 夜间。
+ * 写入新键并立即应用；返回当前深色布尔值。
+ */
+export const setNightModePreference = (mode: NightModePreference): boolean => {
+  const normalized = resolveNightModePreference(mode)
+  writeStorage(NIGHT_MODE_PREF_KEY, normalized)
+  ensureSystemDarkListener()
+  return applyNightModeInternal(normalized)
+}
+
+/**
+ * 旧版二态 API（保持兼容：debug_bridge 等消费方仍以 boolean 切换）。
+ * true → dark、false → light；返回当前深色布尔值。
+ */
+export const applyNightModePreference = (enabled: boolean): boolean =>
+  setNightModePreference(enabled ? 'dark' : 'light')
+
+/**
+ * 启动初始化：读取偏好（含旧键一次性迁移）、注册系统深浅色监听并应用。
+ * 返回当前深色布尔值。
+ */
 export const initNightModeClass = (): boolean => {
   if (typeof document === 'undefined') return false
-  const classList = document.documentElement.classList
-
-  try {
-    const stored = localStorage.getItem(NIGHT_MODE_STORAGE_KEY)
-    if (stored === '1') return applyNightModePreference(true)
-    if (stored === '0') return applyNightModePreference(false)
-  } catch {
-    // localStorage 读取失败时保留当前 DOM 状态。
-  }
-
-  return typeof classList.contains === 'function' ? classList.contains('dark') : false
+  const mode = getNightModePreference()
+  ensureSystemDarkListener()
+  return applyNightModeInternal(mode)
 }
 
 export const isNightModeEnabled = (): boolean => {

--- a/apps/client/src/utils/theme-bridge.spec.ts
+++ b/apps/client/src/utils/theme-bridge.spec.ts
@@ -302,7 +302,7 @@ describe('initThemeBridge', () => {
     expect(mockRoot.classList.add).not.toHaveBeenCalledWith('dark')
   })
 
-  it('应在无持久化主题偏好且 OS 为 dark 时使用 dark 预设但不自动开启夜晚模式', () => {
+  it('应在无持久化主题偏好且 OS 为 dark 时使用 dark 预设，并按 system 偏好开启夜晚模式（#757）', () => {
     mockMatchMedia.mockReturnValue({
       matches: true,
       addEventListener: vi.fn(),
@@ -310,10 +310,11 @@ describe('initThemeBridge', () => {
 
     initThemeBridge()
 
-    expect(mockRoot.classList.add).not.toHaveBeenCalledWith('dark')
+    // #757：无用户偏好时默认跟随系统（system），OS 为 dark 即开启夜晚模式
+    expect(mockRoot.classList.add).toHaveBeenCalledWith('dark')
   })
 
-  it('应在无持久化偏好且 OS 为 light 时使用默认 light 预设', () => {
+  it('应在无持久化偏好且 OS 为 light 时使用默认 light 预设并清除 dark class（#757）', () => {
     mockMatchMedia.mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -321,7 +322,8 @@ describe('initThemeBridge', () => {
 
     initThemeBridge()
 
-    expect(mockRoot.classList.remove).not.toHaveBeenCalledWith('dark')
+    // #757：system 偏好 + OS 浅色 → 主动移除 dark class（保证与系统一致）
+    expect(mockRoot.classList.remove).toHaveBeenCalledWith('dark')
   })
 
   it('应根据独立夜晚模式偏好恢复 html.dark', () => {


### PR DESCRIPTION
## TL;DR

三个用户反馈修复：①添加课程表单填全仍报「课程名称不能为空」（弹窗固化过期 prop 引用）；②开屏页选「课表」启动仍显示首页（syncFromHash 无 hash 强制回首页）；③深浅色新增「跟随系统」三态模式并作为默认。

## #760 添加课程误报

- `ScheduleAddCourseDialog.vue`：`const form = props.addCourseForm`（setup 固化引用）→ `computed(() => props.addCourseForm)`，编辑器整体替换表单对象后弹窗绑定始终跟随新对象
- 新增 spec 5 测：源码契约门闩（禁止固化写法）+ 完整数据流复刻（常驻挂载→resetAddCourseForm 整体替换→computed 绑定写入→validateAddCourse 通过）+ 编辑回填同验 + 旧写法反面复现

## #761 开屏页设置生效

- `NavigationCoordinator.syncFromHash`：无 hash 路由时直接 return，保留 setup 阶段按 startupPage 得到的 currentView，不再强制回首页
- 新增 `readStartupHashDeepLink`：仅 `#/学号/视图` 算深链（hash 优先）；冷启动时 startupPage 设置优先（残留 history 快照不再覆盖——次要隐患一并修复）；`#/学号`（无视图）保留学号 hint 快速课表启动不受影响
- 新增 startupView.spec 6 测（冷启动+设置 schedule / 未设置 home / 深链 hash 路由）

## #757 深浅色跟随系统

- night_mode.ts 三态模型 `system | light | dark`：新键 `hbu_theme_mode`，旧键 `hbu_dark_mode`（'1'→dark / '0'→light）一次性迁移落盘，无键默认 **system**（跟随系统）
- system 态 matchMedia `(prefers-color-scheme: dark)` + change 监听即时切换；手动 light/dark 不受系统变化影响；`html.dark` 语义不变（isNightModeEnabled 消费方零改动）
- 设置页：二态 toggle → 三态 chip（跟随系统/白天/夜间，默认跟随系统），保留原全屏过渡动画
- **#758 联动接入**：night_mode 新增 `syncWidgetThemeMode`（动态 import widget_bridge、函数存在才调用、失败静默），三个触发点（初始化/用户切换/system change）将应用模式同步给桌面小组件——配合已合并的 #764，#758「颜色跟随应用内模式」在本 PR 合并后完整生效

## 测试

- `npm run typecheck` 0 错误
- `test:ci` 1216/1217（唯一失败 `bottom_tab_bar_safe_area.spec` 需 build 产物 dist/assets，在基点 4e2c6846 复跑同样失败，pre-existing 环境性）
- 新增/更新：ScheduleAddCourseDialog.spec 5、startupView.spec 6、night_mode.spec 12、theme-bridge.spec 32（2 条适配新语义）、SettingsView.spec 3

Closes #760
Closes #761
Closes #757
Closes #758