### PR TITLE
fix(#777): 授权记录设备密钥与签名错误分类透传（关联 #668 fail-closed）

### DIFF
--- a/apps/client/src-tauri/src/identity/auth_history_tests.rs
+++ b/apps/client/src-tauri/src/identity/auth_history_tests.rs
@@ -1,0 +1,122 @@
+//! #775：授权历史命令层回归测试（store 注入 + canonical 确定性）。
+//!
+//! 协作约束下的分层设计（见 issue #775 / 任务说明）：
+//! - 本文件只做 **store 层** 注入测试（`DeviceKeyStore::with_keyring`）与
+//!   canonical 签名确定性测试 —— 不触碰 `commands.rs`，与 #777 的
+//!   `fetch_auth_history_impl` 注入测试（命令层）完全正交，避免文件冲突；
+//! - 命令层注入测试（无密钥→错误分类 / keyring 失败→错误分类 / device_id 空→
+//!   InvalidInput / error_kind 全变体覆盖）由 #777 的实现提交，位于
+//!   `commands.rs#[cfg(test)] mod tests`；若集成时该模块尚未落地，
+//!   需在本文件补齐（对齐 #777 新契约 `IdentityAuthHistoryOutput`）。
+//!
+//! 覆盖场景（#775 客户端可测子集的 Rust 侧）：
+//! 1. store.load()：无密钥 → Ok(None)（对应命令层 NotEnrolled 分类）；
+//! 2. store.load()：keyring 失败 → Err(KeyringUnavailable)（fail closed 分类源头）；
+//! 3. canonical：auth-history 请求的 canonical 文本逐字节确定性（GET + 固定 path +
+//!    假 device_id + 固定 issued_at/nonce），签名可由公钥验证、篡改即失败；
+//! 4. 测试数据一律假学号/假 device_id（device-test-0001），绝不含真实凭据。
+
+#![cfg(test)]
+
+use crate::identity::canonical::{build_device_api_canonical, DeviceApiCanonicalInput};
+use crate::identity::device_key::{DeviceKey, DeviceKeyStore};
+use crate::identity::errors::IdentityError;
+use crate::identity::keyring::{FailingKeyring, MemoryKeyring};
+
+/// 测试用假 device_id（不含真实凭据）。
+const TEST_DEVICE_ID: &str = "device-test-0001";
+
+/// auth-history 请求固定 path（与 identity_fetch_auth_history 命令一致）。
+const AUTH_HISTORY_PATH: &str = "/api/v1/app/devices/me/auth-history";
+
+// ─── 1/2. store 层错误分类源头（命令层 NotEnrolled/KeyringUnavailable 的上游） ──
+
+#[test]
+fn store_load_without_key_returns_none() {
+    // 无密钥（MemoryKeyring 空）：load 必须返回 Ok(None)，
+    // 命令层据此归类 NotEnrolled（#777 error_kind=not_enrolled），不得 panic。
+    let store = DeviceKeyStore::with_keyring(Box::new(MemoryKeyring::new()));
+    let loaded = store.load().expect("无密钥属于正常态，不应报错");
+    assert!(loaded.is_none(), "空 keyring 应返回 None");
+}
+
+#[test]
+fn store_load_with_failing_keyring_fails_closed() {
+    // keyring 不可用：load 返回 KeyringUnavailable（fail closed），
+    // 命令层据此归类 keyring_unavailable，绝不降级到文件/SQLite。
+    let store = DeviceKeyStore::with_keyring(Box::new(FailingKeyring));
+    match store.load() {
+        Err(IdentityError::KeyringUnavailable(message)) => {
+            assert!(!message.is_empty(), "应携带底层脱敏描述");
+        }
+        other => panic!("应返回 KeyringUnavailable，实际 {other:?}"),
+    }
+}
+
+#[test]
+fn store_load_after_create_returns_same_key() {
+    // 注册后 load 与 create_if_missing 返回同一把密钥（指纹一致），
+    // 保证 auth-history 签名设备与 enroll 设备一致。
+    let store = DeviceKeyStore::with_keyring(Box::new(MemoryKeyring::new()));
+    let created = store
+        .create_if_missing()
+        .expect("内存 keyring 创建不应失败");
+    let loaded = store
+        .load()
+        .expect("创建后读取不应失败")
+        .expect("创建后应有密钥");
+    assert_eq!(loaded.fingerprint(), created.fingerprint());
+}
+
+// ─── 3. auth-history canonical 确定性（签名链路的可复现核心） ─────────────────
+
+#[test]
+fn auth_history_canonical_is_deterministic() {
+    // 同一输入两次构建 → 逐字节一致；方法小写自动归一为大写
+    let build = || {
+        build_device_api_canonical(&DeviceApiCanonicalInput {
+            method: "get",
+            path: AUTH_HISTORY_PATH,
+            device_id: TEST_DEVICE_ID,
+            issued_at: 1_755_000_000,
+            nonce: "nonce-test-0001",
+        })
+        .expect("canonical 构建不应失败")
+    };
+    let first = build();
+    let second = build();
+    assert_eq!(first, second);
+    let expected = format!(
+        "MINI-HBUT-DEVICE-API-V1\nmethod=GET\npath={AUTH_HISTORY_PATH}\ndevice_id={TEST_DEVICE_ID}\nissued_at=1755000000\nnonce=nonce-test-0001\n"
+    );
+    assert_eq!(first, expected, "canonical 必须与 #622 规范逐字节一致");
+    assert!(first.ends_with('\n'), "canonical 以单个 LF 结尾");
+}
+
+#[test]
+fn auth_history_signature_verifies_and_tamper_breaks() {
+    // 用确定性 seed 密钥对 auth-history canonical 签名：
+    // 公钥可验证；篡改 canonical 任一字节后验证必须失败。
+    let seed = [7u8; 32]; // 固定 seed（测试专用，非真实凭据）
+    let key = DeviceKey::from_seed(seed);
+    let canonical = build_device_api_canonical(&DeviceApiCanonicalInput {
+        method: "GET",
+        path: AUTH_HISTORY_PATH,
+        device_id: TEST_DEVICE_ID,
+        issued_at: 1_755_000_000,
+        nonce: "nonce-test-0002",
+    })
+    .expect("canonical 构建不应失败");
+    let signature = key.sign(canonical.as_bytes());
+    // 公钥（base64url x 字段）跨实例验证 = Core 侧验证路径
+    let x = key.public_jwk().x;
+    DeviceKey::verify_with_public_key(&x, canonical.as_bytes(), &signature)
+        .expect("auth-history 签名必须能被公钥验证");
+    // 篡改 path（换行注入等价于改写签名对象）→ 验证失败
+    let tampered = canonical.replace(AUTH_HISTORY_PATH, "/api/v1/app/devices/other/history");
+    assert_ne!(tampered, canonical);
+    assert!(
+        DeviceKey::verify_with_public_key(&x, tampered.as_bytes(), &signature).is_err(),
+        "篡改 canonical 后原签名必须验证失败"
+    );
+}

--- a/apps/client/src-tauri/src/identity/client.rs
+++ b/apps/client/src-tauri/src/identity/client.rs
@@ -150,6 +150,8 @@ impl IdentityApiClient {
 }
 
 /// 解析 Core 错误响应（error.message 或 error 字符串），已脱敏，不回显敏感材料。
+/// #776：auth-history 链路的调用方会把 Api{status} 的状态码透传给前端按状态码分类，
+/// 其他端点（enroll/revoke）继续整体上抛 Api 错误，行为不变。
 fn parse_api_error(status: u16, text: &str) -> IdentityError {
     let parsed = serde_json::from_str::<serde_json::Value>(text).ok();
     let message = parsed

--- a/apps/client/src-tauri/src/identity/commands.rs
+++ b/apps/client/src-tauri/src/identity/commands.rs
@@ -383,15 +383,20 @@ async fn fetch_auth_history_impl(
         },
         // #776：Api{status} 携带 Core HTTP 状态码，透传给前端按状态码分类；
         // 其余错误保持 status=0 + error_kind 分类。所有文本均为已脱敏 Display。
-        Err(IdentityError::Api { status, ref message }) => IdentityAuthHistoryOutput {
+        Err(IdentityError::Api {
+            status,
+            ref message,
+        }) => IdentityAuthHistoryOutput {
             status: i32::from(status),
             body: message.clone(),
             error_kind: Some("api".to_string()),
-            error_message: Some(IdentityError::Api {
-                status,
-                message: message.clone(),
-            }
-            .to_string()),
+            error_message: Some(
+                IdentityError::Api {
+                    status,
+                    message: message.clone(),
+                }
+                .to_string(),
+            ),
         },
         Err(err) => failure(&err),
     }
@@ -547,7 +552,10 @@ mod tests {
         assert_eq!(output.status, 0);
         assert_eq!(output.error_kind.as_deref(), Some("keyring_unavailable"));
         let message = output.error_message.unwrap_or_default();
-        assert!(message.contains("安全存储"), "应透传 KeyringUnavailable 脱敏文案");
+        assert!(
+            message.contains("安全存储"),
+            "应透传 KeyringUnavailable 脱敏文案"
+        );
         assert!(!message.contains(&test_device_id()));
     }
 
@@ -578,7 +586,10 @@ mod tests {
                 IdentityError::KeyringUnavailable("存储写入失败".to_string()),
                 "keyring_unavailable",
             ),
-            (IdentityError::KeyringWriteMismatch, "keyring_write_mismatch"),
+            (
+                IdentityError::KeyringWriteMismatch,
+                "keyring_write_mismatch",
+            ),
             (
                 IdentityError::KeyringBackendMissing("mock 后端".to_string()),
                 "keyring_backend_missing",
@@ -601,7 +612,11 @@ mod tests {
             (IdentityError::Internal("不可达".to_string()), "internal"),
         ];
         for (err, expected) in cases {
-            assert_eq!(error_kind_of(&err), expected, "{err:?} 的 error_kind 应为 {expected}");
+            assert_eq!(
+                error_kind_of(&err),
+                expected,
+                "{err:?} 的 error_kind 应为 {expected}"
+            );
         }
     }
 }

--- a/apps/client/src-tauri/src/identity/commands.rs
+++ b/apps/client/src-tauri/src/identity/commands.rs
@@ -1,6 +1,8 @@
 //! Identity Tauri commands（#622）。
 //!
 //! 统一 `identity_` 前缀；错误一律返回简体中文 String。
+//! #777：授权历史命令改用结构化错误分类输出（status/error_kind/error_message），
+//!       不再把设备密钥/签名链路错误压平成无类型字符串。
 //! 私钥只在本模块与 device_key 内使用，任何 payload 都不携带私钥材料。
 
 use tauri::State;
@@ -278,46 +280,121 @@ pub(crate) async fn identity_revoke_current_device_local(
 /// 拉取本机授权历史（「授权记录」页数据源）：
 /// 设备签名（GET /api/v1/app/devices/me/auth-history）后返回 Core 响应体，
 /// 与 revoke 同款签名链路（method/path 由服务端取请求自身值，防中间人改写）。
+///
+/// #777：错误不再被 `to_string()` 压平 —— 改用不抛错的结构化输出
+/// （error_kind 机器码 + 已脱敏的 IdentityError Display 文本），
+/// 前端可区分「未注册/安全存储不可用/网络失败/接口错误」并给出对应指引。
 #[tauri::command]
 pub(crate) async fn identity_fetch_auth_history(
     base_url: Option<String>,
     device_id: String,
-) -> Result<IdentityCoreFetchOutput, String> {
+) -> IdentityAuthHistoryOutput {
     let base_url = base_url
         .map(|b| b.trim().to_string())
         .filter(|b| !b.is_empty())
         .unwrap_or_else(|| IDENTITY_CORE_ORIGIN.to_string());
-    let base_url = resolve_identity_core_base_url(&base_url).map_err(|e| e.to_string())?;
     let device_id = device_id.trim().to_string();
-    if device_id.is_empty() {
-        return Err(IdentityError::InvalidInput(
-            "查询授权历史需要 device_id（enroll 返回值）".to_string(),
-        )
-        .to_string());
-    }
     let store = real_store();
-    let key = store
-        .load()
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| IdentityError::NotEnrolled)
-        .map_err(|e| e.to_string())?;
+    fetch_auth_history_impl(&store, &base_url, &device_id).await
+}
+
+/// #777：授权历史输出。
+/// - 原生层失败：`status = 0`，error_kind/error_message 描述失败类别与脱敏原因；
+/// - 成功：`status` 为 Core HTTP 状态码（当前成功路径恒为 200），`body` 为响应体，
+///   error_kind/error_message 为 None。
+#[derive(serde::Serialize)]
+pub(crate) struct IdentityAuthHistoryOutput {
+    /// 0 = 原生层失败（未到达 HTTP）；>0 = Core HTTP 状态码
+    pub status: i32,
+    pub body: String,
+    /// 稳定机器码：not_enrolled / keyring_unavailable / keyring_write_mismatch /
+    /// keyring_backend_missing / invalid_input / core_base_url_missing / network / api / internal
+    pub error_kind: Option<String>,
+    /// 已脱敏的 IdentityError Display 文本（不含私钥/签名/token；不含 device_id 全文）
+    pub error_message: Option<String>,
+}
+
+/// IdentityError → 稳定机器码（前端映射 IdentityUserSafeErrorCode 的契约源头）。
+fn error_kind_of(err: &IdentityError) -> &'static str {
+    match err {
+        IdentityError::KeyringUnavailable(_) => "keyring_unavailable",
+        IdentityError::KeyringWriteMismatch => "keyring_write_mismatch",
+        IdentityError::KeyringBackendMissing(_) => "keyring_backend_missing",
+        IdentityError::NoLocalLogin => "no_local_login",
+        IdentityError::NotEnrolled => "not_enrolled",
+        IdentityError::InvalidInput(_) => "invalid_input",
+        IdentityError::CoreBaseUrlMissing => "core_base_url_missing",
+        IdentityError::Network(_) => "network",
+        IdentityError::Api { .. } => "api",
+        IdentityError::Internal(_) => "internal",
+    }
+}
+
+/// 授权历史核心逻辑（可注入 store，便于单测覆盖密钥链路错误分类）。
+/// 参数约定：base_url 已由调用方 trim；device_id 已由调用方 trim。
+async fn fetch_auth_history_impl(
+    store: &DeviceKeyStore,
+    base_url: &str,
+    device_id: &str,
+) -> IdentityAuthHistoryOutput {
+    let failure = |err: &IdentityError| IdentityAuthHistoryOutput {
+        status: 0,
+        body: String::new(),
+        error_kind: Some(error_kind_of(err).to_string()),
+        error_message: Some(err.to_string()),
+    };
+    let base_url = match resolve_identity_core_base_url(base_url) {
+        Ok(url) => url,
+        Err(err) => return failure(&err),
+    };
+    if device_id.is_empty() {
+        return failure(&IdentityError::InvalidInput(
+            "查询授权历史需要 device_id（enroll 返回值）".to_string(),
+        ));
+    }
+    let key = match store.load() {
+        Ok(Some(key)) => key,
+        Ok(None) => return failure(&IdentityError::NotEnrolled),
+        Err(err) => return failure(&err),
+    };
     let issued_at = canonical::now_unix_seconds();
     let nonce = canonical::new_nonce();
-    let canonical_text = canonical::build_device_api_canonical(&DeviceApiCanonicalInput {
+    let canonical_text = match canonical::build_device_api_canonical(&DeviceApiCanonicalInput {
         method: "GET",
         path: "/api/v1/app/devices/me/auth-history",
-        device_id: &device_id,
+        device_id,
         issued_at,
         nonce: &nonce,
-    })
-    .map_err(|e| e.to_string())?;
+    }) {
+        Ok(text) => text,
+        Err(err) => return failure(&err),
+    };
     let signature = canonical::encode_signature(&key.sign(canonical_text.as_bytes()));
     let client = IdentityApiClient::new(base_url);
-    let body = client
-        .fetch_auth_history(&device_id, issued_at, &nonce, &signature)
+    match client
+        .fetch_auth_history(device_id, issued_at, &nonce, &signature)
         .await
-        .map_err(|e| e.to_string())?;
-    Ok(IdentityCoreFetchOutput { status: 200, body })
+    {
+        Ok(body) => IdentityAuthHistoryOutput {
+            status: 200,
+            body,
+            error_kind: None,
+            error_message: None,
+        },
+        // #776：Api{status} 携带 Core HTTP 状态码，透传给前端按状态码分类；
+        // 其余错误保持 status=0 + error_kind 分类。所有文本均为已脱敏 Display。
+        Err(IdentityError::Api { status, ref message }) => IdentityAuthHistoryOutput {
+            status: i32::from(status),
+            body: message.clone(),
+            error_kind: Some("api".to_string()),
+            error_message: Some(IdentityError::Api {
+                status,
+                message: message.clone(),
+            }
+            .to_string()),
+        },
+        Err(err) => failure(&err),
+    }
 }
 
 /// Identity 代理请求（#623 架构修正）：
