### PR TITLE
feat(electricity): 缴电费入口下新增「仅演示」提醒——需在 i 湖工自行缴费

### DIFF
--- a/apps/client/src/components/ElectricityView.vue
+++ b/apps/client/src/components/ElectricityView.vue
@@ -1180,6 +1180,11 @@ watch(
         <div v-if="showPayQr && payQr" class="pay-qr">
           <img :src="payQr" alt="缴电费" width="180" height="180" />
         </div>
+        <!-- 提醒：本页仅查询演示，缴费需前往官方 i 湖工 -->
+        <p class="pay-demo-hint">
+          <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0;">info</span>
+          <span>应用内缴费入口仅供演示跳转，无法完成实际缴费；请前往 <strong>i 湖工</strong> 自行缴费。</span>
+        </p>
       </section>
     </main>
   </div>

--- a/apps/client/src/styles/views/ElectricityView.scoped.css
+++ b/apps/client/src/styles/views/ElectricityView.scoped.css
@@ -336,6 +336,31 @@ html.dark .glass-card-warning {
   border: 1px solid #e2e8f0;
   background: #fff;
 }
+/* 缴费仅演示提醒 */
+.pay-demo-hint {
+  margin-top: 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #64748b;
+}
+.pay-demo-hint .material-symbols-outlined {
+  font-size: 16px;
+  flex: none;
+  margin-top: 1px;
+}
+.pay-demo-hint strong {
+  color: #475569;
+  font-weight: 700;
+}
+html.dark .pay-demo-hint {
+  color: #94a3b8;
+}
+html.dark .pay-demo-hint strong {
+  color: #cbd5e1;
+}
 html.dark .util-card {
   background: var(--ui-surface, #111827);
   border-color: #334155;


### PR DESCRIPTION
## 背景

电费查询页底部的「缴电费」按钮实为一码通官方页面的演示跳转，部分用户误以为可以在应用内直接完成缴费。

## 变更

- `ElectricityView.vue`：缴电费按钮区（pay-card）下方新增常驻提醒条：应用内缴费入口仅供演示跳转，无法完成实际缴费，需前往 **i 湖工** 自行缴费
- `ElectricityView.scoped.css`：新增 `.pay-demo-hint` 样式（含 info 图标对齐、strong 强调色、暗色模式适配）

纯展示层改动，无逻辑/接口变更。