### PR TITLE
fix(#810): 顶部安全区固定留白——外层占位+全局变量+Android inset 注入

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -312,6 +312,10 @@ jobs:
         working-directory: apps/client
         run: python scripts/patch_android_background.py
 
+      - name: Patch Android safe-area-top injection (#810)
+        working-directory: apps/client
+        run: python scripts/patch_android_safe_area.py
+
       - name: Patch Android notification permissions
         working-directory: apps/client
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,10 @@ jobs:
         working-directory: apps/client
         run: python scripts/patch_android_background.py
 
+      - name: Patch Android safe-area-top injection (#810)
+        working-directory: apps/client
+        run: python scripts/patch_android_safe_area.py
+
       - name: Patch Android notification permissions
         working-directory: apps/client
         run: |

--- a/apps/client/scripts/patch_android_safe_area.py
+++ b/apps/client/scripts/patch_android_safe_area.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+#810：将顶部安全区 inset 注入逻辑 patch 进 Tauri 生成的 Android MainActivity.kt。
+
+背景：Android 端 `enableEdgeToEdge()` 让 WebView 延伸到透明状态栏之下，但 WebView 内
+`env(safe-area-inset-top)` 恒为 0，前端无法感知状态栏高度，滚动内容会穿透状态栏。
+
+本脚本在 `npm run tauri android init` 之后、构建之前执行，对
+`<工作目录>/src-tauri/gen/android/app/src/main/java/com/hbut/mini/MainActivity.kt` 幂等追加：
+1. androidx.core.view 相关 import（ViewCompat / WindowCompat / WindowInsetsCompat）
+2. setOnApplyWindowInsetsListener：读取 WindowInsets.Type.statusBars() 的 top，
+   通过 evaluateJavascript 写入 documentElement 的 CSS 变量 --android-safe-top
+3. onWebViewCreate 回调里兜底注入一次（覆盖 insets 回调早于 WebView 创建的时序）；
+   insets listener 在旋转 / 折叠屏布局变化时自动重新回调，天然覆盖配置变化
+
+目标路径解析：优先相对当前工作目录（CI 在 apps/client 下执行），其次相对本脚本
+所在仓库根（便于本地从任意目录调用）。
+
+幂等性：以标记字符串 "Mini-HBUT safe-area-top inset patch (#810)" 判重，重复执行不重复插入。
+androidx.core 依赖说明：androidx.activity:activity-ktx 1.10.1 / appcompat 1.7.1
+均传递依赖 androidx.core（WindowCompat 所在库），gen 工程默认可用，无需追加依赖。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_DIR = SCRIPT_DIR.parent
+
+
+def candidate_roots() -> list[Path]:
+    """目标根目录候选：cwd 优先（CI 语义），脚本所在工程根兜底（本地语义）。"""
+    roots = []
+    cwd = Path(os.getcwd()).resolve()
+    roots.append(cwd)
+    if cwd != PROJECT_DIR and PROJECT_DIR.name == "client":
+        roots.append(PROJECT_DIR)
+    return roots
+
+
+def find_mainactivity() -> Path | None:
+    for root in candidate_roots():
+        candidate = root / "src-tauri" / "gen" / "android" / "app" / "src" / "main" / "java" / "com" / "hbut" / "mini" / "MainActivity.kt"
+        if candidate.exists():
+            return candidate
+    return None
+
+# 幂等标记：存在即视为已 patch，跳过
+PATCH_MARKER = "Mini-HBUT safe-area-top inset patch (#810)"
+
+# 需要的 import 行（已存在则跳过对应行）
+REQUIRED_IMPORTS = [
+    "import android.view.View",
+    "import android.webkit.WebView",
+    "import androidx.core.view.ViewCompat",
+    "import androidx.core.view.WindowCompat",
+    "import androidx.core.view.WindowInsetsCompat",
+]
+
+INSET_LISTENER_BLOCK = '''
+    // Mini-HBUT safe-area-top inset patch (#810) BEGIN
+    // Android WebView 中 env(safe-area-inset-top) 恒为 0，
+    // 这里读取原生 statusBars inset 并注入 CSS 变量 --android-safe-top 供前端消费。
+    // 变量取值链见 apps/client/src/index.css：
+    // --app-safe-top = max(--android-safe-top, env(...), --app-safe-top-fallback)
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    val hbutRootView = findViewById<View>(android.R.id.content)
+    ViewCompat.setOnApplyWindowInsetsListener(hbutRootView) { view, insets ->
+      val statusBarTop = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+      if (statusBarTop > 0) {
+        injectSafeAreaTop(statusBarTop)
+      }
+      insets
+    }
+    // Mini-HBUT safe-area-top inset patch (#810) END
+'''
+
+INJECT_FUNCTION_BLOCK = '''
+  // Mini-HBUT safe-area-top inset patch (#810) BEGIN
+  // 把状态栏高度写入 WebView 根元素的 CSS 变量 --android-safe-top；
+  // WebView 未就绪时延迟重试（首帧 insets 回调早于页面加载完成的情况）。
+  // insets listener 在旋转 / 折叠屏布局变化时自动重新回调，无需额外监听配置变化。
+  private fun injectSafeAreaTop(statusBarTop: Int) {
+    val wv = webView
+    if (wv == null) {
+      android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({ injectSafeAreaTop(statusBarTop) }, 200)
+      return
+    }
+    wv.evaluateJavascript(
+      "document.documentElement.style.setProperty('--android-safe-top','${statusBarTop}px');try{window.dispatchEvent(new Event('androidSafeTopChange'))}catch(e){}",
+      null
+    )
+  }
+  // Mini-HBUT safe-area-top inset patch (#810) END
+'''
+
+WEBVIEW_FIELD_BLOCK = '''
+  // Mini-HBUT safe-area-top inset patch (#810) BEGIN
+  // 持有 WebView 引用：由 WryActivity.setWebView -> onWebViewCreate 回调填充
+  private var webView: android.webkit.WebView? = null
+
+  override fun onWebViewCreate(webView: WebView) {
+    super.onWebViewCreate(webView)
+    this.webView = webView
+    // WebView 创建后主动注入一次（覆盖 insets 回调早于 WebView 创建的时序）
+    val insets = ViewCompat.getRootWindowInsets(window.decorView)
+    val statusBarTop = insets?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
+    if (statusBarTop > 0) {
+      injectSafeAreaTop(statusBarTop)
+    }
+  }
+  // Mini-HBUT safe-area-top inset patch (#810) END
+'''
+
+
+def patch_imports(text: str) -> tuple[str, bool]:
+    """幂等追加所需 import（缺失的才插入，位置放在最后一个 import 之后）。"""
+    missing = [imp for imp in REQUIRED_IMPORTS if imp not in text]
+    if not missing:
+        return text, False
+    import_lines = re.findall(r"^import .*$", text, flags=re.MULTILINE)
+    if not import_lines:
+        raise SystemExit("No import statements found in MainActivity.kt")
+    last_import = import_lines[-1]
+    insert_block = "\n".join(missing)
+    text = text.replace(last_import, last_import + "\n" + insert_block, 1)
+    return text, True
+
+
+def patch_inset_listener(text: str) -> tuple[str, bool]:
+    """在 onCreate 的 enableEdgeToEdge() 之后插入 insets 监听（幂等）。"""
+    if PATCH_MARKER in text:
+        return text, False
+    edge_match = re.search(r"^[ \t]*enableEdgeToEdge\(\)\s*$", text, flags=re.MULTILINE)
+    if not edge_match:
+        raise SystemExit("enableEdgeToEdge() call not found in MainActivity.kt")
+    insert_at = edge_match.end()
+    text = text[:insert_at] + "\n" + INSET_LISTENER_BLOCK.rstrip("\n") + "\n" + text[insert_at:]
+
+    # 类体末尾追加 injectSafeAreaTop + onWebViewCreate（最后一个 '}' 之前）
+    inject_and_webview = INJECT_FUNCTION_BLOCK + WEBVIEW_FIELD_BLOCK
+    class_end = text.rstrip().rfind("}")
+    if class_end <= 0:
+        raise SystemExit("Cannot locate class closing brace in MainActivity.kt")
+    head = text[:class_end].rstrip("\n")
+    tail = text[class_end:]
+    text = head + "\n" + inject_and_webview.rstrip("\n") + "\n" + tail
+    return text, True
+
+
+def main() -> int:
+    print("=" * 60)
+    print("Patch Tauri Android MainActivity with safe-area-top inset injection (#810)")
+    print("=" * 60)
+
+    kt_path = find_mainactivity()
+    if kt_path is None:
+        print("[ERROR] MainActivity.kt not found (run 'npm run tauri android init' first):")
+        for root in candidate_roots():
+            print(
+                "  - "
+                + str(
+                    root
+                    / "src-tauri/gen/android/app/src/main/java/com/hbut/mini/MainActivity.kt"
+                )
+            )
+        return 1
+
+    text = kt_path.read_text(encoding="utf-8")
+    text, imports_added = patch_imports(text)
+    text, listener_added = patch_inset_listener(text)
+    if imports_added or listener_added:
+        kt_path.write_text(text, encoding="utf-8")
+        print(f"[OK] Patched {kt_path}")
+    else:
+        print(f"[OK] {kt_path} already contains safe-area-top inset patch; nothing to do")
+    if imports_added:
+        print("  [ADD] androidx.core.view / android.view imports")
+    if listener_added:
+        print("  [ADD] ViewCompat.setOnApplyWindowInsetsListener + JS CSS var injection")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/client/src/App.vue
+++ b/apps/client/src/App.vue
@@ -180,17 +180,22 @@ const {
   />
 
   <!-- #681：全应用唯一滚动容器，切页回顶依赖此 ref；缺失会导致滚动位置跨 Tab 串扰 -->
-  <main
-    :ref="bindAppShellRef"
-    class="app-shell"
-    :class="{
-      'no-scroll': currentView === 'ai',
-      'ai-full': currentView === 'ai',
-      'schedule-full': currentView === 'schedule',
-      'module-host-full': currentView === 'more_module_host',
-      'ios-safe': isIOSLike
-    }"
-  >
+  <!-- #810：.app-viewport = 顶部安全区占位条 + .app-shell。
+       占位条在滚动容器之外，滚动内容永远到不了状态栏区域；
+       吸顶 header（sticky; top: 0）吸附基准变为 .app-shell 顶边 = 安全区下沿，自动正确 -->
+  <div class="app-viewport">
+    <div class="safe-area-spacer" aria-hidden="true"></div>
+    <main
+      :ref="bindAppShellRef"
+      class="app-shell"
+      :class="{
+        'no-scroll': currentView === 'ai',
+        'ai-full': currentView === 'ai',
+        'schedule-full': currentView === 'schedule',
+        'module-host-full': currentView === 'more_module_host',
+        'ios-safe': isIOSLike
+      }"
+    >
     <DemoModeBanner v-if="isLoggedIn && isTestAccountSession()" />
     <Transition
       name="module-fade"
@@ -571,7 +576,8 @@ const {
       </div>
       </div>
     </Transition>
-  </main>
+    </main>
+  </div>
 
   <nav v-if="showTabBar" class="bottom-tab-bar glass-card">
       <button class="tab-item btn-ripple" :class="{ active: activeTab === 'home' }" @click="handleTabChange('home')">

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -1,5 +1,15 @@
 :root {
   --app-vh: 1vh;
+  /* #810：顶部安全区三层取值（取最大）：
+     - --android-safe-top：Android 原生（MainActivity）注入的 statusBars 高度（WebView 中 env 恒 0）
+     - env(safe-area-inset-top)：iOS WKWebView 真实值
+     - --app-safe-top-fallback：iOS-like 且 env 为 0 时的 44px 兜底（.ios-safe 类注入） */
+  --app-safe-top-fallback: 0px;
+  --app-safe-top: max(
+    var(--android-safe-top, 0px),
+    env(safe-area-inset-top, 0px),
+    var(--app-safe-top-fallback, 0px)
+  );
   --app-safe-bottom-fallback: 0px;
   --app-safe-bottom: max(env(safe-area-inset-bottom, 0px), var(--app-safe-bottom-fallback, 0px));
   --ui-primary: #2563eb;
@@ -72,6 +82,13 @@
     padding-left: env(safe-area-inset-left, 0px);
     padding-right: env(safe-area-inset-right, 0px);
   }
+}
+
+/* #810：iOS-like 设备（App.vue 给 .app-viewport/.app-shell 挂 ios-safe 类）且
+   env(safe-area-inset-top) 为 0 时，给 --app-safe-top 提供 44px 兜底。
+   不能写在 scoped 样式里：scoped 会给 :root/html 选择器附加 data-v 属性，永远匹配不上。 */
+html.ios-safe {
+  --app-safe-top-fallback: 44px;
 }
 
 /* ============================================================

--- a/apps/client/src/styles/safe_area_top_contract.spec.ts
+++ b/apps/client/src/styles/safe_area_top_contract.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { readAppContractSources } from '../utils/contract_source_test'
+
+const readSource = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8')
+
+/**
+ * #810 顶部安全区契约测试：
+ * 「安全区永远空白」三件套 —— 全局变量三层取值 + 外层固定留白 + Android 原生注入。
+ * 防回归点：
+ * 1. index.css 必须定义 --app-safe-top 且取值链含 android/env/fallback 三层 max；
+ * 2. .app-shell 不得再把 padding-top: env(safe-area-inset-top) 放进滚动容器（滚动即穿透）；
+ * 3. .app-shell 高度必须扣除 --app-safe-top（外层 spacer 占位）；
+ * 4. .app-viewport + .safe-area-spacer wrapper 结构必须存在；
+ * 5. Android 原生注入 patch 脚本存在、幂等，且已注册进 dev/release 工作流。
+ */
+describe('safe area top contract (#810)', () => {
+  const appVue = () => readAppContractSources()
+  const indexCss = () => readSource('src/index.css')
+  const shellCss = () => readSource('src/styles/views/App.scoped.css')
+  const devWorkflow = () => readSource('../../.github/workflows/dev-build.yml')
+  const releaseWorkflow = () => readSource('../../.github/workflows/release.yml')
+
+  const tauriBridgeLikeKotlin = `package com.hbut.mini
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+
+class MainActivity : TauriActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
+    super.onCreate(savedInstanceState)
+  }
+}
+`
+
+  const runSafeAreaPatcherInTempRoot = (tempRoot: string) => {
+    execFileSync('python', [resolve(process.cwd(), 'scripts/patch_android_safe_area.py')], {
+      cwd: tempRoot,
+      stdio: 'pipe',
+    })
+  }
+
+  it('defines the three-layer --app-safe-top variable chain in the global css', () => {
+    const css = indexCss()
+    expect(css).toMatch(/--app-safe-top:\s*max\(/)
+    expect(css).toContain('var(--android-safe-top, 0px)')
+    expect(css).toMatch(/env\(safe-area-inset-top,\s*0px\)/)
+    expect(css).toContain('var(--app-safe-top-fallback, 0px)')
+    // 与底部方案同构：fallback 变量必须先声明缺省值
+    expect(css).toMatch(/--app-safe-top-fallback:\s*0px/)
+  })
+
+  it('never puts the top safe-area padding inside the scroll container again', () => {
+    const shellRule = shellCss().match(/\.app-shell\s*\{[^}]*\}/)?.[0] || ''
+    // 根因 1 回归哨兵：padding-top 属于滚动内容，上滑即被滚出视口
+    expect(shellRule).not.toMatch(/padding-top:\s*env\(safe-area-inset-top/)
+    expect(shellRule).not.toMatch(/padding-top:\s*var\(--app-safe-top/)
+  })
+
+  it('keeps the app-shell height subtracting the top safe-area spacer', () => {
+    const css = normalizeCssText(shellCss())
+    const shellRule = css.match(/\.app-shell\{[^}]*\}/)?.[0] || ''
+    expect(shellRule).toContain('height:calc(var(--app-vh,1vh)*100-var(--app-safe-top,0px))')
+    expect(shellRule).toContain('min-height:calc(var(--app-vh,1vh)*100-var(--app-safe-top,0px))')
+    // 滚动容器身份保持不变（全应用唯一滚动容器契约）
+    expect(shellRule).toContain('overflow-y:auto')
+    // no-scroll / 统一子页高度策略同步扣除，避免高度不自洽
+    const noScrollRule = css.match(/\.app-shell\.no-scroll\{[^}]*\}/)?.[0] || ''
+    expect(noScrollRule).toContain('height:calc(var(--app-vh,1vh)*100-var(--app-safe-top,0px))')
+    expect(css).toContain(
+      'min-height:calc(var(--app-vh,1vh)*100-var(--app-safe-top,0px))!important'
+    )
+  })
+
+  it('wraps the app-shell with an outer viewport + top spacer structure', () => {
+    const css = normalizeCssText(shellCss())
+    expect(css).toMatch(/\.app-viewport\{[^}]*display:flex[^}]*flex-direction:column/)
+    const spacerRule = css.match(/\.safe-area-spacer\{[^}]*\}/)?.[0] || ''
+    expect(spacerRule).toContain('height:var(--app-safe-top,0px)')
+    expect(spacerRule).toContain('flex:0 0 auto'.replace(/\s+/g, ''))
+    expect(spacerRule).toContain('background:transparent')
+    // spacer 在滚动容器之外：模板结构必须是 spacer 与 main 平级
+    const app = appVue()
+    expect(app).toContain('class="app-viewport"')
+    expect(app).toMatch(
+      /<div class="safe-area-spacer" aria-hidden="true"><\/div>\s*<main[^>]*class="app-shell"/s
+    )
+  })
+
+  it('keeps the ios-like 44px fallback wired through the global ios-safe class', () => {
+    // scoped 样式无法匹配 html，兜底必须留在全局 index.css
+    expect(indexCss()).toMatch(/html\.ios-safe\s*\{[^}]*--app-safe-top-fallback:\s*44px/s)
+    // App.vue 继续挂 ios-safe 类（isIOSLike 判定）
+    expect(appVue()).toContain("'ios-safe': isIOSLike")
+  })
+
+  it('patches the generated Android MainActivity with an idempotent safe-area injection', () => {
+    const patcher = readSource('scripts/patch_android_safe_area.py')
+
+    expect(patcher).toContain('Mini-HBUT safe-area-top inset patch (#810)')
+    expect(patcher).toContain('setOnApplyWindowInsetsListener')
+    expect(patcher).toContain('WindowInsetsCompat.Type.statusBars()')
+    expect(patcher).toContain('--android-safe-top')
+    expect(patcher).toContain('evaluateJavascript')
+
+    // 幂等：临时目录里对样例 MainActivity 连跑两次，标记只出现固定次数（4 个 BEGIN 块 + 尾部 0）
+    const tempRoot = mkdtempSync(resolve(tmpdir(), 'mini-hbut-safe-area-generated-'))
+    try {
+      const ktPath = resolve(tempRoot, 'src-tauri/gen/android/app/src/main/java/com/hbut/mini/MainActivity.kt')
+      mkdirSync(dirname(ktPath), { recursive: true })
+      writeFileSync(ktPath, tauriBridgeLikeKotlin)
+
+      runSafeAreaPatcherInTempRoot(tempRoot)
+      runSafeAreaPatcherInTempRoot(tempRoot)
+
+      const patched = readFileSync(ktPath, 'utf8')
+      expect(patched.match(/#810\) BEGIN/g)).toHaveLength(3)
+      expect(patched).toContain('injectSafeAreaTop')
+      expect(patched.match(/private var webView/g)).toHaveLength(1)
+      expect(patched).toContain("setProperty('--android-safe-top'")
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('registers the android safe-area patch in the dev and release workflows', () => {
+    const devStep = 'python scripts/patch_android_safe_area.py'
+    expect(devWorkflow()).toContain('Patch Android safe-area-top injection (#810)')
+    expect(devWorkflow()).toContain(devStep)
+    expect(releaseWorkflow()).toContain('Patch Android safe-area-top injection (#810)')
+    expect(releaseWorkflow()).toContain(devStep)
+    // 必须在 android init 之后执行（生成的工程存在后才能 patch）
+    for (const workflow of [devWorkflow(), releaseWorkflow()]) {
+      const initIndex = workflow.indexOf('npm run tauri android init')
+      const patchIndex = workflow.indexOf('python scripts/patch_android_safe_area.py')
+      expect(initIndex).toBeGreaterThanOrEqual(0)
+      expect(patchIndex).toBeGreaterThan(initIndex)
+    }
+  })
+})
+
+const normalizeCssText = (source: string) => source.replace(/\s+/g, '')

--- a/apps/client/src/styles/views/App.scoped.css
+++ b/apps/client/src/styles/views/App.scoped.css
@@ -129,12 +129,30 @@
   }
 }
 
-.app-shell {
-  --safe-top-fallback: 0px;
-  min-height: calc(var(--app-vh, 1vh) * 100);
+/* #810 顶部安全区固定留白：
+   .app-viewport 是「安全区占位（.safe-area-spacer）+ 滚动容器（.app-shell）」的外层包裹。
+   占位条在滚动容器之外，高度 --app-safe-top，滚动内容永远无法进入状态栏区域；
+   背景保持透明，透出 body 的 --ui-bg-gradient（浅色）或 #0f172a（暗色），视觉连续。 */
+.app-viewport {
+  display: flex;
+  flex-direction: column;
   height: calc(var(--app-vh, 1vh) * 100);
+  min-height: calc(var(--app-vh, 1vh) * 100);
+}
+
+.safe-area-spacer {
+  flex: 0 0 auto;
+  height: var(--app-safe-top, 0px);
+  /* 占位条自身透明：浅色模式透出 body 渐变，暗色模式透出 html/body 深色背景 */
+  background: transparent;
+  pointer-events: none;
+}
+
+.app-shell {
+  min-height: calc(var(--app-vh, 1vh) * 100 - var(--app-safe-top, 0px));
+  height: calc(var(--app-vh, 1vh) * 100 - var(--app-safe-top, 0px));
+  flex: 1 1 auto;
   position: relative;
-  padding-top: env(safe-area-inset-top);
   padding-bottom: calc(128px + var(--app-safe-bottom));
   overflow-y: auto;
   overflow-x: hidden;
@@ -152,7 +170,7 @@
 }
 
 .app-shell.no-scroll {
-  height: calc(var(--app-vh, 1vh) * 100);
+  height: calc(var(--app-vh, 1vh) * 100 - var(--app-safe-top, 0px));
   overflow: hidden;
   padding-bottom: var(--app-safe-bottom);
 }
@@ -171,15 +189,19 @@
   width: 100%;
   min-height: 100%;
   height: 100% !important;
+  /* #810：AI 页原按整屏（100vh）设定自身高度并内置 env 安全区，
+     现外壳高度已扣除顶部安全区占位，用 100% 跟随 .app-shell 实际可视高度，
+     否则底部会被 spacer 高度顶出视口 */
+  max-height: 100% !important;
 }
 
-.app-shell.ios-safe {
-  --safe-top-fallback: 44px;
-}
+/* #810：iOS-like 且 env=0 时兜底 44px —— 已迁移到 index.css 的 html.ios-safe 全局规则。
+   （scoped 样式会给 :root/html 选择器附加 data-v 属性导致永远匹配不上 html，故不能放这里） */
 
+/* #810：schedule-full 不再自带顶部 padding（外层 spacer 已留白），
+   --schedule-safe-top 统一走全局 --app-safe-top 三层取值链 */
 .app-shell.schedule-full {
-  --schedule-safe-top: max(env(safe-area-inset-top), var(--safe-top-fallback, 0px));
-  padding-top: var(--schedule-safe-top);
+  --schedule-safe-top: var(--app-safe-top, 0px);
   padding-bottom: calc(128px + var(--app-safe-bottom));
   overflow: hidden;
 }
@@ -200,17 +222,29 @@
 
 @media (max-width: 900px) {
   .app-shell.schedule-full {
-    --schedule-safe-top: max(env(safe-area-inset-top), var(--safe-top-fallback, 0px));
+    --schedule-safe-top: var(--app-safe-top, 0px);
   }
 }
 
-/* 统一业务页面高度策略：避免子页面写死 100vh 导致进入后再次缩放 */
+/* 统一业务页面高度策略：避免子页面写死 100vh 导致进入后再次缩放
+   （#810：同步减去外层顶部安全区占位，保证子页高度与 .app-shell 实际可视高度一致） */
 .app-shell > .dashboard,
 .app-shell > [class$='-view']:not(.schedule-view):not(.ai-view),
 .app-shell > .view-transition-root > .dashboard,
 .app-shell > .view-transition-root > [class$='-view']:not(.schedule-view):not(.ai-view) {
-  min-height: calc(var(--app-vh, 1vh) * 100) !important;
+  min-height: calc(
+    var(--app-vh, 1vh) * 100 - var(--app-safe-top, 0px)
+  ) !important;
   height: auto !important;
+}
+
+/* #810：首页模板自带 Tailwind min-h-screen（=100vh），会比扣除安全区后的
+   .app-shell 可视高度多出一个 spacer 高度，造成首页底部可多滚一段；统一压平 */
+.app-shell > .dashboard.min-h-screen,
+.app-shell > .view-transition-root > .dashboard.min-h-screen {
+  min-height: calc(
+    var(--app-vh, 1vh) * 100 - var(--app-safe-top, 0px)
+  ) !important;
 }
 
 /* 宽屏兜底（#714）：未自带限宽的二级页默认限宽居中，避免宽窗口下拉满全屏。
@@ -250,6 +284,8 @@
   width: 100%;
   min-height: 100%;
   height: 100% !important;
+  /* #810：同 ai-view，跟随扣除安全区占位后的 .app-shell 高度，防止底部溢出 */
+  max-height: 100% !important;
 }
 
 .bottom-tab-bar {


### PR DESCRIPTION
## 关联 Issue

Closes #810

## 改动概览

移动端滚动时内容穿透状态栏、吸顶标题栏穿模。根因三层：

1. `.app-shell` 既是唯一滚动容器又背负 `padding-top: env(safe-area-inset-top)`——padding 属滚动内容，上滑即被滚走；
2. 吸顶标题栏 `sticky; top: 0` 吸附在滚动容器物理顶边（状态栏正下方）；
3. Android `enableEdgeToEdge()` 后 WebView 中 `env(safe-area-inset-top)` 恒 0，44px 兜底仅 iOS-like。

本 PR 落地「安全区永远空白」三件套：

- **全局变量**：`index.css` 新增 `--app-safe-top: max(var(--android-safe-top), env(safe-area-inset-top), var(--app-safe-top-fallback))` 三层取值链（Android 注入 / iOS env / iOS-like 44px 兜底，桌面全 0 自动无空隙）。
- **外层固定留白**：`.app-shell` 包进 `.app-viewport`，滚动容器外前置不随滚动的 `.safe-area-spacer`；`.app-shell` 删除内层 padding-top，高度改为 `calc(var(--app-vh)*100 - var(--app-safe-top))`，`no-scroll`/`schedule-full`/`ai-full`/`more-module-host` 等全屏态同步自洽。sticky 标题栏吸附基准自动变为安全区下沿，**逐页零改动**。
- **Android 原生注入**：新 `scripts/patch_android_safe_area.py` 幂等 patch 生成工程 `MainActivity.kt`——`ViewCompat` insets 监听读 `statusBars()` top，`evaluateJavascript` 注入 `--android-safe-top`；`onWebViewCreate` 兜底注入一次；旋转/折叠屏由 insets 回调天然覆盖。已在 dev-build.yml / release.yml 注册（`tauri android init` 之后、构建之前，紧随现有 background patch 的位置），防重演 #612 的 CI 丢失。

iOS-like 44px 兜底从 `.app-shell.ios-safe`（scoped，`:root/html` 选择器带 data-v 属性永远匹配不上）迁到全局 `html.ios-safe`，修正原方案隐藏缺陷。

## 测试

- [x] 新增 `safe_area_top_contract.spec.ts` 7 条契约（变量三层链、防回归哨兵、高度减法、wrapper 结构、兜底迁移、patch 幂等真执行、CI 注册顺序），默认配置与 `vitest.ci.config.ts` 双绿
- [x] `vue-tsc --noEmit` 通过
- [x] patch 幂等已对真实 gen 工程验证：两次执行标记块恒 3 处、import 无重复
- [x] 桌面端回归自查：三层取值全 0，spacer 高度 0，高度计算不变
- [x] 深浅色自查：spacer 透明方案，浅色透出 body 渐变、深色透出 `#0f172a`，顶部视觉连续

## 已知边界（后续跟进）

- 真机效果（Android 注入值、旋转/折叠屏）留待下一次 dev-build/TestFlight 验证；
- `home_layout_diagnostics.ts` 仍读旧变量 `--safe-top-fallback`（仅调试面板显示空值，不影响布局），建议后续清理。

## 风险与回滚

- 回滚 = revert 单 commit；gen/android 为生成工程不入库，patch 即护栏。