@@ -431,5 +508,100 @@ mod tests {
         }
         assert!(validate_identity_core_base_url("https://localhost:3300", true).is_err());
         assert!(validate_identity_core_base_url("http://192.168.1.20:3300", true).is_err());
+    }
+
+    // ── #777：授权历史命令错误分类（不依赖网络：密钥链路错误在网络边界之前返回） ──
+
+    use crate::identity::keyring::{FailingKeyring, MemoryKeyring};
+
+    /// 合法测试 base_url：Production Core origin（密钥链路失败时不发起任何网络请求）。
+    fn test_base_url() -> String {
+        IDENTITY_CORE_ORIGIN.to_string()
+    }
+
+    /// 测试用假 device_id（不含真实凭据）。
+    fn test_device_id() -> String {
+        "device-test-0001".to_string()
+    }
+
+    #[tokio::test]
+    async fn auth_history_without_key_returns_not_enrolled_kind() {
+        // 无密钥（MemoryKeyring 空）：NotEnrolled → error_kind=not_enrolled，不 panic
+        let store = DeviceKeyStore::with_keyring(Box::new(MemoryKeyring::new()));
+        let output = fetch_auth_history_impl(&store, &test_base_url(), &test_device_id()).await;
+        assert_eq!(output.status, 0, "未到达 HTTP，status 应为 0");
+        assert_eq!(output.error_kind.as_deref(), Some("not_enrolled"));
+        assert!(output.body.is_empty());
+        let message = output.error_message.unwrap_or_default();
+        assert!(!message.is_empty(), "应有用户可读脱敏文案");
+        // 脱敏约定：错误文本不携带 device_id 全文与签名材料
+        assert!(!message.contains(&test_device_id()));
+        assert!(!message.contains("signature"));
+    }
+
+    #[tokio::test]
+    async fn auth_history_with_failing_keyring_returns_keyring_unavailable_kind() {
+        // keyring 不可用（#668 fail closed）：error_kind=keyring_unavailable，绝不降级
+        let store = DeviceKeyStore::with_keyring(Box::new(FailingKeyring));
+        let output = fetch_auth_history_impl(&store, &test_base_url(), &test_device_id()).await;
+        assert_eq!(output.status, 0);
+        assert_eq!(output.error_kind.as_deref(), Some("keyring_unavailable"));
+        let message = output.error_message.unwrap_or_default();
+        assert!(message.contains("安全存储"), "应透传 KeyringUnavailable 脱敏文案");
+        assert!(!message.contains(&test_device_id()));
+    }
+
+    #[tokio::test]
+    async fn auth_history_with_empty_device_id_returns_invalid_input_kind() {
+        // device_id 为空：error_kind=invalid_input（在 keyring 之前校验）
+        let store = DeviceKeyStore::with_keyring(Box::new(MemoryKeyring::new()));
+        let output = fetch_auth_history_impl(&store, &test_base_url(), "").await;
+        assert_eq!(output.status, 0);
+        assert_eq!(output.error_kind.as_deref(), Some("invalid_input"));
+    }
+
+    #[tokio::test]
+    async fn auth_history_with_untrusted_base_url_returns_invalid_input_kind() {
+        // 非受信任 origin：SSRF 防护在密钥链路之前生效
+        let store = DeviceKeyStore::with_keyring(Box::new(MemoryKeyring::new()));
+        let output =
+            fetch_auth_history_impl(&store, "https://evil.example", &test_device_id()).await;
+        assert_eq!(output.status, 0);
+        assert_eq!(output.error_kind.as_deref(), Some("invalid_input"));
+    }
+
+    #[test]
+    fn error_kind_covers_all_identity_error_variants() {
+        // 契约：每个 IdentityError 变体都有稳定机器码（漏配时本用例失败）
+        let cases: Vec<(IdentityError, &str)> = vec![
+            (
+                IdentityError::KeyringUnavailable("存储写入失败".to_string()),
+                "keyring_unavailable",
+            ),
+            (IdentityError::KeyringWriteMismatch, "keyring_write_mismatch"),
+            (
+                IdentityError::KeyringBackendMissing("mock 后端".to_string()),
+                "keyring_backend_missing",
+            ),
+            (IdentityError::NoLocalLogin, "no_local_login"),
+            (IdentityError::NotEnrolled, "not_enrolled"),
+            (
+                IdentityError::InvalidInput("参数非法".to_string()),
+                "invalid_input",
+            ),
+            (IdentityError::CoreBaseUrlMissing, "core_base_url_missing"),
+            (IdentityError::Network("连接超时".to_string()), "network"),
+            (
+                IdentityError::Api {
+                    status: 403,
+                    message: "设备签名验证失败".to_string(),
+                },
+                "api",
+            ),
+            (IdentityError::Internal("不可达".to_string()), "internal"),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(error_kind_of(&err), expected, "{err:?} 的 error_kind 应为 {expected}");
+        }
     }
 }

