### PR TITLE
fix(ci): Release Build Windows job 补齐 MSI 卸载启动器预构建步骤

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,6 +465,15 @@ jobs:
           python scripts/regenerate_official_icons.py
           npx vitest run src/utils/windows_taskbar_icon_contract.spec.ts src/utils/ios_launcher_icon_contract.spec.ts src/utils/android_launcher_icon_contract.spec.ts
 
+      - name: Prepare MSI uninstall launcher (#798)
+        shell: pwsh
+        working-directory: apps/client
+        # 兄弟脚本负责 cargo build 启动器并放到 target/release/ 根目录；
+        # bundler 会在 MSI 打包开始时清空 wix/x64 工作目录，所以 uninstall.exe
+        # 必须放在不被清理的位置，由 main.wxs 以 ..\..\uninstall.exe 相对引用。
+        # 必须在 `tauri build --bundles msi` 之前执行，否则 light.exe 打包失败。
+        run: ./scripts/ci/build_msi_uninstall_launcher.ps1
+
       - name: Build Windows App
         working-directory: apps/client
         run: npm run tauri build -- --bundles nsis,msi


### PR DESCRIPTION
## 问题

v1.4.9 Release Build 的 build-windows job 失败（[run 34074941970](https://github.com/superdaobo/mini-hbut/actions/runs/34074941970)）：

```
failed to bundle project: `failed to run ...WixTools314\light.exe`
```

## 根因

epic #796 引入的 MSI 卸载启动器约定：`main.wxs` 以 `..\..\uninstall.exe` 相对引用 `target/release/uninstall.exe`，该文件必须由 `build_msi_uninstall_launcher.ps1` 在 `tauri build --bundles msi` 之前预编译放置。此步骤已加进 **Windows Release Dry Run** 工作流（该工作流全绿），但 **release.yml** 正式发布工作流漏同步。

其余四个平台（Android/iOS/macOS/Linux）与 create-release 均已 success，仅 Windows MSI 打包受阻，deploy-website 因 needs 未跑。

## 修复

release.yml 的 build-windows job 在 Build Windows App 之前插入与 Dry Run 完全相同的「Prepare MSI uninstall launcher (#798)」步骤。

## 验证路径

合并后在 main 最新 commit 重建 tag `v1.4.9` 触发 Release Build，Windows job 应通过。