### PR TITLE
feat(#769): 恢复设置/账号/课表体验并新增语言选择（#770/#771/#772/#773）

### DIFF
--- a/apps/client/src/App.vue
+++ b/apps/client/src/App.vue
@@ -8,6 +8,11 @@ import AppShell from './shell/AppShell.vue'
 import IdentityApprovalOverlay from './features/identity/components/IdentityApprovalOverlay.vue'
 import { VIEW_COMPONENTS } from './app/viewRegistry'
 import { useAppRuntime } from './app/useAppRuntime'
+// #773：底部公共导航文案接入轻量多语言（默认简体中文 + English）
+import { useLocale } from './utils/app_i18n'
+
+// #773：响应式 locale + t，供底部 TabBar 标签使用（语言切换即时生效）
+const { t: tLocale } = useLocale()
 
 // #623：App.vue 只负责挂载 IdentityApprovalOverlay；fetch/crypto/状态机全部在
 // IdentityCoordinator 内完成（防止 App.vue 退化为上帝文件）。
@@ -575,7 +580,7 @@ const {
             <path d="M3 10.8L12 3l9 7.8V21a1 1 0 0 1-1 1h-5.3a1 1 0 0 1-1-1v-5h-3.4v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V10.8z" />
           </svg>
         </span>
-        <span class="tab-label">首页</span>
+        <span class="tab-label">{{ tLocale('tab.home') }}</span>
       </button>
       <button class="tab-item btn-ripple" :class="{ active: activeTab === 'schedule' }" @click="handleTabChange('schedule')">
         <span class="tab-icon" aria-hidden="true">
@@ -584,7 +589,7 @@ const {
             <path d="M7 2.8v3.5M17 2.8v3.5M3.2 9.3h17.6" />
           </svg>
         </span>
-        <span class="tab-label">课表</span>
+        <span class="tab-label">{{ tLocale('tab.schedule') }}</span>
       </button>
       <button class="tab-item btn-ripple" :class="{ active: activeTab === 'notifications' }" @click="handleTabChange('notifications')">
         <span class="tab-icon" aria-hidden="true">
@@ -593,7 +598,7 @@ const {
             <path d="M9.3 19a2.7 2.7 0 0 0 5.4 0" />
           </svg>
         </span>
-        <span class="tab-label">通知</span>
+        <span class="tab-label">{{ tLocale('tab.notifications') }}</span>
       </button>
       <button class="tab-item btn-ripple" :class="{ active: activeTab === 'me' }" @click="handleTabChange('me')">
         <span class="tab-icon" aria-hidden="true">
@@ -602,7 +607,7 @@ const {
             <path d="M4 20c1.8-3.6 4.7-5.5 8-5.5s6.2 1.9 8 5.5" />
           </svg>
         </span>
-        <span class="tab-label">我的</span>
+        <span class="tab-label">{{ tLocale('tab.me') }}</span>
       </button>
   </nav>
 

--- a/apps/client/src/components/MeView.spec.ts
+++ b/apps/client/src/components/MeView.spec.ts
@@ -43,3 +43,16 @@ describe('MeView account switch contract (#755)', () => {
     expect(vue).toContain("'account-switched'")
   })
 })
+
+describe('MeView account switch modal title icon contract (#770)', () => {
+  it('uses switch_account (in subset font) and never the non-existent swap_account', () => {
+    const vue = source()
+
+    // 回归：swap_account 不是 Material Symbols 官方图标，不在子集字体中，
+    // ligature 无法解析会被浏览器渲染为普通文本（issue #770）
+    // 只断言模板用法（带 class 前缀），避免误伤注释中的图标名说明
+    expect(vue).not.toContain('account-switch-title-icon">swap_account<')
+    // 标题图标必须是子集字体中已收录且语义匹配的 switch_account
+    expect(vue).toContain('material-symbols-outlined account-switch-title-icon">switch_account</span> 切换账号')
+  })
+})

--- a/apps/client/src/components/MeView.vue
+++ b/apps/client/src/components/MeView.vue
@@ -582,7 +582,8 @@ const removeAccount = async (acc) => {
         @click="showAccountSwitchModal = false"
       >
         <div class="modal-card account-switch-modal modal-pop-card" @click.stop>
-          <h3><span class="material-symbols-outlined account-switch-title-icon">swap_account</span> 切换账号</h3>
+          <!-- #770 swap_account 不在 Material Symbols 图标集内，ligature 无法解析会显示为文本；换用子集字体已收录的 switch_account -->
+          <h3><span class="material-symbols-outlined account-switch-title-icon">switch_account</span> 切换账号</h3>
           <p class="intro">在本机已登录账号间快速切换（免重新登录，不会发起网络登录）。切换后自动刷新成绩与课表。</p>
           <ul v-if="savedAccounts.length" class="account-list">
             <li

--- a/apps/client/src/components/SettingsView.spec.ts
+++ b/apps/client/src/components/SettingsView.spec.ts
@@ -36,3 +36,57 @@ describe('SettingsView 深浅色三态（#757）', () => {
     expect(source).not.toContain('applyNightModePreference(')
   })
 })
+
+describe('SettingsView 语言选择（#773）', () => {
+  it('外置模板提供语言 section，含两枚语言选项并绑定 handleLocaleChange', () => {
+    const template = readFileSync(
+      new URL('../templates/views/SettingsView.html', import.meta.url),
+      'utf8'
+    )
+
+    // 语言 section 独立存在，渲染自 localeOptions，激活态绑定响应式 locale
+    expect(template).toContain('v-for="item in localeOptions"')
+    expect(template).toContain(':class="{ active: locale === item.key }"')
+    expect(template).toContain('@click="handleLocaleChange(item.key)"')
+    // 两枚选项标签（语言名按惯例不翻译）
+    expect(template).toContain("item.label")
+    // 说明文案接入 t()
+    expect(template).toContain("t('settings.language.hint')")
+    expect(template).toContain("t('settings.language.label')")
+  })
+
+  it('设置页 header 标题与四个 tab 文案接入 t()', () => {
+    const template = readFileSync(
+      new URL('../templates/views/SettingsView.html', import.meta.url),
+      'utf8'
+    )
+
+    expect(template).toContain("{{ t('settings.title') }}")
+    expect(template).toContain("{{ t('settings.tab.appearance') }}")
+    expect(template).toContain("{{ t('settings.tab.backend') }}")
+    expect(template).toContain("{{ t('settings.tab.security') }}")
+    expect(template).toContain("{{ t('settings.tab.debug') }}")
+  })
+
+  it('脚本接入 useLocale 并提供 handleLocaleChange（点击即切 + toast 反馈）', () => {
+    const source = readFileSync(new URL('./SettingsView.vue', import.meta.url), 'utf8')
+
+    expect(source).toContain("from '../utils/app_i18n'")
+    expect(source).toContain('useLocale()')
+    expect(source).toContain('localeOptions')
+    expect(source).toContain('const handleLocaleChange = (next) => {')
+    expect(source).toContain('setLocale(next)')
+    expect(source).toContain("t('settings.language.toast')")
+  })
+})
+
+describe('App.vue 底部导航语言接入（#773）', () => {
+  it('四个主 tab 标签通过 tLocale() 取词', () => {
+    const source = readFileSync(new URL('../App.vue', import.meta.url), 'utf8')
+
+    expect(source).toContain("tLocale('tab.home')")
+    expect(source).toContain("tLocale('tab.schedule')")
+    expect(source).toContain("tLocale('tab.notifications')")
+    expect(source).toContain("tLocale('tab.me')")
+  })
+})

--- a/apps/client/src/components/SettingsView.vue
+++ b/apps/client/src/components/SettingsView.vue
@@ -48,6 +48,8 @@ import {
   resolveNightModeDark,
   setNightModePreference
 } from '../utils/night_mode'
+// #773：轻量多语言（默认简体中文 + English），本期仅覆盖设置页 header/tab 与本 section 文案
+import { setLocale, useLocale } from '../utils/app_i18n'
 
 const emit = defineEmits(['back', 'openWorkspaceLayout'])
 
@@ -76,6 +78,22 @@ const activeTab = ref('appearance')
 const uiSettings = useUiSettings()
 const appSettings = useAppSettings()
 const fontSettings = useFontSettings()
+
+// #773：语言偏好（响应式 locale + t），切换即时生效，无需重启
+const { locale, t } = useLocale()
+// 语言选项定义：key 即 Locale，label 始终以各自语言展示（惯例：语言名不翻译）
+const localeOptions = [
+  { key: 'zh-CN', label: '简体中文' },
+  { key: 'en', label: 'English' }
+]
+// 点击即切：写存储 + 派发事件（useLocale 监听后本页文案即时更新），toast 文案随 locale
+const handleLocaleChange = (next) => {
+  if (locale.value === next) return
+  setLocale(next)
+  showToast(t('settings.language.toast'), 'success')
+}
+// 组件卸载时不再额外清理：useLocale 内部监听挂在 window 上，随页面生命周期存在，
+// 与 night_mode 等模块的全局监听策略一致（单例页面，无重复注册问题）
 
 // #757 深浅色三态：'system' 跟随系统（默认）/ 'light' 白天 / 'dark' 夜间
 const nightModeOptions = [

--- a/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.spec.ts
+++ b/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.spec.ts
@@ -40,6 +40,37 @@ describe('ScheduleAddCourseDialog #760 源码契约', () => {
   })
 })
 
+describe('ScheduleAddCourseDialog #772 源码契约（颜色选择器与动作按钮样式）', () => {
+  it('必须 import 并注册 CourseColorPicker（组件拆分时曾丢失声明）', () => {
+    const source = readDialogSource()
+    expect(source).toContain(
+      "import CourseColorPicker from '../../../components/CourseColorPicker.vue'"
+    )
+  })
+
+  it('模板必须保留 CourseColorPicker 且双向绑定 form.color', () => {
+    const source = readDialogSource()
+    expect(source).toContain('<CourseColorPicker v-model="form.color" />')
+  })
+
+  it('取消/确认按钮必须保留 drawer-action class（ghost 变体 + 主按钮）', () => {
+    const source = readDialogSource()
+    expect(source).toContain('class="drawer-action ghost"')
+    expect(source).toMatch(/class="drawer-action"(?! ghost)/)
+  })
+
+  it('scoped 样式必须自带 drawer-action 规则（原定义在 ScheduleDrawer.vue，跨组件 scoped 不生效）', () => {
+    const source = readDialogSource()
+    // 基础规则
+    expect(source).toMatch(/\.drawer-action\s*\{[^}]*linear-gradient\(135deg,\s*#3b82f6,\s*#06b6d4\)/)
+    // ghost 变体（浅色模式深色底）
+    expect(source).toMatch(/\.drawer-action\.ghost\s*\{[^}]*background:\s*#111827/)
+    // 按压反馈与 disabled 态
+    expect(source).toContain('.drawer-action:active')
+    expect(source).toContain('.drawer-action:disabled')
+  })
+})
+
 // ─── useScheduleEditor 测试基建 ────────────────────────────────────────────
 
 const storageMap = new Map<string, string>()

--- a/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.vue
+++ b/apps/client/src/features/schedule/components/ScheduleAddCourseDialog.vue
@@ -5,6 +5,8 @@
  */
 import { computed } from 'vue'
 import { periodOptions, weekDayLabels } from '../constants'
+// #772：恢复组件拆分时丢失的颜色选择器（script setup 中 import 即自动注册）
+import CourseColorPicker from '../../../components/CourseColorPicker.vue'
 
 const props = defineProps({
   showAddCourse: { type: Boolean, default: false },
@@ -180,6 +182,41 @@ const form = computed(() => props.addCourseForm)
 .drawer-error {
   font-size: 12px;
   color: #dc2626;
+}
+
+/* #772：组件拆分时 drawer-action 样式遗留在了 ScheduleDrawer.vue 的 scoped 作用域，
+   弹窗内取消/确认按钮因此丢失视觉。此处按 ScheduleDrawer.vue 原规则等值复制
+   （含 ghost 变体、按压反馈、disabled 态）；暗色模式由全局 dark-mode.css 的
+   html.dark .schedule-view .drawer-action 规则接管，与本组件无需重复。 */
+.drawer-action {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(135deg, #3b82f6, #06b6d4);
+  color: white;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(59, 130, 246, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: transform 0.15s ease;
+}
+
+.drawer-action:active {
+  transform: scale(0.98);
+}
+
+.drawer-action.ghost {
+  background: #111827;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.2);
+}
+
+.drawer-action:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 @media (max-width: 768px) {

--- a/apps/client/src/styles/views/SettingsView.scoped.css
+++ b/apps/client/src/styles/views/SettingsView.scoped.css
@@ -239,6 +239,50 @@
   color: #fff;
 }
 
+/* #773 语言选择 section：复用启动页面 toggle 行的视觉，独立类名避免耦合 */
+.language-section {
+  padding: 12px 16px;
+}
+.language-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.language-label {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--ui-text);
+}
+.language-toggle {
+  display: flex;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--ui-surface-border);
+}
+.language-toggle .toggle-btn {
+  padding: 6px 18px;
+  font-size: 13px;
+  font-weight: 700;
+  border: none;
+  background: var(--ui-surface);
+  color: var(--ui-muted);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.language-toggle .toggle-btn + .toggle-btn {
+  border-left: 1px solid var(--ui-surface-border);
+}
+.language-toggle .toggle-btn.active {
+  background: var(--ui-primary);
+  color: #fff;
+}
+.language-hint {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--ui-muted);
+}
+
 .section-head {
   display: flex;
   align-items: center;

--- a/apps/client/src/templates/views/SettingsView.html
+++ b/apps/client/src/templates/views/SettingsView.html
@@ -4,23 +4,23 @@
       <button class="header-icon-btn" @click="emit('back')">
         <span class="material-symbols-outlined">arrow_back</span>
       </button>
-      <h1 class="header-title">设置中心</h1>
+      <h1 class="header-title">{{ t('settings.title') }}</h1>
       <div class="header-spacer"></div>
     </header>
 
     <!-- Tabs -->
     <div class="settings-tab-bar">
       <button class="settings-tab-item" :class="{ active: activeTab === 'appearance' }" @click="activeTab = 'appearance'">
-        外观
+        {{ t('settings.tab.appearance') }}
       </button>
       <button class="settings-tab-item" :class="{ active: activeTab === 'backend' }" @click="activeTab = 'backend'">
-        后端
+        {{ t('settings.tab.backend') }}
       </button>
       <button class="settings-tab-item" :class="{ active: activeTab === 'security' }" @click="activeTab = 'security'">
-        安全
+        {{ t('settings.tab.security') }}
       </button>
       <button class="settings-tab-item" :class="{ active: activeTab === 'debug' }" @click="activeTab = 'debug'">
-        调试
+        {{ t('settings.tab.debug') }}
       </button>
     </div>
 
@@ -79,6 +79,24 @@
           </div>
           <p class="theme-hint">{{ nightModeHint }}</p>
         </div>
+      </section>
+
+      <!-- #773 语言选择：独立 section（置于主题模式之后、界面个性化之前，避免与 #771 主题卡片改动冲突） -->
+      <!-- 本期仅设置页 header/tab 与本 section 文案接入多语言，其余 section 保持中文 -->
+      <section class="settings-section glass-card language-section">
+        <div class="language-row">
+          <span class="language-label">{{ t('settings.language.label') }}</span>
+          <div class="language-toggle">
+            <button
+              v-for="item in localeOptions"
+              :key="item.key"
+              class="toggle-btn btn-ripple"
+              :class="{ active: locale === item.key }"
+              @click="handleLocaleChange(item.key)"
+            >{{ item.label }}</button>
+          </div>
+        </div>
+        <p class="language-hint">{{ t('settings.language.hint') }}</p>
       </section>
 
       <section class="settings-section glass-card">

--- a/apps/client/src/utils/app_i18n.spec.ts
+++ b/apps/client/src/utils/app_i18n.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * #773 轻量多语言模块单元测试。
+ * 覆盖：默认值、非法存储值回落、setLocale 持久化 + 事件派发、t() 回落链。
+ *
+ * 说明：vitest 全局环境为 node（无 localStorage/window），且模块持有
+ * 模块级状态（currentLocale），因此参照 night_mode.spec 的做法：
+ * stub localStorage/window + vi.resetModules 动态 import，保证用例互不污染。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as AppI18nModule from './app_i18n'
+
+type AppI18n = typeof AppI18nModule
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear(),
+  key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+  length: 0
+}
+
+const loadModule = async (): Promise<AppI18n> => {
+  vi.resetModules()
+  return (await import('./app_i18n')) as AppI18n
+}
+
+describe('app_i18n（#773 语言偏好）', () => {
+  beforeEach(() => {
+    storageMap.clear()
+    ;(globalThis as { localStorage?: Storage }).localStorage = stubStorage as unknown as Storage
+    ;(globalThis as { window?: unknown }).window = {
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    delete (globalThis as { localStorage?: unknown }).localStorage
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  it('默认语言为 zh-CN，存储无值时 getLocale 返回默认', async () => {
+    const i18n = await loadModule()
+
+    expect(i18n.DEFAULT_LOCALE).toBe('zh-CN')
+    expect(i18n.getLocale()).toBe('zh-CN')
+  })
+
+  it('模块加载时读取存储：合法值生效，非法/损坏值回落 zh-CN', async () => {
+    // 合法值
+    storageMap.set('hbu_app_locale', 'en')
+    expect((await loadModule()).getLocale()).toBe('en')
+
+    // 非法值（外部写坏的数据）
+    storageMap.set('hbu_app_locale', 'fr-FR')
+    expect((await loadModule()).getLocale()).toBe('zh-CN')
+
+    storageMap.set('hbu_app_locale', '{"malformed')
+    expect((await loadModule()).getLocale()).toBe('zh-CN')
+  })
+
+  it('resolveLocale：非法/空值回落 zh-CN，合法值原样通过', async () => {
+    const i18n = await loadModule()
+
+    expect(i18n.resolveLocale('en')).toBe('en')
+    expect(i18n.resolveLocale('zh-CN')).toBe('zh-CN')
+    expect(i18n.resolveLocale(null)).toBe('zh-CN')
+    expect(i18n.resolveLocale('')).toBe('zh-CN')
+    expect(i18n.resolveLocale('fr-FR')).toBe('zh-CN')
+    expect(i18n.resolveLocale(123)).toBe('zh-CN')
+  })
+
+  it('setLocale 持久化到 hbu_app_locale 并派发 hbu-locale-changed 事件', async () => {
+    const i18n = await loadModule()
+
+    const dispatch = vi.fn()
+    ;(globalThis as { window?: unknown }).window = {
+      dispatchEvent: dispatch,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }
+
+    i18n.setLocale('en')
+
+    expect(storageMap.get('hbu_app_locale')).toBe('en')
+    expect(i18n.getLocale()).toBe('en')
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    const event = dispatch.mock.calls[0][0] as CustomEvent
+    expect(event.type).toBe('hbu-locale-changed')
+    expect(event.detail).toEqual({ locale: 'en' })
+  })
+
+  it('setLocale 对非法入参回落默认值（不写入垃圾数据）', async () => {
+    const i18n = await loadModule()
+
+    // @ts-expect-error 故意传入非法值验证兜底
+    i18n.setLocale('xx-YY')
+
+    expect(i18n.getLocale()).toBe('zh-CN')
+    expect(storageMap.get('hbu_app_locale')).toBe('zh-CN')
+  })
+
+  it('t()：当前 locale 取词，切换后即时生效', async () => {
+    const i18n = await loadModule()
+
+    expect(i18n.t('settings.title')).toBe('设置中心')
+    i18n.setLocale('en')
+    expect(i18n.t('settings.title')).toBe('Settings')
+    expect(i18n.t('tab.home')).toBe('Home')
+  })
+
+  it('t() 回落链：en 缺失 key → zh-CN 字典 → 仍缺失返回 key 本身', async () => {
+    const i18n = await loadModule()
+
+    i18n.setLocale('en')
+    // 临时向 zh-CN 注入 en 缺失的 key，验证回落到 zh-CN 字典（用后清理）
+    const probeKey = 'test.fallback.only-zh'
+    i18n.messages['zh-CN'][probeKey] = '仅中文'
+    try {
+      expect(i18n.t(probeKey)).toBe('仅中文')
+    } finally {
+      delete i18n.messages['zh-CN'][probeKey]
+    }
+    // 双侧都不存在的 key → 返回 key 本身，保证永不空白
+    expect(i18n.t('no.such.key')).toBe('no.such.key')
+    // 清理后字典 key 集合恢复一致
+    expect(Object.keys(i18n.messages['zh-CN'])).not.toContain(probeKey)
+  })
+
+  it('useLocale：监听 hbu-locale-changed 事件，locale ref 跟随更新', async () => {
+    const i18n = await loadModule()
+
+    const localeChangedHandlers: Array<(event: unknown) => void> = []
+    ;(globalThis as { window?: unknown }).window = {
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn((type: string, cb: (event: unknown) => void) => {
+        if (type === 'hbu-locale-changed') localeChangedHandlers.push(cb)
+      }),
+      removeEventListener: vi.fn()
+    }
+
+    const { locale, t: tFn } = i18n.useLocale()
+    expect(locale.value).toBe('zh-CN')
+
+    // setLocale 更新模块状态 + 派发事件（本 stub 只记录监听器，手动回调验证跟随）
+    i18n.setLocale('en')
+    expect(localeChangedHandlers.length).toBeGreaterThan(0)
+    localeChangedHandlers.forEach((cb) => cb({ detail: { locale: 'en' } }))
+    expect(locale.value).toBe('en')
+    // t() 内部读模块级状态，已按新语言取词
+    expect(tFn('tab.me')).toBe('Me')
+  })
+
+  it('字典：zh-CN 与 en 的 key 集合完全一致（防止漏翻译）', async () => {
+    const i18n = await loadModule()
+
+    const zhKeys = Object.keys(i18n.messages['zh-CN']).sort()
+    const enKeys = Object.keys(i18n.messages.en).sort()
+    expect(enKeys).toEqual(zhKeys)
+  })
+})
+

--- a/apps/client/src/utils/app_i18n.ts
+++ b/apps/client/src/utils/app_i18n.ts
@@ -1,0 +1,171 @@
+/**
+ * 轻量应用内多语言模块（issue #773）。
+ *
+ * ⚠️ 本期范围控制（刻意收敛，避免巨量 diff 与回归风险）：
+ * 仅覆盖「设置中心外观页（SettingsView）+ 底部/全局公共导航（App.vue TabBar）」
+ * 的固定文案；其余页面文案保持中文，后续逐步开放（设置页语言项下方有小字说明）。
+ *
+ * 设计要点：
+ * - 不引入 vue-i18n 等第三方库，自建轻量字典 + t() 查找函数；
+ * - 存储：localStorage 键 hbu_app_locale（与项目 hbu_ 前缀惯例一致），
+ *   读取时校验合法性，无效/缺失/损坏 → 回落默认 zh-CN（不污染其他设置键）；
+ * - 切换：setLocale 写存储 + 派发 window 自定义事件 hbu-locale-changed
+ *   （detail 携带新 locale），消费方通过 useLocale() 获得响应式 locale 与 t；
+ * - t() 回落链：当前 locale 字典 → zh-CN 字典 → key 本身（保证永不空白）。
+ */
+
+/** 支持的语言标识：首批 简体中文（默认）+ English */
+export type Locale = 'zh-CN' | 'en'
+
+/** 默认语言：简体中文 */
+export const DEFAULT_LOCALE: Locale = 'zh-CN'
+
+/** 语言偏好存储键（hbu_ 前缀与项目其他设置键一致） */
+export const APP_LOCALE_STORAGE_KEY = 'hbu_app_locale'
+
+/** 语言切换自定义事件名：setLocale 派发，useLocale 监听 */
+export const APP_LOCALE_CHANGED_EVENT = 'hbu-locale-changed'
+
+const LOCALE_VALUES: readonly Locale[] = ['zh-CN', 'en']
+
+/**
+ * 校验并规范化存储值：合法值原样返回，空/非法/损坏 → 默认 zh-CN。
+ */
+export const resolveLocale = (raw: unknown): Locale => {
+  const value = String(raw ?? '').trim()
+  if ((LOCALE_VALUES as readonly string[]).includes(value)) {
+    return value as Locale
+  }
+  return DEFAULT_LOCALE
+}
+
+/**
+ * 界面文案字典：语义化 key，与设置页/导航实际文案一一对应。
+ * 新增文案时 zh-CN 与 en 必须同时补齐（t() 对缺失 key 会回落 zh-CN 再回落 key）。
+ */
+export const messages: Record<Locale, Record<string, string>> = {
+  'zh-CN': {
+    // —— 通用 ——
+    'app.name': '校园小助手',
+    // —— 底部公共导航（App.vue TabBar）——
+    'tab.home': '首页',
+    'tab.schedule': '课表',
+    'tab.notifications': '通知',
+    'tab.me': '我的',
+    // —— 设置中心 header / tab 栏 ——
+    'settings.title': '设置中心',
+    'settings.tab.appearance': '外观',
+    'settings.tab.backend': '后端',
+    'settings.tab.security': '安全',
+    'settings.tab.debug': '调试',
+    // —— 设置中心：语言 section ——
+    'settings.language.label': '语言 / Language',
+    'settings.language.option.zh-CN': '简体中文',
+    'settings.language.option.en': 'English',
+    'settings.language.toast': '语言：简体中文',
+    'settings.language.hint': '更多界面语言支持将逐步开放'
+  },
+  en: {
+    // —— Common ——
+    'app.name': 'Campus Assistant',
+    // —— Bottom tab bar (App.vue) ——
+    'tab.home': 'Home',
+    'tab.schedule': 'Schedule',
+    'tab.notifications': 'Alerts',
+    'tab.me': 'Me',
+    // —— Settings header / tab bar ——
+    'settings.title': 'Settings',
+    'settings.tab.appearance': 'Appearance',
+    'settings.tab.backend': 'Backend',
+    'settings.tab.security': 'Security',
+    'settings.tab.debug': 'Debug',
+    // —— Settings: language section ——
+    'settings.language.label': 'Language / 语言',
+    'settings.language.option.zh-CN': '简体中文',
+    'settings.language.option.en': 'English',
+    'settings.language.toast': 'Language: English',
+    'settings.language.hint': 'More interface languages coming soon'
+  }
+}
+
+/** 模块级当前语言（resolveLocale 保证始终合法） */
+let currentLocale: Locale = DEFAULT_LOCALE
+
+/** 读取当前语言（模块加载时已从存储初始化） */
+export const getLocale = (): Locale => currentLocale
+
+/**
+ * 切换语言：写 localStorage + 更新模块状态 + 派发 hbu-locale-changed 事件。
+ * 存储不可用时仅同步内存状态（与 night_mode 等模块的兜底策略一致）。
+ */
+export const setLocale = (locale: Locale): void => {
+  const next = resolveLocale(locale)
+  currentLocale = next
+  try {
+    localStorage.setItem(APP_LOCALE_STORAGE_KEY, next)
+  } catch {
+    // localStorage 不可用时仅同步内存状态
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent(APP_LOCALE_CHANGED_EVENT, { detail: { locale: next } })
+    )
+  }
+}
+
+/**
+ * 翻译查找：当前 locale 字典 → zh-CN 字典 → key 本身（永不空白）。
+ */
+export const t = (key: string): string => {
+  const dict = messages[currentLocale]
+  if (dict && Object.prototype.hasOwnProperty.call(dict, key)) {
+    return dict[key]
+  }
+  const fallback = messages[DEFAULT_LOCALE]
+  if (fallback && Object.prototype.hasOwnProperty.call(fallback, key)) {
+    return fallback[key]
+  }
+  return key
+}
+
+import { ref } from 'vue'
+
+/**
+ * Vue 组合函数：返回响应式 locale 与 t。
+ * - locale 为 ref，监听 hbu-locale-changed 事件跟随变化（设置页切换即时生效）；
+ * - 可选监听 storage 事件，实现跨标签页同步（Tauri 单窗口场景为兜底）。
+ * 注意：t() 内部读模块级 currentLocale，事件先行同步再更新 ref，
+ * 因此模板重渲染时 t() 已按新语言取词。
+ */
+export const useLocale = () => {
+  const locale = ref<Locale>(currentLocale)
+
+  const syncLocale = (event: Event) => {
+    const detail = (event as CustomEvent<{ locale?: Locale }>).detail
+    const next = resolveLocale(detail?.locale ?? currentLocale)
+    currentLocale = next
+    locale.value = next
+  }
+
+  // 跨标签页同步（可选兜底）：storage 事件在其他标签写入时触发
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === APP_LOCALE_STORAGE_KEY) {
+      currentLocale = resolveLocale(event.newValue)
+      locale.value = currentLocale
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener(APP_LOCALE_CHANGED_EVENT, syncLocale)
+    window.addEventListener('storage', onStorage)
+  }
+
+  return { locale, t }
+}
+
+// 模块加载时从存储初始化（缺失/非法/损坏一律回落 zh-CN）
+try {
+  currentLocale = resolveLocale(localStorage.getItem(APP_LOCALE_STORAGE_KEY))
+} catch {
+  // localStorage 不可用时保持默认 zh-CN
+}


### PR DESCRIPTION
## 概述

epic #769 的四项子任务集成交付，四个子 issue 各自独立开发后合入本集成分支：

| Sub-issue | 内容 | 提交 |
|---|---|---|
| #771 | 设置中心外观模式恢复 SVG 卡片式选择（跟随系统/白天/夜间），保留跟随系统自动切换与全屏过渡动画；清理 113 行死样式 | c1e2aabd |
| #770 | 切换账号弹窗标题图标显示为文字的修复——`swap_account` 并非 Material Symbols 官方图标（字体连字反解实锤），换用子集字体可解析的 `switch_account`，零字体产物变更 | 07b291f6 |
| #772 | 课表添加/修改课程弹窗恢复 `CourseColorPicker` 颜色选择（组件拆分时丢失 import）+ 补齐 `drawer-action` 按钮 scoped 样式（含 ghost/disabled/按压态，与 ScheduleDrawer 原规则等值） | 4aee7dc9 |
| #773 | 设置中心新增语言选择（简体中文默认 + English）：自建轻量 app_i18n（无第三方库），localStorage 持久化 + 无效值回落 + 即时生效；本期覆盖设置页 header/tab、语言 section 与底部 TabBar | db1783e3 |

## 验证

- 集成分支全量：vitest **1268 passed (180 files)**、vue-tsc typecheck 通过、vite build 通过
- 各子分支开发时均已通过单文件 + 全量 + typecheck + build
- 纯前端改动，无 Rust/后端变更，无敏感信息

## 已知无关 flaky

`chaoxing_inbox_channel.spec.ts` 单用例在全量并发跑时偶发 5s 超时（干净 main 基线可复现，单跑稳定通过），与本次改动无关。

Closes #770, closes #771, closes #772, closes #773