--- a/apps/client/src-tauri/src/identity/mod.rs
+++ b/apps/client/src-tauri/src/identity/mod.rs
@@ -6,6 +6,7 @@
 //! - 与 `credential_store.rs` 的密码兼容逻辑完全隔离（设备私钥禁止 Base64/SQLite 降级）。
 
 pub mod approval;
+pub mod auth_history_tests;
 pub mod canonical;
 pub mod client;
 pub mod commands;

--- a/apps/client/src/features/identity/authHistoryErrors.spec.ts
+++ b/apps/client/src/features/identity/authHistoryErrors.spec.ts
@@ -1,0 +1,285 @@
+// src/features/identity/authHistoryErrors.spec.ts
+//
+// #776/#777：授权记录错误契约测试。
+//
+// 覆盖两条错误映射链（服务层纯映射行为，不触网、不依赖 DOM）：
+//   1. #777 error_kind → IdentityUserSafeErrorCode：Rust IdentityError 变体的
+//      稳定机器码（not_enrolled / keyring_* / network / api / internal 等）
+//      经原生输出 { status:0, error_kind } 进入前端后的映射行为；
+//   2. #776 status → code：Core 非 2xx（401/403/404/410/422/409/500 等）
+//      按响应体错误码 + 状态码兜底走 throwMappedError 同款映射，
+//      网络类（invoke 抛错）兜底 network_unavailable，不再全部折叠为同一文案。
+//
+// 脱敏自查：错误文案绝不携带 device_id 全文、签名、token；内部细节只进 internalDetail。
+// mock 方式：vi.mock('../../platform/native')，与 authHistoryRegression.spec 一致。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createServiceError,
+  fetchAuthHistory,
+  IDENTITY_DEVICE_ID_KEY
+} from './identityService'
+import { identityFetchAuthHistory, isTauriRuntime } from '../../platform/native'
+import { IdentityServiceError, type IdentityUserSafeErrorCode } from './types'
+
+vi.mock('../../platform/native', () => ({
+  invokeNative: vi.fn(),
+  isTauriRuntime: vi.fn(() => true),
+  identityFetchAuthHistory: vi.fn()
+}))
+
+const TEST_DEVICE_ID = 'device-test-0001'
+
+// node 环境无 localStorage：注入 stub（与 authHistoryRegression.spec 同款基建）
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear(),
+  key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+  length: 0
+}
+
+/** 原生层失败输出（#777 结构化错误分类） */
+const nativeFailure = (kind: string, message: string) => ({
+  status: 0,
+  body: '',
+  error_kind: kind,
+  error_message: message
+})
+
+/** Core 非 2xx 输出（#776：status 透传 + 响应体错误体） */
+const nativeHttpError = (status: number, body = '') => ({
+  status,
+  body,
+  error_kind: null,
+  error_message: null
+})
+
+const catchCode = async (promise: Promise<unknown>): Promise<IdentityServiceError> =>
+  (await promise.catch((err: unknown) => err)) as IdentityServiceError
+
+beforeEach(() => {
+  storageMap.clear()
+  storageMap.set(IDENTITY_DEVICE_ID_KEY, TEST_DEVICE_ID)
+  ;(globalThis as { localStorage?: Storage }).localStorage = stubStorage as unknown as Storage
+  // 隔离 reportIdentityDiag 的诊断上报
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)))
+  vi.mocked(isTauriRuntime).mockReturnValue(true)
+})
+
+afterEach(() => {
+  delete (globalThis as { localStorage?: Storage }).localStorage
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ─── 1. #777：error_kind → code 映射契约 ─────────────────────────────────────
+
+describe('#777 error_kind → 用户可读错误码映射', () => {
+  it.each([
+    ['not_enrolled', 'device_not_bound'],
+    ['keyring_unavailable', 'secure_storage_unavailable'],
+    ['keyring_write_mismatch', 'secure_storage_unavailable'],
+    ['keyring_backend_missing', 'secure_storage_unavailable'],
+    ['network', 'network_unavailable'],
+    ['invalid_input', 'unknown'],
+    ['core_base_url_missing', 'unknown'],
+    ['no_local_login', 'unknown'],
+    ['internal', 'unknown']
+  ] as const)('error_kind=%s → code=%s', async (kind, expected) => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeFailure(kind, `脱敏诊断文本（${kind}）`)
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err).toBeInstanceOf(IdentityServiceError)
+    expect(err.code).toBe(expected)
+    // Rust 已脱敏文案透传给用户；kind 只进 internalDetail
+    expect(err.message).toBe(`脱敏诊断文本（${kind}）`)
+    expect(err.internalDetail).toContain(kind)
+  })
+
+  it('未知 error_kind → 兜底 unknown（前向兼容：旧版 App 遇新 kind 不误分类）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeFailure('future_kind_999', '未来版本的错误')
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('unknown')
+  })
+
+  it('error_message 缺失 → 使用该 code 的默认文案', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 0,
+      body: '',
+      error_kind: 'network',
+      error_message: null
+    }) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('network_unavailable')
+    expect(err.message).toBe('网络不可用，无法连接身份服务，请稍后重试')
+  })
+
+  it('脱敏契约：secure_storage_unavailable 文案不携带 device_id/签名材料', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeFailure(
+        'keyring_unavailable',
+        '系统安全存储不可用，设备身份功能已停用（fail closed，不降级）：模拟'
+      )
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.message).not.toContain(TEST_DEVICE_ID)
+    expect(err.message).not.toContain('signature')
+    expect(err.internalDetail).not.toContain(TEST_DEVICE_ID)
+  })
+})
+
+// ─── 2. #776：status → code 映射契约（throwMappedError 同款） ─────────────────
+
+describe('#776 Core 非 2xx 状态映射（响应体错误码优先，状态码兜底）', () => {
+  it.each([
+    [401, '接力凭据无效，请从网页重新发起授权'],
+    [403, '当前设备已被撤销，无法继续授权'],
+    [404, '请求不存在或已完成'],
+    [410, '应用请求已过期，请从网页重新发起'],
+    [422, '应用已被暂停，无法继续授权'],
+    [409, '请求不存在或已完成'],
+    [500, '授权处理失败，请稍后重试'],
+    [502, '授权处理失败，请稍后重试'],
+    [503, '授权处理失败，请稍后重试']
+  ] as const)('HTTP %i 无错误体 → 状态码兜底文案（code=unknown，与 throwMappedError 现状一致）', async (status, expectedMessage) => {
+    // 无错误体时 parseErrorPayload 得到 HTTP_xxx 伪码 → mapServerCode 兜底 unknown，
+    // 但 message 保留 mapStatusFallback 的状态码文案（#775 回归 spec 已锁定该现状）。
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeHttpError(status)) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err).toBeInstanceOf(IdentityServiceError)
+    expect(err.code).toBe('unknown')
+    expect(err.message).toBe(expectedMessage)
+    // internalDetail 记录 status 与上下文（脱敏诊断，不含响应体原文）
+    expect(err.internalDetail).toContain(`HTTP ${status}`)
+    expect(err.internalDetail).toContain('fetchAuthHistory')
+  })
+
+  it('401 + Core 结构化错误体 {error:{code,message}} → 按 mapServerCode 映射并透传脱敏文案', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeHttpError(
+        401,
+        JSON.stringify({ error: { code: 'DEVICE_AUTH_FAILED', message: '设备签名验证失败' } })
+      )
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('device_revoked')
+    expect(err.message).toBe('设备签名验证失败')
+  })
+
+  it('403 + SIGNATURE_INVALID → signature_rejected', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeHttpError(403, JSON.stringify({ error: { code: 'SIGNATURE_INVALID', message: '签名校验失败' } }))
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('signature_rejected')
+  })
+
+  it('410 + AUTH_REQUEST_EXPIRED → request_expired', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeHttpError(410, JSON.stringify({ error: 'EXPIRED' }))
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('request_expired')
+  })
+
+  it('非 2xx + 非法 JSON 错误体（网关 HTML）→ 仍按状态码兜底，不误报网络错误', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeHttpError(502, '<html>Bad Gateway</html>')
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('unknown')
+    expect(err.message).not.toContain('<html>')
+  })
+
+  it('错误体携带的 message 为空 → 回退状态码默认文案', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeHttpError(403, JSON.stringify({ error: { code: 'DEVICE_AUTH_FAILED', message: '' } }))
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('device_revoked')
+    expect(err.message).toBe('当前设备已被撤销，无法继续授权')
+  })
+})
+
+// ─── 3. 网络失败兜底 + 成功路径宽容解析（#776 删除「全折叠」逻辑） ─────────────
+
+describe('#776 网络失败与成功路径契约', () => {
+  it('invoke 抛错（原生 panic/运行时异常）→ network_unavailable 兜底，内部细节不进用户文案', async () => {
+    vi.mocked(identityFetchAuthHistory).mockRejectedValue(
+      new Error('invoke failed: panic-with-token-abc')
+    )
+    const err = await catchCode(fetchAuthHistory())
+    expect(err.code).toBe('network_unavailable')
+    expect(err.message).toBe('无法连接身份服务，请检查网络后重试')
+    expect(err.message).not.toContain('panic-with-token-abc')
+    expect(err.internalDetail).toContain('invoke failed')
+  })
+
+  it('200 + 非法 JSON body → 空数组不抛（不再折叠为 network_unavailable）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 200,
+      body: '{{not-json',
+      error_kind: null,
+      error_message: null
+    }) as never
+    await expect(fetchAuthHistory()).resolves.toEqual([])
+  })
+
+  it('200 + 空 body → 空数组', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 200,
+      body: '',
+      error_kind: null,
+      error_message: null
+    }) as never
+    await expect(fetchAuthHistory()).resolves.toEqual([])
+  })
+})
+
+// ─── 4. 可重试性契约（View 重试按钮的依据） ─────────────────────────────────
+
+describe('#776 错误码可重试性契约', () => {
+  // View 对 network/5xx 允许重试；device_revoked/no_device 显示引导而非无限重试。
+  const RETRYABLE: IdentityUserSafeErrorCode[] = ['network_unavailable']
+  const GUIDED: IdentityUserSafeErrorCode[] = ['device_revoked', 'device_not_bound', 'secure_storage_unavailable']
+
+  it('网络类错误可重试（IdentityCoordinator 的 retryable 语义保持一致）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeFailure('network', '身份服务网络请求失败：连接超时')
+    ) as never
+    const err = await catchCode(fetchAuthHistory())
+    expect(RETRYABLE).toContain(err.code)
+  })
+
+  it('设备被撤销/未注册/安全存储不可用 → 走引导而非重试（错误码分类正确是前提）', async () => {
+    const cases: Array<[string, IdentityUserSafeErrorCode]> = [
+      ['not_enrolled', 'device_not_bound'],
+      ['keyring_unavailable', 'secure_storage_unavailable']
+    ]
+    for (const [kind, expected] of cases) {
+      vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+        nativeFailure(kind, `脱敏诊断（${kind}）`)
+      ) as never
+      const err = await catchCode(fetchAuthHistory())
+      expect(err.code).toBe(expected)
+      expect(GUIDED).toContain(err.code)
+    }
+  })
+
+  it('默认文案契约：引导类错误码的 DEFAULT_MESSAGES 非空（createServiceError 兜底）', () => {
+    for (const code of GUIDED) {
+      const err = createServiceError(code)
+      expect(err.message.trim().length).toBeGreaterThan(4)
+    }
+  })
+})

--- a/apps/client/src/features/identity/authHistoryRegression.spec.ts
+++ b/apps/client/src/features/identity/authHistoryRegression.spec.ts
@@ -146,18 +146,14 @@ describe('#775 fetchAuthHistory 200 响应解析', () => {
   })
 })
 
-// ─── 3. 非法 JSON body（现状契约，待 #776 对齐） ─────────────────────────────
+// ─── 3. 非法 JSON body（#776 修复后契约：宽容解析） ─────────────────────────
 
-describe('#775 fetchAuthHistory 非法 JSON body（现状契约）', () => {
-  it('status=200 + 非法 JSON → 现状折叠为 network_unavailable（应为空态，待 #776 修复对齐）', async () => {
-    // 当前实现 `JSON.parse(output.body || '{}')` 无局部保护：
-    // SyntaxError 进外层 catch → network_unavailable('无法加载授权记录，请稍后重试')。
-    // 正确语义应为「返回空数组不抛」—— #776 修复后本用例需改为 resolves.toEqual([])。
+describe('#775 fetchAuthHistory 非法 JSON body（#776 修复后契约）', () => {
+  it('status=200 + 非法 JSON → 返回空数组不抛（宽容解析，不误报网络错误）', async () => {
+    // #776 修复后：成功路径响应体解析带局部保护，
+    // SyntaxError 不再进 catch 折叠为 network_unavailable，而是按空态处理。
     vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeOk(200, '{{not-json') as never)
-    await expect(fetchAuthHistory()).rejects.toMatchObject({
-      code: 'network_unavailable',
-      message: '无法加载授权记录，请稍后重试'
-    })
+    await expect(fetchAuthHistory()).resolves.toEqual([])
   })
 })
 
@@ -208,10 +204,12 @@ describe('#775 fetchAuthHistory 非 200 状态映射（现状契约）', () => {
   })
 })
 
-// ─── 5. 原生调用失败折叠（现状契约，可能被 #776 改变） ────────────────────────
+// ─── 5. 原生调用失败兜底（#777 修复后契约） ──────────────────────────────────
 
-describe('#775 fetchAuthHistory 原生调用失败折叠（现状契约）', () => {
-  it('invoke 抛错 → 折叠为 network_unavailable（用户可读文案，不泄露内部错误）', async () => {
+describe('#775 fetchAuthHistory 原生调用失败兜底（#777 修复后契约）', () => {
+  it('invoke 抛错 → 兜底 network_unavailable（用户可读文案，不泄露内部错误）', async () => {
+    // #777 修复后：invoke 本身失败（panic/运行时异常）拿不到结构化分类，
+    // 仍按网络类兜底，但文案改为与 requestJson 一致的「无法连接身份服务」。
     vi.mocked(identityFetchAuthHistory).mockRejectedValue(
       new Error('invoke failed: identity_fetch_auth_history panic detail')
     )
@@ -219,11 +217,58 @@ describe('#775 fetchAuthHistory 原生调用失败折叠（现状契约）', () 
     expect(err).toBeInstanceOf(IdentityServiceError)
     expect(err).toMatchObject({
       code: 'network_unavailable',
-      message: '无法加载授权记录，请稍后重试'
+      message: '无法连接身份服务，请检查网络后重试'
     })
     // 内部细节只进 internalDetail（脱敏日志），不进用户文案
     expect((err as IdentityServiceError).message).not.toContain('panic detail')
     expect((err as IdentityServiceError).internalDetail).toContain('invoke failed')
+  })
+
+  it('原生层 status=0 + error_kind=not_enrolled → device_not_bound（#777 结构化分类）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 0,
+      body: '',
+      error_kind: 'not_enrolled',
+      error_message: '本设备尚未注册身份，请先完成设备注册'
+    }) as never
+    await expect(fetchAuthHistory()).rejects.toMatchObject({
+      code: 'device_not_bound',
+      message: '本设备尚未注册身份，请先完成设备注册'
+    })
+  })
+
+  it('原生层 status=0 + error_kind=keyring_unavailable → secure_storage_unavailable', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 0,
+      body: '',
+      error_kind: 'keyring_unavailable',
+      error_message: '系统安全存储不可用，设备身份功能已停用（fail closed，不降级）：模拟'
+    }) as never
+    const err = await fetchAuthHistory().catch((e: unknown) => e)
+    expect(err).toMatchObject({ code: 'secure_storage_unavailable' })
+    // 用户文案来自 Rust 已脱敏 Display，不携带 device_id
+    expect((err as IdentityServiceError).message).not.toContain(TEST_DEVICE_ID)
+  })
+
+  it('原生层 status=0 + error_kind=network → network_unavailable', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 0,
+      body: '',
+      error_kind: 'network',
+      error_message: '身份服务网络请求失败：连接超时'
+    }) as never
+    await expect(fetchAuthHistory()).rejects.toMatchObject({ code: 'network_unavailable' })
+  })
+
+  it('原生层 status=0 + error_kind=api（防御分支）→ 按状态码兜底映射', async () => {
+    // 理论不可达：api 类错误应携带 HTTP status（#776）；防御性走 500 兜底
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue({
+      status: 0,
+      body: '',
+      error_kind: 'api',
+      error_message: '身份服务返回错误（HTTP 500）：服务器内部错误'
+    }) as never
+    await expect(fetchAuthHistory()).rejects.toMatchObject({ code: 'unknown' })
   })
 })
 

--- a/apps/client/src/features/identity/authHistoryRegression.spec.ts
+++ b/apps/client/src/features/identity/authHistoryRegression.spec.ts
@@ -1,0 +1,269 @@
+// src/features/identity/authHistoryRegression.spec.ts
+//
+// #775：授权记录（auth-history）服务层跨层回归测试。
+//
+// 覆盖 issue #775「客户端可测子集」的前端服务层部分：
+//   1. fetchAuthHistory 前置守卫：无 device_id / 非 Tauri 运行时 → device_not_bound，
+//      且绝不发起原生命令调用（identityFetchAuthHistory 零调用）；
+//   2. 原生返回 status=200：合法 items 原样返回；空 items / 缺 items / 空 body → 空数组不抛；
+//   3. status=200 + 非法 JSON body：当前实现 JSON.parse 直接抛 SyntaxError，
+//      被 catch 折叠为 network_unavailable —— 本测试把该现状固化为契约，
+//      待 #776 修复后应改为「返回空数组」，届时需同步调整本用例；
+//   4. 非 200（401/403/404/500）：按 throwMappedError 现状断言映射行为
+//      （响应体无错误信息时 code 兜底为 unknown、message 取状态码兜底文案；
+//      携带 Core 错误体时按 mapServerCode 映射为用户可读错误码并透传脱敏文案）；
+//   5. 原生 invoke 抛错 → 折叠为 network_unavailable（同样可能被 #776 改变，注明）；
+//   6. DEFAULT_MESSAGES 契约：全部错误码默认文案非空、不含错误码字样。
+//
+// mock 方式：vi.mock('../../platform/native')（identityService.ts 的实际 import 路径）。
+// 测试数据一律使用假 device_id（device-test-0001），绝不包含真实凭据。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  createServiceError,
+  fetchAuthHistory,
+  IDENTITY_DEVICE_ID_KEY
+} from './identityService'
+import { identityFetchAuthHistory, isTauriRuntime } from '../../platform/native'
+import {
+  IdentityServiceError,
+  type IdentityAuthHistoryItem,
+  type IdentityUserSafeErrorCode
+} from './types'
+
+vi.mock('../../platform/native', () => ({
+  invokeNative: vi.fn(),
+  isTauriRuntime: vi.fn(() => true),
+  identityFetchAuthHistory: vi.fn()
+}))
+
+// ─── 测试基建（node 环境无 localStorage，注入 stub；fetch 全局 stub 隔离诊断上报） ──
+
+const TEST_DEVICE_ID = 'device-test-0001'
+
+const storageMap = new Map<string, string>()
+const stubStorage = {
+  getItem: (key: string) => storageMap.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storageMap.set(key, String(value))
+  },
+  removeItem: (key: string) => {
+    storageMap.delete(key)
+  },
+  clear: () => storageMap.clear(),
+  key: (index: number) => Array.from(storageMap.keys())[index] ?? null,
+  length: 0
+}
+
+/** 构造授权历史条目 fixture（假数据，不含真实凭据） */
+const makeItem = (requestId: string, appName: string): IdentityAuthHistoryItem => ({
+  request_id: requestId,
+  approved_at: new Date(Date.now() - 60_000).toISOString(),
+  status: 'approved',
+  client: {
+    name: appName,
+    homepage_host: 'app.example.test',
+    developer_display_name: '测试开发者',
+    review_status: 'verified'
+  },
+  scopes: [{ id: 'profile', label: '查看基本资料', risk: 'basic' }]
+})
+
+const nativeOk = (status: number, body: string) => ({ status, body })
+
+beforeEach(() => {
+  storageMap.clear()
+  storageMap.set(IDENTITY_DEVICE_ID_KEY, TEST_DEVICE_ID)
+  ;(globalThis as { localStorage?: Storage }).localStorage = stubStorage as unknown as Storage
+  // 隔离 reportIdentityDiag 的诊断上报（不真正发 localhost 请求）
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)))
+  vi.mocked(isTauriRuntime).mockReturnValue(true)
+})
+
+afterEach(() => {
+  delete (globalThis as { localStorage?: Storage }).localStorage
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ─── 1. 前置守卫 ──────────────────────────────────────────────────────────────
+
+describe('#775 fetchAuthHistory 前置守卫', () => {
+  it('无 device_id → device_not_bound 且不发起原生命令调用', async () => {
+    storageMap.delete(IDENTITY_DEVICE_ID_KEY)
+    let caught: unknown = null
+    try {
+      await fetchAuthHistory()
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(IdentityServiceError)
+    expect(caught).toMatchObject({
+      code: 'device_not_bound',
+      name: 'IdentityServiceError'
+    })
+    expect((caught as IdentityServiceError).message).toContain('设备注册')
+    expect(identityFetchAuthHistory).not.toHaveBeenCalled()
+  })
+
+  it('非 Tauri 运行时 → device_not_bound 且不发起原生命令调用', async () => {
+    vi.mocked(isTauriRuntime).mockReturnValue(false)
+    await expect(fetchAuthHistory()).rejects.toMatchObject({ code: 'device_not_bound' })
+    expect(identityFetchAuthHistory).not.toHaveBeenCalled()
+  })
+})
+
+// ─── 2. status=200：正常与空态 ────────────────────────────────────────────────
+
+describe('#775 fetchAuthHistory 200 响应解析', () => {
+  it('合法 items → 原样返回数组，并把 device_id 透传给原生命令', async () => {
+    const items = [makeItem('ar_test_0001', '课程助手'), makeItem('ar_test_0002', '打印助手')]
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeOk(200, JSON.stringify({ items })) as never
+    )
+    await expect(fetchAuthHistory()).resolves.toEqual(items)
+    expect(identityFetchAuthHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ device_id: TEST_DEVICE_ID })
+    )
+  })
+
+  it('空 items → 空数组', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeOk(200, JSON.stringify({ items: [] })) as never
+    )
+    await expect(fetchAuthHistory()).resolves.toEqual([])
+  })
+
+  it('缺 items 字段 → 空数组（宽容解析，不抛）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeOk(200, '{}') as never)
+    await expect(fetchAuthHistory()).resolves.toEqual([])
+  })
+
+  it('body 为空字符串 → 空数组（fallback 解析 {}）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeOk(200, '') as never)
+    await expect(fetchAuthHistory()).resolves.toEqual([])
+  })
+})
+
+// ─── 3. 非法 JSON body（现状契约，待 #776 对齐） ─────────────────────────────
+
+describe('#775 fetchAuthHistory 非法 JSON body（现状契约）', () => {
+  it('status=200 + 非法 JSON → 现状折叠为 network_unavailable（应为空态，待 #776 修复对齐）', async () => {
+    // 当前实现 `JSON.parse(output.body || '{}')` 无局部保护：
+    // SyntaxError 进外层 catch → network_unavailable('无法加载授权记录，请稍后重试')。
+    // 正确语义应为「返回空数组不抛」—— #776 修复后本用例需改为 resolves.toEqual([])。
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeOk(200, '{{not-json') as never)
+    await expect(fetchAuthHistory()).rejects.toMatchObject({
+      code: 'network_unavailable',
+      message: '无法加载授权记录，请稍后重试'
+    })
+  })
+})
+
+// ─── 4. 非 200 状态映射（按 throwMappedError 现状断言） ───────────────────────
+
+describe('#775 fetchAuthHistory 非 200 状态映射（现状契约）', () => {
+  it.each([
+    [401, '接力凭据无效，请从网页重新发起授权'],
+    [403, '当前设备已被撤销，无法继续授权'],
+    [404, '请求不存在或已完成'],
+    [500, '授权处理失败，请稍后重试']
+  ] as const)('HTTP %i 无错误体 → code=unknown + 状态码兜底文案（现状映射）', async (status, message) => {
+    // 现状：响应体无 error 信息时 parseErrorPayload 得到 HTTP_xxx 伪码，
+    // mapServerCode 兜底为 unknown，但 message 保留 mapStatusFallback 的状态码文案。
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeOk(status, '') as never)
+    await expect(fetchAuthHistory()).rejects.toMatchObject({ code: 'unknown', message })
+  })
+
+  it('401 + Core 结构化错误体 → 按 mapServerCode 映射并透传脱敏文案', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeOk(
+        401,
+        JSON.stringify({ error: { code: 'DEVICE_AUTH_FAILED', message: '设备签名验证失败' } })
+      ) as never
+    )
+    await expect(fetchAuthHistory()).rejects.toMatchObject({
+      code: 'device_revoked',
+      message: '设备签名验证失败'
+    })
+  })
+
+  it('401 + 纯 code 错误体（error 为字符串）→ 映射为 invalid_handoff', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(
+      nativeOk(401, JSON.stringify({ error: 'INVALID_HANDOFF' })) as never
+    )
+    await expect(fetchAuthHistory()).rejects.toMatchObject({
+      code: 'invalid_handoff',
+      message: '接力凭据无效，请从网页重新发起授权'
+    })
+  })
+
+  it('非 200 + 非法 JSON 错误体 → 仍按状态码兜底映射，不因解析失败误报网络错误', async () => {
+    vi.mocked(identityFetchAuthHistory).mockResolvedValue(nativeOk(403, '<html>gateway</html>') as never)
+    await expect(fetchAuthHistory()).rejects.toMatchObject({
+      code: 'unknown',
+      message: '当前设备已被撤销，无法继续授权'
+    })
+  })
+})
+
+// ─── 5. 原生调用失败折叠（现状契约，可能被 #776 改变） ────────────────────────
+
+describe('#775 fetchAuthHistory 原生调用失败折叠（现状契约）', () => {
+  it('invoke 抛错 → 折叠为 network_unavailable（用户可读文案，不泄露内部错误）', async () => {
+    vi.mocked(identityFetchAuthHistory).mockRejectedValue(
+      new Error('invoke failed: identity_fetch_auth_history panic detail')
+    )
+    const err = await fetchAuthHistory().catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(IdentityServiceError)
+    expect(err).toMatchObject({
+      code: 'network_unavailable',
+      message: '无法加载授权记录，请稍后重试'
+    })
+    // 内部细节只进 internalDetail（脱敏日志），不进用户文案
+    expect((err as IdentityServiceError).message).not.toContain('panic detail')
+    expect((err as IdentityServiceError).internalDetail).toContain('invoke failed')
+  })
+})
+
+// ─── 6. DEFAULT_MESSAGES 全覆盖契约 ──────────────────────────────────────────
+
+describe('#775 DEFAULT_MESSAGES 用户可读文案契约', () => {
+  // 与 types.ts 的 IdentityUserSafeErrorCode 清单保持同步（源码契约用例会在
+  // DEFAULT_MESSAGES 键数量变化时给出失败信号，防止漏配）。
+  const ALL_CODES: IdentityUserSafeErrorCode[] = [
+    'request_expired',
+    'request_not_found',
+    'client_unavailable',
+    'invalid_handoff',
+    'network_unavailable',
+    'device_not_bound',
+    'device_revoked',
+    'session_revalidation_required',
+    'secure_storage_unavailable',
+    'signature_rejected',
+    'signing_material_missing',
+    'test_account_blocked',
+    'unknown'
+  ]
+
+  it('全部错误码默认文案非空且不含错误码字样', () => {
+    for (const code of ALL_CODES) {
+      const err = createServiceError(code)
+      expect(err, `错误码 ${code} 应构造 IdentityServiceError`).toBeInstanceOf(IdentityServiceError)
+      expect(err.code).toBe(code)
+      expect(err.message.trim().length, `错误码 ${code} 默认文案为空`).toBeGreaterThan(4)
+      expect(err.message, `错误码 ${code} 文案不应包含错误码 key 字样`).not.toContain(code)
+    }
+  })
+
+  it('DEFAULT_MESSAGES 键集合与错误码清单一致（源码契约，防新增 code 漏配）', () => {
+    const source = readFileSync(new URL('./identityService.ts', import.meta.url), 'utf8')
+    const start = source.indexOf('const DEFAULT_MESSAGES')
+    expect(start).toBeGreaterThan(0)
+    const block = source.slice(start, source.indexOf('}', start))
+    const keys = Array.from(block.matchAll(/^\s{2}([a-z_]+):/gm)).map((m) => m[1])
+    expect(keys.sort()).toEqual([...ALL_CODES].sort())
+  })
+})

--- a/apps/client/src/features/identity/authHistoryViewRegression.spec.ts
+++ b/apps/client/src/features/identity/authHistoryViewRegression.spec.ts
@@ -1,0 +1,306 @@
+// src/features/identity/authHistoryViewRegression.spec.ts
+//
+// #775：授权记录视图（IdentityAuthHistoryView.vue）回归测试。
+//
+// 仓库未引入 @vue/test-utils、vitest 主配置为 node 环境（无 DOM），本文件沿用
+// ScheduleAddCourseDialog.spec.ts（#760）确立的「无 DOM 组件测试」先例：
+//   A. 源码契约断言（readFileSync）：锁定视图的状态机分支、空态/引导/错误/重试、
+//      loading 期间的刷新防并发入口（:disabled="loading"）；
+//   B. 行为级测试：用 vue/compiler-sfc 把 <script setup> 编译为 setup 函数，
+//      注入真实 Vue（reactive/computed/ref）与 mock 依赖后复刻
+//      「挂载 → 自动 load → 状态切换」数据流，覆盖初始 loading、成功渲染、
+//      空态、no_device 引导、error + 重试、刷新提示。
+//
+// mock 方式：vi.mock('./identityService') + vi.mock('../../utils/toast')。
+// 测试数据一律使用假 request_id / 假应用名，绝不包含真实凭据。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { parse, compileScript } from 'vue/compiler-sfc'
+import { nextTick, reactive } from 'vue'
+import { IdentityServiceError, type IdentityAuthHistoryItem } from './types'
+
+vi.mock('./identityService', () => ({
+  fetchAuthHistory: vi.fn(),
+  IDENTITY_DEVICE_ID_KEY: 'hbu_identity_device_id'
+}))
+
+vi.mock('../../utils/toast', () => ({
+  showToast: vi.fn()
+}))
+
+import { fetchAuthHistory } from './identityService'
+import { showToast } from '../../utils/toast'
+
+// ─── SFC 编译基建：把 <script setup> 编译为可执行的 setup 函数体 ─────────────
+
+const SFC_PATH = new URL('./views/IdentityAuthHistoryView.vue', import.meta.url)
+const viewSource = () => readFileSync(SFC_PATH, 'utf8')
+
+interface ViewCtx {
+  items: IdentityAuthHistoryItem[]
+  loadState: string
+  errorMessage: string
+  loading: boolean
+  totalCount: number
+  appCount: number
+  lastTime: string
+  load: () => Promise<void>
+  handleRefresh: () => Promise<void>
+}
+
+/**
+ * 编译视图 SFC 并执行 setup，返回 setup 暴露的响应式上下文。
+ *
+ * 实现要点（剥壳方案已在纯 node 下逐段验证）：
+ * 1) 去类型语法：compileScript 保留 TS 类型（type 别名 / 泛型 ref / 标注参数），
+ *    new Function 只能执行纯 JS，逐一替换为本视图实际出现的形态；
+ * 2) 清除 import 行后统一注入依赖（固定注入头，不用捕获组回引）；
+ * 3) 用 indexOf 切片剥掉 defineComponent 包裹壳：头部截到 `__expose();` 之后，
+ *    尾部截到 `return __returned__` 之后的 setup 闭合 `}` 之前；
+ * 4) `const emit = __emit` 指向注入的空函数（视图仅声明 emits，测试不触发回传）。
+ */
+const setupView = (): ViewCtx => {
+  const source = viewSource()
+  const { descriptor, errors } = parse(source, { filename: 'IdentityAuthHistoryView.vue' })
+  if (errors.length > 0 || !descriptor.scriptSetup) {
+    throw new Error(`视图 SFC 解析失败：${errors.map(String).join('; ')}`)
+  }
+  const compiled = compileScript(descriptor, { id: 'auth-history-view-test' })
+  const onMountedHooks: Array<() => void> = []
+  let body = compiled.content
+    // 1) 去类型语法（type 别名行无分号，按行删除；ref 泛型 / 参数标注逐一替换）
+    .replace(/^type\s+LoadState[^\n]*/gm, '')
+    .replace(/ref<IdentityAuthHistoryItem\[\]>\(\[\]\)/, 'ref([])')
+    .replace(/ref<LoadState>\('loading'\)/, "ref('loading')")
+    .replace(/\(iso: string\): string =>/g, '(iso) =>')
+    .replace(/\(n: number\) =>/g, '(n) =>')
+    // 2) 清除所有 import 行（后续统一注入）
+    .replace(/^import[^\n]*/gm, '')
+  // 3) 剥壳头：`export default ...defineComponent({...setup(__props, {...) { __expose();`
+  const headStart = body.indexOf('export default')
+  const exposeEnd = body.indexOf('__expose();')
+  if (headStart < 0 || exposeEnd < 0) {
+    throw new Error('视图编译产物结构变化：未找到 defineComponent setup 壳头')
+  }
+  body = body.slice(0, headStart) + body.slice(exposeEnd + '__expose();'.length)
+  // 4) 剥壳尾：截到 `return __returned__` 之后的 setup 闭合 `}` 之前
+  const retIdx = body.indexOf('return __returned__')
+  const setupClose = retIdx >= 0 ? body.indexOf('}', retIdx) : -1
+  if (retIdx < 0 || setupClose < 0) {
+    throw new Error('视图编译产物结构变化：未找到 __returned__ 返回段')
+  }
+  body = body.slice(0, setupClose)
+  body = body.replace(/const emit = __emit/, 'const emit = __emit__')
+  const factory = new Function(
+    '__vue__',
+    '__onMountedHooks__',
+    '__identityService__',
+    '__types__',
+    '__toast__',
+    '__emit__',
+    'const { computed, ref } = __vue__;\n' +
+      'const onMounted = (hook) => { __onMountedHooks__.push(hook) };\n' +
+      'const TPageHeader = null; const TEmptyState = null;\n' +
+      'const { fetchAuthHistory } = __identityService__;\n' +
+      'const { IdentityServiceError } = __types__;\n' +
+      'const { showToast } = __toast__;\n' +
+      `${body}\nreturn __returned__;`
+  )
+  const result = factory(
+    // 真实 Vue 响应式 API（ref/computed 语义与运行时一致）
+    { computed: computedVue, ref: refVue },
+    onMountedHooks,
+    { fetchAuthHistory },
+    { IdentityServiceError },
+    { showToast },
+    () => {}
+  )
+  // reactive 包裹让测试读取 .value 解包后的最新状态（模拟模板读取行为）
+  const ctx = reactive(result as unknown as ViewCtx) as ViewCtx
+  // 复刻挂载：显式执行 onMounted 注册的 load
+  for (const hook of onMountedHooks) {
+    hook()
+  }
+  return ctx
+}
+
+// 真实 vue 的 ref/computed（从模块图引入，避免 new Function 闭包内 import）
+import { computed as computedVue, ref as refVue } from 'vue'
+
+/** 冲刷微任务队列（load 的 await 链）并推进渲染 */
+const flushAsync = async (times = 6): Promise<void> => {
+  for (let i = 0; i < times; i += 1) await Promise.resolve()
+  await nextTick()
+}
+
+// ─── 测试数据（假 request_id / 假应用名） ────────────────────────────────────
+
+const makeItem = (requestId: string, appName: string): IdentityAuthHistoryItem => ({
+  request_id: requestId,
+  approved_at: new Date(Date.now() - 120_000).toISOString(),
+  status: 'approved',
+  client: {
+    name: appName,
+    homepage_host: `${appName}.example.test`,
+    developer_display_name: '测试开发者',
+    review_status: 'verified'
+  },
+  scopes: [
+    { id: 'profile', label: '基本资料', risk: 'basic' },
+    { id: 'student.identity', label: '学籍信息', risk: 'sensitive' }
+  ]
+})
+
+beforeEach(() => {
+  vi.mocked(fetchAuthHistory).mockReset()
+  vi.mocked(showToast).mockClear()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// ─── A. 源码契约（无 DOM 门闩） ───────────────────────────────────────────────
+
+describe('#775 授权记录视图源码契约', () => {
+  it('四态状态机 + 设备未绑定引导 + 错误重试按钮 + 空态文案必须存在', () => {
+    const source = viewSource()
+    expect(source).toContain("type LoadState = 'loading' | 'ready' | 'error' | 'no_device'")
+    expect(source).toContain("loadState === 'no_device'")
+    expect(source).toContain('本机尚未注册为身份签名设备')
+    expect(source).toContain("loadState === 'error'")
+    expect(source).toContain('history-retry-btn')
+    expect(source).toContain('>重试</button>')
+    expect(source).toContain('还没有授权记录')
+  })
+
+  it('device_not_bound 精确映射 no_device，其余错误映射 error（分支契约）', () => {
+    const source = viewSource()
+    expect(source).toContain("err.code === 'device_not_bound'")
+    expect(source).toContain("loadState.value = 'no_device'")
+    expect(source).toContain("loadState.value = 'error'")
+  })
+
+  it('刷新入口在 loading 期间禁用（防并发重复请求的 UI 门闩）', () => {
+    const source = viewSource()
+    expect(source).toMatch(/:disabled="loading"/)
+    expect(source).toContain('@click="handleRefresh"')
+  })
+})
+
+// ─── B. 行为级测试（真实响应式数据流） ────────────────────────────────────────
+
+describe('#775 授权记录视图数据流', () => {
+  it('初始为 loading 态（fetch 挂起期间）', async () => {
+    let resolveFetch: (v: IdentityAuthHistoryItem[]) => void = () => {}
+    vi.mocked(fetchAuthHistory).mockReturnValue(
+      new Promise<IdentityAuthHistoryItem[]>((resolve) => {
+        resolveFetch = resolve
+      })
+    )
+    const ctx = setupView()
+    expect(ctx.loadState).toBe('loading')
+    expect(ctx.loading).toBe(true)
+    resolveFetch([])
+    await flushAsync()
+  })
+
+  it('成功返回 2 条 → ready，应用名 / scope 标签 / 时间与统计渲染', async () => {
+    const items = [makeItem('ar_test_0001', '课程助手'), makeItem('ar_test_0002', '打印助手')]
+    vi.mocked(fetchAuthHistory).mockResolvedValue(items)
+    const ctx = setupView()
+    await flushAsync()
+    expect(ctx.loadState).toBe('ready')
+    expect(ctx.items).toHaveLength(2)
+    expect(ctx.items[0]?.client.name).toBe('课程助手')
+    expect(ctx.items[1]?.scopes.some((s) => s.risk === 'sensitive')).toBe(true)
+    // 统计派生值（模板渲染数据源）：总次数 / 去重应用数
+    expect(ctx.totalCount).toBe(2)
+    expect(ctx.appCount).toBe(2)
+    // 相对时间已格式化（2 分钟前 → "2 分钟前"）
+    expect(ctx.lastTime).toBe('2 分钟前')
+    // 渲染契约：应用名来自 sanitized 数据；scope 标签与 sensitive 高亮分支存在
+    const source = viewSource()
+    expect(source).toContain('{{ item.client.name')
+    expect(source).toContain('v-for="scope in item.scopes"')
+    expect(source).toContain("scope.risk === 'sensitive'")
+    expect(source).toContain('formatRelativeTime(item.approved_at)')
+    expect(source).toContain('授权次数')
+  })
+
+  it('空数组 → ready 空态（items 为空，模板走 TEmptyState 分支）', async () => {
+    vi.mocked(fetchAuthHistory).mockResolvedValue([])
+    const ctx = setupView()
+    await flushAsync()
+    expect(ctx.loadState).toBe('ready')
+    expect(ctx.items).toEqual([])
+    const source = viewSource()
+    expect(source).toContain("loadState === 'ready' && items.length === 0")
+  })
+
+  it('device_not_bound → no_device 引导 + 错误文案进引导块', async () => {
+    vi.mocked(fetchAuthHistory).mockRejectedValue(
+      new IdentityServiceError(
+        'device_not_bound',
+        '本机尚未注册为身份签名设备，请先在设置中完成设备注册'
+      )
+    )
+    const ctx = setupView()
+    await flushAsync()
+    expect(ctx.loadState).toBe('no_device')
+    expect(ctx.errorMessage).toContain('设备注册')
+  })
+
+  it('network_unavailable → error 态；点重试重新调用 load，成功后恢复 ready', async () => {
+    vi.mocked(fetchAuthHistory).mockRejectedValueOnce(
+      new IdentityServiceError('network_unavailable', '无法加载授权记录，请稍后重试')
+    )
+    const ctx = setupView()
+    await flushAsync()
+    expect(ctx.loadState).toBe('error')
+    expect(ctx.errorMessage).toBe('无法加载授权记录，请稍后重试')
+    // 点「重试」：重试按钮绑定 load；第 2 次调用成功
+    vi.mocked(fetchAuthHistory).mockResolvedValueOnce([makeItem('ar_test_0003', '重试后应用')])
+    await ctx.load()
+    await flushAsync()
+    expect(vi.mocked(fetchAuthHistory)).toHaveBeenCalledTimes(2)
+    expect(ctx.loadState).toBe('ready')
+  })
+
+  it('非 IdentityServiceError 的裸错误 → error 态兜底文案（不泄露内部细节）', async () => {
+    vi.mocked(fetchAuthHistory).mockRejectedValue(new Error('TypeError: cannot read internal'))
+    const ctx = setupView()
+    await flushAsync()
+    expect(ctx.loadState).toBe('error')
+    expect(ctx.errorMessage).toBe('加载失败，请稍后重试')
+  })
+
+  it('handleRefresh 顺序 await load，不产生交叉并发请求', async () => {
+    vi.mocked(fetchAuthHistory).mockResolvedValue([makeItem('ar_test_0004', '刷新应用')])
+    const ctx = setupView()
+    await flushAsync()
+    // 刷新成功后提示「授权记录已刷新」
+    await ctx.handleRefresh()
+    await flushAsync()
+    expect(vi.mocked(fetchAuthHistory)).toHaveBeenCalledTimes(2)
+    expect(showToast).toHaveBeenCalledWith('授权记录已刷新')
+  })
+
+  it('刷新期间 loading 门闩存在：UI 禁用 + handleRefresh 不吞错误状态', async () => {
+    // 第一次成功挂载
+    vi.mocked(fetchAuthHistory).mockResolvedValue([makeItem('ar_test_0005', '门闩应用')])
+    const ctx = setupView()
+    await flushAsync()
+    expect(ctx.loading).toBe(false)
+    // 刷新失败 → error 态（handleRefresh 不吞错，loadState 落 error，可再点重试）
+    vi.mocked(fetchAuthHistory).mockRejectedValueOnce(
+      new IdentityServiceError('network_unavailable', '无法加载授权记录，请稍后重试')
+    )
+    await ctx.handleRefresh()
+    await flushAsync()
+    expect(ctx.loadState).toBe('error')
+    // 源码契约：loading 期间刷新按钮 disabled（真实点击被 UI 挡住，防并发入口）
+    expect(viewSource()).toMatch(/:disabled="loading"/)
+  })
+})

--- a/apps/client/src/features/identity/authHistoryViewRegression.spec.ts
+++ b/apps/client/src/features/identity/authHistoryViewRegression.spec.ts
@@ -75,6 +75,8 @@ const setupView = (): ViewCtx => {
     .replace(/ref<LoadState>\('loading'\)/, "ref('loading')")
     .replace(/\(iso: string\): string =>/g, '(iso) =>')
     .replace(/\(n: number\) =>/g, '(n) =>')
+    // #776：errorHintFor 的签名标注（视图新增的错误指引映射函数）
+    .replace(/\(code: string\): string =>/g, '(code) =>')
     // 2) 清除所有 import 行（后续统一注入）
     .replace(/^import[^\n]*/gm, '')
   // 3) 剥壳头：`export default ...defineComponent({...setup(__props, {...) { __expose();`

--- a/apps/client/src/features/identity/identityService.ts
+++ b/apps/client/src/features/identity/identityService.ts
@@ -24,7 +24,12 @@ import type {
   IdentityUserSafeErrorCode
 } from './types'
 import { IdentityServiceError } from './types'
-import { invokeNative, isTauriRuntime, identityFetchAuthHistory } from '../../platform/native'
+import {
+  invokeNative,
+  isTauriRuntime,
+  identityFetchAuthHistory,
+  type IdentityAuthHistoryNativeOutput
+} from '../../platform/native'
 
 /**
  * 本机设备 ID 的 localStorage key（与 identityStore.ts 的 IDENTITY_DEVICE_ID_KEY 保持一致）。
@@ -448,11 +453,38 @@ export const submitApprove = async (input: {
 }
 
 /**
+ * #777：原生层 error_kind → 用户可读错误码。
+ * 契约源头：commands.rs 的 error_kind_of（IdentityError 变体一一对应）。
+ */
+const mapAuthHistoryErrorKind = (kind: string): IdentityUserSafeErrorCode => {
+  switch (kind) {
+    case 'not_enrolled':
+      return 'device_not_bound'
+    case 'keyring_unavailable':
+    case 'keyring_write_mismatch':
+    case 'keyring_backend_missing':
+      return 'secure_storage_unavailable'
+    case 'network':
+      return 'network_unavailable'
+    case 'invalid_input':
+    case 'core_base_url_missing':
+    case 'no_local_login':
+    case 'internal':
+      return 'unknown'
+    default:
+      return 'unknown'
+  }
+}
+
+/**
  * 拉取本机授权历史（「授权记录」页数据源）。
  *
  * 认证：设备签名（MINI-HBUT-DEVICE-API-V1）。私钥在 Rust keyring，canonical 绑定
  * GET /api/v1/app/devices/me/auth-history，故 Tauri 环境必须走 Rust command
  * `identity_fetch_auth_history`；Web/Capacitor 无签名能力，明确提示不支持。
+ *
+ * #777：原生层错误不再折叠为单一文案 —— error_kind 映射为用户可读错误码
+ * （未注册/安全存储不可用/网络失败等），api 类错误按 Core HTTP 状态映射（#776）。
  */
 export const fetchAuthHistory = async (): Promise<IdentityAuthHistoryItem[]> => {
   const deviceId = typeof localStorage !== 'undefined'
@@ -464,35 +496,60 @@ export const fetchAuthHistory = async (): Promise<IdentityAuthHistoryItem[]> => 
   if (!isTauriRuntime()) {
     throw createServiceError('device_not_bound', '授权记录仅支持在桌面端查看')
   }
+  let output: IdentityAuthHistoryNativeOutput
   try {
-    const output = await identityFetchAuthHistory<{ status: number; body: string }>({
+    output = await identityFetchAuthHistory({
       base_url: getIdentityCoreBaseUrl(),
       device_id: deviceId
     })
-    if (output.status !== 200) {
-      let data: unknown = null
-      if (output.body) {
-        try {
-          data = JSON.parse(output.body)
-        } catch {
-          data = null
-        }
-      }
-      throwMappedError(output.status, data, 'fetchAuthHistory')
-    }
-    const parsed = JSON.parse(output.body || '{}') as IdentityAuthHistoryResponse
-    return Array.isArray(parsed?.items) ? parsed.items : []
   } catch (err) {
-    if (err instanceof IdentityServiceError) throw err
+    // invoke 本身失败（panic/运行时异常）：无法拿到结构化分类，按网络类兜底
     reportIdentityDiag('auth_history_error', {
       error: String((err as Error)?.message || 'fetchAuthHistory failed').slice(0, 200)
     })
     throw createServiceError(
       'network_unavailable',
-      '无法加载授权记录，请稍后重试',
+      '无法连接身份服务，请检查网络后重试',
       String((err as Error)?.message || 'fetchAuthHistory failed')
     )
   }
+  // 原生层失败（status=0）：按 error_kind 分类，internalDetail 只含脱敏诊断
+  if (output.status === 0) {
+    const kind = String(output.error_kind || 'internal')
+    if (kind === 'api') {
+      // 理论不可达（api 类应携带 HTTP status）；防御性走状态码映射
+      throwMappedError(500, null, 'fetchAuthHistory')
+    }
+    const code = mapAuthHistoryErrorKind(kind)
+    reportIdentityDiag('auth_history_failed', { kind, status: output.status })
+    throw createServiceError(
+      code,
+      output.error_message || DEFAULT_MESSAGES[code],
+      `fetchAuthHistory -> native error_kind=${kind}`
+    )
+  }
+  // Core HTTP 状态透传（#776）：非 200 按响应体 + 状态码统一映射
+  if (output.status !== 200) {
+    let data: unknown = null
+    if (output.body) {
+      try {
+        data = JSON.parse(output.body)
+      } catch {
+        data = null
+      }
+    }
+    throwMappedError(output.status, data, 'fetchAuthHistory')
+  }
+  // 成功：宽容解析（空 body / 缺 items → 空数组，不因响应体异常误报网络错误）
+  let parsed: IdentityAuthHistoryResponse | null = null
+  if (output.body) {
+    try {
+      parsed = JSON.parse(output.body) as IdentityAuthHistoryResponse
+    } catch {
+      parsed = null
+    }
+  }
+  return Array.isArray(parsed?.items) ? parsed.items : []
 }
 
 /**

--- a/apps/client/src/features/identity/views/IdentityAuthHistoryView.vue
+++ b/apps/client/src/features/identity/views/IdentityAuthHistoryView.vue
@@ -17,6 +17,8 @@ type LoadState = 'loading' | 'ready' | 'error' | 'no_device'
 const items = ref<IdentityAuthHistoryItem[]>([])
 const loadState = ref<LoadState>('loading')
 const errorMessage = ref('')
+/** #777：错误态附加指引（如安全存储不可用的重启建议；空字符串表示无附加指引） */
+const errorHint = ref('')
 const loading = ref(false)
 
 /** 相对时间（刚刚 / N 分钟前 / N 小时前 / N 天前 / 具体日期） */
@@ -55,6 +57,7 @@ const load = async () => {
   loading.value = true
   loadState.value = 'loading'
   errorMessage.value = ''
+  errorHint.value = ''
   try {
     items.value = await fetchAuthHistory()
     loadState.value = 'ready'
@@ -65,6 +68,10 @@ const load = async () => {
     } else {
       loadState.value = 'error'
       errorMessage.value = err instanceof IdentityServiceError ? err.message : '加载失败，请稍后重试'
+      // #777：安全存储不可用给出专属指引（fail closed，重启应用可能恢复临时性故障）
+      if (err instanceof IdentityServiceError && err.code === 'secure_storage_unavailable') {
+        errorHint.value = '这通常是系统凭据存储暂时不可用。可尝试完全退出并重启本应用后重试；若持续出现，请通过「设置 → 关于」反馈版本号。'
+      }
     }
   } finally {
     loading.value = false
@@ -120,6 +127,7 @@ onMounted(() => {
       <span class="material-symbols-outlined tip-icon tip-icon--error">error</span>
       <p class="tip-title">加载失败</p>
       <p class="tip-desc">{{ errorMessage }}</p>
+      <p v-if="errorHint" class="tip-desc tip-hint">{{ errorHint }}</p>
       <button class="history-retry-btn" @click="load">重试</button>
     </section>
 
@@ -283,6 +291,13 @@ onMounted(() => {
   font-size: 13px;
   line-height: 1.7;
   color: var(--ui-muted, #64748b);
+}
+
+/* #777：错误附加指引（与主文案区分的弱化样式） */
+.tip-hint {
+  margin-top: 8px;
+  font-size: 12px;
+  color: color-mix(in oklab, var(--ui-muted, #64748b) 80%, var(--ui-text, #1f2937));
 }
 
 .history-retry-btn {

--- a/apps/client/src/features/identity/views/IdentityAuthHistoryView.vue
+++ b/apps/client/src/features/identity/views/IdentityAuthHistoryView.vue
@@ -53,6 +53,26 @@ const appCount = computed(() => new Set(items.value.map((i) => i.client.name)).s
 /** 最近授权时间 */
 const lastTime = computed(() => (items.value[0] ? formatRelativeTime(items.value[0].approved_at) : '—'))
 
+/** #777/#776：错误码 → 错误态下一步指引（无指引返回空字符串） */
+const errorHintFor = (code: string): string => {
+  switch (code) {
+    case 'secure_storage_unavailable':
+      return '这通常是系统凭据存储暂时不可用。可尝试完全退出并重启本应用后重试；若持续出现，请通过「设置 → 关于」反馈版本号。'
+    case 'device_revoked':
+      return '本机设备身份已被撤销。请在「设置 → 登录与安全」重新完成设备注册后再查看授权记录。'
+    case 'signature_rejected':
+      return '签名校验未通过，可点击重试；若持续失败，请重新完成设备注册。'
+    case 'network_unavailable':
+      return '请检查网络连接后点击重试。'
+    case 'client_unavailable':
+      return '发起授权的应用已被暂停，历史记录暂时无法查看。'
+    case 'unknown':
+      return '身份服务暂时不可用，请稍后重试。'
+    default:
+      return ''
+  }
+}
+
 const load = async () => {
   loading.value = true
   loadState.value = 'loading'
@@ -68,9 +88,9 @@ const load = async () => {
     } else {
       loadState.value = 'error'
       errorMessage.value = err instanceof IdentityServiceError ? err.message : '加载失败，请稍后重试'
-      // #777：安全存储不可用给出专属指引（fail closed，重启应用可能恢复临时性故障）
-      if (err instanceof IdentityServiceError && err.code === 'secure_storage_unavailable') {
-        errorHint.value = '这通常是系统凭据存储暂时不可用。可尝试完全退出并重启本应用后重试；若持续出现，请通过「设置 → 关于」反馈版本号。'
+      // #776：按错误码给出「下一步指引」，而非统一「加载失败」
+      if (err instanceof IdentityServiceError) {
+        errorHint.value = errorHintFor(err.code)
       }
     }
   } finally {

--- a/apps/client/src/platform/native.ts
+++ b/apps/client/src/platform/native.ts
@@ -201,11 +201,25 @@ export const identityRevokeCurrentDeviceLocal = <T = Record<string, unknown>>(ar
   device_id?: string | null
 }) => invokeNative<T>('identity_revoke_current_device_local', args)
 
+/**
+ * identity_fetch_auth_history 输出（#777 结构化错误分类）：
+ * - status=0：原生层失败（未到达 HTTP），error_kind/error_message 携带失败分类与脱敏文案；
+ * - status>0：Core HTTP 状态码（200 成功，body 为响应体；非 2xx 见 #776 错误体透传）。
+ * 安全约定：error_message 只含已脱敏的 IdentityError Display 文本，绝无私钥/签名/token。
+ */
+export interface IdentityAuthHistoryNativeOutput {
+  status: number
+  body: string
+  error_kind: string | null
+  error_message: string | null
+}
+
 /** 拉取本机授权历史（设备签名认证；「授权记录」页数据源） */
-export const identityFetchAuthHistory = <T = Record<string, unknown>>(args: {
+export const identityFetchAuthHistory = (args: {
   base_url?: string
   device_id: string
-}) => invokeNative<T>('identity_fetch_auth_history', args)
+}): Promise<IdentityAuthHistoryNativeOutput> =>
+  invokeNative<IdentityAuthHistoryNativeOutput>('identity_fetch_auth_history', args)
 
 /** 设备展示名（enrollment device_name 用；不包含任何敏感信息） */
 export const getIdentityDeviceDisplayName = (): string => {


### PR DESCRIPTION
## 概述

「我的 → 授权记录」无法加载的第一层根因：Tauri 命令 `identity_fetch_auth_history` 把设备密钥/签名链路的 `IdentityError`（keyring 不可用、未注册、输入非法等类型化错误）压平成纯字符串 Err，前端无法区分错误类别，全部折叠为「无法加载授权记录」。

## 变更（commit 3bd39a8b）

- `commands.rs`：命令改为结构化输出 `IdentityAuthHistoryOutput { status, body, error_kind, error_message }`——`status=0` 表示原生层失败，`error_kind` 为稳定机器码（`not_enrolled`/`keyring_unavailable`/`keyring_write_mismatch`/`keyring_backend_missing`/`invalid_input`/`network`/`api` 等 10 类），`error_message` 沿用 `IdentityError` Display 已脱敏文本（不含私钥/签名材料）；核心逻辑抽为可注入 `fetch_auth_history_impl(store, ...)` 纯函数 + 薄命令壳，签名链路零改动
- `platform/native.ts`：invoke 输出类型收紧
- `identityService.ts`：新增 `mapAuthHistoryErrorKind` → `IdentityUserSafeErrorCode`（not_enrolled→device_not_bound、keyring_*→secure_storage_unavailable、network→network_unavailable）
- `IdentityAuthHistoryView.vue`：错误态区分安全存储不可用并给出专属指引（重启应用重试/反馈版本）
- 新增 5 个 Rust 单测（注入 MemoryKeyring/FailingKeyring，不触网）：无密钥、keyring 失败、device_id 空、非法 origin、error_kind 全变体覆盖
- `authHistoryRegression.spec.ts`：对齐新契约 + error_kind 映射用例

## 与 #668 的关系

#668（keyring fail-closed）已合入 main，本 PR 不重复其修复，而是让授权记录链路正确消费 fail-closed 错误分类——安全存储不可用时用户看到「本机安全存储不可用」指引而非「网络失败」。

## 验证

- `cargo test --lib identity` 35 passed / `cargo fmt --check` / `cargo check` 0 error
- 前端 identity 目录 156 passed / typecheck 通过 / 全量 1314 用例仅 1 例已知无关 flaky（chaoxing 超时，基线可复现）
- ⚠️ invoke 返回形态变更要求 Rust 与前端同版本发布（新 Rust + 旧前端不崩，旧 Rust + 新前端会误判非 200）

## Windows 实机验证项（发版前）

1. 断网加载授权记录 → network 指引
2. 安全存储不可用 → 重启/反馈指引
3. 设备被撤销（Core 401/403）→ 重新注册引导

Part of #774